### PR TITLE
feat: Free T3 bands + hyperthyroid alert pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -26,7 +26,7 @@ object BiomarkerConditionPatterns {
     val all by lazy {
         listOf(
             inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
-            vitaminDDeficiencySignature, hypothyroidSignature,
+            vitaminDDeficiencySignature, hypothyroidSignature, hyperthyroidSignature,
         )
     }
 
@@ -218,9 +218,8 @@ object BiomarkerConditionPatterns {
      * adults and presents with the classic slow-metabolism signature
      * (bradycardia + fatigue) that wearables can corroborate.
      *
-     * Hyperthyroidism (TSH below 0.4) is captured by the bands but doesn't
-     * have its own pattern yet — a dedicated hyperthyroid signature with
-     * tachycardia + RHR↑ + active minutes↑ corroborators is a future PR.
+     * The mirror condition (hyperthyroidism, TSH below 0.4 with tachycardia
+     * and elevated free T3) ships as [hyperthyroidSignature] below.
      */
     val hypothyroidSignature = ConditionPattern(
         id = "biomarker_hypothyroid_signature",
@@ -260,5 +259,55 @@ object BiomarkerConditionPatterns {
             "Surks MI et al. (2004) — Subclinical thyroid disease: scientific review and guidelines",
         ),
         earlyDetection = "Subclinical hypothyroidism is silent for months and the wearable signature (bradycardia + fatigue) overlaps with fitness, illness recovery, and overtraining. Pairing it with a measured TSH narrows the signal to thyroid involvement.",
+    )
+
+    /**
+     * TSH below 0.4 mIU/L (AACE/ATA 2012 subclinical-hyperthyroidism threshold,
+     * Biondi & Cooper 2008) paired with at least one of: free T3 above 4.2
+     * pg/mL (the upper end of the adult reference range — T3 is the most
+     * sensitive single marker for T3-predominant thyrotoxicosis), sustained
+     * resting-HR tachycardia, or elevated active minutes. The mirror of
+     * [hypothyroidSignature]: same gating logic on the lab, opposite
+     * direction on every corroborator.
+     */
+    val hyperthyroidSignature = ConditionPattern(
+        id = "biomarker_hyperthyroid_signature",
+        title = "Suppressed TSH with corroborating high-metabolism signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.TSH, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "AACE/ATA 2012 — TSH <0.4 mIU/L is the subclinical-hyperthyroid threshold",
+                required = true,
+                absoluteBelow = 0.4,
+            ),
+            SignalRule(
+                MetricType.FREE_T3, DeviationDirection.ABOVE, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "Ross DS et al. 2016 — free T3 above the adult reference range (>4.2 pg/mL) indicates thyrotoxicosis, often T3-predominant",
+                absoluteAbove = 4.2,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Klein & Ojamaa 2001 — hyperthyroidism produces sinus tachycardia via increased sympathetic drive and direct chronotropic effect",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.ABOVE, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Biondi & Cooper 2008 — hyperthyroidism presents with restlessness and elevated baseline activity; sustained active-minute increase corroborates the lab",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent TSH reading sits below 0.4 mIU/L — the AACE/ATA subclinical-hyperthyroidism threshold — while at least one corroborating signal of accelerated metabolism has appeared: elevated free T3, sustained tachycardia, or increased baseline activity. The lab anchors the pattern; the wearable signals are individually nonspecific.",
+        suggestedAction = "Discuss the TSH and (if available) free T3 values along with the resting-HR and active-minutes trends with a healthcare provider. A repeat TSH 6–12 weeks later is the standard clinical follow-up for a suppressed reading; persistent suppression warrants free T3 / free T4 confirmation.",
+        references = listOf(
+            "Garber JR et al. (2012) — Clinical practice guidelines for hypothyroidism (AACE/ATA, includes hyperthyroid reference ranges)",
+            "Ross DS et al. (2016) — 2016 American Thyroid Association guidelines for hyperthyroidism and other causes of thyrotoxicosis",
+            "Biondi B, Cooper DS (2008) — The clinical significance of subclinical thyroid dysfunction",
+            "Klein I, Ojamaa K (2001) — Thyroid hormone and the cardiovascular system",
+        ),
+        earlyDetection = "Subclinical hyperthyroidism is silent for months and the wearable signature (tachycardia + restlessness) overlaps with caffeine, anxiety, stimulant medication, and early infection. Pairing it with a suppressed TSH narrows the signal to thyroid involvement.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -68,12 +68,27 @@ object RegionConfigProvider {
         ),
         // Free T4 (ng/dL) — hypo-focused window. <0.8 overt hypothyroid,
         // 0.8–1.0 borderline-low, ≥1.0 normal-for-hypo-screening. The
-        // bidirectional hyperthyroid case (high free T4) is covered by the
-        // TSH low-extreme; a future PR can add a dual-direction free T4
-        // band once a hyperthyroid pattern lands. (AACE 2012)
+        // hyperthyroid case is covered by the TSH low-extreme and by Free T3
+        // (which rises earlier than Free T4 in T3-toxicosis presentations);
+        // a single-axis BiomarkerBands can't express both a low-concern and
+        // a high-concern threshold, and Free T4 is the lower-yield half of
+        // that pair, so it stays hypo-focused here. (AACE 2012)
         MetricType.FREE_T4 to BiomarkerBands(
             normalCeiling = 0.8, borderlineCeiling = 1.0,
             concerningDirection = BandDirection.BELOW,
+        ),
+        // Free T3 (pg/mL): <2.3 low (hypothyroid), 2.3–4.2 normal,
+        // 4.2–6.5 borderline-high (subclinical / early thyrotoxicosis),
+        // ≥6.5 overt hyperthyroidism / T3-toxicosis. Bidirectional via
+        // [lowCeiling] so both extremes flag — Free T3 is the most
+        // sensitive single marker for T3-predominant hyperthyroidism, which
+        // can present with elevated Free T3 before Free T4 leaves range.
+        // (Ross DS et al. 2016 — ATA Hyperthyroidism Guideline;
+        // Garber JR et al. 2012 — AACE/ATA reference ranges)
+        MetricType.FREE_T3 to BiomarkerBands(
+            normalCeiling = 4.2, borderlineCeiling = 6.5,
+            concerningDirection = BandDirection.ABOVE,
+            lowCeiling = 2.3,
         ),
     )
 

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -141,7 +141,7 @@ class BiomarkerBandsTest {
             MetricType.TOTAL_CHOLESTEROL, MetricType.LDL_CHOLESTEROL,
             MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
             MetricType.APO_B, MetricType.VITAMIN_D_25OH,
-            MetricType.TSH, MetricType.FREE_T4,
+            MetricType.TSH, MetricType.FREE_T4, MetricType.FREE_T3,
         )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
@@ -261,6 +261,26 @@ class BiomarkerBandsTest {
         // ≥1.0 normal (for hypo screening)
         assertEquals(BiomarkerBand.NORMAL, ft4.classify(1.0))
         assertEquals(BiomarkerBand.NORMAL, ft4.classify(1.5))
+    }
+
+    @Test
+    fun free_t3_band_uses_bidirectional_AACE_ATA_thresholds() {
+        val ft3 = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.FREE_T3]!!
+        // <2.3 pg/mL = hypothyroid concern (low extreme via lowCeiling)
+        assertEquals(BiomarkerBand.CONCERNING, ft3.classify(1.5))
+        assertEquals(BiomarkerBand.CONCERNING, ft3.classify(2.299))
+        // 2.3–4.2 = normal
+        assertEquals(BiomarkerBand.NORMAL, ft3.classify(2.3))
+        assertEquals(BiomarkerBand.NORMAL, ft3.classify(3.2))
+        assertEquals(BiomarkerBand.NORMAL, ft3.classify(4.199))
+        // 4.2–6.5 = borderline-high (subclinical / early thyrotoxicosis)
+        assertEquals(BiomarkerBand.BORDERLINE, ft3.classify(4.2))
+        assertEquals(BiomarkerBand.BORDERLINE, ft3.classify(5.5))
+        assertEquals(BiomarkerBand.BORDERLINE, ft3.classify(6.499))
+        // ≥6.5 = overt hyperthyroid / T3-toxicosis (CONCERNING high)
+        assertEquals(BiomarkerBand.CONCERNING, ft3.classify(6.5))
+        assertEquals(BiomarkerBand.CONCERNING, ft3.classify(10.0))
     }
 
     @Test

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -234,4 +234,53 @@ class BiomarkerConditionPatternsTest {
     fun hypothyroid_signature_requires_at_least_one_corroborator() {
         assertEquals(2, BiomarkerConditionPatterns.hypothyroidSignature.minActiveSignals)
     }
+
+    // -- hyperthyroid_signature --
+
+    @Test
+    fun hyperthyroid_signature_is_registered_in_global_all_list() {
+        assertTrue(BiomarkerConditionPatterns.hyperthyroidSignature in ConditionPatterns.all)
+    }
+
+    @Test
+    fun hyperthyroid_signature_gates_on_TSH_below_0_4_mIU_per_L() {
+        val pattern = BiomarkerConditionPatterns.hyperthyroidSignature
+        val tshRule = pattern.signalRules.first { it.metricType == MetricType.TSH }
+        assertTrue("TSH rule should be required so the lab anchors the pattern", tshRule.required)
+        assertTrue(tshRule.isAbsolute)
+        // Mirror of the hypothyroid gate: same lab, opposite extreme.
+        assertEquals(0.4, tshRule.absoluteBelow!!, 1e-9)
+        assertNull(tshRule.absoluteAbove)
+        assertEquals(ThresholdSource.LITERATURE, tshRule.source)
+    }
+
+    @Test
+    fun hyperthyroid_signature_uses_free_T3_above_4_2_as_a_thyrotoxicosis_corroborator() {
+        val pattern = BiomarkerConditionPatterns.hyperthyroidSignature
+        val ft3Rule = pattern.signalRules.first { it.metricType == MetricType.FREE_T3 }
+        assertFalse("free T3 is corroborating, not gating", ft3Rule.required)
+        assertTrue(ft3Rule.isAbsolute)
+        // Upper end of adult reference range — T3 is the most sensitive
+        // single marker for T3-predominant thyrotoxicosis.
+        assertEquals(4.2, ft3Rule.absoluteAbove!!, 1e-9)
+        assertNull(ft3Rule.absoluteBelow)
+    }
+
+    @Test
+    fun hyperthyroid_signature_corroborators_match_high_metabolism_presentation() {
+        val pattern = BiomarkerConditionPatterns.hyperthyroidSignature
+        val rhrRule = pattern.signalRules.first { it.metricType == MetricType.RESTING_HEART_RATE }
+        // Tachycardia: ABOVE baseline (mirror of hypo's BELOW), baseline-relative.
+        assertFalse(rhrRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.ABOVE, rhrRule.direction)
+
+        val activityRule = pattern.signalRules.first { it.metricType == MetricType.ACTIVE_MINUTES }
+        assertFalse(activityRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.ABOVE, activityRule.direction)
+    }
+
+    @Test
+    fun hyperthyroid_signature_requires_at_least_one_corroborator() {
+        assertEquals(2, BiomarkerConditionPatterns.hyperthyroidSignature.minActiveSignals)
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,7 +395,7 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c + lipid panel + vit D + TSH/freeT4):**
+**Clinical bands (shipped for hsCRP + HbA1c + lipid panel + vit D + TSH/freeT4/freeT3):**
 `ClinicalThresholds.biomarkerBands` carries three-band classifications
 (NORMAL / BORDERLINE / CONCERNING) per region. `BiomarkerBands` has a
 `concerningDirection` flag — `ABOVE` for most lab values, `BELOW` for HDL
@@ -414,7 +414,7 @@ a direct reading is available.
 `AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
 SENSOR filter, no time window) and compares against the hard cutoff — labs
 are dated and a six-month-old hsCRP is still meaningful.
-`alerts/BiomarkerConditionPatterns.kt` ships five patterns:
+`alerts/BiomarkerConditionPatterns.kt` ships six patterns:
 `inflammation_signature` (hsCRP ≥ 1.0 mg/L + sustained RHR ↑ + HRV ↓
 over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d; ADA 2024 + Hall
@@ -422,16 +422,16 @@ over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
 ≤ 40, TG ≥ 200, ApoB ≥ 120; NCEP ATP III + Sniderman 2019),
 `vitamin_d_deficiency_signature` (25-OH D < 20 ng/mL + at least one of
 sleep efficiency ↓, active minutes ↓, mood-drift score ↑ over 7d;
-Endocrine Society 2011 + Romano/Roy/Anglin), and `hypothyroid_signature`
+Endocrine Society 2011 + Romano/Roy/Anglin), `hypothyroid_signature`
 (TSH ≥ 4.0 mIU/L + at least one of free T4 < 0.8 ng/dL, RHR ↓, active
-minutes ↓ over 7d; AACE/ATA 2012 + Klein/Surks). Biomarker gate rule is
+minutes ↓ over 7d; AACE/ATA 2012 + Klein/Surks), and
+`hyperthyroid_signature` (TSH < 0.4 mIU/L + at least one of free T3 >
+4.2 pg/mL, RHR ↑, active minutes ↑ over 7d; AACE/ATA 2012 + Ross 2016
++ Biondi/Cooper 2008 + Klein 2001). Biomarker gate rule is
 `required = true` so wearable drift alone never fires the pattern.
 
 **Remaining work (separate PRs):**
 
-- Free T3 band + a dedicated `hyperthyroid_signature` (TSH < 0.4 + RHR ↑
-  + active-minutes ↑). The TSH `lowCeiling` shipped now already classifies
-  the lab side; only the pattern is missing.
 - CBC bands + anemia signature (hemoglobin BELOW, hematocrit, WBC, RBC,
   platelets).
 


### PR DESCRIPTION
## Summary

Completes the thyroid side of Phase 8.6 (the §8.6 *Remaining work* item: *Free T3 band + a dedicated `hyperthyroid_signature`*).

- **Free T3 bidirectional bands** in `RegionConfigProvider.universalBiomarkerBands`: <2.3 pg/mL hypothyroid concern (via `lowCeiling`), 2.3–4.2 normal, 4.2–6.5 borderline-high, ≥6.5 overt thyrotoxicosis. Mirrors the TSH bidirectional pattern that landed in PR #69. (Ross 2016; Garber AACE/ATA 2012)
- **`hyperthyroidSignature`** in `BiomarkerConditionPatterns`: gated on TSH < 0.4 mIU/L (subclinical-hyperthyroid threshold, `absoluteBelow`, `required=true`), corroborated by any one of free T3 > 4.2 pg/mL, sustained tachycardia, or elevated active minutes. `minActiveSignals = 2` so wearable drift alone never fires. Direct mirror of `hypothyroidSignature`: same gate lab, opposite extreme; same corroborator metrics, opposite direction.
- ROADMAP §8.6 updated: thyroid bullet is gone from *Remaining work*; CBC + anemia signature is now the only open item.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] New tests: Free T3 band classification across all four band edges, universal-region coverage now includes FREE_T3, hyperthyroid pattern wiring (TSH gate, Free T3 corroborator, ABOVE-direction RHR + active-minutes, `minActiveSignals = 2`, registered in `ConditionPatterns.all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)