### PR TITLE
fix: isolate BBT writes in ReproductiveDatabase

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -395,7 +395,19 @@ object ConditionPatterns {
         risks = "Untreated mental health changes tend to deepen over time. Sustained sleep disruption and autonomic stress (low HRV) impair immune function, increase cardiovascular risk, and worsen cognitive performance. Social withdrawal and activity reduction create a feedback loop that accelerates decline. Early intervention — when physiological signals are shifting but before clinical symptoms fully manifest — has the highest success rate. If you are in crisis, contact a crisis helpline or emergency services immediately."
     )
 
-    /** Menstrual cycle anomalies: BBT pattern deviation, cycle irregularity. Stored in isolated reproductive DB. */
+    /**
+     * Menstrual cycle anomalies: BBT pattern deviation, cycle irregularity.
+     *
+     * BBT and `CYCLE_PHASE` readings live in `ReproductiveDatabase` (separate
+     * SQLCipher file, independent key, independent wipe). The AnomalyDetector
+     * queries only the main `BiosDatabase`, so the BBT rule will currently
+     * find no data and won't activate; the HRV + sleep corroborators are in
+     * the main DB and can still fire the pattern via `minActiveSignals = 2`
+     * (a less specific cycle signal — autonomic + sleep variability without
+     * the temperature anchor). Wiring AnomalyDetector to optionally consult
+     * the reproductive DB is the path to restoring full BBT-anchored
+     * detection; tracked as a follow-up.
+     */
     val menstrualCycleAnomaly = ConditionPattern(
         id = "menstrual_cycle_anomaly",
         title = "Cycle pattern deviation detected",

--- a/android/app/src/main/java/com/bios/app/data/BbtEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BbtEntryRepo.kt
@@ -1,5 +1,6 @@
 package com.bios.app.data
 
+import android.content.Context
 import com.bios.app.engine.CycleInference
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
@@ -17,14 +18,38 @@ import com.bios.contracts.MetricType
  * a daily morning measurement, not a lab value, and because saving it has a
  * downstream effect: [CycleInference] is re-run over the last 90 days of
  * BBT history so the owner sees the cycle classification update in real
- * time. Cycle-phase rows are written with a deterministic id keyed by the
- * UTC day bucket so re-derivation is idempotent (REPLACE on conflict).
+ * time.
+ *
+ * **Storage isolation.** BBT and the derived `CYCLE_PHASE` rows are
+ * persisted in [ReproductiveDatabase] — a separate SQLCipher file with an
+ * independent encryption key, independent retention, and priority
+ * destruction on LETHE duress PIN / dead-man's-switch. The owner can wipe
+ * reproductive data without touching the main DB. The repo lazily calls
+ * [ReproductiveDatabase.initialize] on first construction so the entry
+ * surface "just works" — no separate enable flow — while still landing on
+ * the isolated key. Owners who want to set an explicit passphrase can do
+ * so before first BBT entry; the lazy init only fires when no key exists.
  *
  * Reuses the same `SELF_REPORTED` [DataSource] tag as [BiomarkerEntryRepo]
- * so the baseline engine and anomaly detector keep ignoring it per decision
- * 3 in `docs/SELF_REPORTED_DATA_HOME.md`.
+ * for provenance. Note that the source rows live in the reproductive DB
+ * (foreign-key constraint requires them in the same SQLCipher file as the
+ * readings), so a separate `SELF_REPORTED` row will appear there
+ * alongside the one in the main DB.
+ *
+ * Cycle-phase rows are written with a deterministic id keyed by the UTC
+ * day bucket so re-derivation is idempotent (REPLACE on conflict).
  */
-class BbtEntryRepo(private val db: BiosDatabase) {
+class BbtEntryRepo(context: Context) {
+
+    private val appContext = context.applicationContext
+
+    init {
+        // Idempotent — no-op if a key already exists.
+        ReproductiveDatabase.initialize(appContext)
+    }
+
+    private val db: ReproductiveDatabase
+        get() = ReproductiveDatabase.getInstance(appContext)
 
     /** Physiological BBT bounds (°C). Outside this range = data-entry error. */
     private val minTempC = 35.0
@@ -38,7 +63,7 @@ class BbtEntryRepo(private val db: BiosDatabase) {
             "BBT $temperatureC°C is outside the $minTempC–$maxTempC range"
         }
         val sourceId = getOrCreateSelfReportedSource()
-        db.metricReadingDao().insert(
+        db.readingDao().insert(
             MetricReading(
                 metricType = MetricType.BASAL_BODY_TEMPERATURE.key,
                 value = temperatureC,
@@ -51,14 +76,14 @@ class BbtEntryRepo(private val db: BiosDatabase) {
     }
 
     suspend fun fetchRecentBbts(limit: Int = 30): List<MetricReading> =
-        db.metricReadingDao().fetchLatest(MetricType.BASAL_BODY_TEMPERATURE.key, limit)
+        db.readingDao().fetchLatest(MetricType.BASAL_BODY_TEMPERATURE.key, limit)
 
     suspend fun fetchLatestCyclePhase(): MetricReading? =
-        db.metricReadingDao().fetchLatest(MetricType.CYCLE_PHASE.key, limit = 1).firstOrNull()
+        db.readingDao().fetchLatest(MetricType.CYCLE_PHASE.key, limit = 1).firstOrNull()
 
     private suspend fun rederiveCyclePhases(sourceId: String) {
         val windowStart = System.currentTimeMillis() - rederivationWindowMs
-        val bbts = db.metricReadingDao().fetch(
+        val bbts = db.readingDao().fetch(
             MetricType.BASAL_BODY_TEMPERATURE.key,
             windowStart,
             Long.MAX_VALUE
@@ -66,7 +91,7 @@ class BbtEntryRepo(private val db: BiosDatabase) {
         val phases = CycleInference.deriveCyclePhases(bbts, sourceId)
         if (phases.isEmpty()) return
         val withStableIds = phases.map { it.copy(id = stableCyclePhaseId(it.timestamp)) }
-        db.metricReadingDao().insertAll(withStableIds)
+        db.readingDao().insertAll(withStableIds)
     }
 
     private suspend fun getOrCreateSelfReportedSource(): String {

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -5,6 +5,7 @@ import com.bios.app.data.BiosDatabase
 import com.bios.app.model.Anomaly
 import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
 import com.bios.app.model.PersonalBaseline
@@ -67,6 +68,15 @@ class FhirExporter(
 
         val thirtyDaysAgo = System.currentTimeMillis() - 30L * 24 * 3600 * 1000
         for (metricType in MetricType.entries) {
+            // Reproductive-domain readings live in the isolated ReproductiveDatabase
+            // (separate encryption key, independent wipe, priority destruction on
+            // duress PIN). The main-DB-backed exporter must never read them, both
+            // because the rows aren't here and — critically — because including
+            // them in a default FHIR bundle would collapse the isolation the
+            // separate DB exists to provide. A future per-export "include
+            // reproductive data" opt-in would query ReproductiveDatabase
+            // explicitly; today's default is hard-skip.
+            if (metricType.domain == MetricDomain.WOMENS_HEALTH) continue
             val readings = readingDao.fetch(metricType.key, thirtyDaysAgo, Long.MAX_VALUE)
             for (reading in readings.take(500)) {
                 entries.put(bundleEntry(buildObservationResource(reading, metricType)))

--- a/android/app/src/main/java/com/bios/app/ui/bbt/BbtEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/bbt/BbtEntryScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -53,7 +54,10 @@ fun BbtEntryScreen(
     viewModel: AppViewModel,
     onBack: () -> Unit
 ) {
-    val repo = remember(viewModel.db) { BbtEntryRepo(viewModel.db) }
+    val context = LocalContext.current
+    // BBT writes land in the isolated ReproductiveDatabase, not viewModel.db —
+    // the repo lazily initializes that DB on construction.
+    val repo = remember(context) { BbtEntryRepo(context) }
     val scope = rememberCoroutineScope()
 
     var valueText by remember { mutableStateOf("") }

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -1,5 +1,6 @@
 package com.bios.app
 
+import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
 import org.junit.Assert.*
@@ -275,6 +276,38 @@ class FhirExporterTest {
             MetricType.PLATELETS -> "777-3" to "Platelets [#/volume] in Blood by Automated count"
             else -> null
         }
+    }
+
+    // --- Reproductive-data isolation guard ---
+
+    @Test
+    fun `reproductive metrics stay in WOMENS_HEALTH so FhirExporter skips them by default`() {
+        // The FhirExporter bundle loop skips MetricDomain.WOMENS_HEALTH because
+        // those readings live in the isolated ReproductiveDatabase (separate
+        // SQLCipher key, independent wipe). Moving either of these keys to a
+        // different domain would silently start leaking reproductive data into
+        // the default FHIR export — this test fails first instead.
+        assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.BASAL_BODY_TEMPERATURE.domain)
+        assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.CYCLE_PHASE.domain)
+    }
+
+    @Test
+    fun `every WOMENS_HEALTH MetricType is excluded from the default FHIR enumeration`() {
+        // Mirror of the FhirExporter `for (metricType in MetricType.entries) …
+        // if (domain == WOMENS_HEALTH) continue` loop. If any new reproductive
+        // key is added without a corresponding exporter exclusion (or a
+        // conscious opt-in path), this test makes the gap visible.
+        val included = MetricType.entries.filter { it.domain != MetricDomain.WOMENS_HEALTH }
+        val excluded = MetricType.entries - included.toSet()
+        assertTrue(
+            "WOMENS_HEALTH key(s) leaked into the default-export set: " +
+                "${included.filter { it.domain == MetricDomain.WOMENS_HEALTH }}",
+            included.none { it.domain == MetricDomain.WOMENS_HEALTH }
+        )
+        assertTrue(
+            "Expected at least one WOMENS_HEALTH key to assert non-vacuously",
+            excluded.any { it.domain == MetricDomain.WOMENS_HEALTH }
+        )
     }
 
     private fun ucumCode(metricType: MetricType): String {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -329,14 +329,15 @@ that can't be expressed as a rule over the components.
   three consecutive daily BBTs sit strictly above the coverline. Emits
   FOLLICULAR / OVULATORY / LUTEAL via the `CyclePhase` enum.
 - **BBT writer (shipped):** `data/BbtEntryRepo.kt` + `ui/bbt/BbtEntryScreen.kt`
-  reachable from Settings → "Track BBT". Owner enters a temperature
-  (35–39 °C) and date; the repo persists the BBT row through the same
-  `SELF_REPORTED` `DataSource` the biomarker entry surface uses, then
-  re-runs `CycleInference` over the last 90 days. Derived `cycle_phase`
-  rows use a deterministic id keyed by UTC day bucket so re-derivation
-  is idempotent under `OnConflictStrategy.REPLACE`. The screen surfaces
-  the current phase as soon as enough BBTs are in (≥9 daily samples
-  with a sustained rise).
+  reachable from Settings → "Track BBT". BBT and derived `cycle_phase`
+  rows persist into `ReproductiveDatabase` (separate SQLCipher file,
+  independent key, priority destruction on duress PIN — the post-Dobbs
+  isolation). Lazy `ReproductiveDatabase.initialize()` on first write,
+  no separate enable flow. `CycleInference` re-runs over the last 90
+  days on save; derived rows use a deterministic UTC-day id so
+  re-derivation is idempotent. FHIR exporter skips
+  `MetricDomain.WOMENS_HEALTH` by default; per-export opt-in is the
+  future path to clinician sharing.
 - `cycle_day` — **deferred.** The clinical numbering convention starts
   cycle day 1 at the first day of menstruation; BBT alone cannot
   reliably distinguish menstrual from early follicular. Ships when a
@@ -437,8 +438,7 @@ active minutes ↓ over 7d; WHO 2011 + Williams Hematology + Patel 2008
 + Duke/Abelmann 1969). Biomarker gate rule is `required = true` so
 wearable drift alone never fires the pattern.
 
-**§8.6 complete.** Future biomarker waves (fasting insulin, sex
-hormones, homocysteine, etc.) are new scope, not §8.6 follow-on.
+**§8.6 complete.** Future biomarker waves (fasting insulin, sex hormones, homocysteine, etc.) are new scope, not §8.6 follow-on.
 
 ### 8.7 Stress score — Bios-only autonomic derivation [SHIPPED]
 


### PR DESCRIPTION
## Summary

`BbtEntryRepo` (shipped in §8.5) was writing BBT and derived `CYCLE_PHASE` rows into the main `BiosDatabase`, silently bypassing the `ReproductiveDatabase` (separate SQLCipher key, independent wipe, priority destruction on LETHE duress PIN / dead-man's-switch). The reproductive-isolation guarantee the class docstring promises was being broken on every manual BBT entry.

This is Option 1 of the three discussed offline: restore isolation, lazy init, FHIR repro-export off by default.

### What ships

- **`BbtEntryRepo` rewired.** Constructor now takes `Context` and lazily calls `ReproductiveDatabase.initialize()` (idempotent — no-op if a passphrase already exists; falls back to a random UUID key, so owners who want a custom passphrase can still set one before first entry). All read/write paths route through `ReproductiveDatabase.getInstance(context)` — BBT writes, cycle-phase derivation reads, and the `SELF_REPORTED` `DataSource` row all live in the isolated DB.
- **`BbtEntryScreen`** passes `LocalContext` into the new repo constructor.
- **`FhirExporter`** skips `MetricDomain.WOMENS_HEALTH` in the default bundle loop with a comment explaining *why*. Reproductive data is no longer eligible for the main-DB-backed export. A future per-export opt-in that explicitly queries `ReproductiveDatabase` is the path to clinician sharing.
- **`menstrualCycleAnomaly`** docstring updated: BBT rule will find no data in the main DB and won't activate; HRV + sleep corroborators can still trigger the pattern via `minActiveSignals = 2` (less specific signal — autonomic + sleep variability without the temperature anchor). Cross-DB AnomalyDetector wiring is the right follow-up for fully restoring BBT-anchored detection.
- **Test guard:** new `FhirExporterTest` cases lock in (a) both reproductive keys stay in `MetricDomain.WOMENS_HEALTH`, and (b) the default `MetricType.entries` enumeration excludes them. Adding a reproductive key in a future PR without a matching exporter exclusion (or a conscious opt-in) will fail these tests.
- **ROADMAP §8.5** updated to reflect the new storage location and the FHIR-export default.

### Defaults you signed off on

- Lazy init writes a UUID passphrase to `EncryptedSharedPreferences` on first BBT entry — owner never sees a passphrase prompt by default, but the key is independent of the main DB.
- FHIR export of `BASAL_BODY_TEMPERATURE` / `CYCLE_PHASE` is off; clinician sharing needs an explicit opt-in flow (out of scope here).

### Migration note

Any BBT rows already written under the bug live in the main DB and won't be auto-migrated by this PR. If you've used the BBT entry surface on a real device, those rows stay where they are until manually moved (or wiped). For a development install with synthetic data, just clear app storage. Flagging for a possible follow-up migration PR if real data exists.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] `FhirExporterTest` new cases — reproductive keys stay in WOMENS_HEALTH; default enumeration excludes them
- [x] Existing `BbtEntryRepoIdTest` still passes (only tests the static `stableCyclePhaseId` helper, no DB needed)
- [x] Existing `ConditionPatternsTest` orphan-guard still passes — `menstrualCycleAnomaly` remains registered in `all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)