### PR TITLE
feat: vitamin D bands + deficiency alert pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -24,7 +24,10 @@ import com.bios.contracts.MetricType
 object BiomarkerConditionPatterns {
 
     val all by lazy {
-        listOf(inflammationSignature, prediabetesSignature, dyslipidemiaSignature)
+        listOf(
+            inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
+            vitaminDDeficiencySignature,
+        )
     }
 
     /**
@@ -153,5 +156,57 @@ object BiomarkerConditionPatterns {
             "Sniderman AD et al. (2019) — Apolipoprotein B particles and cardiovascular disease",
         ),
         earlyDetection = "An isolated LDL elevation can have transient causes (diet, weight cycling). Multi-marker confirmation across the lipid panel narrows the signal to durable dyslipidemia worth investigating.",
+    )
+
+    /**
+     * 25-OH vitamin D below 20 ng/mL (Endocrine Society 2011 deficiency
+     * threshold) paired with at least one wearable signal consistent with
+     * the symptomatic profile: sleep efficiency below baseline (Romano
+     * 2019), reduced activity (Roy 2014), or elevated mood-drift score
+     * (Anglin 2013) when W2F is connected.
+     *
+     * Vit D deficiency is silent for months and the wearable corroborators
+     * are individually noisy — each has many possible causes. The lab gate
+     * narrows the signal to the population where these proxies plausibly
+     * track the deficiency itself.
+     */
+    val vitaminDDeficiencySignature = ConditionPattern(
+        id = "biomarker_vitamin_d_deficiency_signature",
+        title = "Low vitamin D with corroborating recovery signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.VITAMIN_D_25OH, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "Endocrine Society 2011 — 25(OH)D <20 ng/mL is the deficiency threshold",
+                required = true,
+                absoluteBelow = 20.0,
+            ),
+            SignalRule(
+                MetricType.SLEEP_EFFICIENCY, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Romano F et al. 2019 — vitamin D status correlates with sleep regulation",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Roy S et al. 2014 — vitamin D deficiency associated with fatigue and reduced activity tolerance",
+            ),
+            SignalRule(
+                MetricType.MOOD_DRIFT_SCORE, DeviationDirection.ABOVE, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Anglin RES et al. 2013 — vitamin D status associated with mood; W2F mood-drift score rises during low-D periods",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent 25-OH vitamin D reading sits below 20 ng/mL — the Endocrine Society deficiency threshold — while at least one corroborating recovery signal has trended in the symptomatic direction over the past seven days. The lab anchors the pattern; the wearable signals on their own have many possible causes.",
+        suggestedAction = "Discuss the vitamin D value and the recovery-signal trend with a healthcare provider. The 25-OH D reading, sleep efficiency trend, and active-minutes trend from Bios are useful to share.",
+        references = listOf(
+            "Holick MF et al. (2011) — Evaluation, treatment, and prevention of vitamin D deficiency",
+            "Romano F et al. (2019) — Vitamin D and sleep regulation",
+            "Roy S et al. (2014) — Correction of low vitamin D improves fatigue in otherwise healthy women",
+            "Anglin RES et al. (2013) — Vitamin D deficiency and depression in adults",
+        ),
+        earlyDetection = "Vitamin D deficiency develops silently over months. Pairing a measured lab value with the wearable signals lets the pattern surface a deficiency that's started affecting sleep / activity / mood before symptoms become explicit.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -51,6 +51,13 @@ object RegionConfigProvider {
         MetricType.APO_B to BiomarkerBands(
             normalCeiling = 90.0, borderlineCeiling = 120.0,
         ),
+        // 25-OH vitamin D (ng/mL): <20 deficient, 20–30 insufficient, ≥30 sufficient
+        // — INVERSE direction: low values are the clinical concern
+        // (Holick et al. 2011 — Endocrine Society Clinical Practice Guideline)
+        MetricType.VITAMIN_D_25OH to BiomarkerBands(
+            normalCeiling = 20.0, borderlineCeiling = 30.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -89,7 +89,7 @@ class BiomarkerBandsTest {
             MetricType.HSCRP, MetricType.HBA1C,
             MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
             MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
-            MetricType.APO_B,
+            MetricType.APO_B, MetricType.VITAMIN_D_25OH,
         )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
@@ -177,5 +177,20 @@ class BiomarkerBandsTest {
         assertEquals(BiomarkerBand.NORMAL, apob.classify(80.0))
         assertEquals(BiomarkerBand.BORDERLINE, apob.classify(90.0))
         assertEquals(BiomarkerBand.CONCERNING, apob.classify(120.0))
+    }
+
+    @Test
+    fun vitamin_d_band_matches_Endocrine_Society_2011_thresholds_with_BELOW_direction() {
+        val vd = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.VITAMIN_D_25OH]!!
+        // <20 ng/mL = deficient (CONCERNING)
+        // 20–29 = insufficient (BORDERLINE)
+        // ≥30 = sufficient (NORMAL)
+        assertEquals(BiomarkerBand.CONCERNING, vd.classify(15.0))
+        assertEquals(BiomarkerBand.CONCERNING, vd.classify(19.999))
+        assertEquals(BiomarkerBand.BORDERLINE, vd.classify(20.0))
+        assertEquals(BiomarkerBand.BORDERLINE, vd.classify(29.999))
+        assertEquals(BiomarkerBand.NORMAL, vd.classify(30.0))
+        assertEquals(BiomarkerBand.NORMAL, vd.classify(50.0))
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -160,4 +160,37 @@ class BiomarkerConditionPatternsTest {
         // prevents an isolated LDL spike from triggering the pattern.
         assertEquals(2, BiomarkerConditionPatterns.dyslipidemiaSignature.minActiveSignals)
     }
+
+    // -- vitamin_d_deficiency_signature --
+
+    @Test
+    fun vitamin_d_signature_gates_on_25_OH_below_20_ng_per_mL() {
+        val pattern = BiomarkerConditionPatterns.vitaminDDeficiencySignature
+        val vdRule = pattern.signalRules.first { it.metricType == MetricType.VITAMIN_D_25OH }
+        assertTrue(vdRule.required)
+        assertTrue(vdRule.isAbsolute)
+        // BELOW threshold — low vit D is the concern, mirroring the bands.
+        assertEquals(20.0, vdRule.absoluteBelow!!, 1e-9)
+        assertNull(vdRule.absoluteAbove)
+        assertEquals(ThresholdSource.LITERATURE, vdRule.source)
+    }
+
+    @Test
+    fun vitamin_d_signature_carries_recovery_proxies_as_corroborators() {
+        val pattern = BiomarkerConditionPatterns.vitaminDDeficiencySignature
+        val corroborators = pattern.signalRules
+            .filter { !it.required }
+            .map { it.metricType }
+            .toSet()
+        // Sleep / activity / mood are the three best-evidenced wearable
+        // proxies for symptomatic vitamin D deficiency.
+        assertTrue(MetricType.SLEEP_EFFICIENCY in corroborators)
+        assertTrue(MetricType.ACTIVE_MINUTES in corroborators)
+        assertTrue(MetricType.MOOD_DRIFT_SCORE in corroborators)
+    }
+
+    @Test
+    fun vitamin_d_signature_requires_at_least_one_corroborator() {
+        assertEquals(2, BiomarkerConditionPatterns.vitaminDDeficiencySignature.minActiveSignals)
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,38 +395,40 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c + full lipid panel):**
+**Clinical bands (shipped for hsCRP + HbA1c + full lipid panel + vit D):**
 `ClinicalThresholds.biomarkerBands` carries three-band classifications
 (NORMAL / BORDERLINE / CONCERNING) per region. `BiomarkerBands` has a
 `concerningDirection` flag — `ABOVE` for most lab values (high is bad),
-`BELOW` for HDL where low is the cardiovascular concern.
+`BELOW` for HDL and 25-OH vitamin D where low is the clinical concern.
 `classify(value)` is inclusive at the lower edge so cut-off values slot
 into the higher-risk band by clinical convention. Universal thresholds:
 hsCRP (Ridker AHA/CDC 2003), HbA1c (ADA 2024), TC / LDL / HDL / TG (NCEP
-ATP III), ApoB (Sniderman 2019). `LongevityReferenceScreen` surfaces
-"Latest: 2.5 mg/L → Borderline" with a colour-coded label when a direct
-reading is available.
+ATP III), ApoB (Sniderman 2019), 25-OH vit D (Endocrine Society 2011).
+`LongevityReferenceScreen` surfaces "Latest: 2.5 mg/L → Borderline" with
+a colour-coded label when a direct reading is available.
 
 **Biomarker-anchored ConditionPatterns (shipped):** `SignalRule` gained
 `absoluteAbove` / `absoluteBelow` + an `isAbsolute` predicate. When set,
 `AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
 SENSOR filter, no time window) and compares against the hard cutoff — labs
 are dated and a six-month-old hsCRP is still meaningful.
-`alerts/BiomarkerConditionPatterns.kt` ships three patterns:
-`inflammation_signature` (required hsCRP ≥ 1.0 mg/L + sustained RHR ↑ +
-HRV ↓ over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature`
-(required HbA1c ≥ 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d;
-ADA 2024 + Hall 2018), and `dyslipidemia_signature` (required LDL ≥
-160 mg/dL + at least one of HDL ≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III
-+ Sniderman 2019). Biomarker gate rule is `required = true` so wearable
-drift alone never fires the pattern.
+`alerts/BiomarkerConditionPatterns.kt` ships four patterns:
+`inflammation_signature` (hsCRP ≥ 1.0 mg/L + sustained RHR ↑ + HRV ↓
+over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
+5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d; ADA 2024 + Hall
+2018), `dyslipidemia_signature` (LDL ≥ 160 mg/dL + at least one of HDL
+≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III + Sniderman 2019), and
+`vitamin_d_deficiency_signature` (25-OH D < 20 ng/mL + at least one of
+sleep efficiency ↓, active minutes ↓, mood-drift score ↑ over 7d;
+Endocrine Society 2011 + Romano/Roy/Anglin). Biomarker gate rule is
+`required = true` so wearable drift alone never fires the pattern.
 
 **Remaining work (separate PRs):**
 
-- Bands for vit D, thyroid panel, CBC. Each batch is one region table
+- Bands for the thyroid panel and CBC. Each batch is one region table
   addition + tests.
 - More biomarker patterns built on the absolute-threshold path:
-  low-thyroid, anemia, vitamin-D-deficiency signatures.
+  low-thyroid, anemia signatures.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Extends the clinical-bands work to 25-OH vitamin D (Endocrine Society 2011 thresholds) and ships a deficiency pattern that gates on a measured lab value paired with the wearable signals most consistent with symptomatic vitamin D deficiency. Vit D deficiency affects ~40% of US adults and develops silently over months, so "measured lab + behavioural drift" is the right surface.

## Vit D bands (Holick et al. 2011, universal across all 6 regions)
| Value | Band |
|-------|------|
| <20 ng/mL | **CONCERNING** (deficient) |
| 20–29 ng/mL | BORDERLINE (insufficient) |
| ≥30 ng/mL | NORMAL (sufficient) |

BELOW direction — reuses the inverse-band machinery shipped for HDL in PR #67.

## Deficiency pattern
- Required: `VITAMIN_D_25OH absoluteBelow = 20` (deficiency threshold)
- Corroborating: `SLEEP_EFFICIENCY` below baseline 1σ for 168h (Romano 2019)
- Corroborating: `ACTIVE_MINUTES` below baseline 1σ for 168h (Roy 2014 — fatigue / activity-tolerance presentation)
- Corroborating: `MOOD_DRIFT_SCORE` above baseline 1σ for 168h (Anglin 2013 — vit D ↔ mood; reads from W2F when connected)
- `minActiveSignals = 2` — lab plus one corroborator. Isolated low vit D without symptomatic drift doesn't fire; isolated drift without the lab doesn't fire either.

## Test plan
- [x] `BiomarkerBandsTest` — vit D classification across all three bands; region-coverage test now includes `VITAMIN_D_25OH`.
- [x] `BiomarkerConditionPatternsTest` — 3 new tests: the `absoluteBelow = 20` gate, the three corroborators (sleep / activity / mood-drift), `minActiveSignals = 2`.
- [x] `AlertContentPolicyTest` validates the new pattern automatically.
- [x] `./scripts/code-quality-check.sh` — all checks pass.
- [ ] **Not run on device/emulator.** Behavioural verification of end-to-end pattern firing still needs a manual or instrumented test.

## Remaining §8.6 work
- Thyroid bands + hypothyroid signature (TSH / free T4 / free T3).
- CBC bands + anemia signature (hemoglobin BELOW, hematocrit, WBC, RBC, platelets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)