### PR TITLE
fix: AnomalyDetector reads EVENT-unit metrics from all kinds

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -370,7 +370,17 @@ class AnomalyDetector(
         val endMillis = System.currentTimeMillis()
         val startMillis = endMillis - hours.toLong() * 3600 * 1000
         return readingDao.fetchValues(
-            metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
+            metricType.key, startMillis, endMillis, readingKindFilterFor(metricType)
         )
     }
 }
+
+// EVENT-unit metrics (tobacco_use, fall_event, …) are intentionally
+// companion-written — SELF_REPORTED or DERIVED. CompanionConditionPatterns
+// rules explicitly want those rows. PR #25 over-applied the SENSOR-only
+// filter to every fetch and broke the cessation / fall-rate patterns; this
+// branches the filter by unit so SENSOR-typed metrics still resolve against
+// sensor sources (the decision 3 reason — z-scores vs a sensor baseline)
+// while EVENT-typed metrics see the data they're meant to see.
+internal fun readingKindFilterFor(metricType: MetricType): String? =
+    if (metricType.unit == MetricUnit.EVENT) null else ReadingKind.SENSOR.name

--- a/android/app/src/test/java/com/bios/app/AnomalyDetectorReadingKindFilterTest.kt
+++ b/android/app/src/test/java/com/bios/app/AnomalyDetectorReadingKindFilterTest.kt
@@ -1,0 +1,56 @@
+package com.bios.app
+
+import com.bios.app.engine.readingKindFilterFor
+import com.bios.app.model.ReadingKind
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the SENSOR-only filter to non-EVENT metrics. Regression guard for the
+ * mistake in PR #25 where every fetch hardcoded SENSOR, which silently zeroed
+ * out the tobacco_use / fall_event / check_in_miss signal rules in
+ * CompanionConditionPatterns — those events are written by SELF_REPORTED or
+ * DERIVED companion sources, so filtering to SENSOR returned no rows.
+ */
+class AnomalyDetectorReadingKindFilterTest {
+
+    @Test
+    fun `EVENT-unit metrics are not SENSOR-filtered`() {
+        // Sweep every EVENT-unit MetricType the contract defines — every
+        // companion-written event surface must read through to its rows.
+        val eventMetrics = MetricType.entries.filter { it.unit == MetricUnit.EVENT }
+        assertEquals(
+            "If this drops to 0, MetricUnit.EVENT is no longer load-bearing — re-check the contract.",
+            true, eventMetrics.isNotEmpty()
+        )
+        for (metric in eventMetrics) {
+            assertNull(
+                "${metric.key} is an EVENT — readingKindFilterFor must return null to admit companion writes",
+                readingKindFilterFor(metric)
+            )
+        }
+    }
+
+    @Test
+    fun `cardiovascular and other sensor metrics resolve to SENSOR`() {
+        val sensorMetrics = listOf(
+            MetricType.HEART_RATE,
+            MetricType.HEART_RATE_VARIABILITY,
+            MetricType.RESTING_HEART_RATE,
+            MetricType.BLOOD_OXYGEN,
+            MetricType.RESPIRATORY_RATE,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.SLEEP_DURATION,
+        )
+        for (metric in sensorMetrics) {
+            assertEquals(
+                "${metric.key} is sensor data — must filter to SENSOR to keep baselines uncorrupted",
+                ReadingKind.SENSOR.name,
+                readingKindFilterFor(metric)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
PR #25 hardcoded `ReadingKind.SENSOR.name` in `fetchRecentValues`, applying the SENSOR-only filter to **every** fetch — including the `SignalRule` reads for EVENT-unit metrics. Those events (`tobacco_use`, `fall_event`, `near_miss_fall`, `check_in_miss`, `tobacco_craving`, `cannabis_use`, `cannabis_craving`) are written by `SELF_REPORTED` or `DERIVED` companion sources by design. Filtering them to SENSOR returned zero rows.

Visible breakage in [CompanionConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/CompanionConditionPatterns.kt):
- **Cessation-recovery pattern** — `TOBACCO_USE` ABSENT check would trigger spuriously (no SENSOR rows = "no events" = always ABSENT, regardless of actual smoking)
- **Fall-rate patterns** — `FALL_EVENT` ABOVE rules would never fire
- **Smokeless / Virgil / W2F event-based rules** — all silently inactive

## Fix
Branch the filter by `metricType.unit`:
- `MetricUnit.EVENT` → `null` (admit all kinds; this is the descriptive layer the architecture doc explicitly endorses for self-reports)
- Anything else → `SENSOR` (preserves decision 3: z-scores against a sensor baseline stay clean)

Filter logic extracted to a file-scope `readingKindFilterFor()` so it can be tested without standing up the AnomalyDetector + DB stack. The new test sweeps every EVENT-unit `MetricType` and asserts the filter resolves to null — regression guard against the same mistake.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green, new sweep test included
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] Manual: install a Smokeless companion, log a tobacco_use event, confirm the cessation-recovery pattern no longer fires the ABSENT branch within the configured window

🤖 Generated with [Claude Code](https://claude.com/claude-code)