### PR TITLE
feat: SLEEP_EFFICIENCY + SLEEP_FRAGMENTATION_INDEX derivations

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
@@ -57,4 +57,80 @@ object SleepDerivations {
             confidence = sleepRow.confidence
         )
     }
+
+    /**
+     * Sleep efficiency: (time asleep) / (total session duration) × 100, in percent.
+     * Standard clinical formula (TST / TIB × 100). The session duration here is
+     * approximated by the sum of all stage durations in the input — AWAKE rows at
+     * the head/tail of the session count toward the denominator but not the
+     * numerator, matching the in-bed-but-awake semantics of TIB.
+     *
+     * Returns null when the input has no stage rows, total session duration is
+     * zero, or no non-AWAKE time is recorded — there is no efficiency to report
+     * for a session that contains no sleep.
+     */
+    fun deriveSleepEfficiency(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val stages = readings
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .sortedBy { it.timestamp }
+        if (stages.isEmpty()) return null
+
+        val total = stages.sumOf { it.durationSec ?: 0 }
+        if (total == 0) return null
+
+        val asleep = stages
+            .filter { it.value.toInt() != SleepStage.AWAKE.value }
+            .sumOf { it.durationSec ?: 0 }
+        if (asleep == 0) return null
+
+        return MetricReading(
+            metricType = MetricType.SLEEP_EFFICIENCY.key,
+            value = asleep.toDouble() / total.toDouble() * 100.0,
+            timestamp = stages.first().timestamp,
+            durationSec = total,
+            sourceId = sourceId,
+            confidence = stages.first().confidence
+        )
+    }
+
+    /**
+     * Sleep fragmentation index: count of awakenings after initial sleep onset.
+     * An awakening is a transition from a non-AWAKE stage to an AWAKE stage that
+     * occurs after the first non-AWAKE row in the session. The initial AWAKE
+     * period before sleep onset is not counted (that's latency, not fragmentation).
+     *
+     * Returns null when the input has no stage rows, or contains no non-AWAKE row
+     * — there is no post-onset window to measure fragmentation over.
+     */
+    fun deriveSleepFragmentation(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val stages = readings
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .sortedBy { it.timestamp }
+        if (stages.isEmpty()) return null
+
+        val firstSleepIdx = stages.indexOfFirst { it.value.toInt() != SleepStage.AWAKE.value }
+        if (firstSleepIdx < 0) return null
+
+        var awakenings = 0
+        var prevWasAwake = false
+        for (row in stages.drop(firstSleepIdx)) {
+            val isAwake = row.value.toInt() == SleepStage.AWAKE.value
+            if (isAwake && !prevWasAwake) awakenings++
+            prevWasAwake = isAwake
+        }
+
+        return MetricReading(
+            metricType = MetricType.SLEEP_FRAGMENTATION_INDEX.key,
+            value = awakenings.toDouble(),
+            timestamp = stages.first().timestamp,
+            sourceId = sourceId,
+            confidence = stages.first().confidence
+        )
+    }
 }

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -219,6 +219,8 @@ class IngestManager(
         val derived = mutableListOf<MetricReading>()
         quality.groupBy { it.sourceId }.forEach { (sourceId, rows) ->
             SleepDerivations.deriveSleepLatency(rows, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepEfficiency(rows, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepFragmentation(rows, sourceId)?.let { derived += it }
         }
         return derived
     }

--- a/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
@@ -87,4 +87,95 @@ class SleepDerivationsTest {
         val latency = SleepDerivations.deriveSleepLatency(readings, "src")!!
         assertEquals(600.0, latency.value, 0.0)
     }
+
+    // MARK: - Efficiency
+
+    @Test
+    fun `efficiency is asleep over total session duration`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),  // 300s awake
+            stage(SleepStage.LIGHT, 1_300_000L),  // 300s
+            stage(SleepStage.DEEP, 1_600_000L),   // 300s
+            stage(SleepStage.AWAKE, 1_900_000L),  // 300s awake
+        )
+        val efficiency = SleepDerivations.deriveSleepEfficiency(readings, "src")!!
+        assertEquals(MetricType.SLEEP_EFFICIENCY.key, efficiency.metricType)
+        assertEquals(50.0, efficiency.value, 0.0001)
+        assertEquals(1_000_000L, efficiency.timestamp)
+        assertEquals(1200, efficiency.durationSec)
+    }
+
+    @Test
+    fun `efficiency is null when only AWAKE rows present`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+        )
+        assertNull(SleepDerivations.deriveSleepEfficiency(readings, "src"))
+    }
+
+    @Test
+    fun `efficiency is 100 percent when no AWAKE rows`() {
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_000_000L),
+            stage(SleepStage.DEEP, 1_300_000L),
+        )
+        val efficiency = SleepDerivations.deriveSleepEfficiency(readings, "src")!!
+        assertEquals(100.0, efficiency.value, 0.0001)
+    }
+
+    @Test
+    fun `efficiency is null when no stage rows`() {
+        assertNull(SleepDerivations.deriveSleepEfficiency(emptyList(), "src"))
+    }
+
+    // MARK: - Fragmentation
+
+    @Test
+    fun `fragmentation counts post-onset awakenings only`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),  // pre-onset, not counted
+            stage(SleepStage.LIGHT, 1_300_000L),  // onset
+            stage(SleepStage.AWAKE, 1_600_000L),  // awakening 1
+            stage(SleepStage.LIGHT, 1_900_000L),
+            stage(SleepStage.DEEP, 2_200_000L),
+            stage(SleepStage.AWAKE, 2_500_000L),  // awakening 2
+        )
+        val frag = SleepDerivations.deriveSleepFragmentation(readings, "src")!!
+        assertEquals(MetricType.SLEEP_FRAGMENTATION_INDEX.key, frag.metricType)
+        assertEquals(2.0, frag.value, 0.0)
+    }
+
+    @Test
+    fun `fragmentation contiguous AWAKE block counts once`() {
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+            stage(SleepStage.AWAKE, 1_600_000L),
+            stage(SleepStage.AWAKE, 1_900_000L),
+            stage(SleepStage.LIGHT, 2_200_000L),
+        )
+        val frag = SleepDerivations.deriveSleepFragmentation(readings, "src")!!
+        assertEquals(1.0, frag.value, 0.0)
+    }
+
+    @Test
+    fun `fragmentation is zero for unbroken sleep`() {
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_000_000L),
+            stage(SleepStage.DEEP, 1_300_000L),
+            stage(SleepStage.REM, 1_600_000L),
+        )
+        val frag = SleepDerivations.deriveSleepFragmentation(readings, "src")!!
+        assertEquals(0.0, frag.value, 0.0)
+    }
+
+    @Test
+    fun `fragmentation is null when session never reaches sleep`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+        )
+        assertNull(SleepDerivations.deriveSleepFragmentation(readings, "src"))
+    }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -31,6 +31,8 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),
     SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
+    SLEEP_EFFICIENCY("sleep_efficiency", MetricUnit.PERCENT, MetricDomain.SLEEP),
+    SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),
 
     // Activity
     STEPS("steps", MetricUnit.COUNT, MetricDomain.ACTIVITY),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -53,6 +53,18 @@ class MetricTypeTest {
     }
 
     @Test
+    fun sleep_efficiency_is_sleep_percent() {
+        assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_EFFICIENCY.domain)
+        assertEquals(MetricUnit.PERCENT, MetricType.SLEEP_EFFICIENCY.unit)
+    }
+
+    @Test
+    fun sleep_fragmentation_is_sleep_count() {
+        assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_FRAGMENTATION_INDEX.domain)
+        assertEquals(MetricUnit.COUNT, MetricType.SLEEP_FRAGMENTATION_INDEX.unit)
+    }
+
+    @Test
     fun body_fat_pct_is_metabolic_percent() {
         assertEquals(MetricDomain.METABOLIC, MetricType.BODY_FAT_PCT.domain)
         assertEquals(MetricUnit.PERCENT, MetricType.BODY_FAT_PCT.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -287,12 +287,24 @@ in the baseline engine. New keys: `lf_hf_ratio`, `parasympathetic_tone`
 (domain: `CARDIOVASCULAR`, unit derived). Resolves the "raw HRV present,
 no autonomic surface" finding from the audit.
 
-### 8.4 Sleep derivations: latency + score
+### 8.4 Sleep derivations: latency + components [LATENCY + COMPONENTS SHIPPED]
 
-`sleep_latency` and `sleep_score` are in the planned set. Derive from
-the existing `sleep_stage` time-series. Sleep latency = wake → first
-non-wake stage; sleep score = composite over duration, efficiency,
-fragmentation, and stage balance. Literature-anchored thresholds only.
+Derive from the existing `sleep_stage` time-series in `engine/SleepDerivations.kt`:
+
+- `sleep_latency` (SECONDS) — first AWAKE → first non-AWAKE.
+- `sleep_efficiency` (PERCENT) — TST / TIB × 100; the canonical clinical
+  formula. Threshold ≥85% is the well-established normal range.
+- `sleep_fragmentation_index` (COUNT) — number of post-onset awakenings;
+  contiguous AWAKE blocks count as one.
+
+**Reframe from `sleep_score`:** the original 8.4 specified a composite
+score. Shipping a 0–100 grade on the owner's sleep clashes with the
+"never evaluate the person" principle — even with literature-anchored
+thresholds, a single number invites comparison and reads as judgment.
+The decomposed components above are clinically richer (each is its own
+literature-backed signal) and stay within the manifesto. `sleep_score`
+is parked unless a future condition pattern needs a single-number input
+that can't be expressed as a rule over the components.
 
 ### 8.5 Cycle inference from BBT
 


### PR DESCRIPTION
## Summary
- Add `SLEEP_EFFICIENCY` (percent, SLEEP) and `SLEEP_FRAGMENTATION_INDEX` (count, SLEEP) to `bios-contracts` MetricType, alongside the `SLEEP_LATENCY` shipped in #52.
- Extend `engine/SleepDerivations.kt` with two pure functions:
  - `deriveSleepEfficiency` — TST / TIB × 100, the canonical clinical formula. AWAKE head/tail rows count toward the denominator (in-bed-but-awake), not the numerator.
  - `deriveSleepFragmentation` — count of post-onset awakenings; contiguous AWAKE blocks count once; pre-onset AWAKE excluded.
- `IngestManager.deriveAll` now calls all three derivations per source group.
- ROADMAP §8.4 updated to record the reframe (see Why).

## Why
This is the deliberate reframe of the original 8.4 `sleep_score` deliverable. A 0–100 composite reads as judgment of the owner's sleep — exactly what the "never evaluate the person" principle warns against, even with literature-anchored thresholds. Decomposing into latency + efficiency + fragmentation keeps the same clinical information and stays manifesto-clean. `sleep_score` is parked unless a future condition pattern genuinely needs a single number that can't be expressed as a rule over the components.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (lint + lethe/standalone builds)
- [x] `:app:testStandaloneDebugUnitTest` + `:bios-contracts:test` pass
- [x] `SleepDerivationsTest` adds 8 cases for efficiency + fragmentation covering happy paths, edge cases, and null-return preconditions
- [x] `MetricTypeTest` pins the two new keys' domain + unit
- [ ] Manual: after an Oura sync of a real night, confirm `sleep_efficiency` and `sleep_fragmentation_index` rows land at the session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)