### PR TITLE
feat: BiomarkerReference knows when a direct lab key exists

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt
@@ -3,13 +3,20 @@ package com.bios.app.alerts
 import com.bios.contracts.MetricType
 
 /**
- * Maps a clinical biomarker tracked in longevity research to the wearable-derived
- * proxy metrics that Bios can monitor. Informational only — never prescriptive.
+ * Maps a clinical biomarker tracked in longevity research to (a) the
+ * wearable-derived proxy metrics that Bios infers from, and (b) the
+ * canonical lab reading itself when the owner has imported or entered one.
+ * Informational only — never prescriptive.
+ *
+ * [directMetric] is non-null when Bios ships a canonical lab key for the
+ * biomarker (e.g. `HSCRP`, `HBA1C`). When it's tracked the reference card
+ * surfaces the direct reading instead of (or in addition to) the proxies.
  */
 data class BiomarkerReference(
     val id: String,
     val clinicalName: String,
     val description: String,
+    val directMetric: MetricType? = null,
     val proxyMetrics: List<MetricType>,
     val proxyExplanation: String,
     val normalRange: String,
@@ -28,12 +35,13 @@ object BiomarkerReferences {
     }
 
     fun forMetric(metricType: MetricType): List<BiomarkerReference> =
-        all.filter { metricType in it.proxyMetrics }
+        all.filter { metricType in it.proxyMetrics || metricType == it.directMetric }
 
     val inflammation = BiomarkerReference(
         id = "hscrp_inflammation",
         clinicalName = "hsCRP (High-Sensitivity C-Reactive Protein)",
         description = "A blood marker of systemic inflammation. Elevated hsCRP is associated with increased cardiovascular risk, infection, and chronic disease progression.",
+        directMetric = MetricType.HSCRP,
         proxyMetrics = listOf(
             MetricType.RESTING_HEART_RATE,
             MetricType.HEART_RATE_VARIABILITY
@@ -53,6 +61,7 @@ object BiomarkerReferences {
         id = "hba1c_metabolic",
         clinicalName = "HbA1c (Glycated Hemoglobin)",
         description = "A 3-month average of blood glucose levels. Elevated HbA1c indicates pre-diabetes or diabetes risk.",
+        directMetric = MetricType.HBA1C,
         proxyMetrics = listOf(
             MetricType.BLOOD_GLUCOSE,
             MetricType.SLEEP_STAGE,

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -92,11 +92,11 @@ fun LongevityReferenceScreen(
 
 @Composable
 private fun CoverageSummaryCard(trackedMetrics: Set<MetricType>) {
-    val allProxyMetrics = BiomarkerReferences.all
-        .flatMap { it.proxyMetrics }
+    val allReferencedMetrics = BiomarkerReferences.all
+        .flatMap { it.proxyMetrics + listOfNotNull(it.directMetric) }
         .toSet()
-    val covered = allProxyMetrics.intersect(trackedMetrics)
-    val missing = allProxyMetrics - trackedMetrics
+    val covered = allReferencedMetrics.intersect(trackedMetrics)
+    val missing = allReferencedMetrics - trackedMetrics
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -175,15 +175,18 @@ private fun BiomarkerCard(
     val proxyStatus = biomarker.proxyMetrics.map { metric ->
         metric to (metric in trackedMetrics)
     }
+    val directTracked = biomarker.directMetric?.let { it in trackedMetrics } == true
     val allTracked = proxyStatus.all { it.second }
     val someTracked = proxyStatus.any { it.second }
 
     val statusColor = when {
+        directTracked -> Color(0xFF4CAF50)
         allTracked -> Color(0xFF4CAF50)
         someTracked -> Color(0xFFFFC107)
         else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
     }
     val statusLabel = when {
+        directTracked -> "Direct lab reading"
         allTracked -> "Fully tracked"
         someTracked -> "Partially tracked"
         else -> "Not tracked"
@@ -242,6 +245,37 @@ private fun BiomarkerCard(
                 Spacer(Modifier.height(12.dp))
                 HorizontalDivider()
                 Spacer(Modifier.height(12.dp))
+
+                biomarker.directMetric?.let { directMetric ->
+                    Text(
+                        "Direct lab reading",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            if (directTracked) Icons.Default.CheckCircle
+                            else Icons.Default.RadioButtonUnchecked,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = if (directTracked) Color(0xFF4CAF50) else Color.Gray
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(directMetric.readableName, style = MaterialTheme.typography.bodySmall)
+                        if (!directTracked) {
+                            Text(
+                                " — enter or import labs in Settings",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                }
 
                 // Proxy metrics status
                 Text(

--- a/android/app/src/test/java/com/bios/app/BiomarkerReferencesTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerReferencesTest.kt
@@ -1,0 +1,64 @@
+package com.bios.app
+
+import com.bios.app.alerts.BiomarkerReferences
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the direct-vs-proxy plumbing on [BiomarkerReferences].
+ *
+ * After §8.6 shipped HSCRP and HBA1C as canonical lab keys, the inflammation
+ * and metabolic-health references should know about their direct readings —
+ * so the longevity screen surfaces "Direct lab reading" status instead of
+ * only describing the wearable proxy. These tests pin that wiring.
+ */
+class BiomarkerReferencesTest {
+
+    @Test
+    fun hsCRP_reference_points_at_HSCRP_as_its_direct_metric() {
+        assertEquals(MetricType.HSCRP, BiomarkerReferences.inflammation.directMetric)
+    }
+
+    @Test
+    fun hba1c_reference_points_at_HBA1C_as_its_direct_metric() {
+        assertEquals(MetricType.HBA1C, BiomarkerReferences.metabolicHealth.directMetric)
+    }
+
+    @Test
+    fun references_without_a_canonical_lab_key_leave_directMetric_null() {
+        // VO2 max, arterial stiffness, cortisol, body composition, sleep —
+        // none of these have a Bios biomarker key today.
+        val withoutDirect = setOf(
+            BiomarkerReferences.cardiorespFitness,
+            BiomarkerReferences.arterialHealth,
+            BiomarkerReferences.stressLoad,
+            BiomarkerReferences.bodyComposition,
+            BiomarkerReferences.sleepArchitecture,
+        )
+        for (ref in withoutDirect) {
+            assertNull("${ref.id} should have no directMetric until a lab key is shipped", ref.directMetric)
+        }
+    }
+
+    @Test
+    fun forMetric_returns_the_reference_when_queried_by_direct_metric() {
+        val refs = BiomarkerReferences.forMetric(MetricType.HSCRP)
+        assertTrue(
+            "HSCRP should resolve at least to the inflammation reference",
+            BiomarkerReferences.inflammation in refs
+        )
+    }
+
+    @Test
+    fun forMetric_still_returns_references_by_proxy_metric() {
+        // RESTING_HEART_RATE proxies multiple biomarkers; the lookup should
+        // continue to find every reference that lists it as a proxy.
+        val refs = BiomarkerReferences.forMetric(MetricType.RESTING_HEART_RATE)
+        assertTrue(BiomarkerReferences.inflammation in refs)
+        assertTrue(BiomarkerReferences.metabolicHealth in refs)
+        assertTrue(BiomarkerReferences.cardiorespFitness in refs)
+    }
+}


### PR DESCRIPTION
## Summary
§8.6 shipped `HSCRP` and `HBA1C` as canonical lab keys, but `BiomarkerReference` still treated them as wearable-only — the inflammation entry only listed RHR + HRV as proxies, hiding the fact that the owner can now enter or import the biomarker directly. This PR closes that loop.

## Changes
- **`BiomarkerReference`**: new nullable `directMetric: MetricType?` field. Non-null when Bios ships a canonical lab key. `inflammation.directMetric = HSCRP`, `metabolicHealth.directMetric = HBA1C`. The other five references (VO2 max, arterial stiffness, cortisol, body composition, sleep architecture) keep it null until lab keys ship for them.
- **`forMetric()`** matches both direct and proxy metrics now, so querying by `HSCRP` / `HBA1C` returns the matching reference.
- **`LongevityReferenceScreen`**: new "Direct lab reading" section at the top of an expanded card when `directMetric != null`. Status pill reads "Direct lab reading" (green) when the direct metric is in the owner's tracked set — strongest signal possible. Coverage card now counts direct metrics alongside proxies.

## Test plan
- [x] `BiomarkerReferencesTest` — HSCRP / HBA1C resolve to their references via `forMetric()`; the five no-lab-key references keep `directMetric = null`; proxy lookups still work (RHR still pulls inflammation + metabolicHealth + cardiorespFitness).
- [x] `./scripts/code-quality-check.sh` — all checks pass.
- [ ] **Not run on device/emulator.** Expanded `BiomarkerCard` layout, status pill, and coverage summary should be smoke-tested before relying on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)