### PR TITLE
fix: register the 4 orphan ConditionPatterns + add coverage guard

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -79,6 +79,7 @@ object ConditionPatterns {
         listOf(
             infectionOnset, sleepDisruption, cardiovascularStress, overtraining,
             metabolicDrift, cardiorespiratoryDeconditioning, chronicInflammation, recoveryDeficit,
+            respiratoryInfection, atrialFibrillationScreen, mentalHealthCorrelate, menstrualCycleAnomaly,
             circadianDisruption,
         ) + CompanionConditionPatterns.all + BiomarkerConditionPatterns.all
     }

--- a/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
@@ -120,6 +120,29 @@ class ConditionPatternsTest {
     }
 
     @Test
+    fun `every ConditionPattern val on the object is registered in the all list`() {
+        // Guard against the Phase 4 regression: four patterns (respiratoryInfection,
+        // atrialFibrillationScreen, mentalHealthCorrelate, menstrualCycleAnomaly)
+        // were defined as `val`s on ConditionPatterns for ~6 weeks without being
+        // added to `all`, so the AnomalyDetector silently never ran them. This
+        // test makes any future drop visible at build time.
+        val registeredIds = ConditionPatterns.all.map { it.id }.toSet()
+        val declaredPatterns = ConditionPatterns::class.java.declaredFields
+            .filter { it.type == com.bios.app.alerts.ConditionPattern::class.java }
+            .map {
+                it.isAccessible = true
+                it.get(ConditionPatterns) as com.bios.app.alerts.ConditionPattern
+            }
+        val missing = declaredPatterns
+            .map { it.id }
+            .filter { it !in registeredIds }
+        assertTrue(
+            "ConditionPattern(s) defined on the object but missing from ConditionPatterns.all: $missing",
+            missing.isEmpty()
+        )
+    }
+
+    @Test
     fun `circadian disruption pattern is registered in the global all list`() {
         assertTrue(ConditionPatterns.circadianDisruption in ConditionPatterns.all)
     }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@
 - SQLCipher encrypted local database (7 tables, AES-256, key in Android Keystore)
 - Separate encrypted reproductive health database (independent key, independent wipe)
 - 14-day rolling personal baselines per metric
-- 12 condition patterns: infection onset, sleep disruption, cardiovascular stress, overtraining, metabolic drift, cardiorespiratory deconditioning, chronic inflammation, recovery deficit, respiratory infection, AFib screening, mental health correlate, menstrual cycle anomaly
+- 13 condition patterns: infection onset, sleep disruption, cardiovascular stress, overtraining, metabolic drift, cardiorespiratory deconditioning, chronic inflammation, recovery deficit, respiratory infection, AFib screening, mental health correlate, menstrual cycle anomaly, circadian disruption
 - 33 signal rules (24 literature-backed with citations)
 - LiteRT anomaly model wrapper (heuristic fallback active — model asset not shipped)
 - 4-tier alert system with push notifications (Observation / Notice / Advisory / Urgent)


### PR DESCRIPTION
## Summary

Surfaced while working on §8.1 (PR #72). Four ConditionPatterns added in the Phase 3B commit (`3cfd4ca`, 2026-04-05) — `respiratoryInfection`, `atrialFibrillationScreen`, `mentalHealthCorrelate`, `menstrualCycleAnomaly` — were defined as `val`s on `ConditionPatterns` but never added to `ConditionPatterns.all`, so the `AnomalyDetector` silently never ran them. ~6 weeks of dead patterns.

- **Register them in `ConditionPatterns.all`.** All four pass the existing pattern invariants (unique id, positive thresholds, durations, weights, `minActiveSignals <= rule count`). No threshold or rule changes — just wiring.
- **Reflection-based guard test** that asserts every `ConditionPattern` `val` declared on the `ConditionPatterns` object appears in `all`. The Phase 4 regression would have failed this test on day one; any future drop will fail at build time instead of being silently lost.
- ROADMAP §Current State count updated from 12 → 13 (counts `circadian_disruption` from PR #72).

Notes I deliberately did *not* fold in here (scope discipline):
- `menstrualCycleAnomaly`'s docstring says "Stored in isolated reproductive DB" — that's stale since §8.5 routed BBT through the main `BiosDatabase` via `BbtEntryRepo`. The pattern works fine with the current BBT location; the comment is a documentation lag worth a separate touch.
- `mentalHealthCorrelate` requires `minActiveSignals = 3` over 7 metrics, three of which are W2F-only — without W2F installed it'll be hard to fire. That's a tuning question, not a registration bug.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] New reflection guard test fails when a `ConditionPattern` `val` is declared but missing from `all` (verified locally by temporarily removing one — test reports the missing id)
- [x] All four newly-registered patterns satisfy the existing `all`-list invariants (titles non-empty, weights / thresholds / durations positive, `minActiveSignals <= rules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)