### PR TITLE
feat: Ambient light writer for phone-sensor adapter

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -247,6 +247,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.SCORE -> "{score}"
     MetricUnit.CATEGORY -> "{category}"
     MetricUnit.EVENT -> "{event}"
+    MetricUnit.LUX -> "lx"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -98,7 +98,8 @@ class IngestManager(
 
         // Phone sensors (always available as last resort)
         if (phoneSensorAdapter?.hasAccelerometer == true ||
-            phoneSensorAdapter?.hasStepCounter == true
+            phoneSensorAdapter?.hasStepCounter == true ||
+            phoneSensorAdapter?.hasAmbientLight == true
         ) {
             phoneSensorSourceId = getOrCreateSource(
                 SourceType.PHONE_SENSOR, "Phone Sensors", SensorType.ACCELEROMETER
@@ -291,6 +292,8 @@ class IngestManager(
             readings += adapter.sampleAccelerometer(SENSOR_SAMPLE_DURATION_MS, sourceId)
             val stepReading = adapter.readStepCounter(sourceId)
             if (stepReading != null) readings += stepReading
+            val lightReading = adapter.sampleAmbientLight(sourceId)
+            if (lightReading != null) readings += lightReading
             readings
         } catch (_: Exception) {
             emptyList()

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
@@ -5,6 +5,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.os.PowerManager
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
@@ -28,6 +29,9 @@ class PhoneSensorAdapter(context: Context) {
     private val sensorManager =
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 
+    private val powerManager =
+        context.getSystemService(Context.POWER_SERVICE) as PowerManager
+
     private val accelerometer: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
 
@@ -37,9 +41,13 @@ class PhoneSensorAdapter(context: Context) {
     private val stepCounter: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
 
+    private val lightSensor: Sensor? =
+        sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+
     val hasAccelerometer: Boolean get() = accelerometer != null
     val hasGyroscope: Boolean get() = gyroscope != null
     val hasStepCounter: Boolean get() = stepCounter != null
+    val hasAmbientLight: Boolean get() = lightSensor != null
 
     /**
      * Collects accelerometer samples for [durationMs] and returns derived metrics.
@@ -99,6 +107,49 @@ class PhoneSensorAdapter(context: Context) {
             sourceId = sourceId,
             confidence = ConfidenceTier.LOW.level
         )
+    }
+
+    /**
+     * Samples the ambient-light sensor once. Returns null when the sensor is
+     * absent or the device is non-interactive (screen off / pocket); in those
+     * states the lux reading would not reflect the owner's actual environment.
+     */
+    suspend fun sampleAmbientLight(sourceId: String): MetricReading? {
+        val sensor = lightSensor ?: return null
+        if (!powerManager.isInteractive) return null
+        val lux = firstValue(sensor, AMBIENT_LIGHT_TIMEOUT_MS) ?: return null
+        return MetricReading(
+            metricType = MetricType.AMBIENT_LIGHT.key,
+            value = lux.toDouble(),
+            timestamp = System.currentTimeMillis(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.LOW.level
+        )
+    }
+
+    /**
+     * Registers a one-shot listener and resumes with the first event's values[0],
+     * or null if the sensor doesn't fire within [timeoutMs].
+     */
+    private suspend fun firstValue(
+        sensor: Sensor,
+        timeoutMs: Long
+    ): Float? = kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+        suspendCancellableCoroutine<Float> { cont ->
+            val listener = object : SensorEventListener {
+                override fun onSensorChanged(event: SensorEvent) {
+                    sensorManager.unregisterListener(this)
+                    if (cont.isActive) cont.resume(event.values[0])
+                }
+                override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+            }
+            sensorManager.registerListener(
+                listener, sensor, SensorManager.SENSOR_DELAY_NORMAL
+            )
+            cont.invokeOnCancellation {
+                sensorManager.unregisterListener(listener)
+            }
+        }
     }
 
     /**
@@ -162,5 +213,6 @@ class PhoneSensorAdapter(context: Context) {
         private const val GRAVITY = 9.81f
         private const val ACTIVITY_THRESHOLD = 1.5 // m/s^2 above gravity
         private const val STEP_SAMPLE_MS = 500L
+        private const val AMBIENT_LIGHT_TIMEOUT_MS = 1_000L
     }
 }

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -217,6 +217,7 @@ class FhirExporterTest {
             MetricUnit.SCORE -> "{score}"
             MetricUnit.CATEGORY -> "{category}"
             MetricUnit.EVENT -> "{event}"
+            MetricUnit.LUX -> "lx"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/PhoneSensorAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSensorAdapterTest.kt
@@ -82,4 +82,18 @@ class PhoneSensorAdapterTest {
         val gravity = 9.81f
         assertTrue(gravity > 9.7f && gravity < 9.9f)
     }
+
+    @Test
+    fun `ambient light reading uses LOW confidence and lux value`() {
+        val reading = MetricReading(
+            metricType = MetricType.AMBIENT_LIGHT.key,
+            value = 240.0,
+            timestamp = 1000L,
+            sourceId = "phone_sensor",
+            confidence = ConfidenceTier.LOW.level
+        )
+        assertEquals("ambient_light", reading.metricType)
+        assertEquals(240.0, reading.value, 0.0)
+        assertEquals(ConfidenceTier.LOW.level, reading.confidence)
+    }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -46,6 +46,9 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Women's Health
     BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH),
 
+    // Environment (phone-sensor adapter)
+    AMBIENT_LIGHT("ambient_light", MetricUnit.LUX, MetricDomain.ENVIRONMENT),
+
     // Companion signals (injected by W2F via ContentProvider)
     TYPING_CADENCE("typing_cadence", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
     CIRCADIAN_PHASE_SHIFT("circadian_phase_shift", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
@@ -94,11 +97,12 @@ enum class MetricUnit(val symbol: String) {
     KILOGRAMS("kg"),
     MG_PER_DL("mg/dL"),
     SCORE(""),
-    EVENT("")
+    EVENT(""),
+    LUX("lx")
 }
 
 enum class MetricDomain {
     CARDIOVASCULAR, RESPIRATORY, TEMPERATURE, SLEEP,
     ACTIVITY, METABOLIC, RECOVERY, WOMENS_HEALTH,
-    MENTAL_HEALTH, INTAKE, SAFETY
+    MENTAL_HEALTH, INTAKE, SAFETY, ENVIRONMENT
 }

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -47,6 +47,13 @@ class MetricTypeTest {
     }
 
     @Test
+    fun ambient_light_is_environment_lux() {
+        assertEquals(MetricDomain.ENVIRONMENT, MetricType.AMBIENT_LIGHT.domain)
+        assertEquals(MetricUnit.LUX, MetricType.AMBIENT_LIGHT.unit)
+        assertEquals("lx", MetricUnit.LUX.symbol)
+    }
+
+    @Test
     fun health_contract_authority_is_stable() {
         assertEquals("com.bios.app.health", BiosHealthContract.AUTHORITY)
     }


### PR DESCRIPTION
## Summary
- New canonical key `AMBIENT_LIGHT` (lux) on a new `MetricDomain.ENVIRONMENT`, plus the matching `MetricUnit.LUX` (UCUM `lx`). Lives in `bios-contracts` so consumers can read it via the existing ContentProvider.
- `PhoneSensorAdapter.sampleAmbientLight()` reads `TYPE_LIGHT` via a one-shot listener with a 1s timeout. Sampling is gated on `PowerManager.isInteractive` — readings while the device is asleep or pocketed wouldn't reflect the owner's actual environment, so we skip them.
- `IngestManager.fetchPhoneSensorReadings()` calls the new sampler alongside accelerometer and step-counter; the existing WorkManager cadence drives sample frequency.
- `FhirExporter` UCUM mapping extended with `LUX -> "lx"` so the exhaustive `when` stays exhaustive (also fixes the matching test mirror).

## Why
Phase 8.1 in [docs/ROADMAP.md](docs/ROADMAP.md) — cheapest-win in the audit. Unlocks circadian-alignment baselines that pair with W2F's `circadian_phase_shift` and SoulRadio's 24-hour loop, without violating SoulRadio's manifesto (Bios derives, SoulRadio does not consume).

## Test plan
- [ ] `./scripts/code-quality-check.sh` passes (lint + lethe + standalone builds + unit tests)
- [ ] `MetricTypeTest.ambient_light_is_environment_lux` pins the contract surface
- [ ] `PhoneSensorAdapterTest.ambient light reading uses LOW confidence and lux value` pins the MetricReading shape
- [ ] Manual on-device: confirm a lux reading lands when the screen is on, and that nothing is written when the device is non-interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)