### PR TITLE
feat: biomarker readings drive ConditionPatterns via absolute thresholds

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -1,0 +1,106 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Cross-correlation patterns that gate on a directly-measured lab biomarker
+ * paired with corroborating wearable-derived signals. Phase 8.6's payoff:
+ * the 16 BIOMARKER keys are no longer just data — they actually drive alerts
+ * when the lab value crosses a literature-anchored clinical threshold *and*
+ * the body's day-to-day signals trend in a compatible direction.
+ *
+ * Each pattern's biomarker rule uses `absoluteAbove` (the new absolute-
+ * threshold SignalRule mode) so the latest lab value is checked against a
+ * hard clinical cutoff, ignoring personal-baseline z-scores. The
+ * corroborating rules stay baseline-relative, so a high-normal hsCRP on its
+ * own won't fire the pattern unless the wearables also drift.
+ *
+ * All text obeys [AlertContentPolicy] — data statements, never lifestyle
+ * judgments. The biomarker rules are `required = true` so wearable drift
+ * alone (without a recent elevated lab) never triggers a biomarker
+ * pattern (per "silence is a feature").
+ */
+object BiomarkerConditionPatterns {
+
+    val all by lazy { listOf(inflammationSignature, prediabetesSignature) }
+
+    /**
+     * Elevated hsCRP (≥1.0 mg/L, borderline-or-higher per Ridker AHA/CDC
+     * 2003) paired with sustained resting-HR elevation and HRV depression.
+     * The vital-sign trends corroborate the lab finding — chronic
+     * inflammation drives autonomic shifts the wearable surface can pick up
+     * over a 7-day window.
+     */
+    val inflammationSignature = ConditionPattern(
+        id = "biomarker_inflammation_signature",
+        title = "Elevated hsCRP with autonomic corroboration",
+        category = ConditionCategory.CARDIOVASCULAR,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.HSCRP, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "Ridker AHA/CDC 2003 — hsCRP ≥1.0 mg/L is the borderline-or-higher inflammation tier",
+                required = true,
+                absoluteAbove = 1.0,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Furman et al. 2019 — chronic inflammation drives resting HR upward over multi-day windows",
+            ),
+            SignalRule(
+                MetricType.HEART_RATE_VARIABILITY, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Furman et al. 2019 — sustained HRV depression accompanies inflammatory states",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent hsCRP reading sits at or above 1.0 mg/L while resting heart rate has trended above baseline and heart rate variability has stayed depressed over the past seven days. Literature links this combination to systemic inflammation; the wearable signals on their own can have many causes, so the direct lab value is what anchors the pattern.",
+        suggestedAction = "Discuss the hsCRP value and the multi-day vital-sign trend with a healthcare provider. The hsCRP reading, resting HR trend, and HRV trend from Bios are all useful to share.",
+        references = listOf(
+            "Ridker PM (2003) — C-reactive protein: a simple test to help predict risk of heart attack and stroke",
+            "Furman D et al. (2019) — Chronic inflammation in the etiology of disease across the life span",
+        ),
+        earlyDetection = "Wearable-only inflammation proxies (resting HR + HRV) are noisy; they respond to fitness, alcohol, sleep, and acute illness as well. Pairing them with a measured hsCRP narrows the signal substantially.",
+    )
+
+    /**
+     * HbA1c at or above 5.7% (prediabetic threshold per ADA 2024) paired
+     * with sustained sleep-efficiency decline and resting-HR elevation.
+     * The wearable signals corroborate metabolic dysregulation; on their
+     * own they're indirect, so the lab anchors the pattern.
+     */
+    val prediabetesSignature = ConditionPattern(
+        id = "biomarker_prediabetes_signature",
+        title = "Elevated HbA1c with metabolic-dysregulation signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.HBA1C, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "ADA 2024 — HbA1c ≥5.7% is the prediabetic threshold",
+                required = true,
+                absoluteAbove = 5.7,
+            ),
+            SignalRule(
+                MetricType.SLEEP_EFFICIENCY, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Hall et al. 2018 — sleep disruption correlates with glucose dysregulation",
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Elevated resting HR is a secondary indicator of metabolic dysfunction",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent HbA1c reading sits at or above 5.7% while sleep efficiency has trended below baseline and resting heart rate has stayed elevated over the past seven days. Literature links this combination to early metabolic dysregulation; the wearable signals are indirect on their own, so the direct lab value anchors the pattern.",
+        suggestedAction = "Discuss the HbA1c value and the sleep / resting HR trend with a healthcare provider. The HbA1c reading, sleep efficiency trend, and resting HR trend from Bios are all useful to share.",
+        references = listOf(
+            "American Diabetes Association (2024) — Standards of Medical Care in Diabetes",
+            "Hall H et al. (2018) — Glucotypes reveal new patterns of glucose dysregulation",
+        ),
+        earlyDetection = "Wearable-only metabolic proxies (sleep, resting HR) are too indirect to be diagnostic. Pairing them with a measured HbA1c narrows the signal to genuine metabolic risk.",
+    )
+}

--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -33,7 +33,22 @@ data class SignalRule(
      * absence before reading positive cardiovascular trends as recovery.
      */
     val required: Boolean = false,
-)
+    /**
+     * Absolute clinical threshold: rule fires when the metric's latest reading
+     * is at or above this value, ignoring [direction] / [thresholdSigma] /
+     * personal baseline. Used for lab biomarkers where the literature
+     * threshold (e.g. hsCRP ≥ 1.0 mg/L) is a hard clinical cutoff, not a
+     * baseline-relative deviation. When non-null, the evaluator reads the
+     * latest reading via `fetchLatest` (no SENSOR filter, no time window) so
+     * self-reported lab values qualify.
+     */
+    val absoluteAbove: Double? = null,
+    /** Mirror of [absoluteAbove] for "at or below" thresholds. */
+    val absoluteBelow: Double? = null,
+) {
+    /** True when this rule is evaluated as an absolute clinical threshold. */
+    val isAbsolute: Boolean get() = absoluteAbove != null || absoluteBelow != null
+}
 
 enum class DeviationDirection {
     ABOVE, BELOW, IRREGULAR,
@@ -64,7 +79,7 @@ object ConditionPatterns {
         listOf(
             infectionOnset, sleepDisruption, cardiovascularStress, overtraining,
             metabolicDrift, cardiorespiratoryDeconditioning, chronicInflammation, recoveryDeficit
-        ) + CompanionConditionPatterns.all
+        ) + CompanionConditionPatterns.all + BiomarkerConditionPatterns.all
     }
 
     /** Infection / illness onset: the Phase 1 primary detection target. */

--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -174,7 +174,19 @@ class AnomalyDetector(
             var isActive = false
             var hasBaseline = false
 
-            if (rule.direction == DeviationDirection.ABSENT) {
+            if (rule.isAbsolute) {
+                // Absolute clinical threshold — no baseline, no time window.
+                // Treat "we have a reading" as having enough data, since labs
+                // are dated and a six-month-old hsCRP is still meaningful.
+                val (value, active) = evaluateAbsoluteRule(rule)
+                hasBaseline = value != null
+                if (hasBaseline) baselinesFound++
+                isActive = active
+                if (isActive) {
+                    activeCount++
+                    totalWeightedScore += rule.weight
+                }
+            } else if (rule.direction == DeviationDirection.ABSENT) {
                 // No baseline needed — "no events in window" is the signal.
                 hasBaseline = true
                 baselinesFound++
@@ -246,6 +258,17 @@ class AnomalyDetector(
         var totalWeight = 0.0
 
         for (rule in pattern.signalRules) {
+            if (rule.isAbsolute) {
+                val (value, active) = evaluateAbsoluteRule(rule)
+                if (rule.required && !active) return null
+                totalWeight += rule.weight
+                if (active && value != null) {
+                    activeDeviations[rule.metricType] = value
+                    totalWeightedScore += rule.weight
+                }
+                continue
+            }
+
             val recentValues = fetchRecentValues(rule.metricType, rule.minDurationHours)
             val (isActive, contributedScore) = when (rule.direction) {
                 DeviationDirection.ABSENT -> {
@@ -372,6 +395,23 @@ class AnomalyDetector(
         return readingDao.fetchValues(
             metricType.key, startMillis, endMillis, readingKindFilterFor(metricType)
         )
+    }
+
+    /**
+     * Evaluates an absolute-threshold rule against the metric's latest
+     * reading (no time window, no SENSOR filter — lab biomarkers are
+     * self-reported and dated months back). Returns the latest value plus
+     * whether it crosses the rule's clinical threshold. Returns
+     * `(null, false)` when no reading exists yet.
+     */
+    private suspend fun evaluateAbsoluteRule(
+        rule: com.bios.app.alerts.SignalRule
+    ): Pair<Double?, Boolean> {
+        val latest = readingDao.fetchLatest(rule.metricType.key, 1).firstOrNull()
+            ?: return null to false
+        val above = rule.absoluteAbove?.let { latest.value >= it } == true
+        val below = rule.absoluteBelow?.let { latest.value <= it } == true
+        return latest.value to (above || below)
     }
 }
 

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -1,0 +1,125 @@
+package com.bios.app
+
+import com.bios.app.alerts.BiomarkerConditionPatterns
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.alerts.SignalRule
+import com.bios.app.alerts.ThresholdSource
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the absolute-threshold extension to [SignalRule] and the biomarker
+ * patterns that depend on it. These patterns are how the BIOMARKER contract
+ * surface earns its keep under the §8.8 acceptance rule ("each new key has
+ * at least one cross-correlation use"). If they regress silently, the labs
+ * stop driving alerts.
+ */
+class BiomarkerConditionPatternsTest {
+
+    // -- SignalRule.isAbsolute --
+
+    @Test
+    fun isAbsolute_is_false_for_baseline_relative_rules() {
+        val rule = SignalRule(
+            MetricType.HEART_RATE, DeviationDirection.ABOVE,
+            thresholdSigma = 1.5, minDurationHours = 24, weight = 1.0
+        )
+        assertFalse(rule.isAbsolute)
+    }
+
+    @Test
+    fun isAbsolute_is_true_when_absoluteAbove_is_set() {
+        val rule = SignalRule(
+            MetricType.HSCRP, DeviationDirection.ABOVE,
+            thresholdSigma = 0.0, minDurationHours = 0, weight = 1.0,
+            absoluteAbove = 1.0
+        )
+        assertTrue(rule.isAbsolute)
+    }
+
+    @Test
+    fun isAbsolute_is_true_when_absoluteBelow_is_set() {
+        val rule = SignalRule(
+            MetricType.BLOOD_GLUCOSE, DeviationDirection.BELOW,
+            thresholdSigma = 0.0, minDurationHours = 0, weight = 1.0,
+            absoluteBelow = 70.0
+        )
+        assertTrue(rule.isAbsolute)
+    }
+
+    // -- Pattern wiring --
+
+    @Test
+    fun biomarker_patterns_are_registered_in_global_all_list() {
+        assertTrue(BiomarkerConditionPatterns.inflammationSignature in ConditionPatterns.all)
+        assertTrue(BiomarkerConditionPatterns.prediabetesSignature in ConditionPatterns.all)
+    }
+
+    @Test
+    fun inflammation_signature_gates_on_hsCRP_at_or_above_1_mg_per_L() {
+        val pattern = BiomarkerConditionPatterns.inflammationSignature
+        val hsCrpRule = pattern.signalRules.first { it.metricType == MetricType.HSCRP }
+        assertTrue("hsCRP rule should be required so the lab anchors the pattern", hsCrpRule.required)
+        assertTrue(hsCrpRule.isAbsolute)
+        assertEquals(1.0, hsCrpRule.absoluteAbove!!, 1e-9)
+        assertNull(hsCrpRule.absoluteBelow)
+        assertEquals(ThresholdSource.LITERATURE, hsCrpRule.source)
+    }
+
+    @Test
+    fun inflammation_signature_pairs_lab_with_baseline_relative_vital_signs() {
+        val pattern = BiomarkerConditionPatterns.inflammationSignature
+        val supporting = pattern.signalRules.filter { !it.isAbsolute }
+        // Resting HR up and HRV down are the canonical autonomic shifts under
+        // chronic inflammation. Both are baseline-relative (no absolute).
+        val supportingMetrics = supporting.map { it.metricType }.toSet()
+        assertTrue(MetricType.RESTING_HEART_RATE in supportingMetrics)
+        assertTrue(MetricType.HEART_RATE_VARIABILITY in supportingMetrics)
+        for (rule in supporting) {
+            assertFalse(
+                "Corroborating rules must not be required — they're supporting, not gating",
+                rule.required
+            )
+        }
+    }
+
+    @Test
+    fun prediabetes_signature_gates_on_HbA1c_at_or_above_5_point_7_pct() {
+        val pattern = BiomarkerConditionPatterns.prediabetesSignature
+        val hba1cRule = pattern.signalRules.first { it.metricType == MetricType.HBA1C }
+        assertTrue(hba1cRule.required)
+        assertTrue(hba1cRule.isAbsolute)
+        assertEquals(5.7, hba1cRule.absoluteAbove!!, 1e-9)
+        assertEquals(ThresholdSource.LITERATURE, hba1cRule.source)
+    }
+
+    @Test
+    fun prediabetes_signature_pairs_lab_with_sleep_and_resting_HR_drift() {
+        val pattern = BiomarkerConditionPatterns.prediabetesSignature
+        val supportingMetrics = pattern.signalRules
+            .filter { !it.isAbsolute }
+            .map { it.metricType }
+            .toSet()
+        assertTrue(MetricType.SLEEP_EFFICIENCY in supportingMetrics)
+        assertTrue(MetricType.RESTING_HEART_RATE in supportingMetrics)
+    }
+
+    @Test
+    fun patterns_carry_literature_citations_for_every_threshold() {
+        for (pattern in BiomarkerConditionPatterns.all) {
+            for (rule in pattern.signalRules) {
+                assertNotNull("${pattern.id}/${rule.metricType.key} should cite its threshold source", rule.source)
+                assertTrue(
+                    "${pattern.id}/${rule.metricType.key} should ship a citation string",
+                    rule.citation.isNotBlank()
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
@@ -38,9 +38,12 @@ class ConditionPatternsTest {
     }
 
     @Test
-    fun `all signal rules have positive thresholds`() {
+    fun `all baseline-relative signal rules have positive thresholds`() {
+        // Absolute-threshold rules carry their cutoff in absoluteAbove /
+        // absoluteBelow and intentionally leave thresholdSigma at 0.
         for (pattern in ConditionPatterns.all) {
             for (rule in pattern.signalRules) {
+                if (rule.isAbsolute) continue
                 assertTrue(
                     "Pattern ${pattern.id}, metric ${rule.metricType}: threshold must be positive",
                     rule.thresholdSigma > 0.0
@@ -62,12 +65,29 @@ class ConditionPatternsTest {
     }
 
     @Test
-    fun `all signal rules have positive duration hours`() {
+    fun `all baseline-relative signal rules have positive duration hours`() {
+        // Absolute-threshold rules read the latest lab via fetchLatest — no
+        // time window is meaningful, so minDurationHours is intentionally 0.
         for (pattern in ConditionPatterns.all) {
             for (rule in pattern.signalRules) {
+                if (rule.isAbsolute) continue
                 assertTrue(
                     "Pattern ${pattern.id}, metric ${rule.metricType}: duration must be positive",
                     rule.minDurationHours > 0
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every absolute-threshold rule sets at least one bound`() {
+        for (pattern in ConditionPatterns.all) {
+            for (rule in pattern.signalRules) {
+                if (!rule.isAbsolute) continue
+                assertTrue(
+                    "Pattern ${pattern.id}, metric ${rule.metricType}: " +
+                        "isAbsolute true but neither absoluteAbove nor absoluteBelow set",
+                    rule.absoluteAbove != null || rule.absoluteBelow != null
                 )
             }
         }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,32 +395,35 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c):**
+**Clinical bands (shipped for hsCRP + HbA1c):** `ClinicalThresholds.biomarkerBands`
+carries three-band classifications (NORMAL / BORDERLINE / HIGH) per region.
+`BiomarkerBands.classify(value)` is inclusive at the lower edge so cut-off
+values slot into the higher-risk band by clinical convention. hsCRP (Ridker
+AHA/CDC 2003): <1.0 mg/L normal, 1.0–3.0 borderline, ≥3.0 high. HbA1c
+(ADA 2024): <5.7% normal, 5.7–6.5% prediabetic, ≥6.5% diabetic. Both are
+clinically universal across the 6 regions via a shared
+`universalBiomarkerBands` constant. `LongevityReferenceScreen` surfaces
+"Latest: 2.5 mg/L → Borderline" with a colour-coded label when a direct
+reading is available.
 
-- `ClinicalThresholds.biomarkerBands: Map<MetricType, BiomarkerBands>`
-  carries three-band classifications (NORMAL / BORDERLINE / HIGH) per
-  region. `BiomarkerBands.classify(value)` is the single decision
-  function; ceilings are inclusive at the lower edge so values on a
-  published cut-off slot into the higher-risk band by clinical
-  convention.
-- hsCRP (Ridker AHA/CDC 2003): <1.0 mg/L normal, 1.0–3.0 borderline,
-  ≥3.0 high. HbA1c (ADA 2024): <5.7% normal, 5.7–6.5% prediabetic,
-  ≥6.5% diabetic. Both are clinically universal across the 6 supported
-  regions, so a shared `universalBiomarkerBands` constant is plugged
-  into every region's `ClinicalThresholds`.
-- `LongevityReferenceScreen` consumes the bands: when the owner has a
-  direct reading, the BiomarkerCard surfaces "Latest: 2.5 mg/L →
-  Borderline" with a colour-coded label. MainActivity fetches the
-  latest direct reading for each biomarker that has a `directMetric`
-  set on its `BiomarkerReference`.
+**Biomarker-anchored ConditionPatterns (shipped):** `SignalRule` gained
+`absoluteAbove` / `absoluteBelow` + an `isAbsolute` predicate. When set,
+`AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
+SENSOR filter, no time window) and compares against the hard cutoff — labs
+are dated and a six-month-old hsCRP is still meaningful.
+`alerts/BiomarkerConditionPatterns.kt` ships two patterns:
+`inflammation_signature` (required hsCRP ≥ 1.0 mg/L + sustained RHR ↑ +
+HRV ↓ over 7d; Ridker 2003 + Furman 2019) and `prediabetes_signature`
+(required HbA1c ≥ 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d;
+ADA 2024 + Hall 2018). Biomarker rule is `required = true` so wearable
+drift alone never fires the pattern.
 
 **Remaining work (separate PRs):**
 
 - Bands for the rest of the biomarker wave (lipid panel, vit D,
   thyroid, CBC). Each batch is one region table addition + tests.
-- Absolute-threshold support in `SignalRule` so biomarker readings can
-  drive `ConditionPattern`s. The bands shipped here are the natural
-  threshold source.
+- More biomarker patterns built on the absolute-threshold path:
+  dyslipidemia, low-thyroid, anemia signatures.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Closes the §8.8 acceptance gap for the BIOMARKER contract surface. The 16 lab keys shipped across PRs #57–60 and #65 now actually fire alerts when the lab value crosses a literature-anchored clinical threshold AND the wearable signals corroborate. Direct labs anchor the pattern; wearable drift alone never triggers a biomarker pattern (silence is a feature).

## What ships
- **`SignalRule` extension**: new `absoluteAbove` / `absoluteBelow` fields + an `isAbsolute` predicate. When set, the evaluator reads via `fetchLatest` — no SENSOR filter (labs are SELF_REPORTED), no time window (a six-month-old hsCRP is still meaningful).
- **`AnomalyDetector.scorePattern`** and **`evaluatePattern`** both branch on `rule.isAbsolute` and use the new path for biomarker rules. Score contribution is the raw rule weight (z-score isn't defined for absolute thresholds).
- **`alerts/BiomarkerConditionPatterns.kt`** ships two patterns:
  - `inflammation_signature` — required `HSCRP ≥ 1.0 mg/L` (Ridker AHA/CDC 2003) + sustained RHR ↑ + HRV ↓ over 7d (Furman 2019).
  - `prediabetes_signature` — required `HBA1C ≥ 5.7%` (ADA 2024) + sustained SLEEP_EFFICIENCY ↓ + RHR ↑ over 7d (Hall 2018).
  - Biomarker rule is `required = true`; `minActiveSignals = 2` so the lab plus one corroborating signal is enough.

## Invariant updates
`ConditionPatternsTest`'s "positive thresholdSigma" and "positive duration hours" invariants now skip `isAbsolute` rules — absolute rules carry their cutoff in `absoluteAbove` / `absoluteBelow`, not sigma/hours. A new invariant enforces that every `isAbsolute` rule sets at least one bound.

## Test plan
- [x] `BiomarkerConditionPatternsTest` — `isAbsolute` predicate; patterns registered; each gates on its biomarker at the correct cutoff; pairs with the right corroborating metrics; every absolute rule cites a literature source.
- [x] `ConditionPatternsTest` — new invariant on isAbsolute rules.
- [x] `AlertContentPolicyTest` validates the new patterns automatically (no prohibited phrases).
- [x] `./scripts/code-quality-check.sh` — all checks pass.
- [ ] **AnomalyDetector behaviour not end-to-end tested.** Project has no in-memory Room scaffolding; pure logic and pattern wiring are tested directly. Behavioral verification needs a manual test or instrumented test once smoke-ready.

## Remaining §8.6 work
- Bands for the rest of the biomarker wave (lipid, vit D, thyroid, CBC). Each batch is one region-table addition + tests.
- More biomarker patterns built on the absolute-threshold path: dyslipidemia, low-thyroid, anemia signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)