### PR TITLE
feat: SLEEP_LATENCY derivation over sleep_stage rows

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
@@ -1,0 +1,60 @@
+package com.bios.app.engine
+
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+
+/**
+ * Pure-function derivations over SLEEP_STAGE readings.
+ *
+ * Derived metrics live next to baseline/anomaly logic in `engine/` rather than
+ * in any adapter, so the same derivation applies regardless of which adapter
+ * sourced the underlying stage rows (Oura, WHOOP, Health Connect, Withings).
+ */
+object SleepDerivations {
+
+    /**
+     * Sleep latency: time from the first AWAKE stage of a sleep session to the
+     * first non-AWAKE stage that follows it. Reported in seconds.
+     *
+     * Returns null when [readings] contains no AWAKE→sleep transition — either
+     * the recording started already asleep, or the session is incomplete. We
+     * intentionally do not fabricate a zero in those cases; absent data is more
+     * honest than a confidently wrong value.
+     *
+     * Only the first AWAKE→sleep transition in the input is considered, so a
+     * single sync window with multiple sessions yields one latency reading for
+     * the earliest session.
+     */
+    fun deriveSleepLatency(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val stages = readings
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .sortedBy { it.timestamp }
+        if (stages.isEmpty()) return null
+
+        val firstAwakeIdx = stages.indexOfFirst { it.value.toInt() == SleepStage.AWAKE.value }
+        if (firstAwakeIdx < 0) return null
+
+        val firstSleepIdx = stages
+            .drop(firstAwakeIdx + 1)
+            .indexOfFirst { it.value.toInt() != SleepStage.AWAKE.value }
+        if (firstSleepIdx < 0) return null
+
+        val awakeRow = stages[firstAwakeIdx]
+        val sleepRow = stages[firstAwakeIdx + 1 + firstSleepIdx]
+        val latencyMs = sleepRow.timestamp - awakeRow.timestamp
+        if (latencyMs <= 0) return null
+
+        return MetricReading(
+            metricType = MetricType.SLEEP_LATENCY.key,
+            value = latencyMs / 1000.0,
+            timestamp = awakeRow.timestamp,
+            durationSec = (latencyMs / 1000).toInt(),
+            sourceId = sourceId,
+            confidence = sleepRow.confidence
+        )
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -4,6 +4,7 @@ import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.DetectionLatencyTracker
 import com.bios.app.engine.PipelineStage
 import com.bios.app.engine.SignalQualityFilter
+import com.bios.app.engine.SleepDerivations
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
@@ -143,7 +144,8 @@ class IngestManager(
 
                 val deduped = deduplicate(allReadings)
                 val quality = SignalQualityFilter.filter(deduped, lastReadingPerMetric)
-                readingDao.insertAll(quality)
+                val derived = deriveAll(quality)
+                readingDao.insertAll(quality + derived)
                 updateLastReadings(quality)
             }
 
@@ -190,7 +192,8 @@ class IngestManager(
 
                 val deduped = deduplicate(allReadings)
                 val quality = SignalQualityFilter.filter(deduped, lastReadingPerMetric)
-                readingDao.insertAll(quality)
+                val derived = deriveAll(quality)
+                readingDao.insertAll(quality + derived)
                 updateLastReadings(quality)
                 current = chunkEnd
                 completedDays++
@@ -203,6 +206,21 @@ class IngestManager(
             _isSyncing.value = false
             _syncProgress.value = 1f
         }
+    }
+
+    // MARK: - Derivations
+
+    /**
+     * Compute derived readings (sleep latency, etc.) over a quality-filtered batch.
+     * Grouping by sourceId keeps each derivation coherent — a session's latency is
+     * computed from one source's stage rows, not a cross-source mix.
+     */
+    private fun deriveAll(quality: List<MetricReading>): List<MetricReading> {
+        val derived = mutableListOf<MetricReading>()
+        quality.groupBy { it.sourceId }.forEach { (sourceId, rows) ->
+            SleepDerivations.deriveSleepLatency(rows, sourceId)?.let { derived += it }
+        }
+        return derived
     }
 
     // MARK: - Deduplication

--- a/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
@@ -1,0 +1,90 @@
+package com.bios.app
+
+import com.bios.app.engine.SleepDerivations
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SleepDerivationsTest {
+
+    private fun stage(stage: SleepStage, timestamp: Long): MetricReading = MetricReading(
+        metricType = MetricType.SLEEP_STAGE.key,
+        value = stage.value.toDouble(),
+        timestamp = timestamp,
+        durationSec = 300,
+        sourceId = "src",
+        confidence = ConfidenceTier.MEDIUM.level
+    )
+
+    @Test
+    fun `latency is the gap from first AWAKE to first non-AWAKE`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+            stage(SleepStage.LIGHT, 1_900_000L),
+            stage(SleepStage.DEEP, 2_500_000L),
+        )
+        val latency = SleepDerivations.deriveSleepLatency(readings, "src")!!
+        assertEquals(MetricType.SLEEP_LATENCY.key, latency.metricType)
+        assertEquals(900.0, latency.value, 0.0)
+        assertEquals(1_000_000L, latency.timestamp)
+        assertEquals("src", latency.sourceId)
+    }
+
+    @Test
+    fun `null when no AWAKE rows are present`() {
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_000_000L),
+            stage(SleepStage.DEEP, 1_600_000L),
+        )
+        assertNull(SleepDerivations.deriveSleepLatency(readings, "src"))
+    }
+
+    @Test
+    fun `null when AWAKE never transitions to sleep`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+        )
+        assertNull(SleepDerivations.deriveSleepLatency(readings, "src"))
+    }
+
+    @Test
+    fun `null when no stage rows are present`() {
+        val readings = listOf<MetricReading>()
+        assertNull(SleepDerivations.deriveSleepLatency(readings, "src"))
+    }
+
+    @Test
+    fun `unordered input is sorted before deriving`() {
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_900_000L),
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.DEEP, 2_500_000L),
+        )
+        val latency = SleepDerivations.deriveSleepLatency(readings, "src")!!
+        assertEquals(900.0, latency.value, 0.0)
+    }
+
+    @Test
+    fun `non-sleep readings are filtered out before deriving`() {
+        val noise = MetricReading(
+            metricType = MetricType.HEART_RATE.key,
+            value = 60.0,
+            timestamp = 1_500_000L,
+            sourceId = "src",
+            confidence = ConfidenceTier.MEDIUM.level
+        )
+        val readings = listOf(
+            noise,
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.REM, 1_600_000L),
+        )
+        val latency = SleepDerivations.deriveSleepLatency(readings, "src")!!
+        assertEquals(600.0, latency.value, 0.0)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -30,6 +30,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Sleep
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),
     SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP),
+    SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
 
     // Activity
     STEPS("steps", MetricUnit.COUNT, MetricDomain.ACTIVITY),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -47,6 +47,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun sleep_latency_is_sleep_seconds() {
+        assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
+        assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)
+    }
+
+    @Test
     fun body_fat_pct_is_metabolic_percent() {
         assertEquals(MetricDomain.METABOLIC, MetricType.BODY_FAT_PCT.domain)
         assertEquals(MetricUnit.PERCENT, MetricType.BODY_FAT_PCT.unit)


### PR DESCRIPTION
## Summary
- Add `SLEEP_LATENCY` (`sleep_latency`, seconds, SLEEP) to `bios-contracts` MetricType.
- New `engine/SleepDerivations.kt`: pure-function derivation over a batch of SLEEP_STAGE readings. Returns the gap from the first AWAKE row to the first non-AWAKE row that follows it, in seconds. Returns null when no AWAKE→sleep transition is present in the input (no fabricated zeros).
- `IngestManager.deriveAll()` runs after the quality filter, groups by sourceId so each session's latency is computed from one source's stage rows, then appends the derived rows to the insert. Wired into both `syncRecentData` and `syncHistoricalData`.
- Adapter-agnostic by design: any adapter that emits SLEEP_STAGE feeds the derivation (Oura, WHOOP, Health Connect, Withings).

## Why
Phase 8.4 in [docs/ROADMAP.md](docs/ROADMAP.md). Splits the original 8.4 — SLEEP_LATENCY ships here as a well-defined clinical derivation; **SLEEP_SCORE is held back to a follow-up PR** so the composite formula can be properly literature-anchored without the manifesto-risky "score" framing this PR.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (lint + lethe/standalone builds + unit tests)
- [x] `SleepDerivationsTest` covers: happy path, no AWAKE rows, no transition, empty input, unordered input, mixed-metric input
- [x] `MetricTypeTest.sleep_latency_is_sleep_seconds` pins the contract surface
- [ ] Manual: after an Oura sync of a real night, confirm one `sleep_latency` row lands at the session start with a sensible value (~5–20 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)