### PR TITLE
fix: CompanionGrant schema + companion-pending UX + sleep duration metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ android/build/
 android/.gradle/
 .gradle/
 
+# Kotlin daemon caches
+android/**/.kotlin/
+android/.kotlin/
+
 # IDE
 .idea/
 *.iml

--- a/android/app/src/main/java/com/bios/app/data/dao/CompanionGrantDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/CompanionGrantDao.kt
@@ -25,6 +25,9 @@ interface CompanionGrantDao {
     @Query("SELECT * FROM companion_grants WHERE state = :state ORDER BY firstSeenAt DESC")
     suspend fun getByState(state: String): List<CompanionGrant>
 
+    @Query("SELECT COUNT(*) FROM companion_grants WHERE state = 'PENDING'")
+    fun pendingCountFlow(): Flow<Int>
+
     @Query("UPDATE companion_grants SET lastAccessAt = :ts, accessCount = accessCount + 1 WHERE packageName = :pkg")
     suspend fun recordAccess(pkg: String, ts: Long)
 

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -38,7 +38,8 @@ class BaselineEngine(
                 MetricType.SKIN_TEMPERATURE_DEVIATION,
                 MetricType.STEPS,
                 MetricType.ACTIVE_MINUTES,
-                MetricType.SLEEP_STAGE
+                MetricType.SLEEP_STAGE,
+                MetricType.SLEEP_DURATION
             )
 
             for (metricType in metricsToBaseline) {
@@ -100,7 +101,8 @@ class BaselineEngine(
             MetricType.BLOOD_OXYGEN,
             MetricType.RESPIRATORY_RATE,
             MetricType.STEPS,
-            MetricType.ACTIVE_CALORIES
+            MetricType.ACTIVE_CALORIES,
+            MetricType.SLEEP_DURATION
         )
 
         for (metricType in metricsToAggregate) {

--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -208,7 +208,7 @@ class HealthConnectAdapter(private val context: Context) {
             )
         )
         return response.records.flatMap { session ->
-            session.stages.mapNotNull { stage ->
+            val stageReadings = session.stages.mapNotNull { stage ->
                 val biosStage = when (stage.stage) {
                     SleepSessionRecord.STAGE_TYPE_AWAKE,
                     SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> SleepStage.AWAKE
@@ -231,6 +231,27 @@ class HealthConnectAdapter(private val context: Context) {
                     confidence = ConfidenceTier.MEDIUM.level
                 )
             }
+
+            // Asleep time = session total minus AWAKE stages (matches Oura/Whoop semantics).
+            // If the session has no stage breakdown, fall back to the full session length.
+            val awakeSec = stageReadings
+                .filter { it.value.toInt() == SleepStage.AWAKE.value }
+                .sumOf { it.durationSec ?: 0 }
+            val sessionSec = java.time.Duration.between(
+                session.startTime, session.endTime
+            ).seconds.toInt()
+            val asleepSec = (sessionSec - awakeSec).coerceAtLeast(0)
+
+            val durationReading = MetricReading(
+                metricType = MetricType.SLEEP_DURATION.key,
+                value = asleepSec.toDouble(),
+                timestamp = session.endTime.toEpochMilli(),
+                durationSec = sessionSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level
+            )
+
+            stageReadings + durationReading
         }
     }
 

--- a/android/app/src/main/java/com/bios/app/provider/CompanionAccessNotifier.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CompanionAccessNotifier.kt
@@ -30,6 +30,11 @@ class CompanionAccessNotifier(private val context: Context) {
     }
 
     fun notifyPending(packageName: String) {
+        val manager = NotificationManagerCompat.from(context)
+        // On API 33+ POST_NOTIFICATIONS is a runtime perm. If the owner declined,
+        // stay silent — the consent UI is still reachable from Settings.
+        if (!manager.areNotificationsEnabled()) return
+
         val intent = Intent(context, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra(EXTRA_NAVIGATE_TO_COMPANIONS, true)
@@ -56,8 +61,11 @@ class CompanionAccessNotifier(private val context: Context) {
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .build()
 
-        NotificationManagerCompat.from(context)
-            .notify(NOTIFICATION_ID_BASE + (packageName.hashCode() and 0xFF), notification)
+        try {
+            manager.notify(NOTIFICATION_ID_BASE + (packageName.hashCode() and 0xFF), notification)
+        } catch (_: SecurityException) {
+            // Race: perm revoked between the check above and notify(). Swallow.
+        }
     }
 
     private fun ensureChannel() {

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -225,7 +225,16 @@ fun BiosApp(viewModel: AppViewModel) {
                 HomeScreen(
                     viewModel = viewModel,
                     onNavigateToDiagnostics = { navController.navigate("diagnostics") },
-                    onNavigateToPpgCapture = { navController.navigate("ppg_capture") }
+                    onNavigateToPpgCapture = { navController.navigate("ppg_capture") },
+                    onNavigateToCompanions = { navController.navigate("companions") },
+                    onNavigateToMetric = { metric ->
+                        selectedTab = tabs.indexOfFirst { it.first == "trends" }
+                        navController.navigate("trends?metric=${metric.key}") {
+                            popUpTo("home") { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
                 )
             }
             composable("ppg_capture") {
@@ -253,7 +262,22 @@ fun BiosApp(viewModel: AppViewModel) {
                     onBack = { navController.popBackStack() }
                 )
             }
-            composable("trends") { TrendsScreen(viewModel) }
+            composable(
+                route = "trends?metric={metric}",
+                arguments = listOf(
+                    navArgument("metric") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                )
+            ) { backStackEntry ->
+                val metricKey = backStackEntry.arguments?.getString("metric")
+                TrendsScreen(
+                    viewModel = viewModel,
+                    initialMetric = metricKey?.let { com.bios.contracts.MetricType.fromKey(it) }
+                )
+            }
             composable("alerts") { AlertsScreen(viewModel) }
             composable("timeline") {
                 TimelineScreen(

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -14,13 +14,15 @@ import com.bios.app.model.PersonalBaseline
 import com.bios.app.ui.AppViewModel
 import kotlin.math.abs
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MetricCard(
     metricType: MetricType,
     label: String,
     icon: ImageVector,
     viewModel: AppViewModel,
-    refreshKey: Any? = null
+    refreshKey: Any? = null,
+    onClick: (() -> Unit)? = null
 ) {
     var latestValue by remember { mutableStateOf<Double?>(null) }
     var baseline by remember { mutableStateOf<PersonalBaseline?>(null) }
@@ -30,45 +32,61 @@ fun MetricCard(
         baseline = viewModel.getBaseline(metricType)
     }
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        )
-    ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    icon,
-                    contentDescription = label,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp)
-                )
-                baseline?.let { bl ->
-                    latestValue?.let { v ->
-                        DeviationIndicator(v, bl)
-                    }
+    val colors = CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceVariant
+    )
+    val modifier = Modifier.fillMaxWidth()
+    if (onClick != null) {
+        Card(modifier = modifier, onClick = onClick, colors = colors) {
+            MetricCardBody(metricType, label, icon, latestValue, baseline)
+        }
+    } else {
+        Card(modifier = modifier, colors = colors) {
+            MetricCardBody(metricType, label, icon, latestValue, baseline)
+        }
+    }
+}
+
+@Composable
+private fun MetricCardBody(
+    metricType: MetricType,
+    label: String,
+    icon: ImageVector,
+    latestValue: Double?,
+    baseline: PersonalBaseline?
+) {
+    Column(modifier = Modifier.padding(12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                icon,
+                contentDescription = label,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp)
+            )
+            baseline?.let { bl ->
+                latestValue?.let { v ->
+                    DeviationIndicator(v, bl)
                 }
             }
-
-            Spacer(Modifier.height(8.dp))
-
-            Text(
-                text = latestValue?.let { formatValue(it, metricType) } ?: "--",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.SemiBold
-            )
-
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = latestValue?.let { formatValue(it, metricType) } ?: "--",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }
 
@@ -89,7 +107,7 @@ private fun DeviationIndicator(value: Double, baseline: PersonalBaseline) {
     )
 }
 
-private fun formatValue(value: Double, metricType: MetricType): String {
+internal fun formatValue(value: Double, metricType: MetricType): String {
     return when (metricType) {
         MetricType.HEART_RATE, MetricType.RESTING_HEART_RATE, MetricType.RESPIRATORY_RATE ->
             "${value.toInt()}"
@@ -102,6 +120,12 @@ private fun formatValue(value: Double, metricType: MetricType): String {
         MetricType.SKIN_TEMPERATURE_DEVIATION -> {
             val sign = if (value >= 0) "+" else ""
             "$sign${String.format("%.1f", value)}°"
+        }
+        MetricType.SLEEP_DURATION -> {
+            val totalMinutes = (value / 60).toInt()
+            val hours = totalMinutes / 60
+            val minutes = totalMinutes % 60
+            "${hours}h ${minutes}m"
         }
         else -> String.format("%.1f", value)
     }

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -34,12 +34,17 @@ import java.util.Locale
 fun HomeScreen(
     viewModel: AppViewModel,
     onNavigateToDiagnostics: () -> Unit = {},
-    onNavigateToPpgCapture: () -> Unit = {}
+    onNavigateToPpgCapture: () -> Unit = {},
+    onNavigateToCompanions: () -> Unit = {},
+    onNavigateToMetric: (MetricType) -> Unit = {}
 ) {
     val unacknowledged by viewModel.unacknowledgedAlerts.collectAsState()
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
     val lastSync by viewModel.ingestManager.lastSyncTime.collectAsState()
     val isSyncing by viewModel.ingestManager.isSyncing.collectAsState()
+    val pendingCompanions by viewModel.db.companionGrantDao()
+        .pendingCountFlow()
+        .collectAsState(initial = 0)
 
     PullToRefreshBox(
         isRefreshing = isSyncing,
@@ -79,6 +84,13 @@ fun HomeScreen(
             (System.currentTimeMillis() - lastSync!!) > staleThresholdMillis
         if (isStale) {
             StaleDataBanner()
+        }
+
+        if (pendingCompanions > 0) {
+            PendingCompanionBanner(
+                count = pendingCompanions,
+                onReview = onNavigateToCompanions
+            )
         }
 
         // Status card
@@ -206,11 +218,12 @@ fun HomeScreen(
             Triple(MetricType.RESPIRATORY_RATE, "Resp. Rate", Icons.Default.Air),
             Triple(MetricType.STEPS, "Steps", Icons.Default.DirectionsWalk),
             Triple(MetricType.SKIN_TEMPERATURE_DEVIATION, "Skin Temp", Icons.Default.Thermostat),
+            Triple(MetricType.SLEEP_DURATION, "Sleep", Icons.Default.Bedtime),
         )
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
-            modifier = Modifier.height(380.dp),
+            modifier = Modifier.height(510.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             userScrollEnabled = false
@@ -221,7 +234,8 @@ fun HomeScreen(
                     label = label,
                     icon = icon,
                     viewModel = viewModel,
-                    refreshKey = lastSync
+                    refreshKey = lastSync,
+                    onClick = { onNavigateToMetric(metricType) }
                 )
             }
         }
@@ -384,6 +398,48 @@ fun QuickSymptomCard(onLogSymptom: (String) -> Unit) {
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun PendingCompanionBanner(count: Int, onReview: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onReview,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                Icons.Default.Apps,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                modifier = Modifier.size(20.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (count == 1) "1 app waiting for approval"
+                    else "$count apps waiting for approval",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+                Text(
+                    "Bios is blocking their access until you decide.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/settings/CompanionAppsRow.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/CompanionAppsRow.kt
@@ -1,0 +1,58 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CompanionAppsRow(
+    pendingCount: Int,
+    approvedCount: Int,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text("Companion Apps")
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            when {
+                pendingCount > 0 -> {
+                    Badge(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError
+                    ) { Text("$pendingCount") }
+                    Spacer(Modifier.width(6.dp))
+                    Text("pending", color = MaterialTheme.colorScheme.error)
+                }
+                approvedCount > 0 -> Text(
+                    "$approvedCount approved",
+                    color = MaterialTheme.colorScheme.primary
+                )
+                else -> Text(
+                    "None",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(Modifier.width(4.dp))
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.core.content.FileProvider
 import com.bios.app.engine.BaselineEngine
 import com.bios.app.export.DataExporter
 import com.bios.app.export.FhirExporter
+import com.bios.app.model.CompanionGrant
 import com.bios.app.model.PrivacyTier
 import com.bios.app.alerts.DailyDigestWorker
 import com.bios.app.privacy.ContributionWorker
@@ -40,6 +41,11 @@ fun SettingsScreen(
     var isExporting by remember { mutableStateOf(false) }
     var showOuraDialog by remember { mutableStateOf(false) }
     var isOuraConnected by remember { mutableStateOf(viewModel.ouraTokenStore.hasToken()) }
+    val companionGrants by viewModel.db.companionGrantDao()
+        .observeAll()
+        .collectAsState(initial = emptyList())
+    val pendingCompanionCount = companionGrants.count { it.state == CompanionGrant.STATE_PENDING }
+    val approvedCompanionCount = companionGrants.count { it.state == CompanionGrant.STATE_GRANTED }
     var privacyTier by remember {
         val prefs = context.getSharedPreferences("bios_settings", Context.MODE_PRIVATE)
         val tier = prefs.getString("privacy_tier", PrivacyTier.PRIVATE.name)
@@ -96,6 +102,13 @@ fun SettingsScreen(
                         Text("Disconnect Oura", color = MaterialTheme.colorScheme.error)
                     }
                 }
+
+                Spacer(Modifier.height(4.dp))
+                CompanionAppsRow(
+                    pendingCount = pendingCompanionCount,
+                    approvedCount = approvedCompanionCount,
+                    onClick = onNavigateToCompanions
+                )
             }
         }
 
@@ -346,15 +359,6 @@ fun SettingsScreen(
                     Icon(Icons.Default.Shield, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
                     Text("Privacy Dashboard")
-                }
-                Spacer(Modifier.height(4.dp))
-                OutlinedButton(
-                    onClick = onNavigateToCompanions,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Icon(Icons.Default.Apps, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("Companion Apps")
                 }
                 Spacer(Modifier.height(4.dp))
                 Button(

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -18,9 +18,14 @@ import com.bios.app.ui.AppViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TrendsScreen(viewModel: AppViewModel) {
+fun TrendsScreen(
+    viewModel: AppViewModel,
+    initialMetric: MetricType? = null
+) {
     val baselines by viewModel.baselines.collectAsState()
-    var selectedMetric by remember { mutableStateOf(MetricType.HEART_RATE) }
+    var selectedMetric by remember(initialMetric) {
+        mutableStateOf(initialMetric ?: MetricType.HEART_RATE)
+    }
 
     val trackableMetrics = listOf(
         MetricType.HEART_RATE to "Heart Rate",
@@ -30,6 +35,7 @@ fun TrendsScreen(viewModel: AppViewModel) {
         MetricType.RESPIRATORY_RATE to "Resp. Rate",
         MetricType.STEPS to "Steps",
         MetricType.SKIN_TEMPERATURE_DEVIATION to "Skin Temp",
+        MetricType.SLEEP_DURATION to "Sleep",
     )
 
     Column(

--- a/android/app/src/test/java/com/bios/app/CompanionGateTest.kt
+++ b/android/app/src/test/java/com/bios/app/CompanionGateTest.kt
@@ -22,6 +22,8 @@ class CompanionGateTest {
         override suspend fun getAll(): List<CompanionGrant> = rows.values.toList()
         override suspend fun getByState(state: String): List<CompanionGrant> =
             rows.values.filter { it.state == state }
+        override fun pendingCountFlow(): Flow<Int> =
+            flowOf(rows.values.count { it.state == CompanionGrant.STATE_PENDING })
         override suspend fun recordAccess(pkg: String, ts: Long) {
             rows[pkg]?.let { rows[pkg] = it.copy(lastAccessAt = ts, accessCount = it.accessCount + 1) }
         }

--- a/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
@@ -1,0 +1,36 @@
+package com.bios.app
+
+import com.bios.app.ui.components.formatValue
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MetricCardFormatTest {
+
+    @Test
+    fun `sleep duration formats seconds as hours and minutes`() {
+        // 7h 23m = 7 * 3600 + 23 * 60 = 26580s
+        assertEquals("7h 23m", formatValue(26580.0, MetricType.SLEEP_DURATION))
+    }
+
+    @Test
+    fun `sleep duration handles whole hours`() {
+        assertEquals("8h 0m", formatValue(8.0 * 3600, MetricType.SLEEP_DURATION))
+    }
+
+    @Test
+    fun `sleep duration handles sub-minute remainder by flooring`() {
+        // 6h 30m 45s -> floor to 6h 30m
+        assertEquals("6h 30m", formatValue(6 * 3600 + 30 * 60 + 45.0, MetricType.SLEEP_DURATION))
+    }
+
+    @Test
+    fun `sleep duration handles zero`() {
+        assertEquals("0h 0m", formatValue(0.0, MetricType.SLEEP_DURATION))
+    }
+
+    @Test
+    fun `heart rate formats as integer bpm`() {
+        assertEquals("72", formatValue(72.4, MetricType.HEART_RATE))
+    }
+}


### PR DESCRIPTION
## Summary

Three commits on this branch, ranging from a Room schema fix to small UX/data additions:

- **`fix: Align CompanionGrant entity with MIGRATION_5_6 schema`** — the original reason for the branch. Entity matched the migration result, restoring DB integrity.
- **`ci: Fetch full history for gitleaks scan`** — let the scanner see the full history rather than the shallow CI checkout.
- **`feat: Companion-pending banner + sleep duration + metric→trends nav`** — three small bundled improvements:
  - Pending-companion banner on Home + Settings badge, backed by new `CompanionGrantDao.pendingCountFlow()`. Companion Apps row lifted to its own file.
  - `SLEEP_DURATION` metric end-to-end — HealthConnectAdapter derives asleep time per session (session length − AWAKE stages, Oura/Whoop semantics), BaselineEngine baselines/aggregates it, MetricCard formats as `Xh Ym`, Home + Trends surface it.
  - Metric cards on Home are now clickable and deep-link to the Trends tab pre-selected on the tapped metric.
  - Also: gitignore Kotlin daemon caches; guard `CompanionAccessNotifier.notify()` with `areNotificationsEnabled()` so missing POST_NOTIFICATIONS no longer trips lint or crashes.

## Test plan

- [x] `scripts/code-quality-check.sh` passes (file-length, secret scan, lint, both flavor builds, unit tests)
- [x] New `MetricCardFormatTest` covers sleep formatting edge cases
- [x] `CompanionGateTest` updated for the new `pendingCountFlow()` DAO method
- [ ] Manual: Install build, trigger a pending companion grant, verify Home banner + Settings badge appear and clear when approved/denied
- [ ] Manual: With a paired wearable, confirm a Sleep card appears on Home with `Xh Ym` formatting and tapping it lands on Trends with Sleep selected
- [ ] Manual: Tap each metric card on Home; verify it deep-links to Trends with the right metric pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)