### PR TITLE
feat: CYCLE_PHASE inference via biphasic BBT shift detection

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/CycleInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CycleInference.kt
@@ -1,0 +1,89 @@
+package com.bios.app.engine
+
+import com.bios.app.model.CyclePhase
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Pure-function cycle-phase inference over BASAL_BODY_TEMPERATURE readings.
+ *
+ * Uses the classic biphasic 3-day rule (Marshall 1968; Barron & Fehring 2005):
+ * establish a follicular-phase baseline as the mean of the first six daily
+ * BBTs, place a coverline 0.1°C above it, and look for the earliest day where
+ * three consecutive daily BBTs sit strictly above the coverline. The day
+ * before that sustained rise is the inferred ovulation day; days before it
+ * are follicular, days from it onward are luteal.
+ *
+ * The engine sits next to [SleepDerivations] in `engine/` so the derivation
+ * applies regardless of which adapter (or manual entry) sourced the BBT
+ * rows. Routing of the derived readings to the encrypted reproductive-health
+ * DB is the caller's responsibility — this function is unopinionated about
+ * persistence.
+ */
+object CycleInference {
+
+    /** Days of follicular baseline before the rise. */
+    private const val MIN_BASELINE_DAYS = 6
+
+    /** Consecutive days above the coverline required to confirm a rise. */
+    private const val MIN_RISE_DAYS = 3
+
+    /** Minimum total daily BBTs needed to attempt inference. */
+    private const val MIN_TOTAL_DAYS = MIN_BASELINE_DAYS + MIN_RISE_DAYS
+
+    /** Coverline offset above follicular baseline, in °C. */
+    private const val COVERLINE_OFFSET_C = 0.1
+
+    private const val MS_PER_DAY = 86_400_000L
+
+    /**
+     * Emit one CYCLE_PHASE reading per day in the input window when a
+     * biphasic shift is detected. Returns an empty list when the input has
+     * fewer than nine daily BBTs or no sustained rise above the coverline —
+     * we don't fabricate a phase classification without the data to support
+     * it.
+     *
+     * Multiple BBT readings on the same calendar day are aggregated by taking
+     * the earliest (morning reading is the clinically canonical sample).
+     * Days are bucketed in UTC; timezone-aware bucketing is a separate
+     * refinement when needed.
+     *
+     * MENSTRUAL is not emitted: distinguishing it from early follicular
+     * requires a menstruation-onset signal that BBT alone cannot provide.
+     */
+    fun deriveCyclePhases(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): List<MetricReading> {
+        val daily = readings
+            .filter { it.metricType == MetricType.BASAL_BODY_TEMPERATURE.key }
+            .groupBy { it.timestamp / MS_PER_DAY }
+            .map { (_, sameDay) -> sameDay.minBy { it.timestamp } }
+            .sortedBy { it.timestamp }
+        if (daily.size < MIN_TOTAL_DAYS) return emptyList()
+
+        val baseline = daily.take(MIN_BASELINE_DAYS).map { it.value }.average()
+        val coverline = baseline + COVERLINE_OFFSET_C
+
+        val riseStart = (MIN_BASELINE_DAYS..daily.size - MIN_RISE_DAYS)
+            .firstOrNull { idx ->
+                (idx until idx + MIN_RISE_DAYS).all { daily[it].value > coverline }
+            }
+            ?: return emptyList()
+
+        return daily.mapIndexed { i, day ->
+            val phase = when {
+                i < riseStart - 1 -> CyclePhase.FOLLICULAR
+                i == riseStart - 1 -> CyclePhase.OVULATORY
+                else -> CyclePhase.LUTEAL
+            }
+            MetricReading(
+                metricType = MetricType.CYCLE_PHASE.key,
+                value = phase.value.toDouble(),
+                timestamp = day.timestamp,
+                sourceId = sourceId,
+                confidence = day.confidence
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -56,6 +56,16 @@ enum class SleepStage(val value: Int) {
     AWAKE(0), LIGHT(1), DEEP(2), REM(3)
 }
 
+// MARK: - Cycle
+
+// MENSTRUAL is reserved for when a menstruation-onset signal exists; BBT
+// alone can't reliably distinguish it from the early follicular phase, so
+// the BBT-driven CycleInference currently emits only FOLLICULAR / OVULATORY
+// / LUTEAL. Numeric values are stable once written; do not renumber.
+enum class CyclePhase(val value: Int) {
+    MENSTRUAL(0), FOLLICULAR(1), OVULATORY(2), LUTEAL(3)
+}
+
 // MARK: - Aggregation
 
 enum class AggregatePeriod { HOUR, DAY, WEEK, MONTH }

--- a/android/app/src/test/java/com/bios/app/CycleInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/CycleInferenceTest.kt
@@ -1,0 +1,148 @@
+package com.bios.app
+
+import com.bios.app.engine.CycleInference
+import com.bios.app.model.CyclePhase
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import org.junit.Assert.*
+import org.junit.Test
+
+class CycleInferenceTest {
+
+    private val sourceId = "test-src"
+    private val msPerDay = 86_400_000L
+    private val day0 = 1_700_000_000_000L
+
+    private fun bbt(dayIndex: Int, valueC: Double, offsetMs: Long = 0L) = MetricReading(
+        metricType = MetricType.BASAL_BODY_TEMPERATURE.key,
+        value = valueC,
+        timestamp = day0 + dayIndex * msPerDay + offsetMs,
+        sourceId = sourceId,
+        confidence = 2
+    )
+
+    @Test
+    fun `returns empty when input is empty`() {
+        assertTrue(CycleInference.deriveCyclePhases(emptyList(), sourceId).isEmpty())
+    }
+
+    @Test
+    fun `returns empty when only non-BBT readings are present`() {
+        val readings = (0 until 12).map { i ->
+            MetricReading(
+                metricType = MetricType.HEART_RATE.key,
+                value = 60.0,
+                timestamp = day0 + i * msPerDay,
+                sourceId = sourceId,
+                confidence = 2
+            )
+        }
+        assertTrue(CycleInference.deriveCyclePhases(readings, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `returns empty when fewer than nine daily BBTs`() {
+        val readings = (0 until 8).map { bbt(it, 36.5) }
+        assertTrue(CycleInference.deriveCyclePhases(readings, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `returns empty when BBT stays flat with no sustained rise`() {
+        val readings = (0 until 14).map { bbt(it, 36.5) }
+        assertTrue(CycleInference.deriveCyclePhases(readings, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `detects biphasic shift and assigns follicular ovulatory luteal phases`() {
+        // Days 0-5 follicular at 36.5°C → baseline 36.5, coverline 36.6.
+        // Days 6-11 luteal at 36.8°C → sustained rise starts at day 6.
+        // Day 5 is the inferred ovulation day.
+        val readings = (0 until 12).map { i ->
+            bbt(i, if (i < 6) 36.5 else 36.8)
+        }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId)
+        assertEquals(12, phases.size)
+
+        for (i in 0 until 5) {
+            assertEquals(
+                "day $i should be FOLLICULAR",
+                CyclePhase.FOLLICULAR.value.toDouble(), phases[i].value, 0.0
+            )
+        }
+        assertEquals(
+            "day 5 should be OVULATORY",
+            CyclePhase.OVULATORY.value.toDouble(), phases[5].value, 0.0
+        )
+        for (i in 6 until 12) {
+            assertEquals(
+                "day $i should be LUTEAL",
+                CyclePhase.LUTEAL.value.toDouble(), phases[i].value, 0.0
+            )
+        }
+    }
+
+    @Test
+    fun `emitted readings are CYCLE_PHASE with the inputs sourceId and timestamp`() {
+        val readings = (0 until 12).map { i ->
+            bbt(i, if (i < 6) 36.5 else 36.8)
+        }
+        val phases = CycleInference.deriveCyclePhases(readings, "src-xyz")
+
+        phases.forEach {
+            assertEquals(MetricType.CYCLE_PHASE.key, it.metricType)
+            assertEquals("src-xyz", it.sourceId)
+        }
+        // Per-day timestamps match the underlying BBT row used for that day.
+        for (i in phases.indices) {
+            assertEquals(readings[i].timestamp, phases[i].timestamp)
+        }
+    }
+
+    @Test
+    fun `ignores brief one-day spikes that fall back below the coverline`() {
+        // Day 6 spikes to 36.9 then days 7-8 drop back. No 3-day sustained
+        // rise → no inference. Days 9-11 rise but only 3 days, starting after
+        // the dip — still valid? Let's verify the formal rule: with the first
+        // 6 days baselining at 36.5 (coverline 36.6), days 9,10,11 are at
+        // 36.8 so they DO meet the rule, with rise starting at day 9.
+        val temps = doubleArrayOf(
+            36.5, 36.5, 36.5, 36.5, 36.5, 36.5,  // baseline
+            36.9, 36.5, 36.5,                    // spike then dip
+            36.8, 36.8, 36.8                     // sustained rise
+        )
+        val readings = temps.mapIndexed { i, t -> bbt(i, t) }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId)
+        assertEquals(12, phases.size)
+        // The spike at day 6 should not be classified as the rise start.
+        // Sustained rise starts at day 9 → ovulation = day 8.
+        assertEquals(CyclePhase.OVULATORY.value.toDouble(), phases[8].value, 0.0)
+        assertEquals(CyclePhase.LUTEAL.value.toDouble(), phases[9].value, 0.0)
+        assertEquals(CyclePhase.FOLLICULAR.value.toDouble(), phases[7].value, 0.0)
+    }
+
+    @Test
+    fun `aggregates multiple same-day BBTs to the earliest reading`() {
+        // Same biphasic shape, but each day has two BBTs (morning + later).
+        // Only the morning reading should drive both the daily aggregate and
+        // the timestamp on the emitted phase row.
+        val readings = (0 until 12).flatMap { i ->
+            val morningT = if (i < 6) 36.5 else 36.8
+            listOf(
+                bbt(i, morningT, offsetMs = 6 * 3_600_000L),    // 06:00
+                bbt(i, morningT + 0.3, offsetMs = 14 * 3_600_000L) // 14:00 (warmer)
+            )
+        }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId)
+        assertEquals(12, phases.size)
+        // Phase timestamps come from the morning rows.
+        for (i in 0 until 12) {
+            assertEquals(
+                day0 + i * msPerDay + 6 * 3_600_000L,
+                phases[i].timestamp
+            )
+        }
+        // Phase classification still matches the biphasic shape.
+        assertEquals(CyclePhase.OVULATORY.value.toDouble(), phases[5].value, 0.0)
+        assertEquals(CyclePhase.LUTEAL.value.toDouble(), phases[6].value, 0.0)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -51,6 +51,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
 
     // Women's Health
     BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH),
+    CYCLE_PHASE("cycle_phase", MetricUnit.CATEGORY, MetricDomain.WOMENS_HEALTH),
 
     // Environment (phone-sensor adapter)
     AMBIENT_LIGHT("ambient_light", MetricUnit.LUX, MetricDomain.ENVIRONMENT),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -59,6 +59,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun cycle_phase_is_womens_health_category() {
+        assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.CYCLE_PHASE.domain)
+        assertEquals(MetricUnit.CATEGORY, MetricType.CYCLE_PHASE.unit)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -316,13 +316,34 @@ literature-backed signal) and stay within the manifesto. `sleep_score`
 is parked unless a future condition pattern needs a single-number input
 that can't be expressed as a rule over the components.
 
-### 8.5 Cycle inference from BBT
+### 8.5 Cycle inference from BBT [PARTIAL — cycle_phase shipped, cycle_day deferred]
 
 `basal_body_temperature` is in the schema with no consumer; `cycle_day`
-and `cycle_phase` are planned-but-unimplemented. Implement cycle-phase
-inference in the existing reproductive-health DB (encrypted, independent
-key, independent wipe — already isolated). Writes the two derived keys
-back to the canonical schema gated by reproductive-data consent.
+and `cycle_phase` are planned-but-unimplemented. Cycle-phase inference
+ships now; persistence routing and `cycle_day` follow when their
+prerequisites land.
+
+- `cycle_phase` (WOMENS_HEALTH, CATEGORY) — **shipped.** Implemented as
+  the classic biphasic 3-day rule (Marshall 1968; Barron & Fehring 2005)
+  in `engine/CycleInference.kt`: follicular baseline = mean of the first
+  six daily BBTs, coverline = baseline + 0.1°C, ovulation = the day
+  before three consecutive daily BBTs sit strictly above the coverline.
+  Pure function over `MetricReading` rows — unopinionated about
+  persistence, so the caller routes the derived readings to the encrypted
+  reproductive-health DB once reproductive-data consent is on. Emits
+  FOLLICULAR / OVULATORY / LUTEAL via the `CyclePhase` enum.
+- `cycle_day` — **deferred.** The clinical numbering convention starts
+  cycle day 1 at the first day of menstruation; BBT alone cannot
+  reliably distinguish menstrual from early follicular, so we'd have to
+  fabricate an origin or invent a non-standard numbering. Ships when a
+  menstruation-onset signal exists (manual log, or a wearable that
+  reports it).
+- `MENSTRUAL` is reserved on the `CyclePhase` enum for the same reason.
+
+A BBT writer is still missing (no current adapter emits
+`basal_body_temperature`); the inference is dormant until a writer
+appears, mirroring how `SleepDerivations` waited for SLEEP_STAGE writers
+to come online.
 
 ### 8.6 Lab / biomarker inbound surface
 


### PR DESCRIPTION
## Summary
- Adds `CYCLE_PHASE` (WOMENS_HEALTH, CATEGORY) to `bios-contracts` and ships the classic biphasic 3-day rule in `engine/CycleInference.kt` (Marshall 1968; Barron & Fehring 2005).
- Pure-function derivation sitting next to `SleepDerivations.kt` — unopinionated about persistence, so the caller can route to the encrypted reproductive-health DB once reproductive-data consent is on.
- ROADMAP §8.5 marked PARTIAL: `cycle_phase` shipped; `cycle_day` and `MENSTRUAL` deferred because BBT alone can't distinguish menstrual from early follicular, and the clinical day-1 convention requires a menstruation-onset signal.

## Algorithm
Aggregate BBT to one daily value (earliest sample of each UTC day). Follicular baseline = mean of the first six daily BBTs; coverline = baseline + 0.1°C. Ovulation = the day before three consecutive daily BBTs sit strictly above the coverline. Brief single-day spikes that don't sustain are not classified as ovulation. Returns empty when there are <9 daily samples or no sustained rise is detected.

## Test plan
- [x] `CycleInferenceTest` — empty input, only non-BBT readings, <9 daily BBTs, flat BBT (no rise), classic biphasic shift (full FOLLICULAR/OVULATORY/LUTEAL labelling), spike-then-sustained-rise correctly resolves to the later rise, multiple same-day BBTs aggregate to the earliest reading.
- [x] `MetricTypeTest` — `CYCLE_PHASE` is WOMENS_HEALTH + CATEGORY.
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, `assembleDebug`, full unit test suite all pass.

## Notes
- No current adapter writes `basal_body_temperature`, so the inference is dormant until a BBT writer (manual entry, future wearable adapter) ships — same posture `SleepDerivations` had before SLEEP_STAGE writers came online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)