### PR TITLE
feat: CBC panel biomarker keys for FHIR import

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -239,6 +239,11 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.TSH -> "3016-3" to "Thyrotropin [Units/volume] in Serum or Plasma"
     MetricType.FREE_T4 -> "3024-7" to "Thyroxine (T4) free [Mass/volume] in Serum or Plasma"
     MetricType.FREE_T3 -> "3051-0" to "Triiodothyronine (T3) free [Mass/volume] in Serum or Plasma"
+    MetricType.HEMOGLOBIN -> "718-7" to "Hemoglobin [Mass/volume] in Blood"
+    MetricType.HEMATOCRIT -> "4544-3" to "Hematocrit [Volume Fraction] of Blood by Automated count"
+    MetricType.WBC -> "6690-2" to "Leukocytes [#/volume] in Blood by Automated count"
+    MetricType.RBC -> "789-8" to "Erythrocytes [#/volume] in Blood by Automated count"
+    MetricType.PLATELETS -> "777-3" to "Platelets [#/volume] in Blood by Automated count"
     else -> null
 }
 
@@ -260,6 +265,9 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.NG_PER_DL -> "ng/dL"
     MetricUnit.PG_PER_ML -> "pg/mL"
     MetricUnit.MIU_PER_L -> "m[IU]/L"
+    MetricUnit.G_PER_DL -> "g/dL"
+    MetricUnit.GIGA_PER_L -> "10*9/L"
+    MetricUnit.TERA_PER_L -> "10*12/L"
     MetricUnit.SCORE -> "{score}"
     MetricUnit.CATEGORY -> "{category}"
     MetricUnit.EVENT -> "{event}"

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -104,9 +104,9 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `24 metric types have LOINC mappings`() {
+    fun `29 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(24, mapped)
+        assertEquals(29, mapped)
     }
 
     @Test
@@ -144,6 +144,25 @@ class FhirExporterTest {
         assertEquals("ng/dL", ucumCode(MetricType.FREE_T4))
         assertEquals("pg/mL", ucumCode(MetricType.FREE_T3))
         assertEquals("m[IU]/L", ucumCode(MetricType.TSH))
+    }
+
+    @Test
+    fun `CBC panel maps to canonical LOINC codes`() {
+        assertEquals("718-7", loincCode(MetricType.HEMOGLOBIN)!!.first)
+        assertEquals("4544-3", loincCode(MetricType.HEMATOCRIT)!!.first)
+        assertEquals("6690-2", loincCode(MetricType.WBC)!!.first)
+        assertEquals("789-8", loincCode(MetricType.RBC)!!.first)
+        assertEquals("777-3", loincCode(MetricType.PLATELETS)!!.first)
+    }
+
+    @Test
+    fun `CBC units map to canonical UCUM codes`() {
+        assertEquals("g/dL", ucumCode(MetricType.HEMOGLOBIN))
+        // WBC and platelets share the 10*9/L cell-count unit per CBC convention.
+        assertEquals("10*9/L", ucumCode(MetricType.WBC))
+        assertEquals("10*9/L", ucumCode(MetricType.PLATELETS))
+        // RBC reports in trillions per litre.
+        assertEquals("10*12/L", ucumCode(MetricType.RBC))
     }
 
     @Test
@@ -249,6 +268,11 @@ class FhirExporterTest {
             MetricType.TSH -> "3016-3" to "Thyrotropin [Units/volume] in Serum or Plasma"
             MetricType.FREE_T4 -> "3024-7" to "Thyroxine (T4) free [Mass/volume] in Serum or Plasma"
             MetricType.FREE_T3 -> "3051-0" to "Triiodothyronine (T3) free [Mass/volume] in Serum or Plasma"
+            MetricType.HEMOGLOBIN -> "718-7" to "Hemoglobin [Mass/volume] in Blood"
+            MetricType.HEMATOCRIT -> "4544-3" to "Hematocrit [Volume Fraction] of Blood by Automated count"
+            MetricType.WBC -> "6690-2" to "Leukocytes [#/volume] in Blood by Automated count"
+            MetricType.RBC -> "789-8" to "Erythrocytes [#/volume] in Blood by Automated count"
+            MetricType.PLATELETS -> "777-3" to "Platelets [#/volume] in Blood by Automated count"
             else -> null
         }
     }
@@ -272,6 +296,9 @@ class FhirExporterTest {
             MetricUnit.NG_PER_DL -> "ng/dL"
             MetricUnit.PG_PER_ML -> "pg/mL"
             MetricUnit.MIU_PER_L -> "m[IU]/L"
+            MetricUnit.G_PER_DL -> "g/dL"
+            MetricUnit.GIGA_PER_L -> "10*9/L"
+            MetricUnit.TERA_PER_L -> "10*12/L"
             MetricUnit.SCORE -> "{score}"
             MetricUnit.CATEGORY -> "{category}"
             MetricUnit.EVENT -> "{event}"

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -71,6 +71,11 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER),
     FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
     FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
+    HEMOGLOBIN("hemoglobin", MetricUnit.G_PER_DL, MetricDomain.BIOMARKER),
+    HEMATOCRIT("hematocrit", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
+    WBC("wbc", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
+    RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER),
+    PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
 
     // Companion signals (injected by W2F via ContentProvider)
     TYPING_CADENCE("typing_cadence", MetricUnit.SCORE, MetricDomain.MENTAL_HEALTH),
@@ -124,6 +129,9 @@ enum class MetricUnit(val symbol: String) {
     NG_PER_DL("ng/dL"),
     PG_PER_ML("pg/mL"),
     MIU_PER_L("mIU/L"),
+    G_PER_DL("g/dL"),
+    GIGA_PER_L("10⁹/L"),
+    TERA_PER_L("10¹²/L"),
     SCORE(""),
     EVENT(""),
     LUX("lx")

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -115,6 +115,25 @@ class MetricTypeTest {
     }
 
     @Test
+    fun cbc_panel_uses_canonical_per_assay_units() {
+        assertEquals(MetricDomain.BIOMARKER, MetricType.HEMOGLOBIN.domain)
+        assertEquals(MetricUnit.G_PER_DL, MetricType.HEMOGLOBIN.unit)
+        assertEquals("g/dL", MetricUnit.G_PER_DL.symbol)
+
+        assertEquals(MetricDomain.BIOMARKER, MetricType.HEMATOCRIT.domain)
+        assertEquals(MetricUnit.PERCENT, MetricType.HEMATOCRIT.unit)
+
+        // WBC and platelets share the giga-per-litre cell-count unit.
+        for (t in setOf(MetricType.WBC, MetricType.PLATELETS)) {
+            assertEquals(MetricDomain.BIOMARKER, t.domain)
+            assertEquals(MetricUnit.GIGA_PER_L, t.unit)
+        }
+
+        assertEquals(MetricDomain.BIOMARKER, MetricType.RBC.domain)
+        assertEquals(MetricUnit.TERA_PER_L, MetricType.RBC.unit)
+    }
+
+    @Test
     fun sleep_latency_is_sleep_seconds() {
         assertEquals(MetricDomain.SLEEP, MetricType.SLEEP_LATENCY.domain)
         assertEquals(MetricUnit.SECONDS, MetricType.SLEEP_LATENCY.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -391,11 +391,21 @@ Each thyroid assay keeps its own clinically-conventional unit — TSH in
 one unit would force misleading conversions across reference ranges
 that are already assay-specific.
 
+**CBC panel (shipped):**
+
+- `HEMOGLOBIN` (LOINC 718-7, `G_PER_DL`).
+- `HEMATOCRIT` (LOINC 4544-3, `PERCENT` — existing unit).
+- `WBC` (LOINC 6690-2, `GIGA_PER_L` → UCUM `10*9/L`).
+- `RBC` (LOINC 789-8, `TERA_PER_L` → UCUM `10*12/L`).
+- `PLATELETS` (LOINC 777-3, `GIGA_PER_L`).
+
+WBC and platelets share the giga-per-litre cell-count unit; RBC alone
+uses tera-per-litre. UCUM symbols `10*9/L` and `10*12/L` are the
+canonical exponential forms — naming the enum entries semantically
+(`GIGA_PER_L`, `TERA_PER_L`) keeps Kotlin call sites readable.
+
 **Remaining work (separate PRs):**
 
-- CBC: hemoglobin (`G_PER_DL`), hematocrit (`PERCENT`, exists), WBC /
-  RBC / platelet counts (cell-count unit needs deciding — `10*9/L` is
-  the UCUM-blessed form).
 - FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
 - Manual structured-entry form for owners without a FHIR-emitting lab.
 - Region-aware reference-range expansion in `RegionConfigProvider`'s


### PR DESCRIPTION
## Summary
- Wave 4 of ROADMAP §8.6's biomarker contract surface — the final contract-only wave.
- Three new `MetricUnit` entries: `G_PER_DL` (g/dL), `GIGA_PER_L` (UCUM `10*9/L`), `TERA_PER_L` (UCUM `10*12/L`). UCUM-blessed exponential symbols are the canonical form; enum entries are named semantically so Kotlin call sites stay readable.
- Five new BIOMARKER keys covering the CBC panel:
  - `HEMOGLOBIN` (G_PER_DL, LOINC 718-7)
  - `HEMATOCRIT` (PERCENT — reuses existing unit, LOINC 4544-3)
  - `WBC` (GIGA_PER_L, LOINC 6690-2)
  - `RBC` (TERA_PER_L, LOINC 789-8)
  - `PLATELETS` (GIGA_PER_L, LOINC 777-3)
- WBC and platelets share the giga-per-litre cell-count unit per CBC convention; RBC alone uses tera-per-litre.
- LOINC + UCUM mappings wired in `FhirExporter`; test mirror updated; mapped-count bumped 24 → 29.

## Test plan
- [x] `MetricTypeTest` — each CBC key carries the BIOMARKER domain and its canonical unit; UCUM symbols match.
- [x] `FhirExporterTest` — all five LOINC codes; UCUM for the three new units (g/dL, 10*9/L, 10*12/L); mapped-count = 29; existing "all UCUM" and "all LOINC displays non-empty" guards still pass.
- [x] `./scripts/code-quality-check.sh` — all checks pass.

## Remaining §8.6 work
The remaining work is structural, not more contract additions:
- FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
- Manual structured-entry form for owners without a FHIR-emitting lab.
- Region-aware reference-range expansion in `RegionConfigProvider`'s `ClinicalThresholds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)