### PR TITLE
feat: vitamin D + thyroid panel biomarker keys for FHIR import

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -235,6 +235,10 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.HDL_CHOLESTEROL -> "2085-9" to "Cholesterol in HDL [Mass/volume] in Serum or Plasma"
     MetricType.TRIGLYCERIDES -> "2571-8" to "Triglyceride [Mass/volume] in Serum or Plasma"
     MetricType.APO_B -> "1884-6" to "Apolipoprotein B [Mass/volume] in Serum or Plasma"
+    MetricType.VITAMIN_D_25OH -> "14635-7" to "25-hydroxyvitamin D2+D3 [Mass/volume] in Serum or Plasma"
+    MetricType.TSH -> "3016-3" to "Thyrotropin [Units/volume] in Serum or Plasma"
+    MetricType.FREE_T4 -> "3024-7" to "Thyroxine (T4) free [Mass/volume] in Serum or Plasma"
+    MetricType.FREE_T3 -> "3051-0" to "Triiodothyronine (T3) free [Mass/volume] in Serum or Plasma"
     else -> null
 }
 
@@ -252,6 +256,10 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.KILOGRAMS -> "kg"
     MetricUnit.MG_PER_DL -> "mg/dL"
     MetricUnit.MG_PER_L -> "mg/L"
+    MetricUnit.NG_PER_ML -> "ng/mL"
+    MetricUnit.NG_PER_DL -> "ng/dL"
+    MetricUnit.PG_PER_ML -> "pg/mL"
+    MetricUnit.MIU_PER_L -> "m[IU]/L"
     MetricUnit.SCORE -> "{score}"
     MetricUnit.CATEGORY -> "{category}"
     MetricUnit.EVENT -> "{event}"

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -104,9 +104,9 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `20 metric types have LOINC mappings`() {
+    fun `24 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(20, mapped)
+        assertEquals(24, mapped)
     }
 
     @Test
@@ -128,6 +128,22 @@ class FhirExporterTest {
         assertEquals("2085-9", loincCode(MetricType.HDL_CHOLESTEROL)!!.first)
         assertEquals("2571-8", loincCode(MetricType.TRIGLYCERIDES)!!.first)
         assertEquals("1884-6", loincCode(MetricType.APO_B)!!.first)
+    }
+
+    @Test
+    fun `vitamin D and thyroid panel map to canonical LOINC codes`() {
+        assertEquals("14635-7", loincCode(MetricType.VITAMIN_D_25OH)!!.first)
+        assertEquals("3016-3", loincCode(MetricType.TSH)!!.first)
+        assertEquals("3024-7", loincCode(MetricType.FREE_T4)!!.first)
+        assertEquals("3051-0", loincCode(MetricType.FREE_T3)!!.first)
+    }
+
+    @Test
+    fun `new biomarker units map to canonical UCUM codes`() {
+        assertEquals("ng/mL", ucumCode(MetricType.VITAMIN_D_25OH))
+        assertEquals("ng/dL", ucumCode(MetricType.FREE_T4))
+        assertEquals("pg/mL", ucumCode(MetricType.FREE_T3))
+        assertEquals("m[IU]/L", ucumCode(MetricType.TSH))
     }
 
     @Test
@@ -229,6 +245,10 @@ class FhirExporterTest {
             MetricType.HDL_CHOLESTEROL -> "2085-9" to "Cholesterol in HDL [Mass/volume] in Serum or Plasma"
             MetricType.TRIGLYCERIDES -> "2571-8" to "Triglyceride [Mass/volume] in Serum or Plasma"
             MetricType.APO_B -> "1884-6" to "Apolipoprotein B [Mass/volume] in Serum or Plasma"
+            MetricType.VITAMIN_D_25OH -> "14635-7" to "25-hydroxyvitamin D2+D3 [Mass/volume] in Serum or Plasma"
+            MetricType.TSH -> "3016-3" to "Thyrotropin [Units/volume] in Serum or Plasma"
+            MetricType.FREE_T4 -> "3024-7" to "Thyroxine (T4) free [Mass/volume] in Serum or Plasma"
+            MetricType.FREE_T3 -> "3051-0" to "Triiodothyronine (T3) free [Mass/volume] in Serum or Plasma"
             else -> null
         }
     }
@@ -248,6 +268,10 @@ class FhirExporterTest {
             MetricUnit.KILOGRAMS -> "kg"
             MetricUnit.MG_PER_DL -> "mg/dL"
             MetricUnit.MG_PER_L -> "mg/L"
+            MetricUnit.NG_PER_ML -> "ng/mL"
+            MetricUnit.NG_PER_DL -> "ng/dL"
+            MetricUnit.PG_PER_ML -> "pg/mL"
+            MetricUnit.MIU_PER_L -> "m[IU]/L"
             MetricUnit.SCORE -> "{score}"
             MetricUnit.CATEGORY -> "{category}"
             MetricUnit.EVENT -> "{event}"

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -67,6 +67,10 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
     TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
     APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    VITAMIN_D_25OH("vitamin_d_25oh", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
+    TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER),
+    FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
+    FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
 
     // Companion signals (injected by W2F via ContentProvider)
     TYPING_CADENCE("typing_cadence", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
@@ -116,6 +120,10 @@ enum class MetricUnit(val symbol: String) {
     KILOGRAMS("kg"),
     MG_PER_DL("mg/dL"),
     MG_PER_L("mg/L"),
+    NG_PER_ML("ng/mL"),
+    NG_PER_DL("ng/dL"),
+    PG_PER_ML("pg/mL"),
+    MIU_PER_L("mIU/L"),
     SCORE(""),
     EVENT(""),
     LUX("lx")

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -91,6 +91,30 @@ class MetricTypeTest {
     }
 
     @Test
+    fun vitamin_d_25oh_is_biomarker_ng_per_ml() {
+        assertEquals(MetricDomain.BIOMARKER, MetricType.VITAMIN_D_25OH.domain)
+        assertEquals(MetricUnit.NG_PER_ML, MetricType.VITAMIN_D_25OH.unit)
+        assertEquals("ng/mL", MetricUnit.NG_PER_ML.symbol)
+    }
+
+    @Test
+    fun thyroid_panel_uses_canonical_per_assay_units() {
+        // Each assay reports in a different unit by clinical convention —
+        // collapsing them into one unit would force misleading conversions.
+        assertEquals(MetricDomain.BIOMARKER, MetricType.TSH.domain)
+        assertEquals(MetricUnit.MIU_PER_L, MetricType.TSH.unit)
+        assertEquals("mIU/L", MetricUnit.MIU_PER_L.symbol)
+
+        assertEquals(MetricDomain.BIOMARKER, MetricType.FREE_T4.domain)
+        assertEquals(MetricUnit.NG_PER_DL, MetricType.FREE_T4.unit)
+        assertEquals("ng/dL", MetricUnit.NG_PER_DL.symbol)
+
+        assertEquals(MetricDomain.BIOMARKER, MetricType.FREE_T3.domain)
+        assertEquals(MetricUnit.PG_PER_ML, MetricType.FREE_T3.unit)
+        assertEquals("pg/mL", MetricUnit.PG_PER_ML.symbol)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -379,10 +379,20 @@ existing FHIR machinery.
   US conventions. SI-unit (mmol/L) conversion is a localization concern,
   not a contract change, and is owned by `RegionConfigProvider`.
 
+**Vitamin D + thyroid panel (shipped):**
+
+- `VITAMIN_D_25OH` (LOINC 14635-7, `NG_PER_ML`).
+- `TSH` (LOINC 3016-3, `MIU_PER_L` → UCUM `m[IU]/L`).
+- `FREE_T4` (LOINC 3024-7, `NG_PER_DL`).
+- `FREE_T3` (LOINC 3051-0, `PG_PER_ML`).
+
+Each thyroid assay keeps its own clinically-conventional unit — TSH in
+`mIU/L`, free T4 in `ng/dL`, free T3 in `pg/mL`. Collapsing them onto
+one unit would force misleading conversions across reference ranges
+that are already assay-specific.
+
 **Remaining work (separate PRs):**
 
-- Vitamin D 25-OH (needs `NG_PER_ML`) and thyroid panel (TSH needs
-  `MIU_PER_L`; free T4 / free T3 each have their own unit conventions).
 - CBC: hemoglobin (`G_PER_DL`), hematocrit (`PERCENT`, exists), WBC /
   RBC / platelet counts (cell-count unit needs deciding — `10*9/L` is
   the UCUM-blessed form).


### PR DESCRIPTION
## Summary
- Wave 3 of ROADMAP §8.6's biomarker contract surface.
- Four new `MetricUnit` entries: `NG_PER_ML` (ng/mL), `NG_PER_DL` (ng/dL), `PG_PER_ML` (pg/mL), `MIU_PER_L` (UCUM `m[IU]/L`).
- Four new BIOMARKER keys with canonical LOINC codes:
  - `VITAMIN_D_25OH` → 14635-7
  - `TSH` → 3016-3
  - `FREE_T4` → 3024-7
  - `FREE_T3` → 3051-0
- LOINC + UCUM mappings wired in `FhirExporter`; test mirror updated; mapped-count assertion bumped 20 → 24.

## Why per-assay units
Each thyroid assay keeps its own clinically-conventional unit. Collapsing them onto one unit would force misleading conversions across reference ranges that are already assay-specific (TSH `mIU/L` everywhere; free T4 `ng/dL` US / `pmol/L` SI; free T3 `pg/mL` US / `pmol/L` SI). SI ↔ US is a localization concern owned by `RegionConfigProvider`, not a contract change.

## Test plan
- [x] `MetricTypeTest` — vitamin D and each thyroid assay carries the BIOMARKER domain and its canonical unit; UCUM symbols match.
- [x] `FhirExporterTest` — all four LOINC codes; UCUM for the four new units; mapped-count = 24; existing "all UCUM" and "all LOINC displays non-empty" guards still pass.
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, `assembleDebug`, full unit test suite all pass.

## Remaining §8.6 work
- CBC: hemoglobin (`G_PER_DL`), hematocrit (`PERCENT`, exists), WBC / RBC / platelet counts (cell-count unit decision — `10*9/L` is UCUM-blessed).
- FHIR R4 Observation parser + file picker.
- Manual structured-entry form.
- Region-aware reference-range expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)