### PR TITLE
feat: ReadingKind enum on DataSource

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -25,7 +25,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         ProfessionalReview::class,
         CompanionGrant::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -62,7 +62,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
                 .build()
         }
 
@@ -197,6 +197,19 @@ abstract class BiosDatabase : RoomDatabase() {
                     )
                 """)
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_companion_grants_state ON companion_grants(state)")
+            }
+        }
+
+        // Existing rows back-fill to SENSOR: every pre-v7 source is either a
+        // sensor adapter (Health Connect, Gadgetbridge, camera PPG) or a
+        // companion writer. Companion writers will be re-tagged at next
+        // ensureSourceFor() call (REPLACE strategy), so the SENSOR default is
+        // only load-bearing until the first companion write after upgrade.
+        private val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE data_sources ADD COLUMN readingKind TEXT NOT NULL DEFAULT 'SENSOR'"
+                )
             }
         }
 

--- a/android/app/src/main/java/com/bios/app/model/DataSource.kt
+++ b/android/app/src/main/java/com/bios/app/model/DataSource.kt
@@ -11,6 +11,7 @@ data class DataSource(
     val deviceName: String? = null,
     val deviceModel: String? = null,
     val sensorType: String,
+    val readingKind: String = ReadingKind.SENSOR.name,
     val connectedAt: Long = System.currentTimeMillis(),
     val lastSyncAt: Long = System.currentTimeMillis()
 )

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -26,6 +26,17 @@ enum class SensorType {
     MICROPHONE, DERIVED
 }
 
+// Kind of data a `DataSource` produces. Engine policies key off this:
+// `BaselineEngine` and `SignalQualityFilter` only consume SENSOR; self-reports
+// and active-test results route to a separate, descriptive (not evaluative)
+// engine. Decided in docs/SELF_REPORTED_DATA_HOME.md.
+enum class ReadingKind {
+    SENSOR,
+    SELF_REPORTED,
+    DERIVED,
+    ACTIVE_TEST
+}
+
 enum class ConfidenceTier(val level: Int) {
     VENDOR_DERIVED(0),
     LOW(1),

--- a/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
+++ b/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
@@ -108,7 +108,8 @@ class BiosHealthProvider : ContentProvider() {
                 sourceType = "companion",
                 deviceName = companion.displayName,
                 deviceModel = companion.packageName,
-                sensorType = SensorType.DERIVED.name
+                sensorType = SensorType.DERIVED.name,
+                readingKind = companion.defaultReadingKind.name
             ))
         }
         ensuredSources += companion.sourceId

--- a/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
@@ -1,5 +1,7 @@
 package com.bios.app.provider
 
+import com.bios.app.model.ReadingKind
+
 /**
  * Companion-write contract: which packages may insert which metric keys via
  * [BiosHealthProvider]'s `/companion/{metricType}` URI, and how their writes
@@ -26,11 +28,17 @@ package com.bios.app.provider
  */
 internal object CompanionContract {
 
+    // `defaultReadingKind` is the dominant kind of data the companion writes.
+    // Mixed-kind companions (e.g. W2F writing both DERIVED cadence and
+    // SELF_REPORTED mood) must split into multiple sourceIds when that
+    // ambiguity actually bites — tracked as an open question in
+    // docs/SELF_REPORTED_DATA_HOME.md.
     data class Companion(
         val packageName: String,
         val displayName: String,
         val sourceId: String,
         val writableMetrics: Set<String>,
+        val defaultReadingKind: ReadingKind,
     )
 
     val PACKAGES: Map<String, Companion> = listOf(
@@ -43,6 +51,7 @@ internal object CompanionContract {
                 "circadian_phase_shift",
                 "mood_drift_score",
             ),
+            defaultReadingKind = ReadingKind.DERIVED,
         ),
         Companion(
             packageName = "com.smokless.smokeless",
@@ -54,6 +63,7 @@ internal object CompanionContract {
                 "cannabis_use",
                 "cannabis_craving",
             ),
+            defaultReadingKind = ReadingKind.SELF_REPORTED,
         ),
         Companion(
             packageName = "com.virgil.app",
@@ -64,6 +74,7 @@ internal object CompanionContract {
                 "near_miss_fall",
                 "check_in_miss",
             ),
+            defaultReadingKind = ReadingKind.DERIVED,
         ),
     ).associateBy { it.packageName }
 

--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -3,6 +3,7 @@ package com.bios.app
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
+import com.bios.app.model.ReadingKind
 import com.bios.app.provider.CompanionContract
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -145,5 +146,25 @@ class BiosHealthProviderContractTest {
     fun `sourceFor returns null for unknown or null packages`() {
         assertNull(CompanionContract.sourceFor("com.unknown.app"))
         assertNull(CompanionContract.sourceFor(null))
+    }
+
+    @Test
+    fun `Smokeless companion source is tagged SELF_REPORTED`() {
+        // Owner-logged tobacco/cannabis events are self-reports, never sensor
+        // streams. BaselineEngine must skip these (decision 3 in
+        // SELF_REPORTED_DATA_HOME) — that filter keys off readingKind.
+        val sml = CompanionContract.sourceFor("com.smokless.smokeless")!!
+        assertEquals(ReadingKind.SELF_REPORTED, sml.defaultReadingKind)
+    }
+
+    @Test
+    fun `W2F and Virgil companion sources are tagged DERIVED`() {
+        // W2F/Virgil write algorithmic outputs (cadence, drift, miss
+        // detection), not raw owner logs. DERIVED is also excluded from
+        // BaselineEngine — but for a different reason (already smoothed).
+        val w2f = CompanionContract.sourceFor("com.w2f.app")!!
+        val virgil = CompanionContract.sourceFor("com.virgil.app")!!
+        assertEquals(ReadingKind.DERIVED, w2f.defaultReadingKind)
+        assertEquals(ReadingKind.DERIVED, virgil.defaultReadingKind)
     }
 }


### PR DESCRIPTION
## Summary
Implements decision #1 of [SELF_REPORTED_DATA_HOME.md](docs/SELF_REPORTED_DATA_HOME.md): tag each `DataSource` with the kind of data it produces (`SENSOR` / `SELF_REPORTED` / `DERIVED` / `ACTIVE_TEST`) so engine policies can filter.

This PR only lands the schema and tags — **no engine behavior changes yet**. `BaselineEngine` and `SignalQualityFilter` still read everything; the filter (decision #3) is a follow-up PR.

## Changes
- `ReadingKind` enum in [Enums.kt](android/app/src/main/java/com/bios/app/model/Enums.kt)
- `readingKind` column on [DataSource](android/app/src/main/java/com/bios/app/model/DataSource.kt) (stored as `String`, default `SENSOR`)
- `MIGRATION_6_7` adds the column with `DEFAULT 'SENSOR'` — every pre-v7 source is a sensor adapter or companion; companions get re-tagged on next `ensureSourceFor()` call via REPLACE strategy
- `CompanionContract.Companion` gains `defaultReadingKind`:
  - Smokeless = `SELF_REPORTED` (owner-logged intake events)
  - W2F + Virgil = `DERIVED` (algorithmic outputs: cadence, drift, miss detection)
- `BiosHealthProvider.ensureSourceFor` passes the companion's `defaultReadingKind` into the `data_sources` row

## Known limitation
Mixed-kind companions (e.g. W2F writing both DERIVED cadence and arguably SELF_REPORTED mood) collapse to one kind per `DataSource`. When this asymmetry actually bites, the companion will need multiple `sourceId`s. Noted in the doc's open questions.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green, including new assertions:
  - `Smokeless companion source is tagged SELF_REPORTED`
  - `W2F and Virgil companion sources are tagged DERIVED`
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] Manual: install on device with v6 data, confirm migration to v7 adds the column with `SENSOR` default and existing readings remain queryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)