### PR TITLE
feat: manual biomarker entry form for self-reported lab values

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
@@ -1,0 +1,60 @@
+package com.bios.app.data
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.DataSource
+import com.bios.app.model.MetricReading
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+
+/**
+ * Persistence path for self-reported lab values entered through the
+ * biomarker entry screen.
+ *
+ * Self-reported readings flow through a single SELF_REPORTED [DataSource]
+ * tagged with [ReadingKind.SELF_REPORTED] so the baseline engine and anomaly
+ * detector keep ignoring them (decision 3 in docs/SELF_REPORTED_DATA_HOME.md).
+ * They still show up in trends, FHIR export, and condition-pattern displays.
+ */
+class BiomarkerEntryRepo(private val db: BiosDatabase) {
+
+    suspend fun add(metricType: MetricType, value: Double, timestamp: Long) {
+        require(metricType.domain == MetricDomain.BIOMARKER) {
+            "BiomarkerEntryRepo only accepts BIOMARKER metrics; got ${metricType.key}"
+        }
+        val sourceId = getOrCreateSelfReportedSource()
+        db.metricReadingDao().insert(
+            MetricReading(
+                metricType = metricType.key,
+                value = value,
+                timestamp = timestamp,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        )
+    }
+
+    suspend fun fetchRecent(limit: Int = 20): List<MetricReading> {
+        val dao = db.metricReadingDao()
+        return MetricType.entries
+            .filter { it.domain == MetricDomain.BIOMARKER }
+            .flatMap { dao.fetchLatest(it.key, limit) }
+            .sortedByDescending { it.timestamp }
+            .take(limit)
+    }
+
+    private suspend fun getOrCreateSelfReportedSource(): String {
+        val dao = db.dataSourceDao()
+        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
+        val source = DataSource(
+            sourceType = SourceType.SELF_REPORTED.key,
+            deviceName = "Self-reported",
+            sensorType = SensorType.DERIVED.name,
+            readingKind = ReadingKind.SELF_REPORTED.name
+        )
+        dao.insert(source)
+        return source.id
+    }
+}

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -17,7 +17,8 @@ enum class SourceType(val key: String) {
     DEXCOM_API("dexcom_api"),
     POLAR_API("polar_api"),
     PHONE_SENSOR("phone_sensor"),
-    CAMERA_PPG("camera_ppg")
+    CAMERA_PPG("camera_ppg"),
+    SELF_REPORTED("self_reported")
 }
 
 enum class SensorType {

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -18,12 +18,14 @@ import com.bios.app.ingest.IngestManager
 import com.bios.app.ingest.OuraApiAdapter
 import com.bios.app.ingest.OuraTokenStore
 import com.bios.app.ingest.PhoneSensorAdapter
+import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.app.model.ActionItem
 import com.bios.app.model.Anomaly
 import com.bios.app.model.HealthEvent
 import com.bios.app.model.HealthEventStatus
 import com.bios.app.model.HealthEventType
 import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.app.model.PersonalBaseline
 import com.bios.app.model.ProfessionalReview
@@ -465,6 +467,30 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     fun submitFeedback(feedback: com.bios.app.model.UserFeedback) {
         viewModelScope.launch {
             db.userFeedbackDao().insert(feedback)
+        }
+    }
+
+    // MARK: - Manual biomarker entry
+
+    val biomarkerEntryRepo = BiomarkerEntryRepo(db)
+
+    private val _recentBiomarkers = MutableStateFlow<List<MetricReading>>(emptyList())
+    val recentBiomarkers: StateFlow<List<MetricReading>> = _recentBiomarkers
+
+    fun refreshRecentBiomarkers(limit: Int = 20) {
+        viewModelScope.launch {
+            _recentBiomarkers.value = biomarkerEntryRepo.fetchRecent(limit)
+        }
+    }
+
+    fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long) {
+        if (metricType.domain != MetricDomain.BIOMARKER) {
+            _error.value = "Manual entry is only supported for biomarker metrics."
+            return
+        }
+        viewModelScope.launch {
+            biomarkerEntryRepo.add(metricType, value, timestamp)
+            _recentBiomarkers.value = biomarkerEntryRepo.fetchRecent(20)
         }
     }
 

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -293,7 +293,14 @@ fun BiosApp(viewModel: AppViewModel) {
                 SettingsScreen(
                     viewModel = viewModel,
                     onNavigateToPrivacy = { navController.navigate("privacy") },
-                    onNavigateToCompanions = { navController.navigate("companions") }
+                    onNavigateToCompanions = { navController.navigate("companions") },
+                    onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") }
+                )
+            }
+            composable("biomarker_entry") {
+                com.bios.app.ui.biomarkers.BiomarkerEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
                 )
             }
             composable("privacy") {

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
@@ -1,0 +1,233 @@
+package com.bios.app.ui.biomarkers
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.AppViewModel
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BiomarkerEntryScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit
+) {
+    val biomarkers = remember {
+        MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }
+    }
+    var selected by remember { mutableStateOf(biomarkers.first()) }
+    var valueText by remember { mutableStateOf("") }
+    var selectedDate by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var pickerExpanded by remember { mutableStateOf(false) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val recent by viewModel.recentBiomarkers.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.refreshRecentBiomarkers() }
+
+    val parsed = valueText.toDoubleOrNull()
+    val isValid = parsed != null && parsed > 0.0
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add lab value") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Self-reported", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(
+                        "Lab values you enter here stay on your device. They show up in trends and FHIR export, " +
+                            "but the baseline engine and anomaly detector ignore them — labs are diagnostic, not streaming.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    ExposedDropdownMenuBox(
+                        expanded = pickerExpanded,
+                        onExpandedChange = { pickerExpanded = it }
+                    ) {
+                        OutlinedTextField(
+                            value = selected.readableName,
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Biomarker") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = pickerExpanded) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                        )
+                        ExposedDropdownMenu(
+                            expanded = pickerExpanded,
+                            onDismissRequest = { pickerExpanded = false }
+                        ) {
+                            biomarkers.forEach { metric ->
+                                DropdownMenuItem(
+                                    text = { Text(metric.readableName) },
+                                    onClick = {
+                                        selected = metric
+                                        pickerExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    OutlinedTextField(
+                        value = valueText,
+                        onValueChange = { valueText = it.filter { c -> c.isDigit() || c == '.' } },
+                        label = { Text("Value") },
+                        suffix = { Text(selected.unit.symbol.ifEmpty { "—" }) },
+                        keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                            keyboardType = KeyboardType.Decimal
+                        ),
+                        singleLine = true,
+                        isError = valueText.isNotEmpty() && !isValid,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    OutlinedButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Drawn on: ${formatDate(selectedDate)}")
+                    }
+
+                    OutlinedButton(
+                        onClick = {
+                            viewModel.addManualBiomarker(selected, parsed!!, selectedDate)
+                            valueText = ""
+                        },
+                        enabled = isValid,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Save")
+                    }
+                }
+            }
+
+            Text("Recent entries", style = MaterialTheme.typography.titleSmall)
+            if (recent.isEmpty()) {
+                Text(
+                    "No lab values entered yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    contentPadding = PaddingValues(vertical = 4.dp)
+                ) {
+                    items(recent, key = { it.id }) { reading ->
+                        RecentBiomarkerRow(reading)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { selectedDate = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+
+@Composable
+private fun RecentBiomarkerRow(reading: MetricReading) {
+    val metric = MetricType.fromKey(reading.metricType)
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Text(
+                metric?.readableName ?: reading.metricType,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "${formatValue(reading.value)} ${metric?.unit?.symbol.orEmpty()}  ·  ${formatDate(reading.timestamp)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
+private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))
+
+private fun formatValue(value: Double): String =
+    if (value == value.toLong().toDouble()) value.toLong().toString()
+    else "%.2f".format(value)

--- a/android/app/src/main/java/com/bios/app/ui/settings/OuraConnectDialog.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/OuraConnectDialog.kt
@@ -1,0 +1,57 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun OuraConnectDialog(
+    onConnect: (token: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var tokenInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Connect Oura Ring") },
+        text = {
+            Column {
+                Text(
+                    "Enter your Oura personal access token. You can create one at cloud.ouraring.com/personal-access-tokens.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("Access Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val trimmed = tokenInput.trim()
+                    if (trimmed.isNotBlank()) onConnect(trimmed)
+                }
+            ) { Text("Connect") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -29,7 +29,8 @@ import kotlinx.coroutines.launch
 fun SettingsScreen(
     viewModel: AppViewModel,
     onNavigateToPrivacy: () -> Unit = {},
-    onNavigateToCompanions: () -> Unit = {}
+    onNavigateToCompanions: () -> Unit = {},
+    onNavigateToBiomarkerEntry: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -109,6 +110,14 @@ fun SettingsScreen(
                     approvedCount = approvedCompanionCount,
                     onClick = onNavigateToCompanions
                 )
+
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = onNavigateToBiomarkerEntry,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Add Lab Values")
+                }
             }
         }
 
@@ -442,40 +451,13 @@ fun SettingsScreen(
     }
 
     if (showOuraDialog) {
-        var tokenInput by remember { mutableStateOf("") }
-        AlertDialog(
-            onDismissRequest = { showOuraDialog = false },
-            title = { Text("Connect Oura Ring") },
-            text = {
-                Column {
-                    Text(
-                        "Enter your Oura personal access token. You can create one at cloud.ouraring.com/personal-access-tokens.",
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = tokenInput,
-                        onValueChange = { tokenInput = it },
-                        label = { Text("Access Token") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
+        OuraConnectDialog(
+            onConnect = { token ->
+                viewModel.ouraTokenStore.saveToken(token)
+                isOuraConnected = true
+                showOuraDialog = false
             },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        if (tokenInput.isNotBlank()) {
-                            viewModel.ouraTokenStore.saveToken(tokenInput.trim())
-                            isOuraConnected = true
-                            showOuraDialog = false
-                        }
-                    }
-                ) { Text("Connect") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showOuraDialog = false }) { Text("Cancel") }
-            }
+            onDismiss = { showOuraDialog = false }
         )
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -1,0 +1,65 @@
+package com.bios.app
+
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the selectors that the biomarker entry surface depends on:
+ *  - the SELF_REPORTED source key string is what gets persisted into the
+ *    data_sources row that owns every manual lab value;
+ *  - filtering MetricType by MetricDomain.BIOMARKER is the canonical way the
+ *    entry screen builds its picker list.
+ *
+ * If either of these silently changes, manually entered lab values get
+ * orphaned or the picker drops biomarkers, and a unit test is the cheapest
+ * place to catch it.
+ */
+class BiomarkerEntrySelectorsTest {
+
+    @Test
+    fun self_reported_source_key_is_stable() {
+        // The key is persisted into data_sources.sourceType for every
+        // manually entered lab; renaming it would orphan existing rows.
+        assertEquals("self_reported", SourceType.SELF_REPORTED.key)
+    }
+
+    @Test
+    fun biomarker_domain_filter_includes_every_shipped_biomarker_key() {
+        val expected = setOf(
+            MetricType.HBA1C, MetricType.HSCRP,
+            MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
+            MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
+            MetricType.APO_B,
+            MetricType.VITAMIN_D_25OH,
+            MetricType.TSH, MetricType.FREE_T4, MetricType.FREE_T3,
+            MetricType.HEMOGLOBIN, MetricType.HEMATOCRIT,
+            MetricType.WBC, MetricType.RBC, MetricType.PLATELETS,
+        )
+        val actual = MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }.toSet()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun biomarker_domain_contains_no_streaming_sensor_keys() {
+        // Spot-check: keys with continuous sensor writers (HR, HRV, sleep, etc.)
+        // must NOT land in BIOMARKER — the entry surface and the
+        // baseline/anomaly engines key off the domain split.
+        val streaming = listOf(
+            MetricType.HEART_RATE,
+            MetricType.HEART_RATE_VARIABILITY,
+            MetricType.BLOOD_GLUCOSE,
+            MetricType.SLEEP_STAGE,
+            MetricType.BODY_MASS,
+        )
+        for (t in streaming) {
+            assertTrue(
+                "${t.key} should not be in BIOMARKER domain",
+                t.domain != MetricDomain.BIOMARKER
+            )
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -404,10 +404,26 @@ uses tera-per-litre. UCUM symbols `10*9/L` and `10*12/L` are the
 canonical exponential forms — naming the enum entries semantically
 (`GIGA_PER_L`, `TERA_PER_L`) keeps Kotlin call sites readable.
 
+**Manual structured-entry form (shipped):**
+
+- `BiomarkerEntryScreen` (`ui/biomarkers/`) reachable from
+  Settings → "Add Lab Values". Owner picks a biomarker (the 16 keys
+  shipped in waves 1–4), enters a numeric value, picks the draw date,
+  saves. Recent entries list at the bottom shows what's been logged.
+- Persistence routes through `BiomarkerEntryRepo` (`data/`): a single
+  `SELF_REPORTED` `DataSource` (new `SourceType.SELF_REPORTED`, sensor
+  type `DERIVED`, `ReadingKind.SELF_REPORTED`) owns every manually
+  entered row. The baseline engine and anomaly detector already filter
+  `kind != SENSOR` (decision 3 in `docs/SELF_REPORTED_DATA_HOME.md`), so
+  lab values show up in trends and FHIR export but never corrupt
+  sensor-derived baselines.
+
 **Remaining work (separate PRs):**
 
 - FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
-- Manual structured-entry form for owners without a FHIR-emitting lab.
+  The manual-entry path proves the write-side of the import flow; the
+  parser inherits the same `BiomarkerEntryRepo` write path so it only
+  has to do the FHIR-side decoding.
 - Region-aware reference-range expansion in `RegionConfigProvider`'s
   `ClinicalThresholds`.
 


### PR DESCRIPTION
## Summary
- Closes the §8.6 write path the four contract waves were dormant without. Owners can enter lab values directly; the FHIR-import PR that follows inherits the same write path and only has to handle the parse side.
- New `BiomarkerEntryScreen` (`ui/biomarkers/`) — biomarker picker over the 16 BIOMARKER keys shipped in waves 1–4, numeric value with the per-key unit suffix, Material3 date picker defaulting to today, save button, recent-entries list. Reachable from **Settings → Add Lab Values**.
- New `BiomarkerEntryRepo` (`data/`) — single `SELF_REPORTED` `DataSource` (new `SourceType.SELF_REPORTED`, sensor type `DERIVED`, `ReadingKind.SELF_REPORTED`) owns every manually entered row. Confidence = `HIGH` (lab-drawn).
- `BaselineEngine` already filters `kind != SENSOR` per decision 3 in `docs/SELF_REPORTED_DATA_HOME.md`, so lab values show up in trends and FHIR export without corrupting sensor-derived baselines.

## Housekeeping
- Extracted `OuraConnectDialog` out of `SettingsScreen` — it was at 499/500 lines, so the "Add Lab Values" button needed room.
- `AppViewModel` grew thin wrappers around the repo plus a `recentBiomarkers` `StateFlow`.

## Test plan
- [x] `BiomarkerEntrySelectorsTest` — `SELF_REPORTED.key == "self_reported"` (renaming orphans existing rows); BIOMARKER-domain filter returns exactly the 16 expected keys (gaining/losing one silently is the failure mode); spot-check that streaming sensor keys aren't in `BIOMARKER`.
- [x] `./scripts/code-quality-check.sh` — file length (all under 500 after the OuraConnectDialog extraction), secrets, lint, `assembleDebug`, full unit test suite all pass.
- [ ] **Not run on device/emulator.** The screen layout, dropdown behaviour, and date picker should be smoke-tested before relying on this in production. Flagging explicitly because Bios's CLAUDE.md asks for honest reporting on UI changes.

## Remaining §8.6 work
- FHIR R4 Observation parser: file picker + LOINC → MetricType mapping. Will plug into the same `BiomarkerEntryRepo` write path.
- Region-aware reference-range expansion in `RegionConfigProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)