### PR TITLE
feat: ambient-light baseline + circadian-disruption pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -78,7 +78,8 @@ object ConditionPatterns {
     val all by lazy {
         listOf(
             infectionOnset, sleepDisruption, cardiovascularStress, overtraining,
-            metabolicDrift, cardiorespiratoryDeconditioning, chronicInflammation, recoveryDeficit
+            metabolicDrift, cardiorespiratoryDeconditioning, chronicInflammation, recoveryDeficit,
+            circadianDisruption,
         ) + CompanionConditionPatterns.all + BiomarkerConditionPatterns.all
     }
 
@@ -417,5 +418,50 @@ object ConditionPatterns {
         prevention = "Menstrual cycle regularity is supported by consistent sleep, regular moderate exercise, adequate nutrition (especially iron and B vitamins), stress management, and maintaining a healthy weight. Extreme caloric restriction, excessive exercise, and chronic stress are common causes of cycle disruption. Tracking your cycle pattern over time helps establish what is normal for you — individual variation is wide, and population averages are less useful than personal baselines.",
         healing = "If a cycle deviation is detected, note any associated symptoms and continue tracking for 2-3 cycles to distinguish a one-time variation from a persistent change. Common causes of temporary irregularity include stress, travel, illness, medication changes, and weight fluctuation. Persistent changes (>3 cycles) warrant gynecological evaluation — possibilities include thyroid dysfunction, PCOS, premature ovarian insufficiency, or structural causes. Your tracked BBT and cycle data can be exported and shared with your provider.",
         risks = "Menstrual cycle irregularities can indicate underlying hormonal or metabolic conditions. Anovulatory cycles (no ovulation) affect fertility and may indicate PCOS or thyroid dysfunction. Shortened luteal phases can impair implantation. Irregular cycles are also associated with higher cardiovascular risk and lower bone density long-term. Early detection of pattern changes — when they're subtle shifts rather than dramatic disruptions — allows earlier investigation and treatment."
+    )
+
+    /**
+     * Circadian disruption: erratic light-exposure pattern over a 7-day window
+     * paired with sleep degradation. The phone's ambient-light sensor (sampled
+     * on a screen-on duty cycle by SyncWorker) is the only Bios-side proxy for
+     * the owner's daily light environment. When the AMBIENT_LIGHT z-score
+     * pattern drifts well past baseline — e.g. a shift to night-shift work,
+     * heavy evening screen exposure replacing daytime sunlight, or jet-lag
+     * misalignment — and sleep architecture concurrently degrades, the
+     * convergence is the strongest non-invasive circadian-disruption signal
+     * available.
+     *
+     * This is the §8.1 cross-correlation consumer of `AMBIENT_LIGHT`: required
+     * = true on the lux rule so wearable sleep drift alone never fires the
+     * pattern (per §8.6 / §8.8 gating discipline).
+     */
+    val circadianDisruption = ConditionPattern(
+        id = "circadian_disruption",
+        title = "Erratic light-exposure pattern with sleep degradation",
+        category = ConditionCategory.SLEEP,
+        signalRules = listOf(
+            SignalRule(MetricType.AMBIENT_LIGHT, DeviationDirection.IRREGULAR, 1.5, 168, 1.2,
+                ThresholdSource.LITERATURE,
+                "Wright KP et al. (2013) — entrainment to the natural light-dark cycle is the dominant circadian zeitgeber; sustained departures from the owner's habitual light pattern are the canonical marker of misalignment",
+                required = true),
+            SignalRule(MetricType.SLEEP_STAGE, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Chang AM et al. (2015) — evening light exposure suppresses melatonin, delays sleep onset, and reduces deep-sleep proportion"),
+            SignalRule(MetricType.SLEEP_DURATION, DeviationDirection.IRREGULAR, 1.5, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Roenneberg T et al. (2007) — social-jetlag-style variability in sleep timing accompanies circadian misalignment and tracks light-exposure irregularity"),
+        ),
+        minActiveSignals = 2,
+        explanation = "Your ambient-light exposure pattern over the past week has deviated substantially from your established baseline, and at least one sleep signal (depth or timing) has degraded in parallel. The combination is consistent with circadian misalignment — caused by night work, heavy evening screen use, jet-lag, or a sudden change in daily light environment. This is a data observation about your environment, not a judgment about your habits.",
+        suggestedAction = "If the disruption is intentional (travel, shift work), no action is needed beyond awareness. Otherwise, increasing morning-daylight exposure and reducing bright-screen exposure within 2 hours of bedtime are the highest-evidence interventions for re-entrainment.",
+        references = listOf(
+            "Wright KP Jr et al. (2013) — Entrainment of the human circadian clock to the natural light-dark cycle",
+            "Chang AM et al. (2015) — Evening use of light-emitting eReaders negatively affects sleep, circadian timing, and next-morning alertness",
+            "Roenneberg T et al. (2007) — Epidemiology of the human circadian clock"
+        ),
+        earlyDetection = "Circadian disruption is silent in the short term — the owner often doesn't notice until sleep quality, mood, or daytime alertness has already degraded. The phone's ambient-light sensor captures the upstream cause (changed light environment) days before downstream symptoms accumulate. Pairing the light-exposure shift with sleep degradation is what distinguishes a meaningful misalignment from a one-off late night.",
+        prevention = "Anchor the day with bright outdoor light within the first hour after waking — the strongest circadian zeitgeber. Keep evening environments dim (especially the 2-3 hours before bed); warm-color bulbs and reduced screen brightness help. For shift workers, maintain a consistent sleep schedule even on off-days; intermittent re-entrainment is worse than a stable shifted phase.",
+        healing = "Most circadian misalignment self-corrects within 7-10 days of restored light-dark cues. Accelerate re-entrainment with timed bright light (morning if phase-delayed, evening if phase-advanced) and strict avoidance of bright light during the new biological night. Consider melatonin (0.3-0.5 mg) 4-6 hours before target sleep onset for travel adjustment, only short-term. If sleep quality and daytime alertness don't recover within 2 weeks, consult a sleep specialist — chronic circadian misalignment can indicate delayed sleep-wake phase disorder or shift-work disorder.",
+        risks = "Chronic circadian disruption is independently associated with metabolic syndrome, cardiovascular disease, mood disorders, and certain cancers (IARC classifies shift work as probably carcinogenic). The mechanism is misaligned hormonal and metabolic rhythms — insulin sensitivity, cortisol, and inflammatory regulation all follow circadian patterns. Short-term mismatches recover; sustained ones compound. Early detection via wearable proxy signals provides the window where lifestyle realignment is highly effective."
     )
 }

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -40,7 +40,8 @@ class BaselineEngine(
                 MetricType.STEPS,
                 MetricType.ACTIVE_MINUTES,
                 MetricType.SLEEP_STAGE,
-                MetricType.SLEEP_DURATION
+                MetricType.SLEEP_DURATION,
+                MetricType.AMBIENT_LIGHT,
             )
 
             for (metricType in metricsToBaseline) {

--- a/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
@@ -120,6 +120,44 @@ class ConditionPatternsTest {
     }
 
     @Test
+    fun `circadian disruption pattern is registered in the global all list`() {
+        assertTrue(ConditionPatterns.circadianDisruption in ConditionPatterns.all)
+    }
+
+    @Test
+    fun `circadian disruption gates on AMBIENT_LIGHT irregularity as the required rule`() {
+        val pattern = ConditionPatterns.circadianDisruption
+        val lightRule = pattern.signalRules.first {
+            it.metricType == com.bios.contracts.MetricType.AMBIENT_LIGHT
+        }
+        assertTrue(
+            "AMBIENT_LIGHT must be the required gate so sleep drift alone never fires the pattern",
+            lightRule.required
+        )
+        assertEquals(DeviationDirection.IRREGULAR, lightRule.direction)
+        assertEquals(168, lightRule.minDurationHours)
+    }
+
+    @Test
+    fun `circadian disruption corroborators cover sleep depth and timing`() {
+        val pattern = ConditionPatterns.circadianDisruption
+        val corroborators = pattern.signalRules
+            .filter { !it.required }
+            .map { it.metricType }
+            .toSet()
+        // Sleep depth (SLEEP_STAGE BELOW) + timing variability (SLEEP_DURATION
+        // IRREGULAR) — the two halves of the sleep-architecture response to
+        // misaligned light exposure.
+        assertTrue(com.bios.contracts.MetricType.SLEEP_STAGE in corroborators)
+        assertTrue(com.bios.contracts.MetricType.SLEEP_DURATION in corroborators)
+    }
+
+    @Test
+    fun `circadian disruption requires at least one corroborator alongside the light gate`() {
+        assertEquals(2, ConditionPatterns.circadianDisruption.minActiveSignals)
+    }
+
+    @Test
     fun `all patterns have a suggested action`() {
         for (pattern in ConditionPatterns.all) {
             assertNotNull("Pattern ${pattern.id} should have a suggested action", pattern.suggestedAction)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -260,24 +260,28 @@ See also: [Smokeless/docs/ECOSYSTEM.md](../../Smokeless/docs/ECOSYSTEM.md).
 > Companion-owned gaps (substance ledger expansion, Virgil wire-up) are
 > tracked in the paired companion ROADMAPs.
 
-### 8.1 Ambient light writer (Phone Sensors adapter)
+### 8.1 Ambient light writer (Phone Sensors adapter) [LIVE]
 
-Cheapest-win in the audit. Phone's ambient-light sensor is already a
-declared adapter source in [ARCHITECTURE.md](ARCHITECTURE.md); the
-`ambient_light` key is in the planned-but-unimplemented set. Wire the
-adapter to emit lux samples on a duty cycle that doesn't burn battery
-(default: 1 sample / 5 min during waking hours, gated by screen-on).
+`PhoneSensorAdapter.sampleAmbientLight()` emits `AMBIENT_LIGHT` (LUX,
+ENVIRONMENT). Duty cycle: `SyncWorker`'s 15-min periodic job (more
+battery-conservative than the original 5-min target, well above Nyquist
+for circadian detection); screen-on gate via `PowerManager.isInteractive`
+keeps pocket / overnight samples out. Added to the BaselineEngine
+allow-list so 14-day personal baselines back the IRREGULAR z-score gate.
 
-Unlocks circadian-alignment baselines, which pair with W2F's
-`circadian_phase_shift` and SoulRadio's 24-hour loop without violating
-SoulRadio's manifesto (Bios derives, SoulRadio does not consume).
+**Cross-correlation consumer (§8.8):** `circadianDisruption` in
+`alerts/ConditionPatterns.kt` — `AMBIENT_LIGHT IRREGULAR` (required,
+168h) + `SLEEP_STAGE BELOW` + `SLEEP_DURATION IRREGULAR`. Citations:
+Wright 2013 (light = dominant zeitgeber), Chang 2015 (evening light
+suppresses melatonin), Roenneberg 2007 (social-jetlag tracks light
+irregularity). Pairs cleanly with W2F's `circadian_phase_shift` without
+violating SoulRadio's manifesto (Bios derives, SoulRadio doesn't consume).
 
 ### 8.2 Body composition via Withings adapter
 
-Withings is already an active adapter ([§Current State](#current-state-v020)),
-but `body_mass` and `body_fat_pct` are not yet in `MetricType`. Add the
-keys (domain: `METABOLIC` or new `BODY_COMPOSITION`), wire the Withings
-adapter to write them, and baseline like any other metric.
+Withings is an active adapter ([§Current State](#current-state-v020));
+`body_mass` and `body_fat_pct` aren't yet in `MetricType`. Add the keys
+(domain: `METABOLIC` or new `BODY_COMPOSITION`), wire the adapter, baseline.
 
 ### 8.3 HRV decomposition (autonomic-tone derivations) [PARTIAL — parasympathetic shipped, LF/HF deferred]
 
@@ -433,10 +437,8 @@ active minutes ↓ over 7d; WHO 2011 + Williams Hematology + Patel 2008
 + Duke/Abelmann 1969). Biomarker gate rule is `required = true` so
 wearable drift alone never fires the pattern.
 
-**§8.6 complete.** Phase 8.6 closes out the biomarker inbound surface
-across foundation, lipid panel, vitamin D, full thyroid axis, and CBC.
-Any future biomarker waves (e.g. fasting insulin, sex hormones,
-homocysteine) are new scope, not §8.6 follow-on.
+**§8.6 complete.** Future biomarker waves (fasting insulin, sex
+hormones, homocysteine, etc.) are new scope, not §8.6 follow-on.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary

Closes §8.1 of the roadmap. The Phone Sensors adapter already sampled `AMBIENT_LIGHT` and `SyncWorker` already invoked it on a 15-minute periodic schedule with screen-on gating — what was missing was the §8.8 cross-correlation acceptance ("each new key has at least one cross-correlation use").

- **`AMBIENT_LIGHT` added to `BaselineEngine.metricsToBaseline`** — 14-day personal baselines now back the IRREGULAR z-score gate the new pattern uses.
- **`circadianDisruption` ConditionPattern** in `alerts/ConditionPatterns.kt`, registered in `ConditionPatterns.all`. Gates on `AMBIENT_LIGHT IRREGULAR` (required, 168h window — so wearable sleep drift alone never fires) and corroborates with `SLEEP_STAGE BELOW` + `SLEEP_DURATION IRREGULAR`. `minActiveSignals = 2`.
- Citations: Wright KP Jr 2013 (light is the dominant circadian zeitgeber), Chang AM 2015 (evening light suppresses melatonin), Roenneberg 2007 (social-jetlag-style timing variability tracks light irregularity).
- Manifesto compliance: pattern explanation reports the *environmental* shift ("your ambient-light exposure pattern over the past week has deviated… caused by night work, heavy evening screen use, jet-lag…") and explicitly notes "this is a data observation about your environment, not a judgment about your habits."
- ROADMAP §8.1 marked **[LIVE]** with where each piece lives. §8.2 prose tightened to make room under the 500-line file cap.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] New tests: pattern is in `ConditionPatterns.all`; `AMBIENT_LIGHT` rule is the required gate with IRREGULAR direction over 168h; corroborators cover both sleep depth (`SLEEP_STAGE`) and sleep timing (`SLEEP_DURATION`); `minActiveSignals = 2`

Note: while reading this code I noticed `respiratoryInfection`, `atrialFibrillationScreen`, `mentalHealthCorrelate`, and `menstrualCycleAnomaly` are defined in `ConditionPatterns.kt` but not in `ConditionPatterns.all` — they aren't running. The "12 condition patterns" count in §Current State assumes they're registered. Worth a follow-up PR; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)