### PR TITLE
feat: STRESS_SCORE derivation via Baevsky's Stress Index

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
@@ -48,6 +48,7 @@ object HrvAnalyzer {
             sdnn = sdnn,
             pnn50 = pnn50,
             lnRmssd = if (rmssd > 0.0) ln(rmssd) else 0.0,
+            stressIndex = computeStressIndex(clean),
             meanIbiMs = meanIbi,
             meanHrBpm = meanHr,
             cleanIbiCount = clean.size,
@@ -115,6 +116,44 @@ object HrvAnalyzer {
         return (nn50.toDouble() / diffs.size) * 100.0
     }
 
+    /** RR histogram bin width for Baevsky stress index. 50ms is the standard. */
+    private const val STRESS_BIN_MS = 50.0
+
+    /**
+     * Baevsky's Stress Index (SI, "Index of Tension") — a geometric autonomic
+     * derivation over the RR tachogram. Rises with sympathetic activation and
+     * parasympathetic withdrawal.
+     *
+     *   SI = AMo / (2 × Mo × MxDMn)
+     *
+     * with Mo and MxDMn in seconds and AMo in percent. Bins are 50ms wide
+     * (the canonical width in Baevsky's work).
+     *
+     * Typical resting values are ~50–150; >200 indicates elevated sympathetic
+     * tone. References: Baevsky & Berseneva 2008; Kobelev et al. 2024 review.
+     *
+     * Returns 0.0 when MxDMn is zero (constant-IBI degenerate case — no
+     * variability, SI undefined).
+     */
+    internal fun computeStressIndex(ibis: List<Double>): Double {
+        if (ibis.size < 2) return 0.0
+        val maxMs = ibis.max()
+        val minMs = ibis.min()
+        val mxDMnSec = (maxMs - minMs) / 1000.0
+        if (mxDMnSec <= 0.0) return 0.0
+
+        val bins = HashMap<Int, Int>()
+        for (ibi in ibis) {
+            val bin = (ibi / STRESS_BIN_MS).toInt()
+            bins[bin] = (bins[bin] ?: 0) + 1
+        }
+        val modeEntry = bins.maxByOrNull { it.value } ?: return 0.0
+        val moSec = ((modeEntry.key + 0.5) * STRESS_BIN_MS) / 1000.0
+        val amoPct = (modeEntry.value.toDouble() / ibis.size) * 100.0
+
+        return amoPct / (2.0 * moSec * mxDMnSec)
+    }
+
     data class HrvResult(
         /** Root Mean Square of Successive Differences (ms). Primary metric. */
         val rmssd: Double,
@@ -129,6 +168,14 @@ object HrvAnalyzer {
          * (Shaffer & Ginsberg 2017, Kleiger 2005). Zero when rmssd is zero.
          */
         val lnRmssd: Double,
+        /**
+         * Baevsky's Stress Index (SI, "Index of Tension"). Geometric autonomic
+         * derivation over the RR tachogram; rises with sympathetic activation
+         * and parasympathetic withdrawal. Typical rest range ~50–150; >200
+         * indicates elevated sympathetic tone. Zero in the degenerate
+         * constant-IBI case (Baevsky & Berseneva 2008).
+         */
+        val stressIndex: Double,
         /** Mean inter-beat interval (ms). */
         val meanIbiMs: Double,
         /** Mean heart rate derived from IBIs (bpm). */

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -156,6 +156,14 @@ class CameraPpgAdapter(private val context: Context) {
                     durationSec = durSec,
                     sourceId = sourceId,
                     confidence = ConfidenceTier.LOW.level
+                ),
+                MetricReading(
+                    metricType = MetricType.STRESS_SCORE.key,
+                    value = hrv.stressIndex,
+                    timestamp = timestamp,
+                    durationSec = durSec,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.LOW.level
                 )
             )
             return CaptureResult(

--- a/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
@@ -110,6 +110,14 @@ class DirectSensorAdapter(context: Context) {
                 durationSec = duration,
                 sourceId = sourceId,
                 confidence = ConfidenceTier.LOW.level
+            ),
+            MetricReading(
+                metricType = MetricType.STRESS_SCORE.key,
+                value = hrv.stressIndex,
+                timestamp = now,
+                durationSec = duration,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.LOW.level
             )
         )
     }

--- a/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
@@ -36,6 +36,7 @@ class CameraPpgAdapterTest {
             sdnn = 24.0,
             pnn50 = 10.0,
             lnRmssd = kotlin.math.ln(18.5),
+            stressIndex = 120.0,
             meanIbiMs = 815.0,
             meanHrBpm = 73.6,
             cleanIbiCount = 5,
@@ -45,7 +46,7 @@ class CameraPpgAdapterTest {
         val result = CameraPpgAdapter.toResult(ppg, hrv, sourceId, now)
 
         assertTrue(result.accepted)
-        assertEquals(3, result.readings.size)
+        assertEquals(4, result.readings.size)
 
         val hr = result.readings.single { it.metricType == MetricType.HEART_RATE.key }
         assertEquals(73.6, hr.value, 0.01)
@@ -61,6 +62,10 @@ class CameraPpgAdapterTest {
         val parR = result.readings.single { it.metricType == MetricType.PARASYMPATHETIC_TONE.key }
         assertEquals(kotlin.math.ln(18.5), parR.value, 1e-9)
         assertEquals(ConfidenceTier.LOW.level, parR.confidence)
+
+        val stressR = result.readings.single { it.metricType == MetricType.STRESS_SCORE.key }
+        assertEquals(120.0, stressR.value, 1e-9)
+        assertEquals(ConfidenceTier.LOW.level, stressR.confidence)
     }
 
     @Test
@@ -110,6 +115,7 @@ class CameraPpgAdapterTest {
         val hrv = HrvAnalyzer.HrvResult(
             rmssd = 15.0, sdnn = 22.0, pnn50 = 5.0,
             lnRmssd = kotlin.math.ln(15.0),
+            stressIndex = 95.0,
             meanIbiMs = 805.0, meanHrBpm = 74.5,
             cleanIbiCount = 5, artifactsRejected = 0
         )

--- a/android/app/src/test/java/com/bios/app/HrvAnalyzerTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrvAnalyzerTest.kt
@@ -140,4 +140,52 @@ class HrvAnalyzerTest {
         assertEquals(0.0, result.rmssd, 0.0)
         assertEquals(0.0, result.lnRmssd, 0.0)
     }
+
+    // -- Baevsky stress index --
+
+    @Test
+    fun `stress index is zero when all IBIs are identical`() {
+        // MxDMn = 0, SI undefined → return 0.
+        val ibis = listOf(800.0, 800.0, 800.0, 800.0, 800.0)
+        assertEquals(0.0, HrvAnalyzer.computeStressIndex(ibis), 0.0)
+    }
+
+    @Test
+    fun `stress index matches Baevsky formula for known IBIs`() {
+        // 800,805,810,815,820 → all in 50ms bin 16 (covers [800, 850)).
+        // Mo bin midpoint = (16 + 0.5) * 50ms = 825ms = 0.825s.
+        // AMo = 5/5 × 100 = 100%. MxDMn = (820 - 800)/1000 = 0.020s.
+        // SI = 100 / (2 × 0.825 × 0.020) = 100 / 0.033 ≈ 3030.3.
+        val ibis = listOf(800.0, 805.0, 810.0, 815.0, 820.0)
+        val si = HrvAnalyzer.computeStressIndex(ibis)
+        assertEquals(3030.30, si, 0.1)
+    }
+
+    @Test
+    fun `stress index falls as variability rises`() {
+        // Same beat count; the spread-out tachogram has both smaller AMo and
+        // larger MxDMn, so the Baevsky SI must drop.
+        val tight = listOf(800.0, 802.0, 798.0, 805.0, 795.0, 800.0)
+        val spread = listOf(700.0, 950.0, 720.0, 880.0, 750.0, 900.0)
+        assertTrue(
+            HrvAnalyzer.computeStressIndex(tight) > HrvAnalyzer.computeStressIndex(spread)
+        )
+    }
+
+    @Test
+    fun `stress index is zero for fewer than two IBIs`() {
+        assertEquals(0.0, HrvAnalyzer.computeStressIndex(listOf(800.0)), 0.0)
+        assertEquals(0.0, HrvAnalyzer.computeStressIndex(emptyList()), 0.0)
+    }
+
+    @Test
+    fun `analyze populates stressIndex consistent with direct call`() {
+        val ibis = listOf(800.0, 815.0, 795.0, 810.0, 805.0, 820.0, 790.0)
+        val result = HrvAnalyzer.analyze(ibis)!!
+        val direct = HrvAnalyzer.computeStressIndex(
+            HrvAnalyzer.rejectArtifacts(ibis)
+        )
+        assertEquals(direct, result.stressIndex, 1e-9)
+        assertTrue(result.stressIndex > 0.0)
+    }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -16,6 +16,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
+    STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -53,6 +53,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun stress_score_is_cardiovascular_score() {
+        assertEquals(MetricDomain.CARDIOVASCULAR, MetricType.STRESS_SCORE.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.STRESS_SCORE.unit)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -337,13 +337,24 @@ No new companion required — the data is canonical multi-system body
 signal, and the import surface is a thin settings flow on top of the
 existing FHIR machinery.
 
-### 8.7 Stress score — Bios-only autonomic derivation
+### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
+
+`stress_score` (CARDIOVASCULAR, SCORE) is computed as Baevsky's Stress
+Index (SI, "Index of Tension") over the cleaned RR tachogram:
+`SI = AMo / (2 × Mo × MxDMn)` on 50ms bins, computed in
+`HrvAnalyzer.HrvResult.stressIndex` and emitted by the PPG and
+direct-sensor adapters alongside `HEART_RATE_VARIABILITY` and
+`PARASYMPATHETIC_TONE`. Baevsky SI rises with sympathetic activation /
+parasympathetic withdrawal; typical rest range ~50–150, with >200
+indicating elevated sympathetic tone (Baevsky & Berseneva 2008). Zero
+in the degenerate constant-IBI case.
 
 Audit ownership debate resolved: `stress_score` is a *passive autonomic
-derivation* over HRV/RHR, not a behavioral score. Bios derives it; W2F
-consumes if it wants, no W2F-side write. Avoids overlap with
-`mood_drift_score` and keeps the boundary clean (W2F owns mood; Bios
-owns autonomic state). Domain: `CARDIOVASCULAR`.
+derivation* over HRV (RHR was considered; the chosen Baevsky formula
+uses the tachogram alone, so no baseline coupling is needed). Bios
+derives it; W2F consumes if it wants, no W2F-side write. Avoids overlap
+with `mood_drift_score` and keeps the boundary clean (W2F owns mood;
+Bios owns autonomic state).
 
 ### 8.8 Acceptance for Phase 8
 


### PR DESCRIPTION
## Summary
- Adds `STRESS_SCORE` (CARDIOVASCULAR, SCORE) to `bios-contracts` and computes it as Baevsky's Stress Index over the cleaned RR tachogram in `HrvAnalyzer.HrvResult.stressIndex`.
- PPG and direct-sensor adapters emit `STRESS_SCORE` alongside `HEART_RATE_VARIABILITY` and `PARASYMPATHETIC_TONE` — same window, same source, same confidence.
- Resolves ROADMAP §8.7. The chosen Baevsky form derives from the tachogram alone, so the score is fully passive — no RHR-baseline coupling needed. Keeps the ecosystem boundary clean (W2F owns mood; Bios owns autonomic state).

## Formula
`SI = AMo / (2 × Mo × MxDMn)` on 50ms RR bins (Mo, MxDMn in seconds; AMo in percent). Rises with sympathetic activation and parasympathetic withdrawal; typical rest range ~50–150; >200 = elevated sympathetic tone (Baevsky & Berseneva 2008). Zero in the degenerate constant-IBI case (MxDMn = 0).

## Test plan
- [x] `:bios-contracts:test` — contract gate for `STRESS_SCORE` (cardiovascular SCORE).
- [x] `HrvAnalyzerTest` — Baevsky formula matches hand-computed expected value; SI falls as variability rises; degenerate constant-IBI and <2-IBI cases return 0; `analyze()` populates `stressIndex` consistent with direct call.
- [x] `CameraPpgAdapterTest` — adapter now emits 4 readings (HR, HRV, parasympathetic_tone, stress_score) with matching timestamp / sourceId / durationSec / confidence.
- [x] `./scripts/code-quality-check.sh` — file length, secret scan, lint, `assembleDebug`, full unit test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)