### PR TITLE
feat: BODY_FAT_PCT metric, persist Withings impedance fat %

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/WithingsApiAdapter.kt
@@ -82,7 +82,7 @@ class WithingsApiAdapter(
 
                 val (metricType, confidence) = when (type) {
                     1 -> Pair(MetricType.BODY_MASS, ConfidenceTier.HIGH) // weight in kg
-                    6 -> Pair(null, ConfidenceTier.MEDIUM) // Fat % - no MetricType yet
+                    6 -> Pair(MetricType.BODY_FAT_PCT, ConfidenceTier.HIGH) // fat % (impedance scale)
                     9 -> Pair(MetricType.BLOOD_PRESSURE_DIASTOLIC, ConfidenceTier.HIGH)
                     10 -> Pair(MetricType.BLOOD_PRESSURE_SYSTOLIC, ConfidenceTier.HIGH)
                     71 -> Pair(MetricType.SKIN_TEMPERATURE, ConfidenceTier.MEDIUM)

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -39,6 +39,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Metabolic
     BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
     BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
+    BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
 
     // Recovery
     RECOVERY_SCORE("recovery_score", MetricUnit.SCORE, MetricDomain.RECOVERY),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -47,6 +47,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun body_fat_pct_is_metabolic_percent() {
+        assertEquals(MetricDomain.METABOLIC, MetricType.BODY_FAT_PCT.domain)
+        assertEquals(MetricUnit.PERCENT, MetricType.BODY_FAT_PCT.unit)
+    }
+
+    @Test
     fun ambient_light_is_environment_lux() {
         assertEquals(MetricDomain.ENVIRONMENT, MetricType.AMBIENT_LIGHT.domain)
         assertEquals(MetricUnit.LUX, MetricType.AMBIENT_LIGHT.unit)

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -77,8 +77,8 @@ tremor_amplitude            -- mm/s2                         [planned — neurol
 // Metabolic
 blood_glucose               -- mg/dL                         [implemented]
 glucose_variability         -- coefficient of variation %    [planned — derived from CGM data]
-body_fat_percentage         -- %                             [planned — Withings scale]
-body_mass                   -- kg                            [planned — Withings scale]
+body_fat_pct                -- %                             [implemented — Withings scale]
+body_mass                   -- kg                            [implemented — Withings scale]
 
 // Stress & Recovery
 eda_level                   -- microsiemens                  [planned — EDA-capable wearables]


### PR DESCRIPTION
## Summary
- Add `BODY_FAT_PCT` (`body_fat_pct`, percent, METABOLIC) to `bios-contracts` MetricType.
- Withings already requested `meastypes=1,6,9,10,71` but the type-6 branch was stubbed with `null`, silently dropping every fat % reading. Route it to `BODY_FAT_PCT` at HIGH confidence — same hardware and measurement window as the BODY_MASS reading from type 1.
- Update DATA_MODEL.md: `body_fat_pct` and `body_mass` move from `[planned]` to `[implemented]`; key renamed from `body_fat_percentage` to the contract convention.

## Why
Phase 8.2 in [docs/ROADMAP.md](docs/ROADMAP.md) — body composition is canonical multi-system body signal and the Withings adapter is already live; finishing the wiring closes the schema-waste gap without a new adapter or new permissions.

## Test plan
- [ ] `./scripts/code-quality-check.sh` passes
- [ ] `MetricTypeTest.body_fat_pct_is_metabolic_percent` pins the contract surface
- [ ] Manual: trigger a Withings sync after weighing on a fat-percent-capable scale, confirm a `body_fat_pct` row lands at HIGH confidence and `body_mass` still lands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)