### PR TITLE
feat: BaselineEngine filters to SENSOR-kind sources only

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
@@ -25,15 +25,25 @@ interface MetricReadingDao {
     """)
     suspend fun fetch(metricType: String, startMillis: Long, endMillis: Long): List<MetricReading>
 
+    // `readingKind = null` returns all sources; pass "SENSOR" from engine code
+    // to exclude self-reports / derived values from baselines and aggregates
+    // (docs/SELF_REPORTED_DATA_HOME.md decision 3).
     @Query("""
-        SELECT value FROM metric_readings
-        WHERE metricType = :metricType
-          AND timestamp >= :startMillis
-          AND timestamp <= :endMillis
-          AND isPrimary = 1
-        ORDER BY timestamp ASC
+        SELECT mr.value FROM metric_readings mr
+        INNER JOIN data_sources ds ON mr.sourceId = ds.id
+        WHERE mr.metricType = :metricType
+          AND mr.timestamp >= :startMillis
+          AND mr.timestamp <= :endMillis
+          AND mr.isPrimary = 1
+          AND (:readingKind IS NULL OR ds.readingKind = :readingKind)
+        ORDER BY mr.timestamp ASC
     """)
-    suspend fun fetchValues(metricType: String, startMillis: Long, endMillis: Long): List<Double>
+    suspend fun fetchValues(
+        metricType: String,
+        startMillis: Long,
+        endMillis: Long,
+        readingKind: String? = null
+    ): List<Double>
 
     @Query("""
         SELECT * FROM metric_readings
@@ -50,19 +60,22 @@ interface MetricReadingDao {
     suspend fun countAll(): Int
 
     @Query("""
-        SELECT AVG(value) FROM metric_readings
-        WHERE metricType = :metricType
-          AND timestamp >= :startMillis
-          AND timestamp <= :endMillis
-          AND isPrimary = 1
-        GROUP BY (timestamp / :bucketMillis)
-        ORDER BY (timestamp / :bucketMillis) ASC
+        SELECT AVG(mr.value) FROM metric_readings mr
+        INNER JOIN data_sources ds ON mr.sourceId = ds.id
+        WHERE mr.metricType = :metricType
+          AND mr.timestamp >= :startMillis
+          AND mr.timestamp <= :endMillis
+          AND mr.isPrimary = 1
+          AND (:readingKind IS NULL OR ds.readingKind = :readingKind)
+        GROUP BY (mr.timestamp / :bucketMillis)
+        ORDER BY (mr.timestamp / :bucketMillis) ASC
     """)
     suspend fun fetchBucketedMeans(
         metricType: String,
         startMillis: Long,
         endMillis: Long,
-        bucketMillis: Long
+        bucketMillis: Long,
+        readingKind: String? = null
     ): List<Double>
 
     @Query("SELECT MIN(timestamp) FROM metric_readings")

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -62,7 +62,12 @@ class BaselineEngine(
         val endMillis = System.currentTimeMillis()
         val startMillis = endMillis - windowDays.toLong() * 24 * 3600 * 1000
 
-        val values = readingDao.fetchValues(metricType.key, startMillis, endMillis)
+        // Baselines only meaningful on direct sensor data — self-reports are
+        // perception not physiology, and DERIVED is already smoothed.
+        // docs/SELF_REPORTED_DATA_HOME.md decision 3.
+        val values = readingDao.fetchValues(
+            metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
+        )
         if (values.size < 10) return  // need minimum samples
 
         val stats = Stats.compute(values)
@@ -106,7 +111,9 @@ class BaselineEngine(
         )
 
         for (metricType in metricsToAggregate) {
-            val values = readingDao.fetchValues(metricType.key, dayStart, dayEnd)
+            val values = readingDao.fetchValues(
+                metricType.key, dayStart, dayEnd, ReadingKind.SENSOR.name
+            )
             if (values.isEmpty()) continue
 
             val stats = Stats.compute(values)
@@ -138,7 +145,7 @@ class BaselineEngine(
     ): List<Double> {
         val dayMillis = 24L * 3600 * 1000
         return readingDao.fetchBucketedMeans(
-            metricType.key, startMillis, endMillis, dayMillis
+            metricType.key, startMillis, endMillis, dayMillis, ReadingKind.SENSOR.name
         )
     }
 

--- a/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
@@ -15,6 +15,14 @@ import kotlin.math.abs
  * Applied in IngestManager before deduplicate + storage. Readings that fail any
  * check are silently dropped — they would corrupt baselines and trigger false alerts.
  *
+ * **SENSOR-only contract.** This filter assumes its input is direct sensor data.
+ * Rate-of-change checks are meaningless for self-reported events (an owner
+ * logging "smoked at 9am" then "smoked at 9:05am" is not a 5-bpm-per-minute
+ * artifact). Companion writes route via `BiosHealthProvider.insertCompanionReading`
+ * and bypass this filter by design — see docs/SELF_REPORTED_DATA_HOME.md
+ * decision 3. If a future call site wants to push SELF_REPORTED or DERIVED
+ * data through here, gate it on `DataSource.readingKind == SENSOR` first.
+ *
  * References:
  * - Makowski et al. (2021) NeuroKit2: signal quality indices
  * - van Gent et al. (2019) HeartPy: noise-resistant PPG analysis


### PR DESCRIPTION
## Summary
Implements decision #3 of [SELF_REPORTED_DATA_HOME.md](docs/SELF_REPORTED_DATA_HOME.md): baselines and daily aggregates only consume direct sensor data. Self-reports are perception, not physiology — averaging owner-logged sleep ratings into a "baseline of sleep" is statistically meaningless and crosses the alignment principle ("evaluate the data, not the person").

Builds on PR #21 (ReadingKind enum on DataSource). Now the column becomes load-bearing.

## DAO change
- `fetchValues` / `fetchBucketedMeans` gain an optional `readingKind: String? = null` filter
- `null` (default) preserves existing behavior for every other caller (DataExporter, FhirExporter, BiosHealthProvider, HealthApiServer, CommunityAggregator, OtaCoordinator, DailyDigestWorker)
- Filter JOINs `data_sources` on `readingKind` so the engine doesn't load every row and post-filter in Kotlin

## Engine change
- [BaselineEngine.computeBaseline](android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt#L65), `computeDailyAggregates`, and `computeDailyMeans` pass `ReadingKind.SENSOR.name`
- With the v7 schema's `'SENSOR'` default on existing rows, baselines for installs with no companions are unchanged
- Companion-written values stop polluting baselines on installs with e.g. Smokeless writing tobacco events (currently those land in `metric_readings` with `readingKind = SELF_REPORTED` after PR #21)

## SignalQualityFilter
KDoc tightened to declare its SENSOR-only contract explicitly. No code change needed: companion writes route via `BiosHealthProvider` and bypass `IngestManager` (the only caller of the filter), so the invariant already holds by construction. The doc protects future call sites from breaking it without thinking.

## Out of scope
- `AnomalyDetector` and `CommunityAggregator` have the same contamination risk and should migrate in follow-up PRs
- The "gentler self-report engine" from decision #3 (descriptive-only pattern detection) is still pending

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] Manual: install on device with a Smokeless companion grant, log a few `tobacco_use` events, confirm HR baseline still computes from sensor data only and is not perturbed by the event count

🤖 Generated with [Claude Code](https://claude.com/claude-code)