### PR TITLE
ci: Cross-repo workflow builds companions against bios-contracts

### DIFF
--- a/.github/scripts/consumer-init.gradle
+++ b/.github/scripts/consumer-init.gradle
@@ -1,0 +1,16 @@
+// Injects mavenLocal() into both pluginManagement and dependencyResolutionManagement
+// for any consumer build invoked with `-I consumer-init.gradle`. Lets the cross-repo
+// contracts workflow ship the bios-contracts AAR through ~/.m2 without editing each
+// companion's settings.gradle. Companions still need to declare the dependency
+// explicitly; this script only makes it resolvable.
+beforeSettings { settings ->
+    settings.pluginManagement.repositories {
+        mavenLocal()
+    }
+    settings.dependencyResolutionManagement {
+        repositoriesMode.set(org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS)
+        repositories {
+            mavenLocal()
+        }
+    }
+}

--- a/.github/workflows/cross-repo-contracts.yml
+++ b/.github/workflows/cross-repo-contracts.yml
@@ -1,0 +1,118 @@
+name: Cross-repo contracts
+
+# Builds the bios-contracts AAR and verifies each companion consumer still
+# compiles against the freshly-published artifact. Today most companions do
+# not yet depend on bios-contracts, so this workflow doubles as a build-health
+# probe for those repos. As soon as a companion declares the dependency, this
+# workflow becomes a real contract gate.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'android/bios-contracts/**'
+      - '.github/workflows/cross-repo-contracts.yml'
+      - '.github/scripts/consumer-init.gradle'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'android/bios-contracts/**'
+      - '.github/workflows/cross-repo-contracts.yml'
+      - '.github/scripts/consumer-init.gradle'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-contracts:
+    name: Publish bios-contracts to local maven
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Publish bios-contracts to ~/.m2
+        working-directory: android
+        run: ./gradlew :bios-contracts:publishToMavenLocal
+
+      - name: Upload contracts artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bios-contracts-m2
+          path: ~/.m2/repository/com/bios
+          retention-days: 1
+
+  consumer-build:
+    name: Build ${{ matrix.consumer.name }}
+    needs: publish-contracts
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        consumer:
+          - name: Smokeless
+            repo: thdelmas/Smokeless
+            gradle-dir: .
+          - name: SoulRadio
+            repo: thdelmas/SoulRadio
+            gradle-dir: .
+          - name: Virgil
+            repo: thdelmas/Virgil
+            gradle-dir: android
+          - name: Fil
+            repo: thdelmas/Fil
+            gradle-dir: android
+    steps:
+      - name: Checkout Bios (for init script)
+        uses: actions/checkout@v4
+        with:
+          path: bios
+
+      - name: Checkout ${{ matrix.consumer.name }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ matrix.consumer.repo }}
+          path: consumer
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-consumer-${{ matrix.consumer.name }}-${{ hashFiles('consumer/**/*.gradle*', 'consumer/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-consumer-${{ matrix.consumer.name }}-
+            gradle-
+
+      - name: Download contracts artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bios-contracts-m2
+          path: ~/.m2/repository/com/bios
+
+      - name: Build ${{ matrix.consumer.name }} against published contracts
+        working-directory: consumer/${{ matrix.consumer.gradle-dir }}
+        run: ./gradlew assembleDebug -I "$GITHUB_WORKSPACE/bios/.github/scripts/consumer-init.gradle" --stacktrace

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -173,11 +173,16 @@ On the Bios side, opt-in emission from HRV/arousal classifications.
 **Manifesto risk:** highest of any Phase 7 item. Defer until 7.1–7.3 land
 and there's a clear, listener-facing reason to ship it.
 
-### 7.6 Cross-repo CI / contract tests
+### 7.6 Cross-repo CI / contract tests [COMPLETE]
 
-Once `bios-contracts` exists (7.4), add a CI workflow that verifies
-companion consumers compile against the latest artifact. Catches breakages
-before they reach a release of either side.
+`cross-repo-contracts.yml` publishes `bios-contracts` to a per-job
+mavenLocal, then builds each public companion (Smokeless, SoulRadio,
+Virgil, Fil) against it through `.github/scripts/consumer-init.gradle`.
+Runs on every change to `android/bios-contracts/**` or the workflow
+itself, plus manual dispatch. Until a companion adds
+`implementation("com.bios:bios-contracts:0.1.0")`, this also serves as a
+companion build-health probe; the day a consumer adopts the artifact, the
+workflow becomes a real contract gate without further setup.
 
 ### 7.7 Smokeless companion: substance-use signals
 


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/cross-repo-contracts.yml`: publishes `bios-contracts` to a per-job mavenLocal, then builds each public companion (Smokeless, SoulRadio, Virgil, Fil) against it.
- New init script `.github/scripts/consumer-init.gradle` injects `mavenLocal()` into pluginManagement + dependencyResolutionManagement so the contracts AAR is resolvable without editing each companion's `settings.gradle`.
- Triggers: changes under `android/bios-contracts/**`, edits to the workflow/init-script themselves, or manual `workflow_dispatch`. Matrix is `fail-fast: false` so each companion reports independently.
- Marks roadmap 7.6 `[COMPLETE]`.

## Why now, what it catches
No companion currently declares `implementation("com.bios:bios-contracts:0.1.0")`, so today the workflow doubles as a companion build-health probe. As soon as one consumer adopts the artifact, the same workflow becomes a real contract gate — no further setup. The AAR is published to `~/.m2/repository/com/bios` and shared between the publish job and each consumer job via `actions/upload-artifact` so consumer jobs do not rebuild contracts.

W2F is private and intentionally excluded from the matrix (no PAT plumbing); when it adopts the artifact we can add it behind a `secrets.COMPANION_PAT`.

## Test plan
- [x] `./gradlew :bios-contracts:publishToMavenLocal` produces the AAR locally
- [x] `./gradlew help -I .github/scripts/consumer-init.gradle` runs cleanly against Smokeless (init-script syntax valid)
- [x] `./scripts/code-quality-check.sh` passes
- [ ] Workflow runs green on this PR (verify in Actions)
- [ ] Trigger via `workflow_dispatch` after merge and confirm all 4 matrix jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)