### PR TITLE
feat: wire Withings adapter end-to-end for body composition

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -90,6 +90,8 @@ class BaselineEngine(
                 MetricType.SLEEP_STAGE,
                 MetricType.SLEEP_DURATION,
                 MetricType.AMBIENT_LIGHT,
+                MetricType.BODY_MASS,
+                MetricType.BODY_FAT_PCT,
             )
 
             for (metricType in metricsToBaseline) {

--- a/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SignalQualityFilter.kt
@@ -106,7 +106,12 @@ object SignalQualityFilter {
         // admitting decimal-place errors; 300 kg upper bound is beyond
         // documented extremes. No rate-of-change cap — body mass doesn't
         // change rapidly between readings.
-        MetricType.BODY_MASS.key to Bounds(20.0, 300.0, null)
+        MetricType.BODY_MASS.key to Bounds(20.0, 300.0, null),
+        // Body fat % physiological range: ~3% (extreme male athlete) to ~60%
+        // (severe obesity). Tighter than the impedance-scale rated range,
+        // wider than population averages — anything outside is a sensor or
+        // entry artifact.
+        MetricType.BODY_FAT_PCT.key to Bounds(3.0, 60.0, null)
     )
 
     internal data class Bounds(

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -238,6 +238,7 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
     MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
     MetricType.BODY_MASS -> "29463-7" to "Body weight"
+    MetricType.BODY_FAT_PCT -> "41982-0" to "Percentage of body fat Measured"
     MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
     MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
     MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -38,6 +38,7 @@ class IngestManager(
     private val phoneSensorAdapter: PhoneSensorAdapter? = null,
     private val gadgetbridgeAdapter: GadgetbridgeAdapter? = null,
     private val directSensorAdapter: DirectSensorAdapter? = null,
+    private val withingsAdapter: WithingsApiAdapter? = null,
     private val latencyTracker: DetectionLatencyTracker? = null
 ) {
     private val readingDao = db.metricReadingDao()
@@ -66,6 +67,7 @@ class IngestManager(
     private var phoneSensorSourceId: String? = null
     private var gadgetbridgeSourceId: String? = null
     private var directSensorSourceId: String? = null
+    private var withingsSourceId: String? = null
 
     // MARK: - Setup
 
@@ -98,6 +100,13 @@ class IngestManager(
             )
         }
 
+        // Withings API (scale-first device — body composition, BP, sleep summary)
+        if (withingsAdapter?.isConnected == true) {
+            withingsSourceId = getOrCreateSource(
+                SourceType.WITHINGS_API, "Withings", SensorType.DERIVED
+            )
+        }
+
         // Phone sensors (always available as last resort)
         if (phoneSensorAdapter?.hasAccelerometer == true ||
             phoneSensorAdapter?.hasStepCounter == true ||
@@ -127,7 +136,8 @@ class IngestManager(
         // matter how many times we ask, so don't burn syncs.
         val hasWearableHistorySource = healthConnectSourceId != null ||
             gadgetbridgeSourceId != null ||
-            ouraSourceId != null
+            ouraSourceId != null ||
+            withingsSourceId != null
         if (!hasWearableHistorySource) return false
         for (metric in PRIMARY_METRICS_FOR_BACKFILL) {
             if (readingDao.count(metric.key) == 0) return true
@@ -155,6 +165,7 @@ class IngestManager(
                         async { fetchGadgetbridgeReadings(start, end) },
                         async { fetchDirectSensorReadings() },
                         async { fetchOuraReadings(start, end) },
+                        async { fetchWithingsReadings(start, end) },
                         async { fetchPhoneSensorReadings() }
                     )
                     jobs.awaitAll().flatten()
@@ -203,7 +214,8 @@ class IngestManager(
                             async { healthConnect.fetchReadings(current, chunkEnd, id) }
                         },
                         async { fetchGadgetbridgeReadings(current, chunkEnd) },
-                        async { fetchOuraReadings(current, chunkEnd) }
+                        async { fetchOuraReadings(current, chunkEnd) },
+                        async { fetchWithingsReadings(current, chunkEnd) }
                     )
                     jobs.awaitAll().flatten()
                 }
@@ -315,6 +327,16 @@ class IngestManager(
     private suspend fun fetchOuraReadings(start: Instant, end: Instant): List<MetricReading> {
         val sourceId = ouraSourceId ?: return emptyList()
         val adapter = ouraAdapter ?: return emptyList()
+        return try {
+            adapter.fetchReadings(start, end, sourceId)
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private suspend fun fetchWithingsReadings(start: Instant, end: Instant): List<MetricReading> {
+        val sourceId = withingsSourceId ?: return emptyList()
+        val adapter = withingsAdapter ?: return emptyList()
         return try {
             adapter.fetchReadings(start, end, sourceId)
         } catch (_: Exception) {

--- a/android/app/src/main/java/com/bios/app/ingest/SyncWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SyncWorker.kt
@@ -31,13 +31,18 @@ class SyncWorker(
             val healthConnect = HealthConnectAdapter(applicationContext)
             val tokenStore = OuraTokenStore(applicationContext)
             val ouraAdapter = if (tokenStore.hasToken()) OuraApiAdapter(tokenStore) else null
+            val apiTokenStore = ApiTokenStore(applicationContext)
+            val withings = if (apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY)) {
+                WithingsApiAdapter(apiTokenStore)
+            } else null
             val phoneSensor = PhoneSensorAdapter(applicationContext)
             val gadgetbridge = GadgetbridgeAdapter(applicationContext)
             val directSensor = DirectSensorAdapter(applicationContext)
             val ingestManager = IngestManager(
                 healthConnect, db, ouraAdapter, phoneSensor,
                 gadgetbridgeAdapter = gadgetbridge,
-                directSensorAdapter = directSensor
+                directSensorAdapter = directSensor,
+                withingsAdapter = withings
             )
 
             // Stage 1: Sync recent data

--- a/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
+++ b/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
@@ -114,7 +114,10 @@ object DataDestroyer {
     private fun destroyTokens(context: Context) {
         try {
             OuraTokenStore(context).clearToken()
-            // Future adapters: WHOOP, Garmin, Withings, Dexcom token stores
+            // Withings (and any future provider stored in the generic
+            // ApiTokenStore: WHOOP, Garmin, Dexcom) wipes in one call —
+            // clearAll() drops every provider key in the encrypted prefs.
+            com.bios.app.ingest.ApiTokenStore(context).clearAll()
             Log.d(TAG, "API tokens cleared")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to clear API tokens", e)

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -11,6 +11,7 @@ import com.bios.app.engine.BaselineEngine
 import com.bios.app.engine.DetectionLatencyTracker
 import com.bios.app.engine.LatencyPercentiles
 import com.bios.app.engine.TFLiteAnomalyModel
+import com.bios.app.ingest.ApiTokenStore
 import com.bios.app.ingest.DirectSensorAdapter
 import com.bios.app.ingest.GadgetbridgeAdapter
 import com.bios.app.ingest.HealthConnectAdapter
@@ -18,6 +19,7 @@ import com.bios.app.ingest.IngestManager
 import com.bios.app.ingest.OuraApiAdapter
 import com.bios.app.ingest.OuraTokenStore
 import com.bios.app.ingest.PhoneSensorAdapter
+import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.app.model.ActionItem
 import com.bios.app.model.Anomaly
@@ -40,20 +42,19 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
 class AppViewModel(application: Application) : AndroidViewModel(application) {
-
     val db = BiosDatabase.getInstance(application)
     val healthConnect = HealthConnectAdapter(application)
     val ouraTokenStore = OuraTokenStore(application)
     val ouraAdapter = OuraApiAdapter(ouraTokenStore)
+    val apiTokenStore = ApiTokenStore(application)
+    val withingsAdapter = WithingsApiAdapter(apiTokenStore)
     val phoneSensorAdapter = PhoneSensorAdapter(application)
     val gadgetbridgeAdapter = GadgetbridgeAdapter(application)
     val directSensorAdapter = DirectSensorAdapter(application)
     val latencyTracker = DetectionLatencyTracker()
     val ingestManager = IngestManager(
         healthConnect, db, ouraAdapter, phoneSensorAdapter,
-        gadgetbridgeAdapter = gadgetbridgeAdapter,
-        directSensorAdapter = directSensorAdapter,
-        latencyTracker = latencyTracker
+        gadgetbridgeAdapter, directSensorAdapter, withingsAdapter, latencyTracker
     )
     val baselineEngine = BaselineEngine(db, latencyTracker)
     val mlModel = TFLiteAnomalyModel.load(application)

--- a/android/app/src/main/java/com/bios/app/ui/settings/ConnectableSourceRow.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/ConnectableSourceRow.kt
@@ -1,0 +1,42 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * One row in Settings → Data Sources for a third-party adapter that needs
+ * an owner-managed credential (Oura, Withings, future WHOOP / Garmin /
+ * Dexcom). Renders the name, the connection state, and — when connected —
+ * a disconnect button below. Keeps SettingsScreen.kt clear of the
+ * adapter-specific boilerplate that grows linearly with adapter count.
+ */
+@Composable
+fun ConnectableSourceRow(
+    name: String,
+    isConnected: Boolean,
+    onConnect: () -> Unit,
+    onDisconnect: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(name)
+        if (isConnected) {
+            Text("Connected", color = MaterialTheme.colorScheme.primary)
+        } else {
+            TextButton(onClick = onConnect) { Text("Connect") }
+        }
+    }
+    if (isConnected) {
+        TextButton(onClick = onDisconnect) {
+            Text("Disconnect $name", color = MaterialTheme.colorScheme.error)
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsRow.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsRow.kt
@@ -1,0 +1,22 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun SettingsRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.core.content.FileProvider
 import com.bios.app.engine.BaselineEngine
 import com.bios.app.export.DataExporter
 import com.bios.app.export.FhirExporter
+import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.model.CompanionGrant
 import com.bios.app.model.PrivacyTier
 import com.bios.app.alerts.DailyDigestWorker
@@ -43,6 +44,10 @@ fun SettingsScreen(
     var isExporting by remember { mutableStateOf(false) }
     var showOuraDialog by remember { mutableStateOf(false) }
     var isOuraConnected by remember { mutableStateOf(viewModel.ouraTokenStore.hasToken()) }
+    var showWithingsDialog by remember { mutableStateOf(false) }
+    var isWithingsConnected by remember {
+        mutableStateOf(viewModel.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY))
+    }
     val companionGrants by viewModel.db.companionGrantDao()
         .observeAll()
         .collectAsState(initial = emptyList())
@@ -81,29 +86,28 @@ fun SettingsScreen(
                     )
                 }
                 Spacer(Modifier.height(4.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text("Oura Ring")
-                    if (isOuraConnected) {
-                        Text("Connected", color = MaterialTheme.colorScheme.primary)
-                    } else {
-                        TextButton(onClick = { showOuraDialog = true }) {
-                            Text("Connect")
-                        }
-                    }
-                }
-                if (isOuraConnected) {
-                    TextButton(
-                        onClick = {
-                            viewModel.ouraTokenStore.clearToken()
-                            isOuraConnected = false
-                        }
-                    ) {
-                        Text("Disconnect Oura", color = MaterialTheme.colorScheme.error)
-                    }
-                }
+                ConnectableSourceRow(
+                    name = "Oura Ring",
+                    isConnected = isOuraConnected,
+                    onConnect = { showOuraDialog = true },
+                    onDisconnect = {
+                        viewModel.ouraTokenStore.clearToken()
+                        isOuraConnected = false
+                    },
+                )
+
+                Spacer(Modifier.height(4.dp))
+                ConnectableSourceRow(
+                    name = "Withings",
+                    isConnected = isWithingsConnected,
+                    onConnect = { showWithingsDialog = true },
+                    onDisconnect = {
+                        viewModel.apiTokenStore.clearToken(
+                            WithingsApiAdapter.PROVIDER_KEY
+                        )
+                        isWithingsConnected = false
+                    },
+                )
 
                 Spacer(Modifier.height(4.dp))
                 CompanionAppsRow(
@@ -468,16 +472,16 @@ fun SettingsScreen(
             onDismiss = { showOuraDialog = false }
         )
     }
-}
 
-@Composable
-private fun SettingsRow(label: String, value: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(label, style = MaterialTheme.typography.bodyMedium)
-        Text(value, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    if (showWithingsDialog) {
+        WithingsConnectDialog(
+            onConnect = { token ->
+                viewModel.apiTokenStore.saveToken(WithingsApiAdapter.PROVIDER_KEY, token)
+                isWithingsConnected = true
+                showWithingsDialog = false
+            },
+            onDismiss = { showWithingsDialog = false }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/settings/WithingsConnectDialog.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/WithingsConnectDialog.kt
@@ -1,0 +1,74 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Withings connection dialog — paste an OAuth-issued access token.
+ *
+ * Withings's API requires OAuth 2.0; this dialog deliberately doesn't
+ * implement the OAuth dance (would require a registered Withings developer
+ * app with client_id / client_secret bound at build time). Instead it
+ * accepts a token the owner has obtained out-of-band — same shape as the
+ * Oura personal-access-token flow, and works with any token issued via a
+ * Withings developer account's OAuth exchange.
+ *
+ * Refresh-token handling is also out of scope: the adapter treats whatever
+ * string is stored as a bearer token. Owners replace the value when it
+ * expires. A full OAuth-with-refresh integration is a future PR once a
+ * Withings developer app is registered for Bios.
+ */
+@Composable
+fun WithingsConnectDialog(
+    onConnect: (token: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var tokenInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Connect Withings") },
+        text = {
+            Column {
+                Text(
+                    "Paste a Withings API access token. Obtain one through a Withings " +
+                        "developer-account OAuth exchange against developer.withings.com — " +
+                        "Bios does not perform the OAuth dance itself yet.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("Access Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val trimmed = tokenInput.trim()
+                    if (trimmed.isNotBlank()) onConnect(trimmed)
+                }
+            ) { Text("Connect") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -105,9 +105,15 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `29 metric types have LOINC mappings`() {
+    fun `body fat percent maps to LOINC 41982-0`() {
+        val (code, _) = loincCode(MetricType.BODY_FAT_PCT)!!
+        assertEquals("41982-0", code)
+    }
+
+    @Test
+    fun `30 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(29, mapped)
+        assertEquals(30, mapped)
     }
 
     @Test
@@ -258,6 +264,7 @@ class FhirExporterTest {
             MetricType.SKIN_TEMPERATURE -> "8310-5" to "Body temperature"
             MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
             MetricType.BODY_MASS -> "29463-7" to "Body weight"
+            MetricType.BODY_FAT_PCT -> "41982-0" to "Percentage of body fat Measured"
             MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
             MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
             MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"

--- a/android/app/src/test/java/com/bios/app/SignalQualityFilterTest.kt
+++ b/android/app/src/test/java/com/bios/app/SignalQualityFilterTest.kt
@@ -113,6 +113,36 @@ class SignalQualityFilterTest {
         assertEquals(98.0, filtered[1].value, 0.01)
     }
 
+    // -- Body composition (Withings adapter) --
+
+    @Test
+    fun `body mass within 20 to 300 kg passes`() {
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_MASS, 70.0)))
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_MASS, 20.0)))
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_MASS, 300.0)))
+    }
+
+    @Test
+    fun `body mass outside 20 to 300 kg is rejected`() {
+        assertFalse(SignalQualityFilter.checkReading(reading(MetricType.BODY_MASS, 5.0)))
+        assertFalse(SignalQualityFilter.checkReading(reading(MetricType.BODY_MASS, 350.0)))
+    }
+
+    @Test
+    fun `body fat percent within 3 to 60 passes`() {
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_FAT_PCT, 18.0)))
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_FAT_PCT, 3.0)))
+        assertTrue(SignalQualityFilter.checkReading(reading(MetricType.BODY_FAT_PCT, 60.0)))
+    }
+
+    @Test
+    fun `body fat percent outside 3 to 60 is rejected`() {
+        // Below 3% — beyond extreme male athlete; almost certainly artifact.
+        assertFalse(SignalQualityFilter.checkReading(reading(MetricType.BODY_FAT_PCT, 1.0)))
+        // Above 60% — beyond documented severe obesity range.
+        assertFalse(SignalQualityFilter.checkReading(reading(MetricType.BODY_FAT_PCT, 70.0)))
+    }
+
     @Test
     fun `unknown metric type passes through`() {
         val r = MetricReading(

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -277,11 +277,9 @@ suppresses melatonin), Roenneberg 2007 (social-jetlag tracks light
 irregularity). Pairs cleanly with W2F's `circadian_phase_shift` without
 violating SoulRadio's manifesto (Bios derives, SoulRadio doesn't consume).
 
-### 8.2 Body composition via Withings adapter
+### 8.2 Body composition via Withings adapter [LIVE]
 
-Withings is an active adapter ([§Current State](#current-state-v020));
-`body_mass` and `body_fat_pct` aren't yet in `MetricType`. Add the keys
-(domain: `METABOLIC` or new `BODY_COMPOSITION`), wire the adapter, baseline.
+`BODY_MASS` + `BODY_FAT_PCT` (`METABOLIC` domain) emit from `WithingsApiAdapter.fetchMeasures` (types 1, 6); wired into `IngestManager` alongside Oura. Settings → Withings pastes an OAuth access token (full OAuth dance is a future PR — needs a registered Withings dev app). Both keys baseline (14-day) + bounded (mass 20–300 kg; fat 3–60 %). `DataDestroyer` wipes via `ApiTokenStore.clearAll()`; LOINC 41982-0 ships in `FhirExporter`.
 
 ### 8.3 HRV decomposition (autonomic-tone derivations) [PARTIAL — parasympathetic shipped, LF/HF deferred]
 


### PR DESCRIPTION
## Summary

Closes Phase 8.2. `WithingsApiAdapter` already existed and emitted `BODY_MASS` + `BODY_FAT_PCT` (plus BP / sleep / temperature) but was **orphaned** — never constructed, never wired into `IngestManager`, no UI to connect an account. This PR closes that loop end-to-end.

### Wiring

- **`AppViewModel`** holds an `ApiTokenStore` + `WithingsApiAdapter` and passes the adapter into `IngestManager` (alongside Oura).
- **`IngestManager`** registers a `WITHINGS_API` source on `setup()` when the adapter has a token, and includes a Withings fetch job in both `syncRecentData` and `syncHistoricalData` coroutine fan-outs. Withings is added to the `hasWearableHistorySource` check so the empty-primary-metric backfill retry includes scale-bound owners.
- **`SyncWorker.doWork()`** constructs the adapter only when `ApiTokenStore.hasToken("withings")`, mirroring the Oura pattern (no adapter = job is a no-op).

### Owner-facing

- **Settings → Withings** — paste-an-OAuth-access-token dialog modeled on the Oura personal-token flow. Full OAuth code-exchange dance is a future PR (needs a registered Withings developer app with client_id / client_secret). Owners with a developer account can obtain a token out-of-band; once stored, the adapter authenticates as Bearer.
- **Disconnect** flow clears the token via `ApiTokenStore.clearToken("withings")`.

### Engine + privacy

- `BODY_MASS` + `BODY_FAT_PCT` added to `BaselineEngine.metricsToBaseline` → 14-day personal baselines back trend detection (satisfies §8.8 acceptance).
- `SignalQualityFilter` gains a `BODY_FAT_PCT` 3–60% physiological bound (mass bound was already there).
- `DataDestroyer.destroyTokens` calls `ApiTokenStore.clearAll()` so Withings (and any future provider stored generically) wipes on duress PIN / dead-man's-switch.
- `FhirExporter` LOINC table gains `41982-0` ("Percentage of body fat Measured") for body fat.

### Refactor (kept under the 500-line cap)

- `ConnectableSourceRow.kt` — extracted the row pattern that's now used by both Oura and Withings (and the future WHOOP / Garmin / Dexcom rows). SettingsScreen goes from a 14-line inline block per source to a ~6-line call.
- `SettingsRow.kt` — peeled the small label/value row helper out so `SettingsScreen.kt` stays under 500 lines as Withings UI is added.

### Tests

- `SignalQualityFilterTest`: BODY_MASS in/out of 20–300 kg range, BODY_FAT_PCT in/out of 3–60% range.
- `FhirExporterTest`: BODY_FAT_PCT maps to LOINC 41982-0; LOINC mapping counter bumped 29 → 30 (locks in any future addition).

## Test plan
- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, build (both flavors), unit tests — all pass
- [x] New SignalQualityFilter + FhirExporter cases pass
- [x] No existing tests regress
- [ ] Manual: settings shows new Withings row; Connect dialog opens; pasting any non-empty string stores it; disconnect clears

## Known limitations / follow-ups
- **OAuth flow is the obvious next layer.** Today's "paste an access token" works for developers with their own Withings account; a real OAuth dance (authorize → redirect → code → token exchange + refresh) is a separate PR that needs registered Withings app credentials.
- **Token refresh** isn't handled — the adapter sends whatever is stored as bearer until cleared. Owners replace the token manually when it expires. Folds naturally into the OAuth PR above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)