### PR TITLE
feat: Reserve reaction_time_ms in MetricType

### DIFF
--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -131,6 +131,25 @@ class BiosHealthProviderContractTest {
     }
 
     @Test
+    fun `reaction_time_ms is reserved but not writable by any companion`() {
+        // Decision 5 of SELF_REPORTED_DATA_HOME: pre-register active-test keys
+        // before a second consumer ships, so both apps land on the same shape.
+        // The key must round-trip through MetricType but stay out of every
+        // companion's writableMetrics until a real producer is wired up.
+        assertNotNull(MetricType.fromKey("reaction_time_ms"))
+        assertFalse(
+            "reaction_time_ms must remain unwritable until a producer is whitelisted",
+            "reaction_time_ms" in CompanionContract.WRITABLE_METRICS
+        )
+        for (pkg in CompanionContract.PACKAGES.keys) {
+            assertFalse(
+                "$pkg must not be able to write reserved key reaction_time_ms",
+                CompanionContract.canWrite(pkg, "reaction_time_ms")
+            )
+        }
+    }
+
+    @Test
     fun `each companion gets a distinct sourceId for provenance`() {
         val w2f = CompanionContract.sourceFor("com.w2f.app")
         val sml = CompanionContract.sourceFor("com.smokless.smokeless")

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -61,7 +61,14 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Timestamp + opaque event-id only — no GPS, SMS contents, or contact identity.
     FALL_EVENT("fall_event", MetricUnit.EVENT, MetricDomain.SAFETY),
     NEAR_MISS_FALL("near_miss_fall", MetricUnit.EVENT, MetricDomain.SAFETY),
-    CHECK_IN_MISS("check_in_miss", MetricUnit.EVENT, MetricDomain.SAFETY);
+    CHECK_IN_MISS("check_in_miss", MetricUnit.EVENT, MetricDomain.SAFETY),
+
+    // Active-test results (reserved, no companion whitelisted yet).
+    // W2F has PVT data today (cognitive_probes); Fil plans SDMT. Reserving
+    // the key now commits the shape upfront so two companions don't ship
+    // divergent definitions of the same signal. See decision 5 in
+    // docs/SELF_REPORTED_DATA_HOME.md.
+    REACTION_TIME_MS("reaction_time_ms", MetricUnit.MILLISECONDS, MetricDomain.MENTAL_HEALTH);
 
     val readableName: String
         get() = key.replace("_", " ").replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
## Summary
Implements decision #5 of [SELF_REPORTED_DATA_HOME.md](docs/SELF_REPORTED_DATA_HOME.md): pre-register the active-test result key before a second consumer ships. W2F already collects PVT data (`cognitive_probes` table); Fil plans SDMT. Reserving the key now commits the shape upfront so two companions don't ship divergent definitions of the same signal.

## Changes
- `MetricType.REACTION_TIME_MS` = `("reaction_time_ms", MILLISECONDS, MENTAL_HEALTH)` in [MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt). Domain mirrors the other cognition-adjacent keys (`TYPING_CADENCE`, `MOOD_DRIFT_SCORE`); revisit if the active-test surface grows enough to warrant a dedicated `COGNITIVE` domain.
- **No companion is whitelisted to write it.** `CompanionContract.WRITABLE_METRICS` is unchanged. The first companion to ship a producer must add itself to the per-package allowlist in the same PR.
- Contract test pins both halves: the key round-trips through `fromKey`, and every existing companion is rejected by `canWrite`.

## Test plan
- [x] `./gradlew :bios-contracts:test` — green
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] When the first producer (W2F PVT or Fil SDMT) wires up, the follow-up PR must add the package to `CompanionContract` and extend the contract test to assert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)