### PR TITLE
feat: CBC bands + anemia alert pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -27,6 +27,7 @@ object BiomarkerConditionPatterns {
         listOf(
             inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
             vitaminDDeficiencySignature, hypothyroidSignature, hyperthyroidSignature,
+            anemiaSignature,
         )
     }
 
@@ -309,5 +310,69 @@ object BiomarkerConditionPatterns {
             "Klein I, Ojamaa K (2001) — Thyroid hormone and the cardiovascular system",
         ),
         earlyDetection = "Subclinical hyperthyroidism is silent for months and the wearable signature (tachycardia + restlessness) overlaps with caffeine, anxiety, stimulant medication, and early infection. Pairing it with a suppressed TSH narrows the signal to thyroid involvement.",
+    )
+
+    /**
+     * Hemoglobin below 12 g/dL (WHO 2011 universal-female anemia
+     * threshold — using the female floor as the conservative universal
+     * cutoff so anemia in either sex is captured without sex-stratified
+     * config) paired with at least one of: hematocrit < 36%, RBC < 4.0
+     * tera/L, sustained resting-HR tachycardia (compensatory cardiac
+     * output for reduced oxygen-carrying capacity), or reduced active
+     * minutes (fatigue is the dominant anemia symptom).
+     *
+     * The three CBC corroborators travel together — a true anemia
+     * pattern shows multiple CBC-axis decreases, not an isolated
+     * hemoglobin drop. Wearable corroborators alone are far too
+     * nonspecific (tachycardia + fatigue overlaps with infection,
+     * dehydration, deconditioning, stress); the hemoglobin gate is what
+     * narrows the signal to anemia specifically.
+     */
+    val anemiaSignature = ConditionPattern(
+        id = "biomarker_anemia_signature",
+        title = "Low hemoglobin with corroborating CBC and effort signals",
+        category = ConditionCategory.CARDIOVASCULAR,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.HEMOGLOBIN, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "WHO 2011 — hemoglobin <12 g/dL is the anemia threshold (non-pregnant women); the male threshold is 13 g/dL, so 12 is a conservative universal floor",
+                required = true,
+                absoluteBelow = 12.0,
+            ),
+            SignalRule(
+                MetricType.HEMATOCRIT, DeviationDirection.BELOW, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "Williams Hematology 10th ed. — hematocrit <36% corroborates a low hemoglobin reading and rules out spurious dilution artifacts",
+                absoluteBelow = 36.0,
+            ),
+            SignalRule(
+                MetricType.RBC, DeviationDirection.BELOW, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "Williams Hematology 10th ed. — RBC <4.0 tera/L narrows the etiology toward reduced production or chronic loss vs. acute bleed",
+                absoluteBelow = 4.0,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Duke & Abelmann 1969 — anemia raises resting heart rate as compensatory cardiac output offsets reduced oxygen-carrying capacity",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Patel KV 2008 — fatigue and reduced exercise tolerance are the dominant clinical symptoms of anemia in adults",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent hemoglobin reading sits below 12 g/dL — the WHO anemia threshold — while at least one corroborating signal has appeared: a matching drop in hematocrit or RBC, sustained tachycardia, or reduced activity. The hemoglobin lab anchors the pattern; the wearable signals on their own overlap with too many other causes (infection, deconditioning, stress) to be diagnostic alone.",
+        suggestedAction = "Discuss the CBC values along with the resting-HR and active-minutes trends with a healthcare provider. Anemia has many causes (iron deficiency, B12/folate, chronic disease, occult bleed) and the workup is straightforward; a repeat CBC plus ferritin / iron studies / B12 is the standard initial follow-up.",
+        references = listOf(
+            "WHO (2011) — Haemoglobin concentrations for the diagnosis of anaemia and assessment of severity",
+            "Beutler E, Waalen J (2006) — The definition of anemia: what is the lower limit of normal of the blood hemoglobin concentration?",
+            "Williams Hematology, 10th ed. — adult CBC reference ranges",
+            "Patel KV (2008) — Epidemiology of anemia in older adults",
+            "Duke M, Abelmann WH (1969) — The hemodynamic response to chronic anemia",
+        ),
+        earlyDetection = "Chronic anemia develops slowly and the wearable signature (rising resting HR, declining activity) is nonspecific in isolation. Pairing it with a measured hemoglobin narrows the signal to the population where these proxies plausibly track oxygen-delivery shortfall.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -90,6 +90,53 @@ object RegionConfigProvider {
             concerningDirection = BandDirection.ABOVE,
             lowCeiling = 2.3,
         ),
+        // -- CBC panel --
+        // Hemoglobin (g/dL): WHO anemia thresholds (<13 men, <12 non-pregnant
+        // women). Single threshold uses the female floor (12) as universal
+        // CONCERNING; 12–13.5 is the sex-dependent BORDERLINE zone where a
+        // male reading is anemic but a female reading is borderline; ≥13.5
+        // is NORMAL across sexes. (WHO 2011 — Haemoglobin concentrations
+        // for the diagnosis of anaemia)
+        MetricType.HEMOGLOBIN to BiomarkerBands(
+            normalCeiling = 12.0, borderlineCeiling = 13.5,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // Hematocrit (%): <36 anemic (female threshold; male anemia floor
+        // is ~41 but using the female value as the universal CONCERNING
+        // floor mirrors the hemoglobin treatment), 36–40 borderline-low,
+        // ≥40 normal. (Williams Hematology 10th ed. — adult reference
+        // ranges; WHO 2011)
+        MetricType.HEMATOCRIT to BiomarkerBands(
+            normalCeiling = 36.0, borderlineCeiling = 40.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // WBC (giga/L = ×10⁹/L): 4.5–11 normal, <4.5 leukopenia (low extreme
+        // via lowCeiling), 11–15 borderline-high leukocytosis (mild
+        // infection / stress response window), ≥15 marked leukocytosis.
+        // Bidirectional — both extremes are clinically meaningful.
+        // (Williams Hematology 10th ed.; George 2009)
+        MetricType.WBC to BiomarkerBands(
+            normalCeiling = 11.0, borderlineCeiling = 15.0,
+            concerningDirection = BandDirection.ABOVE,
+            lowCeiling = 4.5,
+        ),
+        // RBC (tera/L = ×10¹²/L): <4.0 indicates anemia (combined-sex
+        // conservative floor — female lower bound 4.2, male 4.7), 4.0–4.5
+        // borderline-low, ≥4.5 normal. (Williams Hematology 10th ed.)
+        MetricType.RBC to BiomarkerBands(
+            normalCeiling = 4.0, borderlineCeiling = 4.5,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // Platelets (giga/L = ×10⁹/L): NIH/standard hematology grades
+        // thrombocytopenia: <100 clinically significant (CONCERNING),
+        // 100–150 mild (BORDERLINE), ≥150 normal. High extreme
+        // (thrombocytosis) is less common as an initial screening concern;
+        // a single-axis BELOW direction matches the dominant clinical use.
+        // (NCI Common Terminology Criteria; Williams Hematology 10th ed.)
+        MetricType.PLATELETS to BiomarkerBands(
+            normalCeiling = 100.0, borderlineCeiling = 150.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -142,6 +142,8 @@ class BiomarkerBandsTest {
             MetricType.HDL_CHOLESTEROL, MetricType.TRIGLYCERIDES,
             MetricType.APO_B, MetricType.VITAMIN_D_25OH,
             MetricType.TSH, MetricType.FREE_T4, MetricType.FREE_T3,
+            MetricType.HEMOGLOBIN, MetricType.HEMATOCRIT, MetricType.WBC,
+            MetricType.RBC, MetricType.PLATELETS,
         )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands
@@ -296,5 +298,77 @@ class BiomarkerBandsTest {
         assertEquals(BiomarkerBand.BORDERLINE, vd.classify(29.999))
         assertEquals(BiomarkerBand.NORMAL, vd.classify(30.0))
         assertEquals(BiomarkerBand.NORMAL, vd.classify(50.0))
+    }
+
+    // -- CBC panel literature thresholds --
+
+    @Test
+    fun hemoglobin_band_matches_WHO_2011_anemia_threshold_with_BELOW_direction() {
+        val hgb = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.HEMOGLOBIN]!!
+        // <12 g/dL = anemia (WHO universal-female floor; male anemia <13)
+        assertEquals(BiomarkerBand.CONCERNING, hgb.classify(10.0))
+        assertEquals(BiomarkerBand.CONCERNING, hgb.classify(11.999))
+        // 12–13.5 = sex-dependent borderline zone
+        assertEquals(BiomarkerBand.BORDERLINE, hgb.classify(12.0))
+        assertEquals(BiomarkerBand.BORDERLINE, hgb.classify(13.499))
+        // ≥13.5 = normal across sexes
+        assertEquals(BiomarkerBand.NORMAL, hgb.classify(13.5))
+        assertEquals(BiomarkerBand.NORMAL, hgb.classify(15.5))
+    }
+
+    @Test
+    fun hematocrit_band_uses_female_floor_36_as_universal_anemia_concern() {
+        val hct = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.HEMATOCRIT]!!
+        assertEquals(BiomarkerBand.CONCERNING, hct.classify(32.0))
+        assertEquals(BiomarkerBand.BORDERLINE, hct.classify(36.0))
+        assertEquals(BiomarkerBand.BORDERLINE, hct.classify(39.999))
+        assertEquals(BiomarkerBand.NORMAL, hct.classify(40.0))
+        assertEquals(BiomarkerBand.NORMAL, hct.classify(45.0))
+    }
+
+    @Test
+    fun wbc_band_uses_bidirectional_thresholds_for_leukopenia_and_leukocytosis() {
+        val wbc = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.WBC]!!
+        // <4.5 = leukopenia (CONCERNING low)
+        assertEquals(BiomarkerBand.CONCERNING, wbc.classify(3.0))
+        assertEquals(BiomarkerBand.CONCERNING, wbc.classify(4.499))
+        // 4.5–11 = normal
+        assertEquals(BiomarkerBand.NORMAL, wbc.classify(4.5))
+        assertEquals(BiomarkerBand.NORMAL, wbc.classify(7.5))
+        // 11–15 = borderline-high (mild leukocytosis)
+        assertEquals(BiomarkerBand.BORDERLINE, wbc.classify(11.0))
+        assertEquals(BiomarkerBand.BORDERLINE, wbc.classify(14.999))
+        // ≥15 = marked leukocytosis (CONCERNING high)
+        assertEquals(BiomarkerBand.CONCERNING, wbc.classify(15.0))
+        assertEquals(BiomarkerBand.CONCERNING, wbc.classify(25.0))
+    }
+
+    @Test
+    fun rbc_band_treats_low_count_as_concerning() {
+        val rbc = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.RBC]!!
+        assertEquals(BiomarkerBand.CONCERNING, rbc.classify(3.5))
+        assertEquals(BiomarkerBand.BORDERLINE, rbc.classify(4.0))
+        assertEquals(BiomarkerBand.BORDERLINE, rbc.classify(4.499))
+        assertEquals(BiomarkerBand.NORMAL, rbc.classify(4.5))
+        assertEquals(BiomarkerBand.NORMAL, rbc.classify(5.5))
+    }
+
+    @Test
+    fun platelets_band_matches_NCI_thrombocytopenia_grades_with_BELOW_direction() {
+        val plt = RegionConfigProvider.forRegion("US")
+            .clinicalThresholds.biomarkerBands[MetricType.PLATELETS]!!
+        // <100 = clinically significant thrombocytopenia
+        assertEquals(BiomarkerBand.CONCERNING, plt.classify(50.0))
+        assertEquals(BiomarkerBand.CONCERNING, plt.classify(99.999))
+        // 100–150 = mild thrombocytopenia
+        assertEquals(BiomarkerBand.BORDERLINE, plt.classify(100.0))
+        assertEquals(BiomarkerBand.BORDERLINE, plt.classify(149.999))
+        // ≥150 = normal range
+        assertEquals(BiomarkerBand.NORMAL, plt.classify(150.0))
+        assertEquals(BiomarkerBand.NORMAL, plt.classify(300.0))
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerConditionPatternsTest.kt
@@ -283,4 +283,61 @@ class BiomarkerConditionPatternsTest {
     fun hyperthyroid_signature_requires_at_least_one_corroborator() {
         assertEquals(2, BiomarkerConditionPatterns.hyperthyroidSignature.minActiveSignals)
     }
+
+    // -- anemia_signature --
+
+    @Test
+    fun anemia_signature_is_registered_in_global_all_list() {
+        assertTrue(BiomarkerConditionPatterns.anemiaSignature in ConditionPatterns.all)
+    }
+
+    @Test
+    fun anemia_signature_gates_on_hemoglobin_below_12_g_per_dL() {
+        val pattern = BiomarkerConditionPatterns.anemiaSignature
+        val hgbRule = pattern.signalRules.first { it.metricType == MetricType.HEMOGLOBIN }
+        assertTrue("hemoglobin rule should be required so the lab anchors the pattern", hgbRule.required)
+        assertTrue(hgbRule.isAbsolute)
+        // WHO universal-female anemia floor — conservative single threshold
+        // captures anemia in either sex without sex-stratified config.
+        assertEquals(12.0, hgbRule.absoluteBelow!!, 1e-9)
+        assertNull(hgbRule.absoluteAbove)
+        assertEquals(ThresholdSource.LITERATURE, hgbRule.source)
+    }
+
+    @Test
+    fun anemia_signature_carries_full_CBC_corroborator_set() {
+        val pattern = BiomarkerConditionPatterns.anemiaSignature
+        val hctRule = pattern.signalRules.first { it.metricType == MetricType.HEMATOCRIT }
+        assertFalse("hematocrit is corroborating, not gating", hctRule.required)
+        assertTrue(hctRule.isAbsolute)
+        assertEquals(36.0, hctRule.absoluteBelow!!, 1e-9)
+
+        val rbcRule = pattern.signalRules.first { it.metricType == MetricType.RBC }
+        assertFalse(rbcRule.required)
+        assertTrue(rbcRule.isAbsolute)
+        assertEquals(4.0, rbcRule.absoluteBelow!!, 1e-9)
+    }
+
+    @Test
+    fun anemia_signature_wearable_corroborators_match_compensatory_physiology() {
+        val pattern = BiomarkerConditionPatterns.anemiaSignature
+        val rhrRule = pattern.signalRules.first { it.metricType == MetricType.RESTING_HEART_RATE }
+        // Compensatory tachycardia: ABOVE baseline, deviation-relative
+        // (not an absolute clinical cutoff like the labs).
+        assertFalse(rhrRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.ABOVE, rhrRule.direction)
+
+        val activityRule = pattern.signalRules.first { it.metricType == MetricType.ACTIVE_MINUTES }
+        assertFalse(activityRule.isAbsolute)
+        assertEquals(com.bios.app.alerts.DeviationDirection.BELOW, activityRule.direction)
+    }
+
+    @Test
+    fun anemia_signature_requires_at_least_one_corroborator() {
+        // Hemoglobin alone (1 active signal) won't fire; minActiveSignals=2
+        // forces at least one corroborator — either another CBC marker
+        // confirming the drop, or a wearable signal consistent with reduced
+        // oxygen-carrying capacity.
+        assertEquals(2, BiomarkerConditionPatterns.anemiaSignature.minActiveSignals)
+    }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -395,7 +395,7 @@ missing `valueQuantity`, unparseable date) is captured in
 UI: "Import from FHIR" card on the entry screen with a SAF file
 picker + summary dialog.
 
-**Clinical bands (shipped for hsCRP + HbA1c + lipid panel + vit D + TSH/freeT4/freeT3):**
+**Clinical bands (shipped for hsCRP + HbA1c + lipid panel + vit D + TSH/freeT4/freeT3 + CBC panel):**
 `ClinicalThresholds.biomarkerBands` carries three-band classifications
 (NORMAL / BORDERLINE / CONCERNING) per region. `BiomarkerBands` has a
 `concerningDirection` flag — `ABOVE` for most lab values, `BELOW` for HDL
@@ -414,7 +414,7 @@ a direct reading is available.
 `AnomalyDetector` reads the metric's latest reading via `fetchLatest` (no
 SENSOR filter, no time window) and compares against the hard cutoff — labs
 are dated and a six-month-old hsCRP is still meaningful.
-`alerts/BiomarkerConditionPatterns.kt` ships six patterns:
+`alerts/BiomarkerConditionPatterns.kt` ships seven patterns:
 `inflammation_signature` (hsCRP ≥ 1.0 mg/L + sustained RHR ↑ + HRV ↓
 over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
 5.7% + sustained sleep-efficiency ↓ + RHR ↑ over 7d; ADA 2024 + Hall
@@ -424,16 +424,19 @@ over 7d; Ridker 2003 + Furman 2019), `prediabetes_signature` (HbA1c ≥
 sleep efficiency ↓, active minutes ↓, mood-drift score ↑ over 7d;
 Endocrine Society 2011 + Romano/Roy/Anglin), `hypothyroid_signature`
 (TSH ≥ 4.0 mIU/L + at least one of free T4 < 0.8 ng/dL, RHR ↓, active
-minutes ↓ over 7d; AACE/ATA 2012 + Klein/Surks), and
+minutes ↓ over 7d; AACE/ATA 2012 + Klein/Surks),
 `hyperthyroid_signature` (TSH < 0.4 mIU/L + at least one of free T3 >
 4.2 pg/mL, RHR ↑, active minutes ↑ over 7d; AACE/ATA 2012 + Ross 2016
-+ Biondi/Cooper 2008 + Klein 2001). Biomarker gate rule is
-`required = true` so wearable drift alone never fires the pattern.
++ Biondi/Cooper 2008 + Klein 2001), and `anemia_signature` (hemoglobin
+< 12 g/dL + at least one of hematocrit < 36%, RBC < 4.0 tera/L, RHR ↑,
+active minutes ↓ over 7d; WHO 2011 + Williams Hematology + Patel 2008
++ Duke/Abelmann 1969). Biomarker gate rule is `required = true` so
+wearable drift alone never fires the pattern.
 
-**Remaining work (separate PRs):**
-
-- CBC bands + anemia signature (hemoglobin BELOW, hematocrit, WBC, RBC,
-  platelets).
+**§8.6 complete.** Phase 8.6 closes out the biomarker inbound surface
+across foundation, lipid panel, vitamin D, full thyroid axis, and CBC.
+Any future biomarker waves (e.g. fasting insulin, sex hormones,
+homocysteine) are new scope, not §8.6 follow-on.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary

Closes out §8.6 of the roadmap: the last open bullet was *CBC bands + anemia signature*.

- **Five CBC bands** in `RegionConfigProvider.universalBiomarkerBands`:
  - `HEMOGLOBIN` (g/dL): <12 CONCERNING, 12–13.5 BORDERLINE, ≥13.5 NORMAL, direction=BELOW (WHO 2011 anemia thresholds)
  - `HEMATOCRIT` (%): <36 CONCERNING, 36–40 BORDERLINE, ≥40 NORMAL, direction=BELOW (Williams Hematology)
  - `WBC` (giga/L): bidirectional — <4.5 leukopenia, 4.5–11 NORMAL, 11–15 BORDERLINE leukocytosis, ≥15 CONCERNING (via `lowCeiling`)
  - `RBC` (tera/L): <4.0 CONCERNING, 4.0–4.5 BORDERLINE, ≥4.5 NORMAL, direction=BELOW
  - `PLATELETS` (giga/L): <100 CONCERNING, 100–150 BORDERLINE, ≥150 NORMAL, direction=BELOW (NCI thrombocytopenia grades)
- **`anemiaSignature`** in `BiomarkerConditionPatterns`: gated on hemoglobin < 12 g/dL (`absoluteBelow`, `required=true`, WHO universal-female anemia floor — conservative single threshold captures anemia in either sex). Corroborated by any one of hematocrit < 36%, RBC < 4.0 tera/L, sustained compensatory tachycardia (RHR ↑), or reduced active minutes (fatigue). `minActiveSignals = 2`.
- ROADMAP §8.6 marked complete — the biomarker inbound surface now spans foundation, lipid panel, vitamin D, full thyroid axis, and CBC. Future biomarker waves are new scope, not §8.6 follow-on.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] New tests: every CBC band edge classified (NORMAL / BORDERLINE / CONCERNING), WBC bidirectional behaviour at both extremes, universal-region coverage now includes all five CBC keys, anemia pattern wiring (Hb gate, CBC + wearable corroborators, ABOVE-direction RHR + BELOW-direction active-minutes, `minActiveSignals = 2`, registered in `ConditionPatterns.all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)