### PR TITLE
feat: AnomalyDetector + CommunityAggregator filter to SENSOR-kind

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -130,7 +130,12 @@ class AnomalyDetector(
 
         for (metric in metrics) {
             val baseline = baselineDao.fetch(metric) ?: continue
-            val values = readingDao.fetchValues(metric, startMillis, endMillis)
+            // SENSOR-only: z-scores are deviations from a sensor baseline;
+            // mixing in self-reports would compare physiology to perception.
+            // docs/SELF_REPORTED_DATA_HOME.md decision 3.
+            val values = readingDao.fetchValues(
+                metric, startMillis, endMillis, ReadingKind.SENSOR.name
+            )
             if (values.isEmpty()) continue
             zScores[metric] = baseline.zScore(values.average())
         }
@@ -364,6 +369,8 @@ class AnomalyDetector(
     private suspend fun fetchRecentValues(metricType: MetricType, hours: Int): List<Double> {
         val endMillis = System.currentTimeMillis()
         val startMillis = endMillis - hours.toLong() * 3600 * 1000
-        return readingDao.fetchValues(metricType.key, startMillis, endMillis)
+        return readingDao.fetchValues(
+            metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
+        )
     }
 }

--- a/android/app/src/main/java/com/bios/app/privacy/CommunityAggregator.kt
+++ b/android/app/src/main/java/com/bios/app/privacy/CommunityAggregator.kt
@@ -4,6 +4,7 @@ import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.Stats
 import com.bios.contracts.MetricType
 import com.bios.app.model.PrivacyTier
+import com.bios.app.model.ReadingKind
 import kotlin.math.ln
 import kotlin.random.Random
 
@@ -64,7 +65,13 @@ class CommunityAggregator(private val db: BiosDatabase) {
         val startMillis = endMillis - 7L * 24 * 3600 * 1000
 
         for (metricType in CONTRIBUTABLE_METRICS) {
-            val values = readingDao.fetchValues(metricType.key, startMillis, endMillis)
+            // SENSOR-only: a community pool of self-reports would compound
+            // noise across owners (different journaling habits) and is not
+            // what the cross-cohort baselines downstream are designed to
+            // model. docs/SELF_REPORTED_DATA_HOME.md decision 3.
+            val values = readingDao.fetchValues(
+                metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
+            )
             if (values.size < 10) continue
 
             val stats = Stats.compute(values)


### PR DESCRIPTION
## Summary
Extends decision #3 of [SELF_REPORTED_DATA_HOME.md](docs/SELF_REPORTED_DATA_HOME.md) to the two remaining engines that consume `MetricReading` directly. Same risk as `BaselineEngine` (PR #22): mixing self-reports into sensor-shaped statistics produces meaningless numbers and crosses the "evaluate the data, not the person" principle.

## Changes
- [AnomalyDetector.computeCurrentZScores](android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt#L133) and `fetchRecentValues` pass `ReadingKind.SENSOR.name` to `readingDao.fetchValues`. Z-scores are deviations from a sensor baseline; a self-reported mood score has no baseline to deviate from in the same metric space.
- [CommunityAggregator.generateContribution](android/app/src/main/java/com/bios/app/privacy/CommunityAggregator.kt#L66) does the same. A community pool of self-reports would compound noise across owners (different journaling habits, different recall biases) and the differential-privacy parameters were tuned for sensor distributions.

## Behavior
- No change on installs without companions — every existing `DataSource` was back-filled to `readingKind = SENSOR` in `MIGRATION_6_7` (PR #21).
- On installs with e.g. Smokeless writing `tobacco_use` events, those event counts stop polluting HR z-scores and community aggregates.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)