### PR TITLE
feat: lipid panel bands + dyslipidemia alert pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -23,7 +23,9 @@ import com.bios.contracts.MetricType
  */
 object BiomarkerConditionPatterns {
 
-    val all by lazy { listOf(inflammationSignature, prediabetesSignature) }
+    val all by lazy {
+        listOf(inflammationSignature, prediabetesSignature, dyslipidemiaSignature)
+    }
 
     /**
      * Elevated hsCRP (≥1.0 mg/L, borderline-or-higher per Ridker AHA/CDC
@@ -102,5 +104,54 @@ object BiomarkerConditionPatterns {
             "Hall H et al. (2018) — Glucotypes reveal new patterns of glucose dysregulation",
         ),
         earlyDetection = "Wearable-only metabolic proxies (sleep, resting HR) are too indirect to be diagnostic. Pairing them with a measured HbA1c narrows the signal to genuine metabolic risk.",
+    )
+
+    /**
+     * LDL ≥ 160 mg/dL (NCEP ATP III "high" tier) paired with at least one
+     * supporting dyslipidemia marker: HDL below 40 mg/dL, triglycerides at
+     * or above 200 mg/dL, or ApoB at or above 120 mg/dL (Sniderman 2019 —
+     * the atherogenic-particle-count threshold). Multi-marker confirmation
+     * is the clinical pattern for dyslipidemia; a single elevated lipid in
+     * isolation is too noisy to alert on.
+     */
+    val dyslipidemiaSignature = ConditionPattern(
+        id = "biomarker_dyslipidemia_signature",
+        title = "Elevated LDL with corroborating lipid markers",
+        category = ConditionCategory.CARDIOVASCULAR,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.LDL_CHOLESTEROL, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "NCEP ATP III — LDL ≥160 mg/dL is the high-risk tier",
+                required = true,
+                absoluteAbove = 160.0,
+            ),
+            SignalRule(
+                MetricType.HDL_CHOLESTEROL, DeviationDirection.BELOW, 0.0, 0, 1.0,
+                ThresholdSource.LITERATURE,
+                "NCEP ATP III — HDL <40 mg/dL is independently atherogenic",
+                absoluteBelow = 40.0,
+            ),
+            SignalRule(
+                MetricType.TRIGLYCERIDES, DeviationDirection.ABOVE, 0.0, 0, 1.0,
+                ThresholdSource.LITERATURE,
+                "NCEP ATP III — triglycerides ≥200 mg/dL is the high tier",
+                absoluteAbove = 200.0,
+            ),
+            SignalRule(
+                MetricType.APO_B, DeviationDirection.ABOVE, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "Sniderman et al. 2019 — ApoB ≥120 mg/dL is the atherogenic-particle-count threshold",
+                absoluteAbove = 120.0,
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent LDL reading sits at or above 160 mg/dL while at least one corroborating lipid marker — low HDL, high triglycerides, or high ApoB — is also out of range. NCEP and recent ApoB literature treat this multi-marker combination as the dyslipidemia pattern most predictive of atherosclerotic cardiovascular risk.",
+        suggestedAction = "Discuss the lipid panel with a healthcare provider. The LDL, HDL, triglyceride, and ApoB values from Bios are all useful to share alongside the original lab report.",
+        references = listOf(
+            "NCEP ATP III (2002) — Detection, Evaluation, and Treatment of High Blood Cholesterol in Adults",
+            "Sniderman AD et al. (2019) — Apolipoprotein B particles and cardiovascular disease",
+        ),
+        earlyDetection = "An isolated LDL elevation can have transient causes (diet, weight cycling). Multi-marker confirmation across the lipid panel narrows the signal to durable dyslipidemia worth investigating.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
@@ -62,19 +62,25 @@ data class ClinicalThresholds(
 )
 
 /**
- * Three-band clinical classification for a lab value. Bands ascend
- * monotonically: [normalCeiling] is the upper bound of the
- * `NORMAL` band, [borderlineCeiling] is the upper bound of the
- * `BORDERLINE` band; values at or above [borderlineCeiling] are `HIGH`.
+ * Three-band clinical classification for a lab value. Always declared in
+ * ascending value order — [normalCeiling] < [borderlineCeiling] — and the
+ * [concerningDirection] flag picks which extreme is clinically concerning:
  *
- * Use [classify] to map a measurement to a band — the comparisons are
- * inclusive at the lower edge and exclusive at the upper edge so values
- * that sit exactly on the published cut-off slot into the higher-risk
- * band by clinical convention (e.g. HbA1c = 6.5% reads as diabetic).
+ *  - [BandDirection.ABOVE] (default): high values are concerning. Typical
+ *    for hsCRP, HbA1c, LDL, ApoB, triglycerides — values at or above
+ *    [borderlineCeiling] classify as [BiomarkerBand.CONCERNING].
+ *  - [BandDirection.BELOW]: low values are concerning. Typical for HDL —
+ *    values below [normalCeiling] classify as [BiomarkerBand.CONCERNING].
+ *
+ * Comparisons are inclusive at the lower edge and exclusive at the upper
+ * edge so values sitting exactly on a published cut-off slot into the
+ * higher-risk band by clinical convention (e.g. HbA1c = 6.5% reads as
+ * diabetic; HDL = 40 reads as borderline, not concerning).
  */
 data class BiomarkerBands(
     val normalCeiling: Double,
-    val borderlineCeiling: Double
+    val borderlineCeiling: Double,
+    val concerningDirection: BandDirection = BandDirection.ABOVE,
 ) {
     init {
         require(normalCeiling < borderlineCeiling) {
@@ -82,14 +88,24 @@ data class BiomarkerBands(
         }
     }
 
-    fun classify(value: Double): BiomarkerBand = when {
-        value < normalCeiling -> BiomarkerBand.NORMAL
-        value < borderlineCeiling -> BiomarkerBand.BORDERLINE
-        else -> BiomarkerBand.HIGH
+    fun classify(value: Double): BiomarkerBand = when (concerningDirection) {
+        BandDirection.ABOVE -> when {
+            value < normalCeiling -> BiomarkerBand.NORMAL
+            value < borderlineCeiling -> BiomarkerBand.BORDERLINE
+            else -> BiomarkerBand.CONCERNING
+        }
+        BandDirection.BELOW -> when {
+            value >= borderlineCeiling -> BiomarkerBand.NORMAL
+            value >= normalCeiling -> BiomarkerBand.BORDERLINE
+            else -> BiomarkerBand.CONCERNING
+        }
     }
 }
 
-enum class BiomarkerBand { NORMAL, BORDERLINE, HIGH }
+enum class BiomarkerBand { NORMAL, BORDERLINE, CONCERNING }
+
+/** Which end of the value range is clinically concerning. */
+enum class BandDirection { ABOVE, BELOW }
 
 /**
  * Regulatory and compliance configuration per region.

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -26,6 +26,31 @@ object RegionConfigProvider {
         MetricType.HSCRP to BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0),
         // HbA1c (%): <5.7 normal, 5.7–6.5 prediabetic, ≥6.5 diabetic (ADA 2024)
         MetricType.HBA1C to BiomarkerBands(normalCeiling = 5.7, borderlineCeiling = 6.5),
+        // Total cholesterol (mg/dL): <200 desirable, 200–239 borderline, ≥240 high
+        // (NCEP ATP III; AHA 2018 guideline)
+        MetricType.TOTAL_CHOLESTEROL to BiomarkerBands(
+            normalCeiling = 200.0, borderlineCeiling = 240.0,
+        ),
+        // LDL-C (mg/dL): <100 optimal, 100–160 borderline, ≥160 high (NCEP ATP III)
+        MetricType.LDL_CHOLESTEROL to BiomarkerBands(
+            normalCeiling = 100.0, borderlineCeiling = 160.0,
+        ),
+        // HDL-C (mg/dL): <40 concerning low, 40–60 borderline, ≥60 protective
+        // — INVERSE direction: low HDL is the clinical concern (NCEP ATP III)
+        MetricType.HDL_CHOLESTEROL to BiomarkerBands(
+            normalCeiling = 40.0, borderlineCeiling = 60.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // Triglycerides (mg/dL): <150 normal, 150–200 borderline, ≥200 high
+        // (NCEP ATP III)
+        MetricType.TRIGLYCERIDES to BiomarkerBands(
+            normalCeiling = 150.0, borderlineCeiling = 200.0,
+        ),
+        // ApoB (mg/dL): <90 desirable, 90–120 borderline, ≥120 high
+        // (Sniderman et al. 2019; AACC 2023 — particle-count gold standard)
+        MetricType.APO_B to BiomarkerBands(
+            normalCeiling = 90.0, borderlineCeiling = 120.0,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -409,12 +409,12 @@ private val BiomarkerBand.label: String
     get() = when (this) {
         BiomarkerBand.NORMAL -> "Normal range"
         BiomarkerBand.BORDERLINE -> "Borderline"
-        BiomarkerBand.HIGH -> "High range"
+        BiomarkerBand.CONCERNING -> "Concerning"
     }
 
 private val BiomarkerBand.color: Color
     get() = when (this) {
         BiomarkerBand.NORMAL -> Color(0xFF4CAF50)
         BiomarkerBand.BORDERLINE -> Color(0xFFFFA000)
-        BiomarkerBand.HIGH -> Color(0xFFD32F2F)
+        BiomarkerBand.CONCERNING -> Color(0xFFD32F2F)
     }

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -37,8 +37,8 @@ class BiomarkerBandsTest {
     @Test
     fun classify_returns_HIGH_at_or_above_borderline_ceiling() {
         val bands = BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0)
-        assertEquals(BiomarkerBand.HIGH, bands.classify(3.0))
-        assertEquals(BiomarkerBand.HIGH, bands.classify(10.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(3.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(10.0))
     }
 
     @Test
@@ -62,8 +62,8 @@ class BiomarkerBandsTest {
         assertEquals(BiomarkerBand.NORMAL, bands!!.classify(0.5))
         assertEquals(BiomarkerBand.BORDERLINE, bands.classify(1.0))
         assertEquals(BiomarkerBand.BORDERLINE, bands.classify(2.5))
-        assertEquals(BiomarkerBand.HIGH, bands.classify(3.0))
-        assertEquals(BiomarkerBand.HIGH, bands.classify(10.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(3.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(10.0))
     }
 
     // -- HbA1c literature thresholds --
@@ -77,24 +77,105 @@ class BiomarkerBandsTest {
         assertEquals(BiomarkerBand.NORMAL, bands!!.classify(5.0))
         assertEquals(BiomarkerBand.BORDERLINE, bands.classify(5.7))
         assertEquals(BiomarkerBand.BORDERLINE, bands.classify(6.4))
-        assertEquals(BiomarkerBand.HIGH, bands.classify(6.5))
-        assertEquals(BiomarkerBand.HIGH, bands.classify(9.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(6.5))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(9.0))
     }
 
     // -- Region coverage --
 
     @Test
     fun every_supported_region_carries_the_universal_biomarker_bands() {
+        val expected = setOf(
+            MetricType.HSCRP, MetricType.HBA1C,
+            MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
+            MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
+            MetricType.APO_B,
+        )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
-            assertNotNull(
-                "$regionCode should ship hsCRP bands",
-                bands[MetricType.HSCRP]
-            )
-            assertNotNull(
-                "$regionCode should ship HbA1c bands",
-                bands[MetricType.HBA1C]
-            )
+            for (key in expected) {
+                assertNotNull("$regionCode should ship ${key.key} bands", bands[key])
+            }
         }
+    }
+
+    // -- BELOW-direction classification (HDL is the inverse case) --
+
+    @Test
+    fun classify_returns_NORMAL_above_borderline_ceiling_when_direction_is_BELOW() {
+        val bands = BiomarkerBands(
+            normalCeiling = 40.0, borderlineCeiling = 60.0,
+            concerningDirection = com.bios.app.config.BandDirection.BELOW,
+        )
+        // High HDL is protective.
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(70.0))
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(60.0))
+    }
+
+    @Test
+    fun classify_returns_BORDERLINE_inside_the_window_when_direction_is_BELOW() {
+        val bands = BiomarkerBands(
+            normalCeiling = 40.0, borderlineCeiling = 60.0,
+            concerningDirection = com.bios.app.config.BandDirection.BELOW,
+        )
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(40.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(50.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(59.999))
+    }
+
+    @Test
+    fun classify_returns_CONCERNING_below_normal_ceiling_when_direction_is_BELOW() {
+        val bands = BiomarkerBands(
+            normalCeiling = 40.0, borderlineCeiling = 60.0,
+            concerningDirection = com.bios.app.config.BandDirection.BELOW,
+        )
+        // Low HDL is the cardiovascular concern.
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(39.999))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(25.0))
+    }
+
+    // -- Lipid panel literature thresholds --
+
+    @Test
+    fun lipid_panel_bands_match_NCEP_ATP_III_thresholds() {
+        val bands = RegionConfigProvider.forRegion("US").clinicalThresholds.biomarkerBands
+
+        // Total cholesterol: <200 desirable, 200-239 borderline, ≥240 high.
+        val tc = bands[MetricType.TOTAL_CHOLESTEROL]!!
+        assertEquals(BiomarkerBand.NORMAL, tc.classify(180.0))
+        assertEquals(BiomarkerBand.BORDERLINE, tc.classify(200.0))
+        assertEquals(BiomarkerBand.CONCERNING, tc.classify(240.0))
+
+        // LDL: <100 optimal, 100-160 borderline, ≥160 high.
+        val ldl = bands[MetricType.LDL_CHOLESTEROL]!!
+        assertEquals(BiomarkerBand.NORMAL, ldl.classify(95.0))
+        assertEquals(BiomarkerBand.BORDERLINE, ldl.classify(100.0))
+        assertEquals(BiomarkerBand.CONCERNING, ldl.classify(160.0))
+
+        // Triglycerides: <150 normal, 150-200 borderline, ≥200 high.
+        val tg = bands[MetricType.TRIGLYCERIDES]!!
+        assertEquals(BiomarkerBand.NORMAL, tg.classify(140.0))
+        assertEquals(BiomarkerBand.BORDERLINE, tg.classify(150.0))
+        assertEquals(BiomarkerBand.CONCERNING, tg.classify(200.0))
+    }
+
+    @Test
+    fun hdl_band_inverts_so_low_values_are_concerning() {
+        val hdl = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.HDL_CHOLESTEROL]!!
+        assertEquals(BiomarkerBand.CONCERNING, hdl.classify(35.0))
+        assertEquals(BiomarkerBand.BORDERLINE, hdl.classify(40.0))
+        assertEquals(BiomarkerBand.BORDERLINE, hdl.classify(55.0))
+        assertEquals(BiomarkerBand.NORMAL, hdl.classify(60.0))
+        assertEquals(BiomarkerBand.NORMAL, hdl.classify(75.0))
+    }
+
+    @Test
+    fun apob_band_uses_Sniderman_2019_thresholds() {
+        val apob = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.APO_B]!!
+        assertEquals(BiomarkerBand.NORMAL, apob.classify(80.0))
+        assertEquals(BiomarkerBand.BORDERLINE, apob.classify(90.0))
+        assertEquals(BiomarkerBand.CONCERNING, apob.classify(120.0))
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -122,4 +122,42 @@ class BiomarkerConditionPatternsTest {
             }
         }
     }
+
+    // -- dyslipidemia_signature --
+
+    @Test
+    fun dyslipidemia_signature_gates_on_LDL_at_or_above_160_mg_per_dL() {
+        val pattern = BiomarkerConditionPatterns.dyslipidemiaSignature
+        val ldlRule = pattern.signalRules.first { it.metricType == MetricType.LDL_CHOLESTEROL }
+        assertTrue(ldlRule.required)
+        assertTrue(ldlRule.isAbsolute)
+        assertEquals(160.0, ldlRule.absoluteAbove!!, 1e-9)
+    }
+
+    @Test
+    fun dyslipidemia_signature_carries_corroborating_lipid_markers() {
+        val pattern = BiomarkerConditionPatterns.dyslipidemiaSignature
+        val supporting = pattern.signalRules.filter { !it.required }
+        val supportingMetrics = supporting.map { it.metricType }.toSet()
+        assertTrue(MetricType.HDL_CHOLESTEROL in supportingMetrics)
+        assertTrue(MetricType.TRIGLYCERIDES in supportingMetrics)
+        assertTrue(MetricType.APO_B in supportingMetrics)
+    }
+
+    @Test
+    fun dyslipidemia_HDL_rule_uses_absoluteBelow_for_low_concern() {
+        val pattern = BiomarkerConditionPatterns.dyslipidemiaSignature
+        val hdlRule = pattern.signalRules.first { it.metricType == MetricType.HDL_CHOLESTEROL }
+        assertTrue(hdlRule.isAbsolute)
+        assertEquals(40.0, hdlRule.absoluteBelow!!, 1e-9)
+        assertNull(hdlRule.absoluteAbove)
+    }
+
+    @Test
+    fun dyslipidemia_signature_requires_at_least_one_corroborator_via_minActiveSignals() {
+        // LDL required + 1 corroborator = 2 active signals = pattern fires.
+        // LDL alone would only be 1 active signal — minActiveSignals = 2
+        // prevents an isolated LDL spike from triggering the pattern.
+        assertEquals(2, BiomarkerConditionPatterns.dyslipidemiaSignature.minActiveSignals)
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,14 +395,15 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c):** `ClinicalThresholds.biomarkerBands`
-carries three-band classifications (NORMAL / BORDERLINE / HIGH) per region.
-`BiomarkerBands.classify(value)` is inclusive at the lower edge so cut-off
-values slot into the higher-risk band by clinical convention. hsCRP (Ridker
-AHA/CDC 2003): <1.0 mg/L normal, 1.0–3.0 borderline, ≥3.0 high. HbA1c
-(ADA 2024): <5.7% normal, 5.7–6.5% prediabetic, ≥6.5% diabetic. Both are
-clinically universal across the 6 regions via a shared
-`universalBiomarkerBands` constant. `LongevityReferenceScreen` surfaces
+**Clinical bands (shipped for hsCRP + HbA1c + full lipid panel):**
+`ClinicalThresholds.biomarkerBands` carries three-band classifications
+(NORMAL / BORDERLINE / CONCERNING) per region. `BiomarkerBands` has a
+`concerningDirection` flag — `ABOVE` for most lab values (high is bad),
+`BELOW` for HDL where low is the cardiovascular concern.
+`classify(value)` is inclusive at the lower edge so cut-off values slot
+into the higher-risk band by clinical convention. Universal thresholds:
+hsCRP (Ridker AHA/CDC 2003), HbA1c (ADA 2024), TC / LDL / HDL / TG (NCEP
+ATP III), ApoB (Sniderman 2019). `LongevityReferenceScreen` surfaces
 "Latest: 2.5 mg/L → Borderline" with a colour-coded label when a direct
 reading is available.
 
@@ -411,19 +412,21 @@ reading is available.
 `AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
 SENSOR filter, no time window) and compares against the hard cutoff — labs
 are dated and a six-month-old hsCRP is still meaningful.
-`alerts/BiomarkerConditionPatterns.kt` ships two patterns:
+`alerts/BiomarkerConditionPatterns.kt` ships three patterns:
 `inflammation_signature` (required hsCRP ≥ 1.0 mg/L + sustained RHR ↑ +
-HRV ↓ over 7d; Ridker 2003 + Furman 2019) and `prediabetes_signature`
+HRV ↓ over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature`
 (required HbA1c ≥ 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d;
-ADA 2024 + Hall 2018). Biomarker rule is `required = true` so wearable
+ADA 2024 + Hall 2018), and `dyslipidemia_signature` (required LDL ≥
+160 mg/dL + at least one of HDL ≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III
++ Sniderman 2019). Biomarker gate rule is `required = true` so wearable
 drift alone never fires the pattern.
 
 **Remaining work (separate PRs):**
 
-- Bands for the rest of the biomarker wave (lipid panel, vit D,
-  thyroid, CBC). Each batch is one region table addition + tests.
+- Bands for vit D, thyroid panel, CBC. Each batch is one region table
+  addition + tests.
 - More biomarker patterns built on the absolute-threshold path:
-  dyslipidemia, low-thyroid, anemia signatures.
+  low-thyroid, anemia, vitamin-D-deficiency signatures.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Extends PR #65's clinical-bands infrastructure and PR #66's absolute-threshold pattern engine to the full lipid panel. Owners who import a lipid panel now get both colour-coded clinical context AND a cardiovascular-risk alert when LDL crosses the high tier together with corroborating lipid abnormalities.

## Band model refactor
- `BiomarkerBand.HIGH` → `BiomarkerBand.CONCERNING`. Reads correctly for both directions — hsCRP 5.0 is "Concerning" (high inflammation), HDL 35 is also "Concerning" (low HDL).
- `BiomarkerBands` gained `concerningDirection: BandDirection` (ABOVE or BELOW). ABOVE is the default; BELOW is for HDL where low values are the cardiovascular concern.
- `classify()` branches on direction, keeping the inclusive-at-lower-edge convention so cut-off values still slot into the higher-risk band.

## Lipid panel bands (NCEP ATP III + Sniderman 2019, universal across all 6 regions)
| Metric | Normal | Borderline | Concerning |
|--------|--------|------------|------------|
| TOTAL_CHOLESTEROL | <200 | 200–239 | ≥240 mg/dL |
| LDL_CHOLESTEROL | <100 | 100–159 | ≥160 mg/dL |
| HDL_CHOLESTEROL | ≥60 | 40–59 | <40 mg/dL (BELOW) |
| TRIGLYCERIDES | <150 | 150–199 | ≥200 mg/dL |
| APO_B | <90 | 90–119 | ≥120 mg/dL |

## Dyslipidemia pattern
- Required: `LDL_CHOLESTEROL absoluteAbove = 160 mg/dL`
- Corroborating: `HDL absoluteBelow = 40`, `TRIGLYCERIDES absoluteAbove = 200`, `APO_B absoluteAbove = 120`
- `minActiveSignals = 2` — isolated LDL spike never alerts; multi-marker confirmation is the clinical pattern for atherosclerotic risk.

## Test plan
- [x] `BiomarkerBandsTest` — 6 new tests covering BELOW-direction semantics (HDL), every lipid panel band against literature thresholds, expanded region coverage.
- [x] `BiomarkerConditionPatternsTest` — 4 new tests: LDL gate, corroborating markers, HDL `absoluteBelow`, `minActiveSignals = 2`.
- [x] `AlertContentPolicyTest` validates the new pattern automatically.
- [x] `./scripts/code-quality-check.sh` — all checks pass.
- [ ] **Not run on device/emulator.** HDL "Concerning low" display path should be smoke-tested before relying on this.

## Remaining §8.6 work
- Bands for vit D, thyroid, CBC. Each batch is one region table addition + tests.
- Patterns: low-thyroid, anemia, vitamin-D-deficiency signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)