### PR TITLE
feat: clinical bands for hsCRP and HbA1c readings

### DIFF
--- a/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
@@ -50,8 +50,46 @@ data class ClinicalThresholds(
     /** Blood pressure systolic hypertension stage 1 threshold (mmHg). */
     val hypertensionSystolic: Int,
     /** Blood pressure diastolic hypertension stage 1 threshold (mmHg). */
-    val hypertensionDiastolic: Int
+    val hypertensionDiastolic: Int,
+    /**
+     * Clinical bands (low risk / borderline / high risk) for biomarker
+     * readings, indexed by [MetricType]. Values in the metric's native unit
+     * (matching the contract). Missing entries mean Bios has no clinical
+     * band defined for that biomarker yet — the reading is shown without
+     * a risk classification.
+     */
+    val biomarkerBands: Map<MetricType, BiomarkerBands> = emptyMap()
 )
+
+/**
+ * Three-band clinical classification for a lab value. Bands ascend
+ * monotonically: [normalCeiling] is the upper bound of the
+ * `NORMAL` band, [borderlineCeiling] is the upper bound of the
+ * `BORDERLINE` band; values at or above [borderlineCeiling] are `HIGH`.
+ *
+ * Use [classify] to map a measurement to a band — the comparisons are
+ * inclusive at the lower edge and exclusive at the upper edge so values
+ * that sit exactly on the published cut-off slot into the higher-risk
+ * band by clinical convention (e.g. HbA1c = 6.5% reads as diabetic).
+ */
+data class BiomarkerBands(
+    val normalCeiling: Double,
+    val borderlineCeiling: Double
+) {
+    init {
+        require(normalCeiling < borderlineCeiling) {
+            "normalCeiling ($normalCeiling) must be < borderlineCeiling ($borderlineCeiling)"
+        }
+    }
+
+    fun classify(value: Double): BiomarkerBand = when {
+        value < normalCeiling -> BiomarkerBand.NORMAL
+        value < borderlineCeiling -> BiomarkerBand.BORDERLINE
+        else -> BiomarkerBand.HIGH
+    }
+}
+
+enum class BiomarkerBand { NORMAL, BORDERLINE, HIGH }
 
 /**
  * Regulatory and compliance configuration per region.

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -9,6 +9,25 @@ import java.util.Locale
  */
 object RegionConfigProvider {
 
+    /**
+     * Biomarker bands that are clinically identical across all six supported
+     * regions. ADA / WHO / NICE / JSCC all use the same cut-offs for these
+     * two assays; SI ↔ US unit conversions are handled by [UnitDisplay], not
+     * here. When a future biomarker has region-divergent bands (e.g. JDS
+     * uses different HbA1c bands historically; CRP cut-offs are universal),
+     * the region-specific config can override.
+     *
+     * Declared before [configs] so the eager region-config initializers
+     * below see it as initialized (Kotlin object props init top-down).
+     */
+    private val universalBiomarkerBands: Map<MetricType, BiomarkerBands> = mapOf(
+        // hsCRP (mg/L): <1.0 low, 1.0–3.0 moderate, ≥3.0 high
+        // (Ridker 2003; Pearson AHA/CDC 2003)
+        MetricType.HSCRP to BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0),
+        // HbA1c (%): <5.7 normal, 5.7–6.5 prediabetic, ≥6.5 diabetic (ADA 2024)
+        MetricType.HBA1C to BiomarkerBands(normalCeiling = 5.7, borderlineCeiling = 6.5),
+    )
+
     private val configs: Map<String, RegionConfig> = mapOf(
         "US" to usConfig(),
         "GB" to gbConfig(),
@@ -62,7 +81,8 @@ object RegionConfigProvider {
             glucoseInMmol = false,
             fastingGlucoseConcern = 100.0,  // mg/dL (ADA pre-diabetes threshold)
             hypertensionSystolic = 130,     // ACC/AHA 2017 guideline
-            hypertensionDiastolic = 80
+            hypertensionDiastolic = 80,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = true,   // post-Dobbs protection
@@ -90,7 +110,8 @@ object RegionConfigProvider {
             glucoseInMmol = true,
             fastingGlucoseConcern = 5.5,    // mmol/L (NICE pre-diabetes threshold)
             hypertensionSystolic = 140,     // NICE guideline (higher than US)
-            hypertensionDiastolic = 90
+            hypertensionDiastolic = 90,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = false,
@@ -116,7 +137,8 @@ object RegionConfigProvider {
             glucoseInMmol = true,
             fastingGlucoseConcern = 5.6,    // mmol/L (IDF threshold)
             hypertensionSystolic = 140,     // ESC/ESH guideline
-            hypertensionDiastolic = 90
+            hypertensionDiastolic = 90,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = false,
@@ -144,7 +166,8 @@ object RegionConfigProvider {
             glucoseInMmol = true,
             fastingGlucoseConcern = 5.6,    // mmol/L (Diabetes Canada)
             hypertensionSystolic = 140,     // Hypertension Canada
-            hypertensionDiastolic = 90
+            hypertensionDiastolic = 90,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = false,
@@ -170,7 +193,8 @@ object RegionConfigProvider {
             glucoseInMmol = true,
             fastingGlucoseConcern = 5.5,    // mmol/L (RACGP)
             hypertensionSystolic = 140,
-            hypertensionDiastolic = 90
+            hypertensionDiastolic = 90,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = false,
@@ -196,7 +220,8 @@ object RegionConfigProvider {
             glucoseInMmol = false,
             fastingGlucoseConcern = 110.0,   // mg/dL (JDS threshold)
             hypertensionSystolic = 140,      // JSH guideline
-            hypertensionDiastolic = 90
+            hypertensionDiastolic = 90,
+            biomarkerBands = universalBiomarkerBands
         ),
         regulatory = RegulatoryConfig(
             reproductiveDataIsolation = false,

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -32,7 +32,9 @@ import com.bios.app.ui.diagnostics.DiagnosticsScreen
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.bios.app.ui.ppg.PpgCaptureScreen
+import com.bios.app.alerts.BiomarkerReferences
 import com.bios.app.ui.reference.LongevityReferenceScreen
+import com.bios.contracts.MetricType
 import com.bios.app.ui.support.MonthlyAskPopup
 import com.bios.app.ui.support.MonthlyAskScheduler
 import com.bios.app.ui.theme.BiosTheme
@@ -321,8 +323,17 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("longevity_reference") {
                 val trackedMetrics by viewModel.trackedMetricTypes.collectAsState()
+                var latestDirectValues by remember { mutableStateOf<Map<MetricType, Double>>(emptyMap()) }
+                LaunchedEffect(Unit) {
+                    val dao = viewModel.db.metricReadingDao()
+                    val directKeys = BiomarkerReferences.all.mapNotNull { it.directMetric }
+                    latestDirectValues = directKeys.mapNotNull { mt ->
+                        dao.fetchLatest(mt.key, 1).firstOrNull()?.let { mt to it.value }
+                    }.toMap()
+                }
                 LongevityReferenceScreen(
                     trackedMetrics = trackedMetrics,
+                    latestDirectBiomarkerValues = latestDirectValues,
                     onBack = { navController.popBackStack() }
                 )
             }

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -14,14 +14,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.alerts.BiomarkerReference
 import com.bios.app.alerts.BiomarkerReferences
+import com.bios.app.config.BiomarkerBand
+import com.bios.app.config.RegionConfigProvider
 import com.bios.contracts.MetricType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LongevityReferenceScreen(
     trackedMetrics: Set<MetricType>,
+    latestDirectBiomarkerValues: Map<MetricType, Double> = emptyMap(),
     onBack: () -> Unit
 ) {
+    val region = remember { RegionConfigProvider.forCurrentLocale() }
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
             title = { Text("What Longevity Science Tracks") },
@@ -59,7 +63,14 @@ fun LongevityReferenceScreen(
 
             // Biomarker reference cards
             items(BiomarkerReferences.all) { biomarker ->
-                BiomarkerCard(biomarker, trackedMetrics)
+                BiomarkerCard(
+                    biomarker = biomarker,
+                    trackedMetrics = trackedMetrics,
+                    latestDirectValue = biomarker.directMetric?.let { latestDirectBiomarkerValues[it] },
+                    biomarkerBands = biomarker.directMetric?.let {
+                        region.clinicalThresholds.biomarkerBands[it]
+                    }
+                )
             }
 
             // Sources
@@ -168,7 +179,9 @@ private fun CoverageSummaryCard(trackedMetrics: Set<MetricType>) {
 @Composable
 private fun BiomarkerCard(
     biomarker: BiomarkerReference,
-    trackedMetrics: Set<MetricType>
+    trackedMetrics: Set<MetricType>,
+    latestDirectValue: Double? = null,
+    biomarkerBands: com.bios.app.config.BiomarkerBands? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -271,6 +284,19 @@ private fun BiomarkerCard(
                                 " — enter or import labs in Settings",
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (directTracked && latestDirectValue != null && biomarkerBands != null) {
+                        val band = biomarkerBands.classify(latestDirectValue)
+                        Spacer(Modifier.height(2.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Spacer(Modifier.width(24.dp))
+                            Text(
+                                "Latest: ${"%.2f".format(latestDirectValue)} ${directMetric.unit.symbol} → ${band.label}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = band.color,
+                                fontWeight = FontWeight.Medium
                             )
                         }
                     }
@@ -378,3 +404,17 @@ private fun BiomarkerCard(
         }
     }
 }
+
+private val BiomarkerBand.label: String
+    get() = when (this) {
+        BiomarkerBand.NORMAL -> "Normal range"
+        BiomarkerBand.BORDERLINE -> "Borderline"
+        BiomarkerBand.HIGH -> "High range"
+    }
+
+private val BiomarkerBand.color: Color
+    get() = when (this) {
+        BiomarkerBand.NORMAL -> Color(0xFF4CAF50)
+        BiomarkerBand.BORDERLINE -> Color(0xFFFFA000)
+        BiomarkerBand.HIGH -> Color(0xFFD32F2F)
+    }

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -1,0 +1,100 @@
+package com.bios.app
+
+import com.bios.app.config.BiomarkerBand
+import com.bios.app.config.BiomarkerBands
+import com.bios.app.config.RegionConfigProvider
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Guards the clinical-band classification for biomarker readings and the
+ * region-config population the longevity screen depends on.
+ */
+class BiomarkerBandsTest {
+
+    // -- classify() boundary behaviour --
+
+    @Test
+    fun classify_returns_NORMAL_below_the_normal_ceiling() {
+        val bands = BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0)
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(0.5))
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(0.999))
+    }
+
+    @Test
+    fun classify_returns_BORDERLINE_at_or_above_normal_ceiling_and_below_borderline_ceiling() {
+        // Inclusive at the lower edge so values on the cut-off slot into the
+        // higher-risk band by clinical convention.
+        val bands = BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0)
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(1.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(2.5))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(2.999))
+    }
+
+    @Test
+    fun classify_returns_HIGH_at_or_above_borderline_ceiling() {
+        val bands = BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0)
+        assertEquals(BiomarkerBand.HIGH, bands.classify(3.0))
+        assertEquals(BiomarkerBand.HIGH, bands.classify(10.0))
+    }
+
+    @Test
+    fun ceilings_must_be_monotonic() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BiomarkerBands(normalCeiling = 3.0, borderlineCeiling = 1.0)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 1.0)
+        }
+    }
+
+    // -- hsCRP literature thresholds --
+
+    @Test
+    fun hscrp_bands_match_Ridker_2003_thresholds() {
+        val bands = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.HSCRP]
+        assertNotNull("hsCRP bands should be populated for US", bands)
+        // Ridker AHA/CDC 2003: <1.0 low, 1.0-3.0 moderate, ≥3.0 high.
+        assertEquals(BiomarkerBand.NORMAL, bands!!.classify(0.5))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(1.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(2.5))
+        assertEquals(BiomarkerBand.HIGH, bands.classify(3.0))
+        assertEquals(BiomarkerBand.HIGH, bands.classify(10.0))
+    }
+
+    // -- HbA1c literature thresholds --
+
+    @Test
+    fun hba1c_bands_match_ADA_2024_thresholds() {
+        val bands = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.HBA1C]
+        assertNotNull("HbA1c bands should be populated for US", bands)
+        // ADA 2024: <5.7 normal, 5.7-6.5 prediabetic, ≥6.5 diabetic.
+        assertEquals(BiomarkerBand.NORMAL, bands!!.classify(5.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(5.7))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(6.4))
+        assertEquals(BiomarkerBand.HIGH, bands.classify(6.5))
+        assertEquals(BiomarkerBand.HIGH, bands.classify(9.0))
+    }
+
+    // -- Region coverage --
+
+    @Test
+    fun every_supported_region_carries_the_universal_biomarker_bands() {
+        for (regionCode in RegionConfigProvider.supportedRegions()) {
+            val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
+            assertNotNull(
+                "$regionCode should ship hsCRP bands",
+                bands[MetricType.HSCRP]
+            )
+            assertNotNull(
+                "$regionCode should ship HbA1c bands",
+                bands[MetricType.HBA1C]
+            )
+        }
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,10 +395,32 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
+**Clinical bands (shipped for hsCRP + HbA1c):**
+
+- `ClinicalThresholds.biomarkerBands: Map<MetricType, BiomarkerBands>`
+  carries three-band classifications (NORMAL / BORDERLINE / HIGH) per
+  region. `BiomarkerBands.classify(value)` is the single decision
+  function; ceilings are inclusive at the lower edge so values on a
+  published cut-off slot into the higher-risk band by clinical
+  convention.
+- hsCRP (Ridker AHA/CDC 2003): <1.0 mg/L normal, 1.0–3.0 borderline,
+  ≥3.0 high. HbA1c (ADA 2024): <5.7% normal, 5.7–6.5% prediabetic,
+  ≥6.5% diabetic. Both are clinically universal across the 6 supported
+  regions, so a shared `universalBiomarkerBands` constant is plugged
+  into every region's `ClinicalThresholds`.
+- `LongevityReferenceScreen` consumes the bands: when the owner has a
+  direct reading, the BiomarkerCard surfaces "Latest: 2.5 mg/L →
+  Borderline" with a colour-coded label. MainActivity fetches the
+  latest direct reading for each biomarker that has a `directMetric`
+  set on its `BiomarkerReference`.
+
 **Remaining work (separate PRs):**
 
-- Region-aware reference-range expansion in `RegionConfigProvider`'s
-  `ClinicalThresholds` (the last piece of §8.6).
+- Bands for the rest of the biomarker wave (lipid panel, vit D,
+  thyroid, CBC). Each batch is one region table addition + tests.
+- Absolute-threshold support in `SignalRule` so biomarker readings can
+  drive `ConditionPattern`s. The bands shipped here are the natural
+  threshold source.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Closes the loop between the 16-key biomarker contract surface and the clinical-context display: when the owner has a direct hsCRP or HbA1c reading, the longevity reference screen now classifies it as **Normal / Borderline / High** with literature-anchored thresholds.

## What ships
- **`BiomarkerBands` data class** with `(normalCeiling, borderlineCeiling)` + a `classify(value): BiomarkerBand` function. Inclusive at the lower edge so values on a published cut-off slot into the higher-risk band by clinical convention (HbA1c = 6.5% reads as diabetic, not prediabetic).
- **`ClinicalThresholds.biomarkerBands: Map<MetricType, BiomarkerBands>`** with a sensible empty default so other region configs don't churn.
- **All six supported regions** ship the same hsCRP and HbA1c bands — Ridker AHA/CDC 2003 (<1.0 / 1.0–3.0 / ≥3.0 mg/L) and ADA 2024 (<5.7 / 5.7–6.5 / ≥6.5 %) are clinically universal. Shared via a private `universalBiomarkerBands` constant; region-specific configs can override when literature diverges.
- **`LongevityReferenceScreen`** consumes the bands: when the owner has a direct reading, the BiomarkerCard surfaces `"Latest: 2.5 mg/L → Borderline"` with a colour-coded label (green / amber / red). `MainActivity` fetches the latest direct reading for each biomarker that has a `directMetric` set on its `BiomarkerReference`.

## Test plan
- [x] `BiomarkerBandsTest` — boundary behaviour at both ceilings; monotonicity constraint enforced by `require()`; hsCRP and HbA1c thresholds match the cited literature; every supported region carries both bands.
- [x] `./scripts/code-quality-check.sh` — all checks pass. Initial run caught a Kotlin top-down init-order bug (the eager region configs in `configs` referenced `universalBiomarkerBands` before it was initialized); fixed by moving the bands constant above `configs`.
- [ ] **Not run on device/emulator.** The new band line in BiomarkerCard and the color-coded label should be smoke-tested before relying on this.

## Remaining §8.6 work
- Bands for the rest of the biomarker wave (lipid panel, vit D, thyroid, CBC). Each batch is one region-table addition + tests.
- **Absolute-threshold support in `SignalRule`** so biomarker readings can drive `ConditionPattern`s. The bands shipped here are the natural threshold source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)