### PR TITLE
fix: explain empty-baseline UI and re-backfill missing metrics

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
@@ -59,6 +59,27 @@ interface MetricReadingDao {
     @Query("SELECT COUNT(*) FROM metric_readings")
     suspend fun countAll(): Int
 
+    // Counts SENSOR-kind readings only — matches BaselineEngine's filter, so the
+    // result reflects what's actually eligible to seed a baseline.
+    @Query("""
+        SELECT COUNT(*) FROM metric_readings mr
+        INNER JOIN data_sources ds ON mr.sourceId = ds.id
+        WHERE mr.metricType = :metricType
+          AND mr.timestamp >= :startMillis
+          AND mr.timestamp <= :endMillis
+          AND mr.isPrimary = 1
+          AND (:readingKind IS NULL OR ds.readingKind = :readingKind)
+    """)
+    suspend fun countInRange(
+        metricType: String,
+        startMillis: Long,
+        endMillis: Long,
+        readingKind: String? = null
+    ): Int
+
+    @Query("SELECT MAX(timestamp) FROM metric_readings WHERE metricType = :metricType AND isPrimary = 1")
+    suspend fun lastTimestampFor(metricType: String): Long?
+
     @Query("""
         SELECT AVG(mr.value) FROM metric_readings mr
         INNER JOIN data_sources ds ON mr.sourceId = ds.id

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -23,7 +23,55 @@ class BaselineEngine(
     companion object {
         const val MINIMUM_DATA_DAYS = 7
         const val DEFAULT_WINDOW_DAYS = 14
+        const val MIN_SAMPLES_FOR_BASELINE = 10
     }
+
+    /**
+     * What Bios actually has for a metric, expressed in the same terms the
+     * baseline computation uses. Drives UI that explains why a baseline is
+     * (or is not) computable, instead of the previous "needs 7 days" stub
+     * which lied when the real problem was zero ingested readings.
+     */
+    data class Coverage(
+        val sensorSamplesInWindow: Int,
+        val totalSamples: Int,
+        val lastTimestamp: Long?,
+    ) {
+        val hasAnyData: Boolean get() = totalSamples > 0
+        val meetsBaselineMinimum: Boolean get() = sensorSamplesInWindow >= MIN_SAMPLES_FOR_BASELINE
+    }
+
+    suspend fun coverageFor(
+        metricType: MetricType,
+        windowDays: Int = DEFAULT_WINDOW_DAYS
+    ): Coverage {
+        val endMillis = System.currentTimeMillis()
+        val startMillis = endMillis - windowDays.toLong() * 24 * 3600 * 1000
+        val sensor = readingDao.countInRange(
+            metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
+        )
+        val total = readingDao.count(metricType.key)
+        val last = readingDao.lastTimestampFor(metricType.key)
+        return Coverage(
+            sensorSamplesInWindow = sensor,
+            totalSamples = total,
+            lastTimestamp = last,
+        )
+    }
+
+    suspend fun coverageForTracked(): Map<MetricType, Coverage> =
+        TRACKED_METRICS.associateWith { coverageFor(it) }
+
+    private val TRACKED_METRICS = listOf(
+        MetricType.HEART_RATE,
+        MetricType.HEART_RATE_VARIABILITY,
+        MetricType.RESTING_HEART_RATE,
+        MetricType.BLOOD_OXYGEN,
+        MetricType.RESPIRATORY_RATE,
+        MetricType.SKIN_TEMPERATURE_DEVIATION,
+        MetricType.STEPS,
+        MetricType.SLEEP_DURATION,
+    )
 
     // MARK: - Compute all baselines
 
@@ -70,7 +118,7 @@ class BaselineEngine(
         val values = readingDao.fetchValues(
             metricType.key, startMillis, endMillis, ReadingKind.SENSOR.name
         )
-        if (values.size < 10) return  // need minimum samples
+        if (values.size < MIN_SAMPLES_FOR_BASELINE) return
 
         val stats = Stats.compute(values)
 

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -10,6 +10,7 @@ import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
 import com.bios.app.model.SensorType
 import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -109,12 +110,29 @@ class IngestManager(
 
         updateDataAge()
 
-        // Only fetch full history on first launch; otherwise just sync recent data
-        if (_dataAgeDays.value == 0) {
+        // Backfill on first launch (no data at all) OR when a primary metric is
+        // empty — handles the case where the user installed Bios, granted HC
+        // permission later, or only just connected a watch. Without this, the
+        // 24h syncRecentData loop would never recover the missing history.
+        if (_dataAgeDays.value == 0 || hasEmptyPrimaryMetric()) {
             syncHistoricalData()
         } else {
             syncRecentData()
         }
+    }
+
+    private suspend fun hasEmptyPrimaryMetric(): Boolean {
+        // Only worth retrying the historical pull when a wearable-history
+        // source actually exists. Phone-only setups can't backfill HR no
+        // matter how many times we ask, so don't burn syncs.
+        val hasWearableHistorySource = healthConnectSourceId != null ||
+            gadgetbridgeSourceId != null ||
+            ouraSourceId != null
+        if (!hasWearableHistorySource) return false
+        for (metric in PRIMARY_METRICS_FOR_BACKFILL) {
+            if (readingDao.count(metric.key) == 0) return true
+        }
+        return false
     }
 
     // MARK: - Sync
@@ -339,5 +357,15 @@ class IngestManager(
 
     companion object {
         private const val SENSOR_SAMPLE_DURATION_MS = 10_000L // 10 seconds
+
+        // Metrics whose absence triggers a re-backfill on the next setup().
+        // Limited to wearable-sourced metrics so a phone-only run (steps from
+        // the pedometer) doesn't repeatedly attempt full historical pulls
+        // for metrics no source can provide.
+        private val PRIMARY_METRICS_FOR_BACKFILL = listOf(
+            MetricType.HEART_RATE,
+            MetricType.RESTING_HEART_RATE,
+            MetricType.SLEEP_DURATION,
+        )
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -107,13 +107,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _trackedMetricTypes = MutableStateFlow<Set<MetricType>>(emptySet())
     val trackedMetricTypes: StateFlow<Set<MetricType>> = _trackedMetricTypes
+    private val _metricCoverage = MutableStateFlow<Map<MetricType, BaselineEngine.Coverage>>(emptyMap())
+    val metricCoverage: StateFlow<Map<MetricType, BaselineEngine.Coverage>> = _metricCoverage
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error
 
-    fun clearError() {
-        _error.value = null
-    }
+    fun clearError() { _error.value = null }
 
     /** Check permissions without initializing. Returns true if all granted or if alternate sources exist. */
     suspend fun checkPermissions(): Boolean {
@@ -377,9 +377,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private suspend fun refreshBaselines() {
         val allBaselines = db.personalBaselineDao().fetchAll()
         _baselines.value = allBaselines
-        _trackedMetricTypes.value = allBaselines
-            .mapNotNull { MetricType.fromKey(it.metricType) }
-            .toSet()
+        _trackedMetricTypes.value = allBaselines.mapNotNull { MetricType.fromKey(it.metricType) }.toSet()
+        _metricCoverage.value = baselineEngine.coverageForTracked()
     }
 
     fun refreshDiagnostics() {

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bios.app.engine.BaselineEngine
 import com.bios.app.ui.AppViewModel
+import com.bios.contracts.MetricType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,6 +28,7 @@ fun DiagnosticsScreen(
 ) {
     val results by viewModel.diagnosticResults.collectAsState()
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
+    val coverage by viewModel.metricCoverage.collectAsState()
 
     LaunchedEffect(Unit) {
         viewModel.refreshDiagnostics()
@@ -50,40 +52,11 @@ fun DiagnosticsScreen(
             }
         )
 
-        if (dataAge < BaselineEngine.MINIMUM_DATA_DAYS) {
-            // Insufficient data state
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(32.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        Icons.Default.HourglassBottom,
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    Text(
-                        "Building Your Baseline",
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    val remaining = BaselineEngine.MINIMUM_DATA_DAYS - dataAge
-                    Text(
-                        "Diagnostics require at least ${BaselineEngine.MINIMUM_DATA_DAYS} days of data to establish your personal baselines. $remaining more day${if (remaining == 1) "" else "s"} needed.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(Modifier.height(16.dp))
-                    LinearProgressIndicator(
-                        progress = { dataAge.toFloat() / BaselineEngine.MINIMUM_DATA_DAYS.toFloat() },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-            }
+        val anyDataReceived = coverage.values.any { it.hasAnyData }
+        if (!anyDataReceived) {
+            NoDataReceivedState()
+        } else if (dataAge < BaselineEngine.MINIMUM_DATA_DAYS) {
+            InsufficientDataState(dataAge, coverage)
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -92,6 +65,116 @@ fun DiagnosticsScreen(
             ) {
                 items(results) { result ->
                     DiagnosticCard(result, onNavigateToDetail = onNavigateToDetail)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InsufficientDataState(
+    dataAge: Int,
+    coverage: Map<MetricType, BaselineEngine.Coverage>
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.HourglassBottom,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "Building Your Baseline",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(Modifier.height(8.dp))
+            val remaining = BaselineEngine.MINIMUM_DATA_DAYS - dataAge
+            Text(
+                "Diagnostics need at least ${BaselineEngine.MINIMUM_DATA_DAYS} days of ingested data to establish your personal baselines. " +
+                    "Bios has $dataAge day${if (dataAge == 1) "" else "s"} so far — $remaining more needed.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(16.dp))
+            LinearProgressIndicator(
+                progress = { dataAge.toFloat() / BaselineEngine.MINIMUM_DATA_DAYS.toFloat() },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(24.dp))
+            // Per-metric breakdown so the owner can see at a glance which feeds
+            // are silent — the previous "X more days needed" message hid the
+            // case where one source was working but HR specifically had zero
+            // readings.
+            CoverageBreakdown(coverage)
+        }
+    }
+}
+
+@Composable
+private fun NoDataReceivedState() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                Icons.Default.HourglassBottom,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(16.dp))
+            Text("No data received yet", style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "Bios hasn't received any sensor readings. " +
+                    "If you wear a watch every day, the watch's companion app needs to write to Health Connect — " +
+                    "Bios reads from Health Connect, it doesn't pair with the watch directly.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun CoverageBreakdown(coverage: Map<MetricType, BaselineEngine.Coverage>) {
+    val rows = coverage.entries
+        .sortedBy { it.key.readableName }
+        .filter { it.value.totalSamples > 0 || it.key == MetricType.HEART_RATE }
+    if (rows.isEmpty()) return
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                "Per-metric ingestion",
+                style = MaterialTheme.typography.labelLarge
+            )
+            Spacer(Modifier.height(8.dp))
+            for ((metric, cov) in rows) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(metric.readableName, style = MaterialTheme.typography.bodySmall)
+                    Text(
+                        if (cov.totalSamples == 0) "no data"
+                        else "${cov.sensorSamplesInWindow} in 14d",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         }

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -23,6 +23,7 @@ fun TrendsScreen(
     initialMetric: MetricType? = null
 ) {
     val baselines by viewModel.baselines.collectAsState()
+    val coverage by viewModel.metricCoverage.collectAsState()
     var selectedMetric by remember(initialMetric) {
         mutableStateOf(initialMetric ?: MetricType.HEART_RATE)
     }
@@ -67,7 +68,9 @@ fun TrendsScreen(
         if (selectedBaseline != null) {
             BaselineSummaryCard(selectedBaseline)
         } else {
-            NoBaselineCard()
+            val metricLabel = trackableMetrics.firstOrNull { it.first == selectedMetric }?.second
+                ?: selectedMetric.readableName
+            NoBaselineCard(metricLabel, coverage[selectedMetric])
         }
 
         // All baselines
@@ -167,7 +170,10 @@ fun TrendBadge(trend: TrendDirection) {
 }
 
 @Composable
-fun NoBaselineCard() {
+fun NoBaselineCard(
+    metricLabel: String,
+    coverage: BaselineEngine.Coverage?
+) {
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant
@@ -177,15 +183,47 @@ fun NoBaselineCard() {
             modifier = Modifier.padding(24.dp).fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text("No baseline yet", style = MaterialTheme.typography.titleSmall)
+            val (title, body) = noBaselineMessage(metricLabel, coverage)
+            Text(title, style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(4.dp))
             Text(
-                "Bios needs at least ${BaselineEngine.MINIMUM_DATA_DAYS} days of data to compute a baseline for this metric.",
+                body,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }
+}
+
+internal fun noBaselineMessage(
+    metricLabel: String,
+    coverage: BaselineEngine.Coverage?
+): Pair<String, String> {
+    if (coverage == null || !coverage.hasAnyData) {
+        return "No $metricLabel data yet" to
+            "Bios hasn't received any $metricLabel readings. " +
+            "Check that your watch is sending $metricLabel to Health Connect, " +
+            "or that the source you use (Gadgetbridge, Oura, etc.) is connected and syncing."
+    }
+    val staleHours = coverage.lastTimestamp?.let {
+        (System.currentTimeMillis() - it) / (3600L * 1000)
+    } ?: Long.MAX_VALUE
+    if (staleHours >= 48) {
+        val days = (staleHours / 24).toInt()
+        return "$metricLabel feed looks stale" to
+            "Last $metricLabel reading was $days day${if (days == 1) "" else "s"} ago. " +
+            "Bios has ${coverage.totalSamples} reading${if (coverage.totalSamples == 1) "" else "s"} on file, " +
+            "but the source seems to have stopped syncing."
+    }
+    if (!coverage.meetsBaselineMinimum) {
+        return "Building $metricLabel baseline" to
+            "Bios has ${coverage.sensorSamplesInWindow} sensor reading${if (coverage.sensorSamplesInWindow == 1) "" else "s"} " +
+            "in the last ${BaselineEngine.DEFAULT_WINDOW_DAYS} days. " +
+            "Need at least ${BaselineEngine.MIN_SAMPLES_FOR_BASELINE} to compute a baseline."
+    }
+    return "Baseline pending" to
+        "Bios has ${coverage.sensorSamplesInWindow} recent $metricLabel readings. " +
+        "Baseline will compute on the next sync."
 }
 
 private fun formatStat(value: Double): String {

--- a/android/app/src/test/java/com/bios/app/TrendsScreenTest.kt
+++ b/android/app/src/test/java/com/bios/app/TrendsScreenTest.kt
@@ -1,9 +1,11 @@
 package com.bios.app
 
+import com.bios.app.engine.BaselineEngine
 import com.bios.app.model.BaselineContext
 import com.bios.contracts.MetricType
 import com.bios.app.model.PersonalBaseline
 import com.bios.app.model.TrendDirection
+import com.bios.app.ui.trends.noBaselineMessage
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -132,5 +134,68 @@ class TrendsScreenTest {
         val falling = baseline(trendSlope = -0.32)
         assertTrue(String.format("%+.2f", rising.trendSlope).startsWith("+"))
         assertTrue(String.format("%+.2f", falling.trendSlope).startsWith("-"))
+    }
+
+    // -- noBaselineMessage --
+    // The previous "Bios needs at least 7 days of data" line was misleading
+    // when the real problem was that the watch never wrote anything to Health
+    // Connect. These tests pin the message branches that replaced it.
+
+    @Test
+    fun `noBaselineMessage flags zero data with a setup hint`() {
+        val (title, body) = noBaselineMessage("Heart rate", null)
+        assertTrue(title.contains("No Heart rate data"))
+        assertTrue(body.contains("Health Connect"))
+    }
+
+    @Test
+    fun `noBaselineMessage flags zero data when coverage is empty`() {
+        val cov = BaselineEngine.Coverage(
+            sensorSamplesInWindow = 0,
+            totalSamples = 0,
+            lastTimestamp = null
+        )
+        val (title, body) = noBaselineMessage("Heart rate", cov)
+        assertTrue(title.contains("No Heart rate data"))
+        assertTrue(body.contains("hasn't received"))
+    }
+
+    @Test
+    fun `noBaselineMessage flags stale feed when last reading is days old`() {
+        val twoDaysAgo = System.currentTimeMillis() - 3L * 24 * 3600 * 1000
+        val cov = BaselineEngine.Coverage(
+            sensorSamplesInWindow = 5,
+            totalSamples = 100,
+            lastTimestamp = twoDaysAgo
+        )
+        val (title, body) = noBaselineMessage("Heart rate", cov)
+        assertTrue(title.contains("stale"))
+        assertTrue(body.contains("100"))
+    }
+
+    @Test
+    fun `noBaselineMessage reports sample shortfall when below baseline minimum`() {
+        val recent = System.currentTimeMillis() - 3600_000L
+        val cov = BaselineEngine.Coverage(
+            sensorSamplesInWindow = 4,
+            totalSamples = 4,
+            lastTimestamp = recent
+        )
+        val (title, body) = noBaselineMessage("Heart rate", cov)
+        assertTrue(title.contains("Building"))
+        assertTrue(body.contains("4 sensor reading"))
+        assertTrue(body.contains(BaselineEngine.MIN_SAMPLES_FOR_BASELINE.toString()))
+    }
+
+    @Test
+    fun `noBaselineMessage falls back to baseline pending when data is sufficient`() {
+        val recent = System.currentTimeMillis() - 3600_000L
+        val cov = BaselineEngine.Coverage(
+            sensorSamplesInWindow = 50,
+            totalSamples = 50,
+            lastTimestamp = recent
+        )
+        val (title, _) = noBaselineMessage("Heart rate", cov)
+        assertTrue(title.contains("pending"))
     }
 }


### PR DESCRIPTION
## Summary
- The "Bios needs at least 7 days of data" line lied when the real problem was zero ingested HR readings (e.g. watch never wrote to Health Connect, permissions granted late, etc.).
- `NoBaselineCard` and the Diagnostics empty state now describe what Bios actually has — zero readings, stale feed, sample shortfall, or just pending — and Diagnostics adds a per-metric ingestion breakdown so silent feeds are visible at a glance.
- `IngestManager.setup()` re-runs the 30-day backfill when a primary metric (HR / resting HR / sleep duration) has zero readings *and* a wearable-history source is configured. Previously the historical pull only fired when `dataAgeDays == 0`, so users who installed Bios, granted HC permission later, or only just connected a watch were stuck with 24h syncs and no path to recover the missed history.

Adds a `BaselineEngine.Coverage` data class, `MetricReadingDao.countInRange` / `lastTimestampFor`, and unit tests pinning each `noBaselineMessage` branch.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest`
- [x] `./scripts/code-quality-check.sh`
- [ ] Smoke-test on device: install fresh, leave HC empty → confirm "No Heart rate data yet" message; grant later → confirm 30-day backfill triggers on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)