### PR TITLE
feat: PARASYMPATHETIC_TONE derivation via ln(RMSSD)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
@@ -1,6 +1,7 @@
 package com.bios.app.engine
 
 import kotlin.math.abs
+import kotlin.math.ln
 import kotlin.math.sqrt
 
 /**
@@ -46,6 +47,7 @@ object HrvAnalyzer {
             rmssd = rmssd,
             sdnn = sdnn,
             pnn50 = pnn50,
+            lnRmssd = if (rmssd > 0.0) ln(rmssd) else 0.0,
             meanIbiMs = meanIbi,
             meanHrBpm = meanHr,
             cleanIbiCount = clean.size,
@@ -120,6 +122,13 @@ object HrvAnalyzer {
         val sdnn: Double,
         /** Percentage of successive diffs > 50ms. Parasympathetic marker. */
         val pnn50: Double,
+        /**
+         * Natural log of RMSSD — the standard time-domain proxy for HF spectral
+         * power (parasympathetic tone). Correlates ~0.9 with ln(HF) in healthy
+         * adults, and is approximately normally distributed across individuals
+         * (Shaffer & Ginsberg 2017, Kleiger 2005). Zero when rmssd is zero.
+         */
+        val lnRmssd: Double,
         /** Mean inter-beat interval (ms). */
         val meanIbiMs: Double,
         /** Mean heart rate derived from IBIs (bpm). */

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -148,6 +148,14 @@ class CameraPpgAdapter(private val context: Context) {
                     durationSec = durSec,
                     sourceId = sourceId,
                     confidence = ConfidenceTier.LOW.level
+                ),
+                MetricReading(
+                    metricType = MetricType.PARASYMPATHETIC_TONE.key,
+                    value = hrv.lnRmssd,
+                    timestamp = timestamp,
+                    durationSec = durSec,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.LOW.level
                 )
             )
             return CaptureResult(

--- a/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
@@ -102,6 +102,14 @@ class DirectSensorAdapter(context: Context) {
                 durationSec = duration,
                 sourceId = sourceId,
                 confidence = ConfidenceTier.LOW.level
+            ),
+            MetricReading(
+                metricType = MetricType.PARASYMPATHETIC_TONE.key,
+                value = hrv.lnRmssd,
+                timestamp = now,
+                durationSec = duration,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.LOW.level
             )
         )
     }

--- a/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
@@ -35,6 +35,7 @@ class CameraPpgAdapterTest {
             rmssd = 18.5,
             sdnn = 24.0,
             pnn50 = 10.0,
+            lnRmssd = kotlin.math.ln(18.5),
             meanIbiMs = 815.0,
             meanHrBpm = 73.6,
             cleanIbiCount = 5,
@@ -44,7 +45,7 @@ class CameraPpgAdapterTest {
         val result = CameraPpgAdapter.toResult(ppg, hrv, sourceId, now)
 
         assertTrue(result.accepted)
-        assertEquals(2, result.readings.size)
+        assertEquals(3, result.readings.size)
 
         val hr = result.readings.single { it.metricType == MetricType.HEART_RATE.key }
         assertEquals(73.6, hr.value, 0.01)
@@ -56,6 +57,10 @@ class CameraPpgAdapterTest {
         val hrvR = result.readings.single { it.metricType == MetricType.HEART_RATE_VARIABILITY.key }
         assertEquals(18.5, hrvR.value, 0.01)
         assertEquals(ConfidenceTier.LOW.level, hrvR.confidence)
+
+        val parR = result.readings.single { it.metricType == MetricType.PARASYMPATHETIC_TONE.key }
+        assertEquals(kotlin.math.ln(18.5), parR.value, 1e-9)
+        assertEquals(ConfidenceTier.LOW.level, parR.confidence)
     }
 
     @Test
@@ -104,6 +109,7 @@ class CameraPpgAdapterTest {
         )
         val hrv = HrvAnalyzer.HrvResult(
             rmssd = 15.0, sdnn = 22.0, pnn50 = 5.0,
+            lnRmssd = kotlin.math.ln(15.0),
             meanIbiMs = 805.0, meanHrBpm = 74.5,
             cleanIbiCount = 5, artifactsRejected = 0
         )

--- a/android/app/src/test/java/com/bios/app/HrvAnalyzerTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrvAnalyzerTest.kt
@@ -4,6 +4,7 @@ import com.bios.app.engine.HrvAnalyzer
 import org.junit.Assert.*
 import org.junit.Test
 import kotlin.math.abs
+import kotlin.math.ln
 
 class HrvAnalyzerTest {
 
@@ -122,5 +123,21 @@ class HrvAnalyzerTest {
         val result = HrvAnalyzer.analyze(ibis)
         assertNotNull(result)
         assertTrue("Should have rejected artifacts", result!!.artifactsRejected > 0)
+    }
+
+    @Test
+    fun `lnRmssd matches the natural log of RMSSD when positive`() {
+        val ibis = listOf(800.0, 815.0, 795.0, 810.0, 805.0, 820.0, 790.0)
+        val result = HrvAnalyzer.analyze(ibis)!!
+        assertTrue(result.rmssd > 0.0)
+        assertEquals(ln(result.rmssd), result.lnRmssd, 1e-9)
+    }
+
+    @Test
+    fun `lnRmssd is zero when RMSSD is zero`() {
+        val ibis = listOf(800.0, 800.0, 800.0, 800.0, 800.0)
+        val result = HrvAnalyzer.analyze(ibis)!!
+        assertEquals(0.0, result.rmssd, 0.0)
+        assertEquals(0.0, result.lnRmssd, 0.0)
     }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -15,6 +15,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Cardiovascular
     HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
+    PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -47,6 +47,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun parasympathetic_tone_is_cardiovascular_score() {
+        assertEquals(MetricDomain.CARDIOVASCULAR, MetricType.PARASYMPATHETIC_TONE.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.PARASYMPATHETIC_TONE.unit)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -279,13 +279,23 @@ but `body_mass` and `body_fat_pct` are not yet in `MetricType`. Add the
 keys (domain: `METABOLIC` or new `BODY_COMPOSITION`), wire the Withings
 adapter to write them, and baseline like any other metric.
 
-### 8.3 HRV decomposition (autonomic-tone derivations)
+### 8.3 HRV decomposition (autonomic-tone derivations) [PARTIAL — parasympathetic shipped, LF/HF deferred]
 
 Raw HRV is canonical but the clinically useful numbers (LF/HF ratio,
-parasympathetic tone) aren't. Derive over the existing HRV time-series
-in the baseline engine. New keys: `lf_hf_ratio`, `parasympathetic_tone`
-(domain: `CARDIOVASCULAR`, unit derived). Resolves the "raw HRV present,
-no autonomic surface" finding from the audit.
+parasympathetic tone) aren't. Resolves the "raw HRV present, no
+autonomic surface" finding from the audit.
+
+- `parasympathetic_tone` (CARDIOVASCULAR, SCORE) — **shipped.** Computed
+  as `ln(RMSSD)` in `HrvAnalyzer.HrvResult.lnRmssd` and emitted by both
+  PPG and direct-sensor adapters alongside `HEART_RATE_VARIABILITY`.
+  `ln(RMSSD)` is the standard time-domain proxy for HF spectral power
+  (Shaffer & Ginsberg 2017, Kleiger 2005) — correlates ~0.9 with `ln(HF)`
+  in healthy adults and is approximately normally distributed across
+  individuals.
+- `lf_hf_ratio` (CARDIOVASCULAR) — **deferred.** Requires real spectral
+  analysis (FFT or Lomb-Scargle over the IBI tachogram); no time-domain
+  proxy is clinically defensible. Worth its own PR with a vetted FFT
+  implementation and synthetic-signal test coverage.
 
 ### 8.4 Sleep derivations: latency + components [LATENCY + COMPONENTS SHIPPED]
 


### PR DESCRIPTION
## Summary
- Add `PARASYMPATHETIC_TONE` (`parasympathetic_tone`, SCORE, CARDIOVASCULAR) to `bios-contracts` MetricType.
- Compute it as `ln(RMSSD)` in `HrvAnalyzer.HrvResult.lnRmssd`. Zero when RMSSD is zero (constant-IBI degenerate case).
- Emit alongside `HEART_RATE_VARIABILITY` from `DirectSensorAdapter.sampleHrv` and `CameraPpgAdapter.toResult` — same timestamp, duration, sourceId, and confidence; same measurement window, same source of truth.

## Why
Phase 8.3 in [docs/ROADMAP.md](docs/ROADMAP.md). `ln(RMSSD)` is the standard time-domain proxy for HF spectral power — correlates ~0.9 with `ln(HF)` in healthy adults and is approximately normally distributed across individuals (Shaffer & Ginsberg 2017, Kleiger 2005), so it gives Bios the autonomic-tone surface the audit flagged without requiring spectral analysis.

**`lf_hf_ratio` is deliberately deferred** to its own PR — no time-domain proxy is clinically defensible for the LF/HF ratio, so it needs a vetted FFT (or Lomb-Scargle) implementation over the IBI tachogram plus synthetic-signal test coverage. Worth doing right, not bundling here.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (lint + lethe/standalone builds)
- [x] `:app:testStandaloneDebugUnitTest` + `:bios-contracts:test` pass
- [x] `HrvAnalyzerTest` covers `lnRmssd == ln(rmssd)` for positive RMSSD and `lnRmssd == 0` for the zero case
- [x] `CameraPpgAdapterTest` covers the 3-reading shape and `parasympathetic_tone` value
- [x] `MetricTypeTest` pins the contract surface
- [ ] Manual: trigger a camera-PPG capture, confirm a `parasympathetic_tone` row lands alongside `heart_rate` + `heart_rate_variability` at the same timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)