### PR TITLE
feat: LoggedEvent table parallel to MetricReading

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -23,9 +23,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         ActionItem::class,
         UserFeedback::class,
         ProfessionalReview::class,
-        CompanionGrant::class
+        CompanionGrant::class,
+        LoggedEvent::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -40,6 +41,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun userFeedbackDao(): UserFeedbackDao
     abstract fun professionalReviewDao(): ProfessionalReviewDao
     abstract fun companionGrantDao(): CompanionGrantDao
+    abstract fun loggedEventDao(): LoggedEventDao
 
     companion object {
         @Volatile
@@ -62,7 +64,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
                 .build()
         }
 
@@ -209,6 +211,44 @@ abstract class BiosDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL(
                     "ALTER TABLE data_sources ADD COLUMN readingKind TEXT NOT NULL DEFAULT 'SENSOR'"
+                )
+            }
+        }
+
+        // Parallel table for event-shaped data (substance use, falls,
+        // symptom episodes). Schema mirrors the sketch in
+        // docs/SELF_REPORTED_DATA_HOME.md decision 2. Existing data is
+        // left alone — Smokeless's `MetricReading.value=1.0` rows stay
+        // where they are; the migration of legacy data is its own PR
+        // and depends on the still-open question in the doc.
+        private val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS logged_events (
+                        id TEXT NOT NULL PRIMARY KEY,
+                        eventType TEXT NOT NULL,
+                        timestamp INTEGER NOT NULL,
+                        severity INTEGER,
+                        durationMs INTEGER,
+                        value REAL,
+                        sourceId TEXT NOT NULL,
+                        packageName TEXT,
+                        note TEXT,
+                        createdAt INTEGER NOT NULL,
+                        FOREIGN KEY (sourceId) REFERENCES data_sources(id) ON DELETE CASCADE
+                    )
+                """)
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_logged_events_eventType_timestamp " +
+                        "ON logged_events(eventType, timestamp)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_logged_events_timestamp " +
+                        "ON logged_events(timestamp)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_logged_events_sourceId " +
+                        "ON logged_events(sourceId)"
                 )
             }
         }

--- a/android/app/src/main/java/com/bios/app/data/dao/LoggedEventDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/LoggedEventDao.kt
@@ -1,0 +1,59 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.bios.app.model.LoggedEvent
+
+@Dao
+interface LoggedEventDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(event: LoggedEvent)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(events: List<LoggedEvent>)
+
+    @Query("SELECT * FROM logged_events WHERE id = :id")
+    suspend fun fetchById(id: String): LoggedEvent?
+
+    @Query("""
+        SELECT * FROM logged_events
+        WHERE eventType = :eventType
+          AND timestamp >= :startMillis
+          AND timestamp <= :endMillis
+        ORDER BY timestamp ASC
+    """)
+    suspend fun fetchByType(
+        eventType: String,
+        startMillis: Long,
+        endMillis: Long
+    ): List<LoggedEvent>
+
+    @Query("""
+        SELECT * FROM logged_events
+        WHERE timestamp >= :startMillis
+          AND timestamp <= :endMillis
+        ORDER BY timestamp ASC
+    """)
+    suspend fun fetchInWindow(startMillis: Long, endMillis: Long): List<LoggedEvent>
+
+    @Query("SELECT * FROM logged_events ORDER BY timestamp DESC LIMIT :limit")
+    suspend fun fetchRecent(limit: Int = 50): List<LoggedEvent>
+
+    @Query("SELECT COUNT(*) FROM logged_events WHERE eventType = :eventType")
+    suspend fun countByType(eventType: String): Int
+
+    @Query("SELECT COUNT(*) FROM logged_events")
+    suspend fun countAll(): Int
+
+    @Query("DELETE FROM logged_events WHERE id = :id")
+    suspend fun delete(id: String)
+
+    @Query("DELETE FROM logged_events WHERE timestamp < :beforeMillis")
+    suspend fun deleteBefore(beforeMillis: Long): Int
+
+    @Query("DELETE FROM logged_events")
+    suspend fun deleteAll()
+}

--- a/android/app/src/main/java/com/bios/app/model/LoggedEvent.kt
+++ b/android/app/src/main/java/com/bios/app/model/LoggedEvent.kt
@@ -1,0 +1,46 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+// Discrete event-shaped data: substance use, falls, near-misses, acute
+// symptom episodes, check-in misses. Parallel to `MetricReading` (which
+// is timeseries-shaped). Owned by `docs/SELF_REPORTED_DATA_HOME.md`
+// decision 2; that doc explains why these don't squash into
+// `MetricReading.value = 1.0`.
+//
+// `eventType` is a String so it can host both `MetricType` keys
+// (tobacco_use, fall_event, …) and the future `SymptomKind` taxonomy
+// (decision 4) without a schema change. `note` is owner-private and
+// never analyzed — it exists for owner recall, not for engines.
+@Entity(
+    tableName = "logged_events",
+    foreignKeys = [
+        ForeignKey(
+            entity = DataSource::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("eventType", "timestamp"),
+        Index("timestamp"),
+        Index("sourceId")
+    ]
+)
+data class LoggedEvent(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val eventType: String,
+    val timestamp: Long,
+    val severity: Int? = null,
+    val durationMs: Long? = null,
+    val value: Double? = null,
+    val sourceId: String,
+    val packageName: String? = null,
+    val note: String? = null,
+    val createdAt: Long = System.currentTimeMillis()
+)

--- a/android/app/src/test/java/com/bios/app/LoggedEventTest.kt
+++ b/android/app/src/test/java/com/bios/app/LoggedEventTest.kt
@@ -1,0 +1,74 @@
+package com.bios.app
+
+import com.bios.app.model.LoggedEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the LoggedEvent entity shape so the schema sketch in
+ * docs/SELF_REPORTED_DATA_HOME.md decision 2 doesn't drift.
+ * Field renames here are breaking changes — companions wiring up an event
+ * writer compile against this class via the Room-generated DAO.
+ */
+class LoggedEventTest {
+
+    @Test
+    fun `id defaults to a UUID`() {
+        val event = LoggedEvent(
+            eventType = "tobacco_use",
+            timestamp = 1_700_000_000_000L,
+            sourceId = "src-1",
+        )
+        assertNotNull(event.id)
+        // UUID v4 string length is 36 chars (8-4-4-4-12 plus 4 dashes).
+        assertEquals(36, event.id.length)
+    }
+
+    @Test
+    fun `optional fields are null by default`() {
+        val event = LoggedEvent(
+            eventType = "tobacco_use",
+            timestamp = 1L,
+            sourceId = "src-1",
+        )
+        assertNull(event.severity)
+        assertNull(event.durationMs)
+        assertNull(event.value)
+        assertNull(event.packageName)
+        assertNull(event.note)
+    }
+
+    @Test
+    fun `createdAt defaults to roughly now`() {
+        val before = System.currentTimeMillis()
+        val event = LoggedEvent(
+            eventType = "fall_event",
+            timestamp = 1L,
+            sourceId = "src-1",
+        )
+        val after = System.currentTimeMillis()
+        assertTrue(event.createdAt in before..after)
+    }
+
+    @Test
+    fun `severity and duration carry through when provided`() {
+        // Smokeless-style intake event: severity 0-3, durationMs for the
+        // smoking session, note for the owner's own recall.
+        val event = LoggedEvent(
+            eventType = "tobacco_use",
+            timestamp = 1_700_000_000_000L,
+            severity = 2,
+            durationMs = 90_000L,
+            sourceId = "companion_smokeless",
+            packageName = "com.smokless.smokeless",
+            note = "after dinner",
+        )
+        assertEquals(2, event.severity)
+        assertEquals(90_000L, event.durationMs)
+        assertEquals("com.smokless.smokeless", event.packageName)
+        assertEquals("after dinner", event.note)
+    }
+}


### PR DESCRIPTION
## Summary
Implements decision #2 of [SELF_REPORTED_DATA_HOME.md](docs/SELF_REPORTED_DATA_HOME.md): a parallel event-shaped table for substance use, falls, near-misses, acute symptom episodes, and check-in misses. Event-shaped data fits `MetricReading`'s `(value: Double, timestamp: Long)` signature poorly — Smokeless currently encodes occurrences as `value = 1.0`, which gets worse as more event-shaped data flows in.

## Schema
Mirrors the doc's sketch:
- `id`, `eventType`, `timestamp`
- `severity?`, `durationMs?`, `value?` (for events that carry a number)
- `sourceId` (FK to `data_sources`, CASCADE), `packageName` (provenance)
- `note?` — owner-private free-text, never analyzed by engines
- `createdAt` for parity with other entities

`eventType` is a `String` so it hosts both existing [MetricType](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt) keys (tobacco_use, fall_event, ...) and the future `SymptomKind` taxonomy (decision 4) without a schema change.

Indices: `(eventType, timestamp)`, `timestamp`, `sourceId` — mirrors the `MetricReading` index pattern for the same query shapes.

## What this PR is NOT
- **Not a data migration.** Existing Smokeless writes (`MetricReading.value = 1.0`) stay where they are. Migration is listed as an open question in the architecture doc.
- **Not a replacement for `HealthEvent`.** `HealthEvent` is long-form narrative entries with status workflow (symptom → diagnosis → treatment threading). `LoggedEvent` is structured event instances. They coexist.
- **No engine consumes `LoggedEvent` yet.** That's the separate, gentler self-report engine still pending in decision 3.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green (includes new [LoggedEventTest](android/app/src/test/java/com/bios/app/LoggedEventTest.kt) pinning entity defaults)
- [x] `./gradlew :app:assembleDebug` — both flavors build (Room generates the DAO from the entity)
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] Manual: install on device with v7 data, confirm migration to v8 creates `logged_events` with the right schema and indices, no existing data lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)