### PR TITLE
feat: lipid panel + ApoB biomarker keys for FHIR import

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -230,6 +230,11 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.BODY_MASS -> "29463-7" to "Body weight"
     MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
     MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
+    MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"
+    MetricType.LDL_CHOLESTEROL -> "2089-1" to "Cholesterol in LDL [Mass/volume] in Serum or Plasma"
+    MetricType.HDL_CHOLESTEROL -> "2085-9" to "Cholesterol in HDL [Mass/volume] in Serum or Plasma"
+    MetricType.TRIGLYCERIDES -> "2571-8" to "Triglyceride [Mass/volume] in Serum or Plasma"
+    MetricType.APO_B -> "1884-6" to "Apolipoprotein B [Mass/volume] in Serum or Plasma"
     else -> null
 }
 

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -104,9 +104,9 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `15 metric types have LOINC mappings`() {
+    fun `20 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(15, mapped)
+        assertEquals(20, mapped)
     }
 
     @Test
@@ -119,6 +119,15 @@ class FhirExporterTest {
     fun `hsCRP maps to LOINC 30522-7`() {
         val (code, _) = loincCode(MetricType.HSCRP)!!
         assertEquals("30522-7", code)
+    }
+
+    @Test
+    fun `lipid panel and ApoB map to canonical LOINC codes`() {
+        assertEquals("2093-3", loincCode(MetricType.TOTAL_CHOLESTEROL)!!.first)
+        assertEquals("2089-1", loincCode(MetricType.LDL_CHOLESTEROL)!!.first)
+        assertEquals("2085-9", loincCode(MetricType.HDL_CHOLESTEROL)!!.first)
+        assertEquals("2571-8", loincCode(MetricType.TRIGLYCERIDES)!!.first)
+        assertEquals("1884-6", loincCode(MetricType.APO_B)!!.first)
     }
 
     @Test
@@ -215,6 +224,11 @@ class FhirExporterTest {
             MetricType.BODY_MASS -> "29463-7" to "Body weight"
             MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
             MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
+            MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"
+            MetricType.LDL_CHOLESTEROL -> "2089-1" to "Cholesterol in LDL [Mass/volume] in Serum or Plasma"
+            MetricType.HDL_CHOLESTEROL -> "2085-9" to "Cholesterol in HDL [Mass/volume] in Serum or Plasma"
+            MetricType.TRIGLYCERIDES -> "2571-8" to "Triglyceride [Mass/volume] in Serum or Plasma"
+            MetricType.APO_B -> "1884-6" to "Apolipoprotein B [Mass/volume] in Serum or Plasma"
             else -> null
         }
     }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -62,6 +62,11 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // proxies when an owner imports labs.
     HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
     HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER),
+    TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
 
     // Companion signals (injected by W2F via ContentProvider)
     TYPING_CADENCE("typing_cadence", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -78,6 +78,19 @@ class MetricTypeTest {
     }
 
     @Test
+    fun lipid_panel_and_apob_are_biomarker_mg_per_dl() {
+        val lipids = setOf(
+            MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
+            MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
+            MetricType.APO_B,
+        )
+        for (t in lipids) {
+            assertEquals(MetricDomain.BIOMARKER, t.domain)
+            assertEquals(MetricUnit.MG_PER_DL, t.unit)
+        }
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -370,13 +370,22 @@ existing FHIR machinery.
 - LOINC + UCUM mappings wired in `export/FhirExporter.kt` so the
   existing FHIR *export* round-trips the new keys today.
 
+**Lipid panel + ApoB (shipped):**
+
+- `TOTAL_CHOLESTEROL` (LOINC 2093-3), `LDL_CHOLESTEROL` (LOINC 2089-1),
+  `HDL_CHOLESTEROL` (LOINC 2085-9), `TRIGLYCERIDES` (LOINC 2571-8),
+  `APO_B` (LOINC 1884-6) — all `MG_PER_DL`, all in the BIOMARKER domain.
+  No new units; the existing `MG_PER_DL` covers the entire panel under
+  US conventions. SI-unit (mmol/L) conversion is a localization concern,
+  not a contract change, and is owned by `RegionConfigProvider`.
+
 **Remaining work (separate PRs):**
 
-- Expanded biomarker wave: CBC (WBC, RBC, hemoglobin, hematocrit,
-  platelets), full lipid panel (total cholesterol, LDL, HDL,
-  triglycerides), ApoB, vitamin D 25-OH, thyroid (TSH, free T4, free T3).
-  Each batch ships with the units it needs (NG_PER_ML, MIU_PER_L,
-  G_PER_DL, etc.) and the matching LOINC codes.
+- Vitamin D 25-OH (needs `NG_PER_ML`) and thyroid panel (TSH needs
+  `MIU_PER_L`; free T4 / free T3 each have their own unit conventions).
+- CBC: hemoglobin (`G_PER_DL`), hematocrit (`PERCENT`, exists), WBC /
+  RBC / platelet counts (cell-count unit needs deciding — `10*9/L` is
+  the UCUM-blessed form).
 - FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
 - Manual structured-entry form for owners without a FHIR-emitting lab.
 - Region-aware reference-range expansion in `RegionConfigProvider`'s


### PR DESCRIPTION
## Summary
- Wave 2 of ROADMAP §8.6's biomarker contract surface.
- Adds the full lipid panel and ApoB — all use the existing `MG_PER_DL` unit under US conventions, so this is a pure contract-key addition with no new `MetricUnit` entries.
- `TOTAL_CHOLESTEROL` (LOINC 2093-3), `LDL_CHOLESTEROL` (LOINC 2089-1), `HDL_CHOLESTEROL` (LOINC 2085-9), `TRIGLYCERIDES` (LOINC 2571-8), `APO_B` (LOINC 1884-6 — the canonical ApoB measurement, not the ApoB/ApoA-1 ratio).
- LOINC mappings wired in `FhirExporter` so existing FHIR *export* covers the new keys today. Test mirror updated; mapped-count assertion bumped 15 → 20.
- SI-unit (mmol/L) conversion is a localization concern owned by `RegionConfigProvider`, not a contract change.

## Test plan
- [x] `MetricTypeTest` — all five keys are `BIOMARKER` + `MG_PER_DL`.
- [x] `FhirExporterTest` — each key maps to its canonical LOINC code; mapped-count = 20; all entries still have UCUM; LOINC display names still non-empty.
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, `assembleDebug`, full unit test suite all pass.

## Remaining §8.6 work
- Vitamin D 25-OH (`NG_PER_ML`) and thyroid panel (TSH `MIU_PER_L`; T4 / T3 each have their own unit conventions).
- CBC: hemoglobin (`G_PER_DL`), hematocrit (`PERCENT`, exists), WBC / RBC / platelet counts (cell-count unit needs deciding — `10*9/L` is the UCUM-blessed form).
- FHIR R4 Observation parser + file picker.
- Manual structured-entry form.
- Region-aware reference-range expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)