### PR TITLE
feat: FHIR R4 Observation import for biomarker readings

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
@@ -1,0 +1,211 @@
+package com.bios.app.export
+
+import android.content.Context
+import android.net.Uri
+import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import java.time.Instant
+
+/**
+ * Reads a FHIR R4 JSON file (Bundle or single Observation) and routes
+ * recognised lab values into [BiomarkerEntryRepo].
+ *
+ * Lives next to [FhirExporter] and shares its LOINC table — the reverse map
+ * is built by scanning [MetricType.entries] through [loincCode], so the
+ * export and import sides never drift.
+ *
+ * Skip-and-report semantics: a malformed Observation never aborts the
+ * import. Each rejection is captured in [FhirImportSummary.skipped] with a
+ * human-readable reason, so the owner sees what didn't make it through.
+ */
+object FhirImporter {
+
+    /** LOINC code -> MetricType, derived from the export-side table. */
+    val loincToMetricType: Map<String, MetricType> by lazy {
+        buildMap {
+            for (type in MetricType.entries) {
+                val pair = loincCode(type) ?: continue
+                put(pair.first, type)
+            }
+        }
+    }
+
+    /**
+     * Read a FHIR JSON file from [uri], parse it, and write every accepted
+     * biomarker reading via [repo]. Returns a summary of what was accepted,
+     * skipped, or unparseable.
+     */
+    suspend fun importFromUri(
+        context: Context,
+        uri: Uri,
+        repo: BiomarkerEntryRepo
+    ): FhirImportSummary = withContext(Dispatchers.IO) {
+        val text = readUriToString(context, uri)
+            ?: return@withContext FhirImportSummary.fileError("Could not read selected file")
+
+        val summary = parse(text)
+        for (reading in summary.accepted) {
+            repo.add(reading.metricType, reading.value, reading.timestamp)
+        }
+        summary
+    }
+
+    /** Pure parse over a FHIR JSON string. No I/O, no DB. */
+    fun parse(json: String): FhirImportSummary {
+        val root = try {
+            JSONObject(json)
+        } catch (e: JSONException) {
+            return FhirImportSummary.fileError("Not valid JSON: ${e.message}")
+        }
+
+        val resourceType = root.optString("resourceType")
+        val observations = when (resourceType) {
+            "Bundle" -> extractBundleObservations(root)
+            "Observation" -> listOf(root)
+            else -> return FhirImportSummary.fileError(
+                "Unsupported resourceType \"$resourceType\" — expected Bundle or Observation"
+            )
+        }
+
+        val accepted = mutableListOf<AcceptedReading>()
+        val skipped = mutableListOf<SkippedObservation>()
+        for (obs in observations) {
+            when (val outcome = parseObservation(obs)) {
+                is ParseOutcome.Accepted -> accepted += outcome.reading
+                is ParseOutcome.Skipped -> skipped += outcome.skipped
+            }
+        }
+        return FhirImportSummary(accepted = accepted, skipped = skipped, fileError = null)
+    }
+
+    private fun extractBundleObservations(bundle: JSONObject): List<JSONObject> {
+        val entries = bundle.optJSONArray("entry") ?: return emptyList()
+        val out = mutableListOf<JSONObject>()
+        for (i in 0 until entries.length()) {
+            val resource = entries.optJSONObject(i)?.optJSONObject("resource") ?: continue
+            if (resource.optString("resourceType") == "Observation") out += resource
+        }
+        return out
+    }
+
+    private fun parseObservation(obs: JSONObject): ParseOutcome {
+        val loinc = findLoincCode(obs.optJSONObject("code")?.optJSONArray("coding"))
+            ?: return ParseOutcome.Skipped(
+                SkippedObservation("No LOINC coding on Observation", loincCode = null)
+            )
+
+        val metric = loincToMetricType[loinc]
+            ?: return ParseOutcome.Skipped(
+                SkippedObservation("LOINC $loinc not mapped to a Bios MetricType", loincCode = loinc)
+            )
+
+        if (metric.domain != MetricDomain.BIOMARKER) {
+            return ParseOutcome.Skipped(
+                SkippedObservation(
+                    "${metric.key} is not a biomarker — only biomarkers import through this surface",
+                    loincCode = loinc
+                )
+            )
+        }
+
+        val valueQuantity = obs.optJSONObject("valueQuantity")
+            ?: return ParseOutcome.Skipped(
+                SkippedObservation("Observation has no valueQuantity", loincCode = loinc)
+            )
+        if (!valueQuantity.has("value")) {
+            return ParseOutcome.Skipped(
+                SkippedObservation("valueQuantity missing numeric value", loincCode = loinc)
+            )
+        }
+        val value = valueQuantity.optDouble("value", Double.NaN)
+        if (value.isNaN() || value <= 0.0) {
+            return ParseOutcome.Skipped(
+                SkippedObservation("Non-positive or non-numeric value", loincCode = loinc)
+            )
+        }
+
+        val timestamp = readEffectiveDateTime(obs)
+            ?: return ParseOutcome.Skipped(
+                SkippedObservation(
+                    "Missing or unparseable effectiveDateTime / issued", loincCode = loinc
+                )
+            )
+
+        return ParseOutcome.Accepted(AcceptedReading(metric, value, timestamp))
+    }
+
+    private fun findLoincCode(coding: JSONArray?): String? {
+        if (coding == null) return null
+        for (i in 0 until coding.length()) {
+            val entry = coding.optJSONObject(i) ?: continue
+            if (entry.optString("system") == "http://loinc.org") {
+                val code = entry.optString("code")
+                if (code.isNotBlank()) return code
+            }
+        }
+        return null
+    }
+
+    private fun readEffectiveDateTime(obs: JSONObject): Long? {
+        val candidates = listOf(
+            obs.optString("effectiveDateTime"),
+            obs.optString("issued"),
+            obs.optJSONObject("effectivePeriod")?.optString("start").orEmpty()
+        )
+        for (s in candidates) {
+            if (s.isBlank()) continue
+            try {
+                return Instant.parse(s).toEpochMilli()
+            } catch (_: Exception) {
+                // try next candidate
+            }
+        }
+        return null
+    }
+
+    private fun readUriToString(context: Context, uri: Uri): String? = try {
+        context.contentResolver.openInputStream(uri)?.use { it.readBytes().decodeToString() }
+    } catch (_: Exception) {
+        null
+    }
+
+    private sealed class ParseOutcome {
+        data class Accepted(val reading: AcceptedReading) : ParseOutcome()
+        data class Skipped(val skipped: SkippedObservation) : ParseOutcome()
+    }
+}
+
+data class AcceptedReading(
+    val metricType: MetricType,
+    val value: Double,
+    val timestamp: Long
+)
+
+data class SkippedObservation(
+    val reason: String,
+    val loincCode: String? = null
+)
+
+data class FhirImportSummary(
+    val accepted: List<AcceptedReading>,
+    val skipped: List<SkippedObservation>,
+    val fileError: String?
+) {
+    val acceptedCount: Int get() = accepted.size
+    val skippedCount: Int get() = skipped.size
+    val isFileError: Boolean get() = fileError != null
+
+    companion object {
+        fun fileError(message: String) = FhirImportSummary(
+            accepted = emptyList(),
+            skipped = emptyList(),
+            fileError = message
+        )
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
@@ -1,5 +1,7 @@
 package com.bios.app.ui.biomarkers
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DatePicker
@@ -37,15 +40,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.bios.app.export.FhirImportSummary
+import com.bios.app.export.FhirImporter
 import com.bios.app.model.MetricReading
 import com.bios.app.ui.AppViewModel
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -64,7 +72,31 @@ fun BiomarkerEntryScreen(
     var selectedDate by remember { mutableLongStateOf(System.currentTimeMillis()) }
     var pickerExpanded by remember { mutableStateOf(false) }
     var showDatePicker by remember { mutableStateOf(false) }
+    var importing by remember { mutableStateOf(false) }
+    var importSummary by remember { mutableStateOf<FhirImportSummary?>(null) }
     val recent by viewModel.recentBiomarkers.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val fhirLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            importing = true
+            scope.launch {
+                try {
+                    importSummary = FhirImporter.importFromUri(
+                        context = context,
+                        uri = uri,
+                        repo = viewModel.biomarkerEntryRepo
+                    )
+                    viewModel.refreshRecentBiomarkers()
+                } finally {
+                    importing = false
+                }
+            }
+        }
+    }
 
     LaunchedEffect(Unit) { viewModel.refreshRecentBiomarkers() }
 
@@ -163,6 +195,29 @@ fun BiomarkerEntryScreen(
                 }
             }
 
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Import from FHIR", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(
+                        "Bring in lab results as a FHIR R4 JSON Bundle (Observation resources). " +
+                            "Codes outside Bios's biomarker set are skipped and reported back.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    OutlinedButton(
+                        onClick = {
+                            fhirLauncher.launch(
+                                arrayOf("application/json", "application/fhir+json", "*/*")
+                            )
+                        },
+                        enabled = !importing,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(if (importing) "Importing…" else "Pick a FHIR file")
+                    }
+                }
+            }
+
             Text("Recent entries", style = MaterialTheme.typography.titleSmall)
             if (recent.isEmpty()) {
                 Text(
@@ -200,6 +255,57 @@ fun BiomarkerEntryScreen(
             DatePicker(state = state)
         }
     }
+
+    importSummary?.let { summary ->
+        FhirImportSummaryDialog(summary = summary, onDismiss = { importSummary = null })
+    }
+}
+
+@Composable
+private fun FhirImportSummaryDialog(summary: FhirImportSummary, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                if (summary.isFileError) "Import failed"
+                else "Imported ${summary.acceptedCount} reading" +
+                    if (summary.acceptedCount == 1) "" else "s"
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (summary.isFileError) {
+                    Text(summary.fileError!!, style = MaterialTheme.typography.bodyMedium)
+                } else {
+                    if (summary.acceptedCount > 0) {
+                        Text(
+                            summary.accepted.joinToString("\n") { r ->
+                                val mt = r.metricType
+                                "• ${mt.readableName}: ${"%.2f".format(r.value)} ${mt.unit.symbol}"
+                            },
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                    if (summary.skippedCount > 0) {
+                        Text(
+                            "Skipped ${summary.skippedCount}:",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            summary.skipped.joinToString("\n") { s ->
+                                val code = s.loincCode?.let { " [$it]" } ?: ""
+                                "• ${s.reason}$code"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Close") } }
+    )
 }
 
 @Composable

--- a/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
@@ -1,0 +1,249 @@
+package com.bios.app
+
+import com.bios.app.export.FhirImporter
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FhirImporterTest {
+
+    // -- Reverse LOINC table --
+
+    @Test
+    fun `reverse LOINC table is the inverse of FhirExporter loincCode for every biomarker`() {
+        val biomarkers = MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }
+        // Every shipped biomarker has a LOINC mapping on the export side.
+        for (type in biomarkers) {
+            val pair = com.bios.app.export.loincCode(type)
+            assertNotNull("${type.key} should have a LOINC mapping", pair)
+            val code = pair!!.first
+            assertEquals(
+                "Reverse lookup for $code should resolve back to ${type.key}",
+                type,
+                FhirImporter.loincToMetricType[code]
+            )
+        }
+    }
+
+    @Test
+    fun `reverse LOINC table has no duplicate LOINC codes across MetricType entries`() {
+        val codes = MetricType.entries.mapNotNull { com.bios.app.export.loincCode(it)?.first }
+        assertEquals(
+            "Each LOINC code should map to exactly one MetricType",
+            codes.toSet().size,
+            codes.size
+        )
+    }
+
+    // -- Single Observation --
+
+    @Test
+    fun `parses a single HbA1c Observation`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [
+                  { "system": "http://loinc.org", "code": "4548-4", "display": "HbA1c" }
+                ]
+              },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4, "unit": "%", "code": "%" }
+            }
+        """.trimIndent()
+
+        val summary = FhirImporter.parse(json)
+        assertNull(summary.fileError)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(0, summary.skippedCount)
+        val r = summary.accepted.single()
+        assertEquals(MetricType.HBA1C, r.metricType)
+        assertEquals(5.4, r.value, 1e-9)
+        assertEquals(java.time.Instant.parse("2024-12-01T08:30:00Z").toEpochMilli(), r.timestamp)
+    }
+
+    // -- Bundle --
+
+    @Test
+    fun `parses a Bundle containing multiple Observations`() {
+        val json = """
+            {
+              "resourceType": "Bundle",
+              "type": "collection",
+              "entry": [
+                { "resource": ${observation("4548-4", 5.4, "2024-12-01T08:30:00Z")} },
+                { "resource": ${observation("30522-7", 1.2, "2024-12-01T08:30:00Z")} },
+                { "resource": ${observation("2089-1", 95.0, "2024-12-01T08:30:00Z")} }
+              ]
+            }
+        """.trimIndent()
+
+        val summary = FhirImporter.parse(json)
+        assertNull(summary.fileError)
+        assertEquals(3, summary.acceptedCount)
+        val types = summary.accepted.map { it.metricType }.toSet()
+        assertEquals(
+            setOf(MetricType.HBA1C, MetricType.HSCRP, MetricType.LDL_CHOLESTEROL),
+            types
+        )
+    }
+
+    @Test
+    fun `Bundle entries without resource or non-Observation resources are ignored silently`() {
+        val json = """
+            {
+              "resourceType": "Bundle",
+              "entry": [
+                { "request": { "method": "GET", "url": "Patient/1" } },
+                { "resource": { "resourceType": "Patient", "id": "1" } },
+                { "resource": ${observation("4548-4", 5.4, "2024-12-01T00:00:00Z")} }
+              ]
+            }
+        """.trimIndent()
+
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(0, summary.skippedCount) // non-Observation entries don't show as "skipped" — they're not labs
+    }
+
+    // -- Skip + report --
+
+    @Test
+    fun `Observation without LOINC coding is skipped with reason`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "code": { "coding": [
+                { "system": "https://bios.health/metrics", "code": "hba1c" }
+              ] },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4 }
+            }
+        """.trimIndent()
+
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        assertTrue(summary.skipped.single().reason.contains("LOINC"))
+    }
+
+    @Test
+    fun `unmapped LOINC code is skipped and reports the code so the owner can see it`() {
+        val json = observation("99999-9", 1.0, "2024-12-01T00:00:00Z")
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        val skipped = summary.skipped.single()
+        assertEquals("99999-9", skipped.loincCode)
+        assertTrue(skipped.reason.contains("99999-9"))
+    }
+
+    @Test
+    fun `non-biomarker LOINC mapping is rejected by the entry surface`() {
+        // 8867-4 maps to HEART_RATE, which is CARDIOVASCULAR not BIOMARKER.
+        // The importer should reject it even though there's a valid mapping —
+        // labs-only is the contract of this entry surface.
+        val json = observation("8867-4", 72.0, "2024-12-01T00:00:00Z")
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        assertTrue(summary.skipped.single().reason.contains("not a biomarker"))
+    }
+
+    @Test
+    fun `Observation without valueQuantity is skipped`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "code": { "coding": [ { "system": "http://loinc.org", "code": "4548-4" } ] },
+              "effectiveDateTime": "2024-12-01T00:00:00Z"
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        assertTrue(summary.skipped.single().reason.contains("valueQuantity"))
+    }
+
+    @Test
+    fun `Observation with zero or negative value is skipped`() {
+        val zero = observation("4548-4", 0.0, "2024-12-01T00:00:00Z")
+        val negative = observation("4548-4", -1.5, "2024-12-01T00:00:00Z")
+        for (json in listOf(zero, negative)) {
+            val summary = FhirImporter.parse(json)
+            assertEquals(0, summary.acceptedCount)
+            assertEquals(1, summary.skippedCount)
+        }
+    }
+
+    @Test
+    fun `Observation without any parseable date is skipped`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "code": { "coding": [ { "system": "http://loinc.org", "code": "4548-4" } ] },
+              "valueQuantity": { "value": 5.4 }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        assertTrue(summary.skipped.single().reason.contains("effectiveDateTime"))
+    }
+
+    @Test
+    fun `falls back from effectiveDateTime to issued when effectiveDateTime is absent`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "code": { "coding": [ { "system": "http://loinc.org", "code": "4548-4" } ] },
+              "issued": "2024-12-01T10:00:00Z",
+              "valueQuantity": { "value": 5.4 }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(
+            java.time.Instant.parse("2024-12-01T10:00:00Z").toEpochMilli(),
+            summary.accepted.single().timestamp
+        )
+    }
+
+    // -- File-level errors --
+
+    @Test
+    fun `malformed JSON returns a fileError`() {
+        val summary = FhirImporter.parse("not actually json")
+        assertNotNull(summary.fileError)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(0, summary.skippedCount)
+    }
+
+    @Test
+    fun `non-FHIR root resourceType returns a fileError`() {
+        val summary = FhirImporter.parse("""{ "resourceType": "Patient", "id": "abc" }""")
+        assertNotNull(summary.fileError)
+        assertTrue(summary.fileError!!.contains("Bundle or Observation"))
+    }
+
+    // -- Fixture helpers --
+
+    private fun observation(loinc: String, value: Double, instant: String) = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": {
+            "coding": [
+              { "system": "http://loinc.org", "code": "$loinc" }
+            ]
+          },
+          "effectiveDateTime": "$instant",
+          "valueQuantity": { "value": $value }
+        }
+    """.trimIndent()
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -358,74 +358,52 @@ No new companion required — the data is canonical multi-system body
 signal, and the import surface is a thin settings flow on top of the
 existing FHIR machinery.
 
-**Foundation (shipped):**
+**16 biomarker keys shipped** across four waves in
+`bios-contracts/MetricType` (`MetricDomain.BIOMARKER`), each with its
+canonical LOINC + UCUM mapping wired into `export/FhirExporter.kt`:
 
-- `BIOMARKER` domain added to `MetricDomain`; `MG_PER_L` added to
-  `MetricUnit` (UCUM "mg/L").
-- First-wave biomarker keys: `HBA1C` (PERCENT, LOINC 4548-4) and
-  `HSCRP` (MG_PER_L, LOINC 30522-7). Both already have clinical-context
-  entries in `alerts/BiomarkerReference.kt`; direct readings will
-  displace the wearable proxies in those references when an owner
-  imports labs.
-- LOINC + UCUM mappings wired in `export/FhirExporter.kt` so the
-  existing FHIR *export* round-trips the new keys today.
+| Wave | Keys | Units added |
+|------|------|-------------|
+| Foundation | `HBA1C` (4548-4), `HSCRP` (30522-7) | `MG_PER_L` |
+| Lipid + ApoB | `TOTAL_CHOLESTEROL` (2093-3), `LDL_CHOLESTEROL` (2089-1), `HDL_CHOLESTEROL` (2085-9), `TRIGLYCERIDES` (2571-8), `APO_B` (1884-6) | — (reuses `MG_PER_DL`) |
+| Vit D + thyroid | `VITAMIN_D_25OH` (14635-7), `TSH` (3016-3), `FREE_T4` (3024-7), `FREE_T3` (3051-0) | `NG_PER_ML`, `NG_PER_DL`, `PG_PER_ML`, `MIU_PER_L` |
+| CBC panel | `HEMOGLOBIN` (718-7), `HEMATOCRIT` (4544-3), `WBC` (6690-2), `RBC` (789-8), `PLATELETS` (777-3) | `G_PER_DL`, `GIGA_PER_L` (UCUM `10*9/L`), `TERA_PER_L` (UCUM `10*12/L`) |
 
-**Lipid panel + ApoB (shipped):**
+Each thyroid assay keeps its own clinically-conventional unit (TSH
+`mIU/L`, free T4 `ng/dL`, free T3 `pg/mL`); collapsing onto one unit
+would force misleading conversions across assay-specific reference
+ranges. SI ↔ US conversions are a localization concern owned by
+`RegionConfigProvider`, not contract changes.
 
-- `TOTAL_CHOLESTEROL` (LOINC 2093-3), `LDL_CHOLESTEROL` (LOINC 2089-1),
-  `HDL_CHOLESTEROL` (LOINC 2085-9), `TRIGLYCERIDES` (LOINC 2571-8),
-  `APO_B` (LOINC 1884-6) — all `MG_PER_DL`, all in the BIOMARKER domain.
-  No new units; the existing `MG_PER_DL` covers the entire panel under
-  US conventions. SI-unit (mmol/L) conversion is a localization concern,
-  not a contract change, and is owned by `RegionConfigProvider`.
+**Write path (shipped):** `BiomarkerEntryRepo` (`data/`) wraps a single
+`SELF_REPORTED` `DataSource` (new `SourceType.SELF_REPORTED`,
+`ReadingKind.SELF_REPORTED`). `BaselineEngine` already filters
+`kind != SENSOR` per decision 3 in `docs/SELF_REPORTED_DATA_HOME.md`,
+so lab values show up in trends and FHIR export but never corrupt
+sensor-derived baselines.
 
-**Vitamin D + thyroid panel (shipped):**
+**Manual entry (shipped):** `BiomarkerEntryScreen` (`ui/biomarkers/`)
+reachable from Settings → "Add Lab Values". Picker over the 16
+biomarkers, numeric value with the per-key unit suffix, Material3
+date picker, recent-entries list.
 
-- `VITAMIN_D_25OH` (LOINC 14635-7, `NG_PER_ML`).
-- `TSH` (LOINC 3016-3, `MIU_PER_L` → UCUM `m[IU]/L`).
-- `FREE_T4` (LOINC 3024-7, `NG_PER_DL`).
-- `FREE_T3` (LOINC 3051-0, `PG_PER_ML`).
-
-Each thyroid assay keeps its own clinically-conventional unit — TSH in
-`mIU/L`, free T4 in `ng/dL`, free T3 in `pg/mL`. Collapsing them onto
-one unit would force misleading conversions across reference ranges
-that are already assay-specific.
-
-**CBC panel (shipped):**
-
-- `HEMOGLOBIN` (LOINC 718-7, `G_PER_DL`).
-- `HEMATOCRIT` (LOINC 4544-3, `PERCENT` — existing unit).
-- `WBC` (LOINC 6690-2, `GIGA_PER_L` → UCUM `10*9/L`).
-- `RBC` (LOINC 789-8, `TERA_PER_L` → UCUM `10*12/L`).
-- `PLATELETS` (LOINC 777-3, `GIGA_PER_L`).
-
-WBC and platelets share the giga-per-litre cell-count unit; RBC alone
-uses tera-per-litre. UCUM symbols `10*9/L` and `10*12/L` are the
-canonical exponential forms — naming the enum entries semantically
-(`GIGA_PER_L`, `TERA_PER_L`) keeps Kotlin call sites readable.
-
-**Manual structured-entry form (shipped):**
-
-- `BiomarkerEntryScreen` (`ui/biomarkers/`) reachable from
-  Settings → "Add Lab Values". Owner picks a biomarker (the 16 keys
-  shipped in waves 1–4), enters a numeric value, picks the draw date,
-  saves. Recent entries list at the bottom shows what's been logged.
-- Persistence routes through `BiomarkerEntryRepo` (`data/`): a single
-  `SELF_REPORTED` `DataSource` (new `SourceType.SELF_REPORTED`, sensor
-  type `DERIVED`, `ReadingKind.SELF_REPORTED`) owns every manually
-  entered row. The baseline engine and anomaly detector already filter
-  `kind != SENSOR` (decision 3 in `docs/SELF_REPORTED_DATA_HOME.md`), so
-  lab values show up in trends and FHIR export but never corrupt
-  sensor-derived baselines.
+**FHIR Observation import (shipped):** `FhirImporter` (`export/`)
+reads a FHIR R4 JSON file (Bundle or single Observation), extracts
+LOINC + `valueQuantity` + date (with `issued` / `effectivePeriod.start`
+fallbacks), and routes accepted readings through the same
+`BiomarkerEntryRepo` write path. The LOINC → MetricType reverse map is
+built by scanning `MetricType.entries` through `loincCode()`, so
+export and import sides never drift. Skip-and-report semantics: every
+rejection (no LOINC coding, unmapped code, non-biomarker mapping,
+missing `valueQuantity`, unparseable date) is captured in
+`FhirImportSummary.skipped` with a reason and the offending LOINC.
+UI: "Import from FHIR" card on the entry screen with a SAF file
+picker + summary dialog.
 
 **Remaining work (separate PRs):**
 
-- FHIR R4 Observation parser: file picker + LOINC → MetricType mapping.
-  The manual-entry path proves the write-side of the import flow; the
-  parser inherits the same `BiomarkerEntryRepo` write path so it only
-  has to do the FHIR-side decoding.
 - Region-aware reference-range expansion in `RegionConfigProvider`'s
-  `ClinicalThresholds`.
+  `ClinicalThresholds` (the last piece of §8.6).
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Closes the §8.6 read loop end-to-end. Owners can import lab results straight from a FHIR file rather than re-typing every value.

- `FhirImporter` (`export/`, next to `FhirExporter`) reads a FHIR R4 JSON file (Bundle or single Observation) and extracts each Observation's LOINC code, `valueQuantity.value`, and date (`effectiveDateTime` / `issued` / `effectivePeriod.start` fallbacks).
- Reverse LOINC → MetricType map is built by scanning `MetricType.entries` through the existing `FhirExporter.loincCode()` — single source of truth, so export and import sides never drift.
- Accepted readings flow through `BiomarkerEntryRepo`, so imported labs get the same `SELF_REPORTED` source attribution and the same exclusion from sensor baselines as values entered through the manual form.
- **Skip-and-report semantics**: every rejection (no LOINC coding, unmapped code, non-biomarker mapping, missing `valueQuantity`, non-positive value, unparseable date) is captured in `FhirImportSummary.skipped` with a reason and the offending LOINC.
- UI: "Import from FHIR" card on `BiomarkerEntryScreen` with a SAF file picker and a summary dialog enumerating accepted readings and skip reasons.

## Test plan
- [x] `FhirImporterTest` — 14 cases covering: reverse-map round-trip through `loincCode()` for every biomarker (single source of truth); LOINC table has no duplicates; single-Observation parse; Bundle parse with multiple entries; Bundle entries without `resource` / non-Observation resources skipped silently; non-biomarker LOINC (e.g. heart rate 8867-4) rejected with reason; unmapped LOINC reports the offending code; missing `valueQuantity` / zero or negative value / missing date skipped with reason; falls back to `issued` when `effectiveDateTime` absent; malformed JSON returns a `fileError`; non-FHIR `resourceType` returns a `fileError`.
- [x] `./scripts/code-quality-check.sh` — all checks pass. ROADMAP §8.6 was compacted into a single waves table to stay under the 500-line cap after this update.
- [ ] **Not run on device/emulator.** SAF file picker, import progress state, and summary dialog layout should be smoke-tested before relying on this.
- **Encrypted FHIR exports** (`EncryptedExporter` format) are not handled; plaintext only.

## Remaining §8.6 work
Just region-aware reference-range expansion in `RegionConfigProvider`'s `ClinicalThresholds`. The structural work for §8.6 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)