### PR TITLE
fix: Add BODY_MASS, stop routing Withings weight to BLOOD_GLUCOSE

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
@@ -101,7 +101,12 @@ object SignalQualityFilter {
         MetricType.ACTIVE_MINUTES.key to Bounds(0.0, 1440.0, null),
         MetricType.SLEEP_DURATION.key to Bounds(0.0, 86400.0, null),
         MetricType.RECOVERY_SCORE.key to Bounds(0.0, 100.0, null),
-        MetricType.BASAL_BODY_TEMPERATURE.key to Bounds(35.0, 39.0, 1.0)
+        MetricType.BASAL_BODY_TEMPERATURE.key to Bounds(35.0, 39.0, 1.0),
+        // 20 kg lower bound covers severe pediatric / wasting cases without
+        // admitting decimal-place errors; 300 kg upper bound is beyond
+        // documented extremes. No rate-of-change cap — body mass doesn't
+        // change rapidly between readings.
+        MetricType.BODY_MASS.key to Bounds(20.0, 300.0, null)
     )
 
     internal data class Bounds(

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -227,6 +227,7 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.SLEEP_DURATION -> "93832-4" to "Sleep duration"
     MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
     MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
+    MetricType.BODY_MASS -> "29463-7" to "Body weight"
     else -> null
 }
 
@@ -241,6 +242,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.SECONDS -> "s"
     MetricUnit.COUNT -> "{count}"
     MetricUnit.KCAL -> "kcal"
+    MetricUnit.KILOGRAMS -> "kg"
     MetricUnit.MG_PER_DL -> "mg/dL"
     MetricUnit.SCORE -> "{score}"
     MetricUnit.CATEGORY -> "{category}"

--- a/android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt
@@ -81,7 +81,7 @@ class WithingsApiAdapter(
                 val value = m.getDouble("value") * Math.pow(10.0, m.getDouble("unit"))
 
                 val (metricType, confidence) = when (type) {
-                    1 -> Pair(MetricType.BLOOD_GLUCOSE, ConfidenceTier.HIGH) // Using as body mass placeholder
+                    1 -> Pair(MetricType.BODY_MASS, ConfidenceTier.HIGH) // weight in kg
                     6 -> Pair(null, ConfidenceTier.MEDIUM) // Fat % - no MetricType yet
                     9 -> Pair(MetricType.BLOOD_PRESSURE_DIASTOLIC, ConfidenceTier.HIGH)
                     10 -> Pair(MetricType.BLOOD_PRESSURE_SYSTOLIC, ConfidenceTier.HIGH)

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -98,9 +98,15 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `12 metric types have LOINC mappings`() {
+    fun `body mass maps to LOINC 29463-7`() {
+        val (code, _) = loincCode(MetricType.BODY_MASS)!!
+        assertEquals("29463-7", code)
+    }
+
+    @Test
+    fun `13 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(12, mapped)
+        assertEquals(13, mapped)
     }
 
     // --- UCUM code mappings ---
@@ -189,6 +195,7 @@ class FhirExporterTest {
             MetricType.SLEEP_DURATION -> "93832-4" to "Sleep duration"
             MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
             MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
+            MetricType.BODY_MASS -> "29463-7" to "Body weight"
             else -> null
         }
     }
@@ -205,6 +212,7 @@ class FhirExporterTest {
             MetricUnit.SECONDS -> "s"
             MetricUnit.COUNT -> "{count}"
             MetricUnit.KCAL -> "kcal"
+            MetricUnit.KILOGRAMS -> "kg"
             MetricUnit.MG_PER_DL -> "mg/dL"
             MetricUnit.SCORE -> "{score}"
             MetricUnit.CATEGORY -> "{category}"

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -38,6 +38,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
 
     // Metabolic
     BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
+    BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
 
     // Recovery
     RECOVERY_SCORE("recovery_score", MetricUnit.SCORE, MetricDomain.RECOVERY),
@@ -90,6 +91,7 @@ enum class MetricUnit(val symbol: String) {
     SECONDS("s"),
     COUNT(""),
     KCAL("kcal"),
+    KILOGRAMS("kg"),
     MG_PER_DL("mg/dL"),
     SCORE(""),
     EVENT("")


### PR DESCRIPTION
## Summary
Closes #20. Withings API `type=1` is **weight in kg**, not blood glucose. The existing placeholder in [WithingsApiAdapter.kt:84](android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt#L84) routed every smart-scale reading into `MetricReading` rows tagged `BLOOD_GLUCOSE` with `HIGH` confidence. A 70 kg reading registered as 70 mg/dL — borderline hypoglycemic — feeding the glucose baseline and any condition rule keyed on it.

## Changes
- [MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt): adds `BODY_MASS = ("body_mass", KILOGRAMS, METABOLIC)` and `MetricUnit.KILOGRAMS = "kg"`. METABOLIC fits body-mass-as-risk-factor; a dedicated `BODY_COMPOSITION` domain would be scope creep and easy to introduce later if Withings types 6/76/77 (fat%, lean mass, hydration) get hoisted.
- [WithingsApiAdapter.kt](android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt): `type=1` now routes to `BODY_MASS`; placeholder comment dropped.
- [SignalQualityFilter.kt](android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt): `BODY_MASS` bounded to 20–300 kg, no rate-of-change cap (weight doesn't change rapidly between readings, and anything outside the bounds is already a sensor error).
- [FhirExporter.kt](android/app/src/main/java/com/bios/app/export/FhirExporter.kt): `BODY_MASS` → LOINC `29463-7` "Body weight"; `KILOGRAMS` → UCUM `kg`.
- [FhirExporterTest.kt](android/app/src/test/java/com/bios/app/FhirExporterTest.kt): mirror functions updated, new test asserts LOINC mapping, count bumped 12 → 13.

## What this PR does NOT do
**No data migration.** Existing `BLOOD_GLUCOSE` rows on installs with a Withings scale are still wrong, but cleaning them up needs an owner-facing prompt (delete? attempt reassignment by sourceId?) and is better as a separate PR. New scale syncs after upgrade write to `BODY_MASS` correctly.

## Test plan
- [x] `./gradlew :bios-contracts:test` — green
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — green
- [x] `./gradlew :app:assembleDebug` — both flavors build
- [x] `./gradlew :app:lintStandaloneDebug` — clean
- [x] `./scripts/code-quality-check.sh` — all checks pass
- [ ] Manual: connect a Withings smart scale, sync, confirm new readings land in `metric_readings` with `metricType = body_mass`, and FHIR export labels them LOINC `29463-7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)