### PR TITLE
fix: Align CompanionGrant entity with MIGRATION_5_6 schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Gitleaks-action scans <pr-head>^..<pr-head>; the parent commit must
+          # be present in the checkout, so we need full history.
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/android/app/src/main/java/com/bios/app/model/CompanionGrant.kt
+++ b/android/app/src/main/java/com/bios/app/model/CompanionGrant.kt
@@ -1,9 +1,17 @@
 package com.bios.app.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "companion_grants")
+// `defaultValue` and the `state` index match what MIGRATION_5_6 emits — without
+// these, Room's schema check crashes on every upgrade from v5 to v6 because the
+// on-disk table has the default + index but the entity declares neither.
+@Entity(
+    tableName = "companion_grants",
+    indices = [Index(value = ["state"])],
+)
 data class CompanionGrant(
     @PrimaryKey val packageName: String,
     val state: String,
@@ -11,7 +19,7 @@ data class CompanionGrant(
     val grantedAt: Long? = null,
     val revokedAt: Long? = null,
     val lastAccessAt: Long? = null,
-    val accessCount: Long = 0
+    @ColumnInfo(defaultValue = "0") val accessCount: Long = 0,
 ) {
     companion object {
         const val STATE_PENDING = "PENDING"


### PR DESCRIPTION
## Summary
- Fixes the `IllegalStateException: Migration didn't properly handle: companion_grants` crash that hits any device upgrading from schema v5 → v6.
- `MIGRATION_5_6` was emitting `accessCount INTEGER NOT NULL DEFAULT 0` and `CREATE INDEX index_companion_grants_state`, but the `@Entity` declared neither. Room's runtime schema check compares the on-disk table against what the entity says and aborts on any drift.
- Adds `@ColumnInfo(defaultValue = "0")` on `accessCount` and `indices = [Index(value = ["state"])]` on the `@Entity` so they match what the migration writes. Fresh installs now also get the index, matching upgraded installs (previously they wouldn't have had it).

The mismatch was introduced in `84f4849` (CompanionGate foundation) but only manifests on upgrade — fresh installs build directly from the entity and never hit the migration path. Caught when launching the app on a device that had a v5 install of Bios.

## Test plan
- [x] `./gradlew :app:installStandaloneDebug` — installs on Pixel 9a emulator running v5 schema
- [x] App launches and stays alive (`pidof com.bios.app` returns); previously crashed within ~7s with the migration error
- [x] `adb logcat -b crash` is empty post-fix
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — passes
- [ ] (Manual) Verify on a fresh install too, to confirm the new `Index("state")` doesn't trip anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)