### PR TITLE
feat: BIOMARKER domain + HBA1C / HSCRP foundation for FHIR import

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -228,6 +228,8 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
     MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
     MetricType.BODY_MASS -> "29463-7" to "Body weight"
+    MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
+    MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
     else -> null
 }
 
@@ -244,6 +246,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.KCAL -> "kcal"
     MetricUnit.KILOGRAMS -> "kg"
     MetricUnit.MG_PER_DL -> "mg/dL"
+    MetricUnit.MG_PER_L -> "mg/L"
     MetricUnit.SCORE -> "{score}"
     MetricUnit.CATEGORY -> "{category}"
     MetricUnit.EVENT -> "{event}"

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -104,9 +104,26 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `13 metric types have LOINC mappings`() {
+    fun `15 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(13, mapped)
+        assertEquals(15, mapped)
+    }
+
+    @Test
+    fun `HbA1c maps to LOINC 4548-4`() {
+        val (code, _) = loincCode(MetricType.HBA1C)!!
+        assertEquals("4548-4", code)
+    }
+
+    @Test
+    fun `hsCRP maps to LOINC 30522-7`() {
+        val (code, _) = loincCode(MetricType.HSCRP)!!
+        assertEquals("30522-7", code)
+    }
+
+    @Test
+    fun `mg per L maps to mg per L UCUM`() {
+        assertEquals("mg/L", ucumCode(MetricType.HSCRP))
     }
 
     // --- UCUM code mappings ---
@@ -196,6 +213,8 @@ class FhirExporterTest {
             MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
             MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
             MetricType.BODY_MASS -> "29463-7" to "Body weight"
+            MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
+            MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
             else -> null
         }
     }
@@ -214,6 +233,7 @@ class FhirExporterTest {
             MetricUnit.KCAL -> "kcal"
             MetricUnit.KILOGRAMS -> "kg"
             MetricUnit.MG_PER_DL -> "mg/dL"
+            MetricUnit.MG_PER_L -> "mg/L"
             MetricUnit.SCORE -> "{score}"
             MetricUnit.CATEGORY -> "{category}"
             MetricUnit.EVENT -> "{event}"

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -56,6 +56,13 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Environment (phone-sensor adapter)
     AMBIENT_LIGHT("ambient_light", MetricUnit.LUX, MetricDomain.ENVIRONMENT),
 
+    // Biomarkers (lab-drawn or imported via FHIR; slow-moving, no streaming).
+    // First wave matches the clinical concepts already described in
+    // alerts/BiomarkerReference.kt — direct readings displace the wearable
+    // proxies when an owner imports labs.
+    HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
+    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER),
+
     // Companion signals (injected by W2F via ContentProvider)
     TYPING_CADENCE("typing_cadence", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
     CIRCADIAN_PHASE_SHIFT("circadian_phase_shift", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
@@ -103,6 +110,7 @@ enum class MetricUnit(val symbol: String) {
     KCAL("kcal"),
     KILOGRAMS("kg"),
     MG_PER_DL("mg/dL"),
+    MG_PER_L("mg/L"),
     SCORE(""),
     EVENT(""),
     LUX("lx")
@@ -111,5 +119,5 @@ enum class MetricUnit(val symbol: String) {
 enum class MetricDomain {
     CARDIOVASCULAR, RESPIRATORY, TEMPERATURE, SLEEP,
     ACTIVITY, METABOLIC, RECOVERY, WOMENS_HEALTH,
-    MENTAL_HEALTH, INTAKE, SAFETY, ENVIRONMENT
+    MENTAL_HEALTH, INTAKE, SAFETY, ENVIRONMENT, BIOMARKER
 }

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -65,6 +65,19 @@ class MetricTypeTest {
     }
 
     @Test
+    fun hba1c_is_biomarker_percent() {
+        assertEquals(MetricDomain.BIOMARKER, MetricType.HBA1C.domain)
+        assertEquals(MetricUnit.PERCENT, MetricType.HBA1C.unit)
+    }
+
+    @Test
+    fun hscrp_is_biomarker_mg_per_l() {
+        assertEquals(MetricDomain.BIOMARKER, MetricType.HSCRP.domain)
+        assertEquals(MetricUnit.MG_PER_L, MetricType.HSCRP.unit)
+        assertEquals("mg/L", MetricUnit.MG_PER_L.symbol)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -345,7 +345,7 @@ A BBT writer is still missing (no current adapter emits
 appears, mirroring how `SleepDerivations` waited for SLEEP_STAGE writers
 to come online.
 
-### 8.6 Lab / biomarker inbound surface
+### 8.6 Lab / biomarker inbound surface [FOUNDATION SHIPPED]
 
 FHIR R4 export is shipped ([§Current State](#current-state-v020)); FHIR
 *import* is the symmetric add. Accept lab results (CBC, lipid, ApoB,
@@ -357,6 +357,30 @@ thresholds already region-config'd per the localization layer).
 No new companion required — the data is canonical multi-system body
 signal, and the import surface is a thin settings flow on top of the
 existing FHIR machinery.
+
+**Foundation (shipped):**
+
+- `BIOMARKER` domain added to `MetricDomain`; `MG_PER_L` added to
+  `MetricUnit` (UCUM "mg/L").
+- First-wave biomarker keys: `HBA1C` (PERCENT, LOINC 4548-4) and
+  `HSCRP` (MG_PER_L, LOINC 30522-7). Both already have clinical-context
+  entries in `alerts/BiomarkerReference.kt`; direct readings will
+  displace the wearable proxies in those references when an owner
+  imports labs.
+- LOINC + UCUM mappings wired in `export/FhirExporter.kt` so the
+  existing FHIR *export* round-trips the new keys today.
+
+**Remaining work (separate PRs):**
+
+- Expanded biomarker wave: CBC (WBC, RBC, hemoglobin, hematocrit,
+  platelets), full lipid panel (total cholesterol, LDL, HDL,
+  triglycerides), ApoB, vitamin D 25-OH, thyroid (TSH, free T4, free T3).
+  Each batch ships with the units it needs (NG_PER_ML, MIU_PER_L,
+  G_PER_DL, etc.) and the matching LOINC codes.
+- FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
+- Manual structured-entry form for owners without a FHIR-emitting lab.
+- Region-aware reference-range expansion in `RegionConfigProvider`'s
+  `ClinicalThresholds`.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
- Lands the contract surface for ROADMAP §8.6 so the FHIR-import and manual-entry PRs that follow have a stable contract to bind to.
- New `BIOMARKER` MetricDomain (lab-drawn / imported, slow-moving, non-streaming — distinct from sensor metrics).
- New `MG_PER_L` MetricUnit, UCUM `mg/L`.
- First-wave biomarker keys: `HBA1C` (PERCENT, LOINC 4548-4) and `HSCRP` (MG_PER_L, LOINC 30522-7). Both already have clinical-context entries in `BiomarkerReference.kt`; direct readings will displace the wearable proxies there when an owner imports labs.
- LOINC + UCUM mappings wired in `FhirExporter` so the existing FHIR *export* round-trips the new keys today. Test mirror updated; mapped-count assertion bumped 13 → 15.

## Why a foundation slice
The full §8.6 scope (FHIR parser + file picker + manual-entry form + region-aware reference ranges + the full biomarker wave) was estimated at ~5 days in the audit. This PR ships the contract foundation alone — small, low-risk, and unblocks the larger pieces without committing to a UI or parser design yet. No SignalQualityFilter bounds (biomarkers are lab-drawn discrete values, same posture as `BODY_FAT_PCT`).

## Test plan
- [x] `MetricTypeTest` — `BIOMARKER` domain present; `HBA1C` (BIOMARKER + PERCENT) and `HSCRP` (BIOMARKER + MG_PER_L); `MG_PER_L.symbol == "mg/L"`.
- [x] `FhirExporterTest` — `HBA1C` → LOINC 4548-4, `HSCRP` → LOINC 30522-7, `MG_PER_L` UCUM `mg/L`, mapped-count = 15, all entries have UCUM, all LOINC mappings have non-empty display names.
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, `assembleDebug`, full unit test suite all pass.

## Remaining §8.6 work (separate PRs)
- Expanded biomarker wave: CBC, full lipid panel, ApoB, vitamin D 25-OH, thyroid panel. Each batch ships with the new units it needs (NG_PER_ML, MIU_PER_L, G_PER_DL, etc.) and matching LOINC codes.
- FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
- Manual structured-entry form for owners without a FHIR-emitting lab.
- Region-aware reference-range expansion in `RegionConfigProvider`'s `ClinicalThresholds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)