### PR TITLE
feat: thyroid bands + hypothyroid alert pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -26,7 +26,7 @@ object BiomarkerConditionPatterns {
     val all by lazy {
         listOf(
             inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
-            vitaminDDeficiencySignature,
+            vitaminDDeficiencySignature, hypothyroidSignature,
         )
     }
 
@@ -208,5 +208,57 @@ object BiomarkerConditionPatterns {
             "Anglin RES et al. (2013) — Vitamin D deficiency and depression in adults",
         ),
         earlyDetection = "Vitamin D deficiency develops silently over months. Pairing a measured lab value with the wearable signals lets the pattern surface a deficiency that's started affecting sleep / activity / mood before symptoms become explicit.",
+    )
+
+    /**
+     * TSH ≥ 4.0 mIU/L (AACE/ATA 2012 subclinical-hypothyroidism threshold)
+     * paired with at least one of: free T4 below 0.8 ng/dL (overt
+     * hypothyroidism), sustained resting-HR bradycardia, or reduced active
+     * minutes. Hypothyroidism is ~10× more common than hyperthyroidism in
+     * adults and presents with the classic slow-metabolism signature
+     * (bradycardia + fatigue) that wearables can corroborate.
+     *
+     * Hyperthyroidism (TSH below 0.4) is captured by the bands but doesn't
+     * have its own pattern yet — a dedicated hyperthyroid signature with
+     * tachycardia + RHR↑ + active minutes↑ corroborators is a future PR.
+     */
+    val hypothyroidSignature = ConditionPattern(
+        id = "biomarker_hypothyroid_signature",
+        title = "Elevated TSH with corroborating low-metabolism signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.TSH, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "AACE/ATA 2012 — TSH ≥4.0 mIU/L is the subclinical-hypothyroid threshold",
+                required = true,
+                absoluteAbove = 4.0,
+            ),
+            SignalRule(
+                MetricType.FREE_T4, DeviationDirection.BELOW, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "AACE 2012 — free T4 <0.8 ng/dL alongside elevated TSH indicates overt hypothyroidism",
+                absoluteBelow = 0.8,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Klein & Ojamaa 2001 — hypothyroidism produces sinus bradycardia via reduced sympathetic drive",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Surks et al. 2004 — fatigue and reduced exercise tolerance are dominant hypothyroid symptoms",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent TSH reading sits at or above 4.0 mIU/L — the AACE/ATA subclinical-hypothyroidism threshold — while at least one corroborating signal of slowed metabolism has appeared: low free T4, sustained bradycardia, or reduced activity. The lab anchors the pattern; the wearable signals are individually nonspecific.",
+        suggestedAction = "Discuss the TSH and free T4 values along with the resting-HR and active-minutes trends with a healthcare provider. A repeat TSH 6–12 weeks later is the standard clinical follow-up for elevated readings.",
+        references = listOf(
+            "Garber JR et al. (2012) — Clinical practice guidelines for hypothyroidism (AACE/ATA)",
+            "Klein I, Ojamaa K (2001) — Thyroid hormone and the cardiovascular system",
+            "Surks MI et al. (2004) — Subclinical thyroid disease: scientific review and guidelines",
+        ),
+        earlyDetection = "Subclinical hypothyroidism is silent for months and the wearable signature (bradycardia + fatigue) overlaps with fitness, illness recovery, and overtraining. Pairing it with a measured TSH narrows the signal to thyroid involvement.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfig.kt
@@ -69,8 +69,14 @@ data class ClinicalThresholds(
  *  - [BandDirection.ABOVE] (default): high values are concerning. Typical
  *    for hsCRP, HbA1c, LDL, ApoB, triglycerides — values at or above
  *    [borderlineCeiling] classify as [BiomarkerBand.CONCERNING].
- *  - [BandDirection.BELOW]: low values are concerning. Typical for HDL —
- *    values below [normalCeiling] classify as [BiomarkerBand.CONCERNING].
+ *  - [BandDirection.BELOW]: low values are concerning. Typical for HDL,
+ *    25-OH vitamin D — values below [normalCeiling] classify as
+ *    [BiomarkerBand.CONCERNING].
+ *
+ * For markers that are concerning at **both** extremes (TSH is the canonical
+ * case: low → hyperthyroid, high → hypothyroid), [lowCeiling] adds a second
+ * CONCERNING band on the low side without breaking the simple ABOVE shape.
+ * Only meaningful when [concerningDirection] is `ABOVE`.
  *
  * Comparisons are inclusive at the lower edge and exclusive at the upper
  * edge so values sitting exactly on a published cut-off slot into the
@@ -81,23 +87,35 @@ data class BiomarkerBands(
     val normalCeiling: Double,
     val borderlineCeiling: Double,
     val concerningDirection: BandDirection = BandDirection.ABOVE,
+    val lowCeiling: Double? = null,
 ) {
     init {
         require(normalCeiling < borderlineCeiling) {
             "normalCeiling ($normalCeiling) must be < borderlineCeiling ($borderlineCeiling)"
         }
+        if (lowCeiling != null) {
+            require(concerningDirection == BandDirection.ABOVE) {
+                "lowCeiling only applies when concerningDirection = ABOVE (BELOW already treats low values as concerning)"
+            }
+            require(lowCeiling < normalCeiling) {
+                "lowCeiling ($lowCeiling) must be < normalCeiling ($normalCeiling)"
+            }
+        }
     }
 
-    fun classify(value: Double): BiomarkerBand = when (concerningDirection) {
-        BandDirection.ABOVE -> when {
-            value < normalCeiling -> BiomarkerBand.NORMAL
-            value < borderlineCeiling -> BiomarkerBand.BORDERLINE
-            else -> BiomarkerBand.CONCERNING
-        }
-        BandDirection.BELOW -> when {
-            value >= borderlineCeiling -> BiomarkerBand.NORMAL
-            value >= normalCeiling -> BiomarkerBand.BORDERLINE
-            else -> BiomarkerBand.CONCERNING
+    fun classify(value: Double): BiomarkerBand {
+        if (lowCeiling != null && value < lowCeiling) return BiomarkerBand.CONCERNING
+        return when (concerningDirection) {
+            BandDirection.ABOVE -> when {
+                value < normalCeiling -> BiomarkerBand.NORMAL
+                value < borderlineCeiling -> BiomarkerBand.BORDERLINE
+                else -> BiomarkerBand.CONCERNING
+            }
+            BandDirection.BELOW -> when {
+                value >= borderlineCeiling -> BiomarkerBand.NORMAL
+                value >= normalCeiling -> BiomarkerBand.BORDERLINE
+                else -> BiomarkerBand.CONCERNING
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -58,6 +58,23 @@ object RegionConfigProvider {
             normalCeiling = 20.0, borderlineCeiling = 30.0,
             concerningDirection = BandDirection.BELOW,
         ),
+        // TSH (mIU/L): <0.4 hyperthyroid, 0.4–4.0 normal, 4.0–10.0 subclinical
+        // hypothyroid, ≥10.0 overt hypothyroid. Bidirectional: both extremes
+        // are clinical concerns (AACE/ATA 2012; ATA 2014 — adult guidelines).
+        MetricType.TSH to BiomarkerBands(
+            normalCeiling = 4.0, borderlineCeiling = 10.0,
+            concerningDirection = BandDirection.ABOVE,
+            lowCeiling = 0.4,
+        ),
+        // Free T4 (ng/dL) — hypo-focused window. <0.8 overt hypothyroid,
+        // 0.8–1.0 borderline-low, ≥1.0 normal-for-hypo-screening. The
+        // bidirectional hyperthyroid case (high free T4) is covered by the
+        // TSH low-extreme; a future PR can add a dual-direction free T4
+        // band once a hyperthyroid pattern lands. (AACE 2012)
+        MetricType.FREE_T4 to BiomarkerBands(
+            normalCeiling = 0.8, borderlineCeiling = 1.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -51,6 +51,57 @@ class BiomarkerBandsTest {
         }
     }
 
+    // -- lowCeiling: bidirectional CONCERNING bands --
+
+    @Test
+    fun lowCeiling_requires_ABOVE_direction() {
+        // BELOW direction already treats low values as concerning, so a
+        // lowCeiling on top of that is meaningless and rejected outright.
+        assertThrows(IllegalArgumentException::class.java) {
+            BiomarkerBands(
+                normalCeiling = 4.0, borderlineCeiling = 10.0,
+                concerningDirection = com.bios.app.config.BandDirection.BELOW,
+                lowCeiling = 0.4,
+            )
+        }
+    }
+
+    @Test
+    fun lowCeiling_must_be_below_normalCeiling() {
+        assertThrows(IllegalArgumentException::class.java) {
+            BiomarkerBands(
+                normalCeiling = 4.0, borderlineCeiling = 10.0,
+                lowCeiling = 4.0,  // not strictly less
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            BiomarkerBands(
+                normalCeiling = 4.0, borderlineCeiling = 10.0,
+                lowCeiling = 5.0,  // above normalCeiling
+            )
+        }
+    }
+
+    @Test
+    fun lowCeiling_classifies_low_extreme_as_CONCERNING() {
+        val bands = BiomarkerBands(
+            normalCeiling = 4.0, borderlineCeiling = 10.0,
+            lowCeiling = 0.4,
+        )
+        // TSH-like: low extreme is hyperthyroid concern.
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(0.1))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(0.399))
+        // Inclusive at the lower edge of NORMAL.
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(0.4))
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(2.0))
+        assertEquals(BiomarkerBand.NORMAL, bands.classify(3.999))
+        // High side: BORDERLINE then CONCERNING.
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(4.0))
+        assertEquals(BiomarkerBand.BORDERLINE, bands.classify(9.999))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(10.0))
+        assertEquals(BiomarkerBand.CONCERNING, bands.classify(50.0))
+    }
+
     // -- hsCRP literature thresholds --
 
     @Test
@@ -90,6 +141,7 @@ class BiomarkerBandsTest {
             MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
             MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
             MetricType.APO_B, MetricType.VITAMIN_D_25OH,
+            MetricType.TSH, MetricType.FREE_T4,
         )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
@@ -177,6 +229,38 @@ class BiomarkerBandsTest {
         assertEquals(BiomarkerBand.NORMAL, apob.classify(80.0))
         assertEquals(BiomarkerBand.BORDERLINE, apob.classify(90.0))
         assertEquals(BiomarkerBand.CONCERNING, apob.classify(120.0))
+    }
+
+    @Test
+    fun tsh_band_uses_AACE_ATA_2012_bidirectional_thresholds() {
+        val tsh = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.TSH]!!
+        // <0.4 hyperthyroid concern (low extreme)
+        assertEquals(BiomarkerBand.CONCERNING, tsh.classify(0.2))
+        // 0.4–4.0 normal
+        assertEquals(BiomarkerBand.NORMAL, tsh.classify(0.4))
+        assertEquals(BiomarkerBand.NORMAL, tsh.classify(2.0))
+        // 4.0–10.0 subclinical hypothyroid (BORDERLINE)
+        assertEquals(BiomarkerBand.BORDERLINE, tsh.classify(4.0))
+        assertEquals(BiomarkerBand.BORDERLINE, tsh.classify(7.5))
+        // ≥10.0 overt hypothyroid (CONCERNING high)
+        assertEquals(BiomarkerBand.CONCERNING, tsh.classify(10.0))
+        assertEquals(BiomarkerBand.CONCERNING, tsh.classify(25.0))
+    }
+
+    @Test
+    fun free_t4_band_uses_hypo_focused_BELOW_thresholds() {
+        val ft4 = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.FREE_T4]!!
+        // <0.8 overt hypothyroid
+        assertEquals(BiomarkerBand.CONCERNING, ft4.classify(0.5))
+        assertEquals(BiomarkerBand.CONCERNING, ft4.classify(0.799))
+        // 0.8–1.0 borderline-low
+        assertEquals(BiomarkerBand.BORDERLINE, ft4.classify(0.8))
+        assertEquals(BiomarkerBand.BORDERLINE, ft4.classify(0.999))
+        // ≥1.0 normal (for hypo screening)
+        assertEquals(BiomarkerBand.NORMAL, ft4.classify(1.0))
+        assertEquals(BiomarkerBand.NORMAL, ft4.classify(1.5))
     }
 
     @Test

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -193,4 +193,45 @@ class BiomarkerConditionPatternsTest {
     fun vitamin_d_signature_requires_at_least_one_corroborator() {
         assertEquals(2, BiomarkerConditionPatterns.vitaminDDeficiencySignature.minActiveSignals)
     }
+
+    // -- hypothyroid_signature --
+
+    @Test
+    fun hypothyroid_signature_gates_on_TSH_at_or_above_4_mIU_per_L() {
+        val pattern = BiomarkerConditionPatterns.hypothyroidSignature
+        val tshRule = pattern.signalRules.first { it.metricType == MetricType.TSH }
+        assertTrue(tshRule.required)
+        assertTrue(tshRule.isAbsolute)
+        assertEquals(4.0, tshRule.absoluteAbove!!, 1e-9)
+        assertNull(tshRule.absoluteBelow)
+        assertEquals(ThresholdSource.LITERATURE, tshRule.source)
+    }
+
+    @Test
+    fun hypothyroid_signature_uses_free_T4_below_0_8_as_an_overt_hypo_corroborator() {
+        val pattern = BiomarkerConditionPatterns.hypothyroidSignature
+        val ft4Rule = pattern.signalRules.first { it.metricType == MetricType.FREE_T4 }
+        assertFalse("free T4 is corroborating, not gating", ft4Rule.required)
+        assertTrue(ft4Rule.isAbsolute)
+        assertEquals(0.8, ft4Rule.absoluteBelow!!, 1e-9)
+    }
+
+    @Test
+    fun hypothyroid_signature_corroborators_match_slow_metabolism_presentation() {
+        val pattern = BiomarkerConditionPatterns.hypothyroidSignature
+        val rhrRule = pattern.signalRules.first { it.metricType == MetricType.RESTING_HEART_RATE }
+        // Bradycardia: BELOW baseline, not absolute (this is a deviation
+        // rule, not a clinical-cutoff rule like the lab gates).
+        assertFalse(rhrRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.BELOW, rhrRule.direction)
+
+        val activityRule = pattern.signalRules.first { it.metricType == MetricType.ACTIVE_MINUTES }
+        assertFalse(activityRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.BELOW, activityRule.direction)
+    }
+
+    @Test
+    fun hypothyroid_signature_requires_at_least_one_corroborator() {
+        assertEquals(2, BiomarkerConditionPatterns.hypothyroidSignature.minActiveSignals)
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,40 +395,45 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c + full lipid panel + vit D):**
+**Clinical bands (shipped for hsCRP + HbA1c + lipid panel + vit D + TSH/freeT4):**
 `ClinicalThresholds.biomarkerBands` carries three-band classifications
 (NORMAL / BORDERLINE / CONCERNING) per region. `BiomarkerBands` has a
-`concerningDirection` flag — `ABOVE` for most lab values (high is bad),
-`BELOW` for HDL and 25-OH vitamin D where low is the clinical concern.
-`classify(value)` is inclusive at the lower edge so cut-off values slot
-into the higher-risk band by clinical convention. Universal thresholds:
-hsCRP (Ridker AHA/CDC 2003), HbA1c (ADA 2024), TC / LDL / HDL / TG (NCEP
-ATP III), ApoB (Sniderman 2019), 25-OH vit D (Endocrine Society 2011).
-`LongevityReferenceScreen` surfaces "Latest: 2.5 mg/L → Borderline" with
-a colour-coded label when a direct reading is available.
+`concerningDirection` flag — `ABOVE` for most lab values, `BELOW` for HDL
+and 25-OH vitamin D — plus an optional `lowCeiling` for markers like TSH
+that are concerning at both extremes (TSH low → hyperthyroid, high →
+hypothyroid). `classify(value)` is inclusive at the lower edge so cut-off
+values slot into the higher-risk band by clinical convention. Universal
+thresholds: hsCRP (Ridker AHA/CDC 2003), HbA1c (ADA 2024), TC / LDL / HDL
+/ TG (NCEP ATP III), ApoB (Sniderman 2019), 25-OH vit D (Endocrine
+Society 2011), TSH + free T4 (AACE/ATA 2012). `LongevityReferenceScreen`
+surfaces "Latest: 2.5 mg/L → Borderline" with a colour-coded label when
+a direct reading is available.
 
 **Biomarker-anchored ConditionPatterns (shipped):** `SignalRule` gained
 `absoluteAbove` / `absoluteBelow` + an `isAbsolute` predicate. When set,
 `AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
 SENSOR filter, no time window) and compares against the hard cutoff — labs
 are dated and a six-month-old hsCRP is still meaningful.
-`alerts/BiomarkerConditionPatterns.kt` ships four patterns:
+`alerts/BiomarkerConditionPatterns.kt` ships five patterns:
 `inflammation_signature` (hsCRP ≥ 1.0 mg/L + sustained RHR ↑ + HRV ↓
 over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d; ADA 2024 + Hall
 2018), `dyslipidemia_signature` (LDL ≥ 160 mg/dL + at least one of HDL
-≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III + Sniderman 2019), and
+≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III + Sniderman 2019),
 `vitamin_d_deficiency_signature` (25-OH D < 20 ng/mL + at least one of
 sleep efficiency ↓, active minutes ↓, mood-drift score ↑ over 7d;
-Endocrine Society 2011 + Romano/Roy/Anglin). Biomarker gate rule is
+Endocrine Society 2011 + Romano/Roy/Anglin), and `hypothyroid_signature`
+(TSH ≥ 4.0 mIU/L + at least one of free T4 < 0.8 ng/dL, RHR ↓, active
+minutes ↓ over 7d; AACE/ATA 2012 + Klein/Surks). Biomarker gate rule is
 `required = true` so wearable drift alone never fires the pattern.
 
 **Remaining work (separate PRs):**
 
-- Bands for the thyroid panel and CBC. Each batch is one region table
-  addition + tests.
-- More biomarker patterns built on the absolute-threshold path:
-  low-thyroid, anemia signatures.
+- Free T3 band + a dedicated `hyperthyroid_signature` (TSH < 0.4 + RHR ↑
+  + active-minutes ↑). The TSH `lowCeiling` shipped now already classifies
+  the lab side; only the pattern is missing.
+- CBC bands + anemia signature (hemoglobin BELOW, hematocrit, WBC, RBC,
+  platelets).
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary
Extends the bands infrastructure to handle bidirectionally-concerning biomarkers (TSH: low → hyperthyroid, high → hypothyroid) and ships a hypothyroid signature paired with the slow-metabolism wearable signature (bradycardia + reduced activity). Hypothyroidism is ~10× more common than hyperthyroidism in adults; this PR lands the more impactful direction first.

## BiomarkerBands extension
New optional `lowCeiling: Double?` field. When set (only valid with `concerningDirection = ABOVE`), values below it classify as `CONCERNING`, creating a second concerning band at the low extreme. `classify()` checks `lowCeiling` first, then falls through to existing ABOVE/BELOW logic.

## Thyroid bands (AACE/ATA 2012, universal across all 6 regions)
| Metric | Bands |
|--------|-------|
| TSH (mIU/L) | <0.4 CONCERNING (hyper) · 0.4–4.0 NORMAL · 4.0–10.0 BORDERLINE (subclinical hypo) · ≥10.0 CONCERNING (overt hypo) |
| Free T4 (ng/dL) | <0.8 CONCERNING · 0.8–1.0 BORDERLINE · ≥1.0 NORMAL (BELOW direction, hypo-focused) |

Free T3 band + hyperthyroid bands for free T4 deferred — see Remaining work.

## Hypothyroid pattern
- Required: `TSH absoluteAbove = 4.0 mIU/L` (AACE/ATA subclinical threshold)
- Corroborating: `FREE_T4 absoluteBelow = 0.8 ng/dL` (overt hypothyroid)
- Corroborating: `RESTING_HEART_RATE` below baseline 1σ for 168h (bradycardia — Klein & Ojamaa 2001)
- Corroborating: `ACTIVE_MINUTES` below baseline 1σ for 168h (Surks 2004)
- `minActiveSignals = 2` — TSH plus one corroborator.

## Test plan
- [x] `BiomarkerBandsTest` — 4 new tests on the `lowCeiling` extension (validator that requires ABOVE direction, monotonicity validator, low-extreme classification, the full TSH integration). New `free_t4` test covering all three bands.
- [x] `BiomarkerConditionPatternsTest` — 4 new tests: TSH gate, free-T4 absolute corroborator, baseline-relative RHR + activity corroborators, `minActiveSignals = 2`.
- [x] Region-coverage test expanded to include `TSH` + `FREE_T4`.
- [x] `AlertContentPolicyTest` validates the new pattern automatically.
- [x] `./scripts/code-quality-check.sh` — all checks pass.
- [ ] **Not run on device/emulator.** End-to-end pattern verification still needs manual or instrumented testing.

## Remaining §8.6 work
- Free T3 band + a dedicated `hyperthyroid_signature` (TSH < 0.4 + RHR ↑ + active-minutes ↑). The TSH `lowCeiling` shipped here already classifies the lab side; only the pattern is missing.
- CBC bands + anemia signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)