### PR TITLE
feat: anchor cycle_day on owner-logged menstruation onsets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Bios shares LETHE's protection philosophy:
 - See docs/PRIVACY_ARCHITECTURE.md for privacy/encryption details
 - See docs/CONSUMER_API.md for the `BiosHealthProvider` ContentProvider contract (read by W2F, future companions)
 - See docs/ECOSYSTEM_BOUNDARIES.md for what belongs in Bios vs. companion apps (Fil, W2F, Virgil, SoulRadio)
-- See docs/ROADMAP.md for the owner-protection roadmap (Phases 1-6 complete; Phase 7 consent/keystore + `bios-contracts` artifact shipped — sub-items 7.5 (SoulRadio inbound) and 7.6 (cross-repo CI) remain)
+- See docs/ROADMAP.md for the owner-protection roadmap (Phases 1-6 complete; Phase 7 effectively complete except 7.5 SoulRadio inbound, deferred on manifesto grounds; Phase 8 perimeter completion in flight — see ROADMAP for per-item status)
 
 ## Code Conventions
 

--- a/android/app/src/main/java/com/bios/app/data/BbtEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BbtEntryRepo.kt
@@ -1,7 +1,6 @@
 package com.bios.app.data
 
 import android.content.Context
-import com.bios.app.engine.CycleInference
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
@@ -55,14 +54,11 @@ class BbtEntryRepo(context: Context) {
     private val minTempC = 35.0
     private val maxTempC = 39.0
 
-    /** How far back cycle inference looks each time a BBT is saved. */
-    private val rederivationWindowMs = 90L * 86_400_000L
-
     suspend fun addBbt(temperatureC: Double, timestamp: Long) {
         require(temperatureC in minTempC..maxTempC) {
             "BBT $temperatureC°C is outside the $minTempC–$maxTempC range"
         }
-        val sourceId = getOrCreateSelfReportedSource()
+        val sourceId = SelfReportedSource.getOrCreate(db)
         db.readingDao().insert(
             MetricReading(
                 metricType = MetricType.BASAL_BODY_TEMPERATURE.key,
@@ -72,7 +68,7 @@ class BbtEntryRepo(context: Context) {
                 confidence = ConfidenceTier.HIGH.level
             )
         )
-        rederiveCyclePhases(sourceId)
+        CycleDerivation.rederive(db, sourceId)
     }
 
     suspend fun fetchRecentBbts(limit: Int = 30): List<MetricReading> =
@@ -81,20 +77,24 @@ class BbtEntryRepo(context: Context) {
     suspend fun fetchLatestCyclePhase(): MetricReading? =
         db.readingDao().fetchLatest(MetricType.CYCLE_PHASE.key, limit = 1).firstOrNull()
 
-    private suspend fun rederiveCyclePhases(sourceId: String) {
-        val windowStart = System.currentTimeMillis() - rederivationWindowMs
-        val bbts = db.readingDao().fetch(
-            MetricType.BASAL_BODY_TEMPERATURE.key,
-            windowStart,
-            Long.MAX_VALUE
-        )
-        val phases = CycleInference.deriveCyclePhases(bbts, sourceId)
-        if (phases.isEmpty()) return
-        val withStableIds = phases.map { it.copy(id = stableCyclePhaseId(it.timestamp)) }
-        db.readingDao().insertAll(withStableIds)
+    companion object {
+        /**
+         * Deterministic primary key for a derived CYCLE_PHASE row. Kept as
+         * a forwarding alias for callers that pinned to this name before
+         * the helper was extracted into [CycleDerivation].
+         */
+        fun stableCyclePhaseId(timestamp: Long): String =
+            CycleDerivation.stableCyclePhaseId(timestamp)
     }
+}
 
-    private suspend fun getOrCreateSelfReportedSource(): String {
+/**
+ * Shared resolver for the SELF_REPORTED [DataSource] row in the isolated
+ * reproductive DB. Both [BbtEntryRepo] and [PeriodEntryRepo] write through
+ * this single row so manual entries appear under one provenance tag.
+ */
+internal object SelfReportedSource {
+    suspend fun getOrCreate(db: ReproductiveDatabase): String {
         val dao = db.dataSourceDao()
         dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
         val source = DataSource(
@@ -105,18 +105,5 @@ class BbtEntryRepo(context: Context) {
         )
         dao.insert(source)
         return source.id
-    }
-
-    companion object {
-        /**
-         * Deterministic primary key for a derived CYCLE_PHASE row. Keyed by
-         * the UTC day bucket so re-running [CycleInference] over a growing
-         * BBT series produces stable row ids — `OnConflictStrategy.REPLACE`
-         * on `MetricReadingDao.insertAll` handles dedupe.
-         */
-        fun stableCyclePhaseId(timestamp: Long): String {
-            val day = timestamp / 86_400_000L
-            return "cycle_phase_self_reported_$day"
-        }
     }
 }

--- a/android/app/src/main/java/com/bios/app/data/CycleDerivation.kt
+++ b/android/app/src/main/java/com/bios/app/data/CycleDerivation.kt
@@ -1,0 +1,81 @@
+package com.bios.app.data
+
+import com.bios.app.engine.CycleInference
+import com.bios.contracts.MetricType
+
+/**
+ * Shared re-derivation surface for cycle phases + day-of-cycle numbering.
+ *
+ * Both [BbtEntryRepo] (on new BBT) and [PeriodEntryRepo] (on new
+ * menstruation onset) call [rederive] so the CYCLE_PHASE and CYCLE_DAY
+ * series stay in sync regardless of which writer touched the database.
+ *
+ * Re-derivation walks the last 90 days of BBT + onset data, re-runs
+ * [CycleInference], and upserts the derived rows with deterministic UTC-
+ * day IDs so `OnConflictStrategy.REPLACE` keeps the series idempotent
+ * across repeated runs.
+ */
+internal object CycleDerivation {
+
+    private const val MS_PER_DAY = 86_400_000L
+    private const val WINDOW_MS = 90L * MS_PER_DAY
+
+    suspend fun rederive(db: ReproductiveDatabase, sourceId: String) {
+        val now = System.currentTimeMillis()
+        val windowStart = now - WINDOW_MS
+
+        val bbts = db.readingDao().fetch(
+            MetricType.BASAL_BODY_TEMPERATURE.key,
+            windowStart,
+            Long.MAX_VALUE
+        )
+        val onsets = db.readingDao().fetch(
+            MetricType.MENSTRUATION_ONSET.key,
+            windowStart,
+            Long.MAX_VALUE
+        )
+
+        val phases = CycleInference.deriveCyclePhases(bbts, sourceId, onsets)
+        if (phases.isNotEmpty()) {
+            db.readingDao().insertAll(
+                phases.map { it.copy(id = stableCyclePhaseId(it.timestamp)) }
+            )
+        }
+
+        val days = CycleInference.deriveCycleDays(onsets, now, sourceId)
+        if (days.isNotEmpty()) {
+            db.readingDao().insertAll(
+                days.map { it.copy(id = stableCycleDayId(it.timestamp)) }
+            )
+        }
+    }
+
+    /**
+     * Deterministic primary key for a derived CYCLE_PHASE row, keyed by
+     * the UTC day bucket so re-running [CycleInference] over a growing
+     * BBT + onset series produces stable row ids.
+     */
+    fun stableCyclePhaseId(timestamp: Long): String {
+        val day = timestamp / MS_PER_DAY
+        return "cycle_phase_self_reported_$day"
+    }
+
+    /**
+     * Deterministic primary key for a derived CYCLE_DAY row, keyed by the
+     * UTC day bucket. Same idempotence rationale as [stableCyclePhaseId].
+     */
+    fun stableCycleDayId(timestamp: Long): String {
+        val day = timestamp / MS_PER_DAY
+        return "cycle_day_self_reported_$day"
+    }
+
+    /**
+     * Deterministic primary key for a manually logged MENSTRUATION_ONSET
+     * row. Two onsets on the same UTC day collapse into one — the owner
+     * meant to log day-1, not duplicate it.
+     */
+    fun stableMenstruationOnsetId(timestamp: Long): String {
+        val day = timestamp / MS_PER_DAY
+        return "menstruation_onset_self_reported_$day"
+    }
+}

--- a/android/app/src/main/java/com/bios/app/data/PeriodEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/PeriodEntryRepo.kt
@@ -1,0 +1,57 @@
+package com.bios.app.data
+
+import android.content.Context
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Persistence path for manually logged menstruation onsets — owner taps
+ * "Log period start" on the date their period began — plus the cycle-day
+ * and cycle-phase derivations that re-run on every save.
+ *
+ * Lives alongside [BbtEntryRepo] on the same isolated [ReproductiveDatabase]
+ * (separate SQLCipher file, independent encryption key, priority
+ * destruction on LETHE duress PIN / dead-man's-switch). The owner can
+ * wipe reproductive data — including their period log — without touching
+ * the main DB.
+ *
+ * Saves are idempotent per UTC day via [CycleDerivation.stableMenstruationOnsetId],
+ * so re-logging the same day collapses into one row. Cycle-day numbering
+ * (cycle day 1 = first day of menstruation) anchors on the most recent
+ * onset on or before each day; the MENSTRUAL phase overlays the five
+ * days starting at each onset (FIGO/Munro 2018 median).
+ */
+class PeriodEntryRepo(context: Context) {
+
+    private val appContext = context.applicationContext
+
+    init {
+        // Idempotent — no-op if a key already exists.
+        ReproductiveDatabase.initialize(appContext)
+    }
+
+    private val db: ReproductiveDatabase
+        get() = ReproductiveDatabase.getInstance(appContext)
+
+    suspend fun addOnset(timestamp: Long) {
+        val sourceId = SelfReportedSource.getOrCreate(db)
+        db.readingDao().insert(
+            MetricReading(
+                id = CycleDerivation.stableMenstruationOnsetId(timestamp),
+                metricType = MetricType.MENSTRUATION_ONSET.key,
+                value = 1.0,
+                timestamp = timestamp,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        )
+        CycleDerivation.rederive(db, sourceId)
+    }
+
+    suspend fun fetchRecentOnsets(limit: Int = 12): List<MetricReading> =
+        db.readingDao().fetchLatest(MetricType.MENSTRUATION_ONSET.key, limit)
+
+    suspend fun fetchLatestCycleDay(): MetricReading? =
+        db.readingDao().fetchLatest(MetricType.CYCLE_DAY.key, limit = 1).firstOrNull()
+}

--- a/android/app/src/main/java/com/bios/app/engine/CycleInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CycleInference.kt
@@ -1,24 +1,38 @@
 package com.bios.app.engine
 
+import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.CyclePhase
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 
 /**
- * Pure-function cycle-phase inference over BASAL_BODY_TEMPERATURE readings.
+ * Pure-function cycle-phase inference over BASAL_BODY_TEMPERATURE readings,
+ * with optional MENSTRUAL overlay from owner-logged menstruation onsets.
  *
- * Uses the classic biphasic 3-day rule (Marshall 1968; Barron & Fehring 2005):
- * establish a follicular-phase baseline as the mean of the first six daily
- * BBTs, place a coverline 0.1°C above it, and look for the earliest day where
- * three consecutive daily BBTs sit strictly above the coverline. The day
- * before that sustained rise is the inferred ovulation day; days before it
- * are follicular, days from it onward are luteal.
+ * Two complementary derivations live here:
  *
- * The engine sits next to [SleepDerivations] in `engine/` so the derivation
- * applies regardless of which adapter (or manual entry) sourced the BBT
- * rows. Routing of the derived readings to the encrypted reproductive-health
- * DB is the caller's responsibility — this function is unopinionated about
- * persistence.
+ * 1. [deriveCyclePhases] — biphasic 3-day rule (Marshall 1968; Barron &
+ *    Fehring 2005): establish a follicular-phase baseline as the mean of
+ *    the first six daily BBTs, place a coverline 0.1°C above it, and look
+ *    for the earliest day where three consecutive daily BBTs sit strictly
+ *    above the coverline. The day before that sustained rise is the
+ *    inferred ovulation day; days before it are follicular, days from it
+ *    onward are luteal. When an owner logs menstruation onsets,
+ *    [CyclePhase.MENSTRUAL] is overlaid on the five days starting from
+ *    each onset (FIGO/Munro 2018 median menstrual duration) — owner-
+ *    asserted ground truth wins over the BBT-derived classification on
+ *    those days.
+ *
+ * 2. [deriveCycleDays] — anchors the clinical day-of-cycle numbering on
+ *    logged onsets (cycle day 1 = first day of menstruation). Days before
+ *    any logged onset receive no emission; we don't fabricate a numbering
+ *    without an anchor.
+ *
+ * Both functions sit next to [SleepDerivations] in `engine/` so the
+ * derivations apply regardless of which adapter (or manual entry) sourced
+ * the rows. Routing the derived readings to the encrypted reproductive-
+ * health DB is the caller's responsibility — these functions are
+ * unopinionated about persistence.
  */
 object CycleInference {
 
@@ -34,33 +48,103 @@ object CycleInference {
     /** Coverline offset above follicular baseline, in °C. */
     private const val COVERLINE_OFFSET_C = 0.1
 
+    /**
+     * Default duration of the MENSTRUAL phase in days, anchored from a
+     * logged menstruation onset. Five days is the FIGO/Munro 2018 median
+     * for normal menstrual bleeding (range 2–7); we use the median rather
+     * than the upper bound because over-attributing MENSTRUAL to early-
+     * follicular days would corrupt the BBT-derived classification more
+     * often than the reverse. Owners who bleed longer (or shorter) can log
+     * their next onset on its actual day; the cycle_day series resets at
+     * that point.
+     */
+    private const val MENSTRUAL_WINDOW_DAYS = 5L
+
     private const val MS_PER_DAY = 86_400_000L
 
     /**
-     * Emit one CYCLE_PHASE reading per day in the input window when a
-     * biphasic shift is detected. Returns an empty list when the input has
-     * fewer than nine daily BBTs or no sustained rise above the coverline —
-     * we don't fabricate a phase classification without the data to support
-     * it.
+     * Emit one CYCLE_PHASE reading per day where a classification can be
+     * made. Returns an empty list when there are no BBTs and no onsets;
+     * otherwise returns at least one reading per onset window day plus
+     * any BBT-derived classifications.
      *
-     * Multiple BBT readings on the same calendar day are aggregated by taking
-     * the earliest (morning reading is the clinically canonical sample).
-     * Days are bucketed in UTC; timezone-aware bucketing is a separate
-     * refinement when needed.
+     * Multiple BBT readings on the same calendar day are aggregated by
+     * taking the earliest (morning reading is the clinically canonical
+     * sample). Days are bucketed in UTC; timezone-aware bucketing is a
+     * separate refinement when needed.
      *
-     * MENSTRUAL is not emitted: distinguishing it from early follicular
-     * requires a menstruation-onset signal that BBT alone cannot provide.
+     * MENSTRUAL emissions take precedence on overlapping days — an owner
+     * who logs their period is asserting ground truth that BBT
+     * thermoregulation alone cannot match.
      */
     fun deriveCyclePhases(
         readings: List<MetricReading>,
+        sourceId: String,
+        onsets: List<MetricReading> = emptyList()
+    ): List<MetricReading> {
+        val bbtPhasesByBucket = bbtDerivedPhasesByBucket(readings, sourceId)
+        val menstrualBuckets = menstrualDayBuckets(onsets)
+
+        val merged = bbtPhasesByBucket.toMutableMap()
+        for (bucket in menstrualBuckets) {
+            val existing = merged[bucket]
+            merged[bucket] = MetricReading(
+                metricType = MetricType.CYCLE_PHASE.key,
+                value = CyclePhase.MENSTRUAL.value.toDouble(),
+                timestamp = existing?.timestamp ?: (bucket * MS_PER_DAY),
+                sourceId = sourceId,
+                confidence = existing?.confidence ?: ConfidenceTier.HIGH.level
+            )
+        }
+        return merged.values.sortedBy { it.timestamp }
+    }
+
+    /**
+     * Emit one CYCLE_DAY reading per UTC day from the earliest onset
+     * bucket through [upToTimestamp]'s bucket (inclusive). Cycle day 1 is
+     * the day of the most recent onset on or before the bucket. Days
+     * before any logged onset receive no emission — we don't fabricate a
+     * numbering without an anchor.
+     */
+    fun deriveCycleDays(
+        onsets: List<MetricReading>,
+        upToTimestamp: Long,
         sourceId: String
     ): List<MetricReading> {
+        val onsetBuckets = onsets
+            .filter { it.metricType == MetricType.MENSTRUATION_ONSET.key }
+            .map { it.timestamp / MS_PER_DAY }
+            .toSortedSet()
+            .toList()
+        if (onsetBuckets.isEmpty()) return emptyList()
+
+        val earliest = onsetBuckets.first()
+        val latest = upToTimestamp / MS_PER_DAY
+        if (latest < earliest) return emptyList()
+
+        return (earliest..latest).map { bucket ->
+            val anchor = onsetBuckets.last { it <= bucket }
+            val dayNumber = (bucket - anchor) + 1
+            MetricReading(
+                metricType = MetricType.CYCLE_DAY.key,
+                value = dayNumber.toDouble(),
+                timestamp = bucket * MS_PER_DAY,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        }
+    }
+
+    private fun bbtDerivedPhasesByBucket(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): Map<Long, MetricReading> {
         val daily = readings
             .filter { it.metricType == MetricType.BASAL_BODY_TEMPERATURE.key }
             .groupBy { it.timestamp / MS_PER_DAY }
             .map { (_, sameDay) -> sameDay.minBy { it.timestamp } }
             .sortedBy { it.timestamp }
-        if (daily.size < MIN_TOTAL_DAYS) return emptyList()
+        if (daily.size < MIN_TOTAL_DAYS) return emptyMap()
 
         val baseline = daily.take(MIN_BASELINE_DAYS).map { it.value }.average()
         val coverline = baseline + COVERLINE_OFFSET_C
@@ -69,7 +153,7 @@ object CycleInference {
             .firstOrNull { idx ->
                 (idx until idx + MIN_RISE_DAYS).all { daily[it].value > coverline }
             }
-            ?: return emptyList()
+            ?: return emptyMap()
 
         return daily.mapIndexed { i, day ->
             val phase = when {
@@ -77,13 +161,22 @@ object CycleInference {
                 i == riseStart - 1 -> CyclePhase.OVULATORY
                 else -> CyclePhase.LUTEAL
             }
-            MetricReading(
+            (day.timestamp / MS_PER_DAY) to MetricReading(
                 metricType = MetricType.CYCLE_PHASE.key,
                 value = phase.value.toDouble(),
                 timestamp = day.timestamp,
                 sourceId = sourceId,
                 confidence = day.confidence
             )
-        }
+        }.toMap()
     }
+
+    private fun menstrualDayBuckets(onsets: List<MetricReading>): Set<Long> =
+        onsets
+            .filter { it.metricType == MetricType.MENSTRUATION_ONSET.key }
+            .flatMap { onset ->
+                val onsetBucket = onset.timestamp / MS_PER_DAY
+                (0L until MENSTRUAL_WINDOW_DAYS).map { onsetBucket + it }
+            }
+            .toSet()
 }

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -59,10 +59,12 @@ enum class SleepStage(val value: Int) {
 
 // MARK: - Cycle
 
-// MENSTRUAL is reserved for when a menstruation-onset signal exists; BBT
-// alone can't reliably distinguish it from the early follicular phase, so
-// the BBT-driven CycleInference currently emits only FOLLICULAR / OVULATORY
-// / LUTEAL. Numeric values are stable once written; do not renumber.
+// MENSTRUAL is emitted when an owner-logged menstruation onset
+// (MetricType.MENSTRUATION_ONSET) anchors the cycle — BBT alone can't
+// distinguish menstrual from early-follicular thermoregulation, so the
+// BBT-only path still emits FOLLICULAR / OVULATORY / LUTEAL. See
+// CycleInference.deriveCyclePhases for the overlay rule. Numeric values
+// are stable once written; do not renumber.
 enum class CyclePhase(val value: Int) {
     MENSTRUAL(0), FOLLICULAR(1), OVULATORY(2), LUTEAL(3)
 }

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -297,7 +297,8 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToPrivacy = { navController.navigate("privacy") },
                     onNavigateToCompanions = { navController.navigate("companions") },
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
-                    onNavigateToBbtEntry = { navController.navigate("bbt_entry") }
+                    onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
+                    onNavigateToPeriodEntry = { navController.navigate("period_entry") }
                 )
             }
             composable("biomarker_entry") {
@@ -308,6 +309,12 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("bbt_entry") {
                 com.bios.app.ui.bbt.BbtEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable("period_entry") {
+                com.bios.app.ui.period.PeriodEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/period/PeriodEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/period/PeriodEntryScreen.kt
@@ -1,0 +1,200 @@
+package com.bios.app.ui.period
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.PeriodEntryRepo
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PeriodEntryScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit
+) {
+    val context = LocalContext.current
+    val repo = remember(context) { PeriodEntryRepo(context) }
+    val scope = rememberCoroutineScope()
+
+    var selectedDate by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var recent by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
+    var latestCycleDay by remember { mutableStateOf<MetricReading?>(null) }
+
+    suspend fun refresh() {
+        recent = repo.fetchRecentOnsets()
+        latestCycleDay = repo.fetchLatestCycleDay()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Log Period Start") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Menstruation onset", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(
+                        "Logging the first day of your period anchors cycle-day numbering " +
+                            "(day 1 = first day of menstruation) and marks the first five days as " +
+                            "the menstrual phase. Stays on device in the reproductive database, " +
+                            "never used by the sensor baseline engine.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    OutlinedButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Period started on: ${formatDate(selectedDate)}")
+                    }
+
+                    OutlinedButton(
+                        onClick = {
+                            scope.launch {
+                                repo.addOnset(selectedDate)
+                                refresh()
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Save")
+                    }
+                }
+            }
+
+            latestCycleDay?.let { day ->
+                Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            "Cycle day ${day.value.toInt()}",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            "Anchored on the most recent onset you logged",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+
+            Text("Recent onsets", style = MaterialTheme.typography.titleSmall)
+            if (recent.isEmpty()) {
+                Text(
+                    "No onsets logged yet. Each entry resets the cycle-day counter to 1.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    contentPadding = PaddingValues(vertical = 4.dp)
+                ) {
+                    items(recent, key = { it.id }) { onset ->
+                        RecentOnsetRow(onset)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { selectedDate = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+
+@Composable
+private fun RecentOnsetRow(reading: MetricReading) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Text(
+                formatDate(reading.timestamp),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "Period start",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
+private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -32,7 +32,8 @@ fun SettingsScreen(
     onNavigateToPrivacy: () -> Unit = {},
     onNavigateToCompanions: () -> Unit = {},
     onNavigateToBiomarkerEntry: () -> Unit = {},
-    onNavigateToBbtEntry: () -> Unit = {}
+    onNavigateToBbtEntry: () -> Unit = {},
+    onNavigateToPeriodEntry: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -129,6 +130,13 @@ fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Track BBT")
+                }
+                Spacer(Modifier.height(4.dp))
+                OutlinedButton(
+                    onClick = onNavigateToPeriodEntry,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Log period start")
                 }
             }
         }
@@ -487,7 +495,5 @@ fun SettingsScreen(
 
 private fun saveTier(context: Context, tier: PrivacyTier) {
     context.getSharedPreferences("bios_settings", Context.MODE_PRIVATE)
-        .edit()
-        .putString("privacy_tier", tier.name)
-        .apply()
+        .edit().putString("privacy_tier", tier.name).apply()
 }

--- a/android/app/src/test/java/com/bios/app/CycleDerivationIdTest.kt
+++ b/android/app/src/test/java/com/bios/app/CycleDerivationIdTest.kt
@@ -1,0 +1,59 @@
+package com.bios.app
+
+import com.bios.app.data.CycleDerivation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Guards the deterministic primary keys used by [CycleDerivation] so
+ * re-derivation stays idempotent under `OnConflictStrategy.REPLACE`. The
+ * BBT-side `cycle_phase` id is guarded separately by
+ * [BbtEntryRepoIdTest]; this file covers the two ids added with the
+ * menstruation-onset path: `cycle_day` and `menstruation_onset`.
+ */
+class CycleDerivationIdTest {
+
+    private val midnightUtc = 19_737L * 86_400_000L  // 2024-01-15T00:00:00Z
+    private val laterSameDay = midnightUtc + 6 * 60 * 60 * 1000L
+    private val nextDay = midnightUtc + 86_400_000L
+
+    @Test
+    fun cycle_day_id_collapses_into_one_per_utc_day() {
+        assertEquals(
+            CycleDerivation.stableCycleDayId(midnightUtc),
+            CycleDerivation.stableCycleDayId(laterSameDay)
+        )
+        assertNotEquals(
+            CycleDerivation.stableCycleDayId(midnightUtc),
+            CycleDerivation.stableCycleDayId(nextDay)
+        )
+    }
+
+    @Test
+    fun menstruation_onset_id_collapses_into_one_per_utc_day() {
+        assertEquals(
+            CycleDerivation.stableMenstruationOnsetId(midnightUtc),
+            CycleDerivation.stableMenstruationOnsetId(laterSameDay)
+        )
+        assertNotEquals(
+            CycleDerivation.stableMenstruationOnsetId(midnightUtc),
+            CycleDerivation.stableMenstruationOnsetId(nextDay)
+        )
+    }
+
+    @Test
+    fun ids_are_namespaced_so_they_cant_collide_across_metric_types() {
+        val ts = 1_700_000_000_000L
+        val phaseId = CycleDerivation.stableCyclePhaseId(ts)
+        val dayId = CycleDerivation.stableCycleDayId(ts)
+        val onsetId = CycleDerivation.stableMenstruationOnsetId(ts)
+        assert(phaseId.startsWith("cycle_phase_self_reported_"))
+        assert(dayId.startsWith("cycle_day_self_reported_"))
+        assert(onsetId.startsWith("menstruation_onset_self_reported_"))
+        // Different prefixes → different ids on the same day.
+        assertNotEquals(phaseId, dayId)
+        assertNotEquals(phaseId, onsetId)
+        assertNotEquals(dayId, onsetId)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/CycleInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/CycleInferenceTest.kt
@@ -21,6 +21,14 @@ class CycleInferenceTest {
         confidence = 2
     )
 
+    private fun onset(dayIndex: Int, offsetMs: Long = 0L) = MetricReading(
+        metricType = MetricType.MENSTRUATION_ONSET.key,
+        value = 1.0,
+        timestamp = day0 + dayIndex * msPerDay + offsetMs,
+        sourceId = sourceId,
+        confidence = 3
+    )
+
     @Test
     fun `returns empty when input is empty`() {
         assertTrue(CycleInference.deriveCyclePhases(emptyList(), sourceId).isEmpty())
@@ -118,6 +126,134 @@ class CycleInferenceTest {
         assertEquals(CyclePhase.OVULATORY.value.toDouble(), phases[8].value, 0.0)
         assertEquals(CyclePhase.LUTEAL.value.toDouble(), phases[9].value, 0.0)
         assertEquals(CyclePhase.FOLLICULAR.value.toDouble(), phases[7].value, 0.0)
+    }
+
+    @Test
+    fun `overlays MENSTRUAL on the five days starting at each onset`() {
+        // 12-day biphasic series; onset logged on day 0 marks days 0-4 menstrual.
+        val readings = (0 until 12).map { i -> bbt(i, if (i < 6) 36.5 else 36.8) }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId, onsets = listOf(onset(0)))
+        assertEquals(12, phases.size)
+
+        for (i in 0..4) {
+            assertEquals(
+                "day $i should be MENSTRUAL",
+                CyclePhase.MENSTRUAL.value.toDouble(), phases[i].value, 0.0
+            )
+        }
+        // Days 5+ unaffected by the onset window.
+        assertEquals(CyclePhase.OVULATORY.value.toDouble(), phases[5].value, 0.0)
+        assertEquals(CyclePhase.LUTEAL.value.toDouble(), phases[6].value, 0.0)
+    }
+
+    @Test
+    fun `MENSTRUAL emissions on overlapping days preserve the BBT timestamp`() {
+        // Sanity check: when MENSTRUAL overrides a BBT day, the phase row's
+        // timestamp still tracks the BBT sample (not bucket-midnight) so the
+        // derivation re-runs against the same UTC day bucket and the row
+        // visibly carries the original measurement instant. `day0` is not
+        // bucket-aligned, so this distinguishes "BBT timestamp preserved"
+        // from "bucket * MS_PER_DAY substituted."
+        val readings = (0 until 12).map { i -> bbt(i, if (i < 6) 36.5 else 36.8) }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId, onsets = listOf(onset(0)))
+        for (i in 0..4) {
+            assertEquals(day0 + i * msPerDay, phases[i].timestamp)
+        }
+    }
+
+    @Test
+    fun `emits MENSTRUAL for each onset day even without any BBT data`() {
+        val phases = CycleInference.deriveCyclePhases(
+            emptyList(), sourceId, onsets = listOf(onset(0))
+        )
+        assertEquals(5, phases.size)
+        phases.forEach {
+            assertEquals(MetricType.CYCLE_PHASE.key, it.metricType)
+            assertEquals(CyclePhase.MENSTRUAL.value.toDouble(), it.value, 0.0)
+            assertEquals(sourceId, it.sourceId)
+        }
+    }
+
+    @Test
+    fun `MENSTRUAL overrides a colliding BBT-derived OVULATORY classification`() {
+        // Owner logs an onset on day 5 — the BBT-derived inferred ovulation
+        // day. Owner-asserted ground truth wins.
+        val readings = (0 until 12).map { i -> bbt(i, if (i < 6) 36.5 else 36.8) }
+        val phases = CycleInference.deriveCyclePhases(readings, sourceId, onsets = listOf(onset(5)))
+        for (i in 5..9) {
+            assertEquals(
+                "day $i should be MENSTRUAL",
+                CyclePhase.MENSTRUAL.value.toDouble(), phases[i].value, 0.0
+            )
+        }
+        assertEquals(CyclePhase.LUTEAL.value.toDouble(), phases[10].value, 0.0)
+    }
+
+    @Test
+    fun `multiple onsets each open their own five-day MENSTRUAL window`() {
+        val phases = CycleInference.deriveCyclePhases(
+            emptyList(), sourceId, onsets = listOf(onset(0), onset(28))
+        )
+        assertEquals(10, phases.size)
+        phases.forEach {
+            assertEquals(CyclePhase.MENSTRUAL.value.toDouble(), it.value, 0.0)
+        }
+    }
+
+    @Test
+    fun `derives cycle day 1 on the onset day`() {
+        val days = CycleInference.deriveCycleDays(listOf(onset(0)), day0, sourceId)
+        assertEquals(1, days.size)
+        assertEquals(MetricType.CYCLE_DAY.key, days[0].metricType)
+        assertEquals(1.0, days[0].value, 0.0)
+        assertEquals(sourceId, days[0].sourceId)
+    }
+
+    @Test
+    fun `cycle day increments daily after the onset`() {
+        val days = CycleInference.deriveCycleDays(
+            listOf(onset(0)), day0 + 6 * msPerDay, sourceId
+        )
+        assertEquals(7, days.size)
+        for (i in 0..6) {
+            assertEquals((i + 1).toDouble(), days[i].value, 0.0)
+        }
+    }
+
+    @Test
+    fun `a new onset resets cycle day numbering to 1`() {
+        // Onsets at day 0 and day 28; query up to day 30 → 31 emissions.
+        val days = CycleInference.deriveCycleDays(
+            listOf(onset(0), onset(28)),
+            day0 + 30 * msPerDay,
+            sourceId
+        )
+        assertEquals(31, days.size)
+        assertEquals("cycle day 1 on onset day 0", 1.0, days[0].value, 0.0)
+        assertEquals("cycle day 28 the day before the next onset", 28.0, days[27].value, 0.0)
+        assertEquals("cycle day 1 reset on second onset", 1.0, days[28].value, 0.0)
+        assertEquals("cycle day 3 two days into the second cycle", 3.0, days[30].value, 0.0)
+    }
+
+    @Test
+    fun `cycle day emissions land on UTC midnight timestamps`() {
+        val days = CycleInference.deriveCycleDays(
+            listOf(onset(0)), day0 + 2 * msPerDay, sourceId
+        )
+        days.forEach { assertEquals(0L, it.timestamp % msPerDay) }
+    }
+
+    @Test
+    fun `cycle day returns empty when no onsets are logged`() {
+        assertTrue(CycleInference.deriveCycleDays(emptyList(), day0, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `cycle day returns empty when upToTimestamp predates the earliest onset`() {
+        val days = CycleInference.deriveCycleDays(
+            listOf(onset(10)), day0 + 5 * msPerDay, sourceId
+        )
+        assertTrue(days.isEmpty())
     }
 
     @Test

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -52,6 +52,8 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // Women's Health
     BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH),
     CYCLE_PHASE("cycle_phase", MetricUnit.CATEGORY, MetricDomain.WOMENS_HEALTH),
+    MENSTRUATION_ONSET("menstruation_onset", MetricUnit.EVENT, MetricDomain.WOMENS_HEALTH),
+    CYCLE_DAY("cycle_day", MetricUnit.COUNT, MetricDomain.WOMENS_HEALTH),
 
     // Environment (phone-sensor adapter)
     AMBIENT_LIGHT("ambient_light", MetricUnit.LUX, MetricDomain.ENVIRONMENT),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -65,6 +65,18 @@ class MetricTypeTest {
     }
 
     @Test
+    fun menstruation_onset_is_womens_health_event() {
+        assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.MENSTRUATION_ONSET.domain)
+        assertEquals(MetricUnit.EVENT, MetricType.MENSTRUATION_ONSET.unit)
+    }
+
+    @Test
+    fun cycle_day_is_womens_health_count() {
+        assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.CYCLE_DAY.domain)
+        assertEquals(MetricUnit.COUNT, MetricType.CYCLE_DAY.unit)
+    }
+
+    @Test
     fun hba1c_is_biomarker_percent() {
         assertEquals(MetricDomain.BIOMARKER, MetricType.HBA1C.domain)
         assertEquals(MetricUnit.PERCENT, MetricType.HBA1C.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -318,30 +318,32 @@ literature-backed signal) and stay within the manifesto. `sleep_score`
 is parked unless a future condition pattern needs a single-number input
 that can't be expressed as a rule over the components.
 
-### 8.5 Cycle inference from BBT [LIVE — cycle_phase active, cycle_day deferred]
+### 8.5 Cycle inference from BBT [LIVE]
 
 - `cycle_phase` (WOMENS_HEALTH, CATEGORY) — **live.** Classic biphasic
   3-day rule (Marshall 1968; Barron & Fehring 2005) in
   `engine/CycleInference.kt`: follicular baseline = mean of the first six
   daily BBTs, coverline = baseline + 0.1°C, ovulation = the day before
   three consecutive daily BBTs sit strictly above the coverline. Emits
-  FOLLICULAR / OVULATORY / LUTEAL via the `CyclePhase` enum.
-- **BBT writer (shipped):** `data/BbtEntryRepo.kt` + `ui/bbt/BbtEntryScreen.kt`
-  reachable from Settings → "Track BBT". BBT and derived `cycle_phase`
-  rows persist into `ReproductiveDatabase` (separate SQLCipher file,
+  FOLLICULAR / OVULATORY / LUTEAL, plus MENSTRUAL on the five days from
+  each owner-logged onset (FIGO/Munro 2018 median; overrides any
+  colliding BBT-derived classification — owner-asserted ground truth wins).
+- `cycle_day` (WOMENS_HEALTH, COUNT) — **live.** Anchored on
+  `menstruation_onset` (WOMENS_HEALTH, EVENT) — cycle day 1 = first day
+  of menstruation per clinical convention. The most recent onset on or
+  before each day sets the anchor, so a new onset cleanly resets the
+  counter to 1. Days before any logged onset receive no emission.
+- **Writers (shipped):** `data/BbtEntryRepo.kt` + `ui/bbt/BbtEntryScreen.kt`
+  ("Track BBT") and `data/PeriodEntryRepo.kt` +
+  `ui/period/PeriodEntryScreen.kt` ("Log period start"), both reachable
+  from Settings. BBT, onsets, and the derived `cycle_phase` / `cycle_day`
+  rows all persist into `ReproductiveDatabase` (separate SQLCipher file,
   independent key, priority destruction on duress PIN — the post-Dobbs
-  isolation). Lazy `ReproductiveDatabase.initialize()` on first write,
-  no separate enable flow. `CycleInference` re-runs over the last 90
-  days on save; derived rows use a deterministic UTC-day id so
-  re-derivation is idempotent. FHIR exporter skips
-  `MetricDomain.WOMENS_HEALTH` by default; per-export opt-in is the
-  future path to clinician sharing.
-- `cycle_day` — **deferred.** The clinical numbering convention starts
-  cycle day 1 at the first day of menstruation; BBT alone cannot
-  reliably distinguish menstrual from early follicular. Ships when a
-  menstruation-onset signal exists (manual log, or a wearable that
-  reports it).
-- `MENSTRUAL` is reserved on the `CyclePhase` enum for the same reason.
+  isolation). Lazy initialize on first write, no separate enable flow.
+  `data/CycleDerivation.kt` re-runs both derivations on every BBT or
+  onset save with deterministic UTC-day ids so the two writers stay
+  idempotent and in sync. FHIR exporter skips `MetricDomain.WOMENS_HEALTH`
+  by default; per-export opt-in is the future path to clinician sharing.
 
 ### 8.6 Lab / biomarker inbound surface [FOUNDATION SHIPPED]
 


### PR DESCRIPTION
## Summary
- Unlocks ROADMAP §8.5's deferred `cycle_day`: adds a `MENSTRUATION_ONSET` (EVENT) signal that an owner logs from Settings → "Log period start", and a `CYCLE_DAY` (COUNT) derivation that anchors day 1 on the most recent onset per the clinical numbering convention. Logging a new onset cleanly resets the counter; days before any onset receive no emission (no anchor = no number).
- `MENSTRUAL` flips from reserved to emitted on the five days from each onset (FIGO/Munro 2018 median). It overrides any colliding BBT-derived classification — owner-asserted ground truth beats thermoregulation guesswork.
- New `data/PeriodEntryRepo.kt` mirrors `BbtEntryRepo`, both now end the 90-day re-derivation through a shared `data/CycleDerivation.kt` so the CYCLE_PHASE + CYCLE_DAY series stay in sync regardless of which writer touched the isolated `ReproductiveDatabase`.
- ROADMAP §8.5 marked LIVE; CLAUDE.md's Phase 7 status line corrected (7.6 already complete, 7.5 deferred on manifesto grounds; Phase 8 is the active surface).

## Test plan
- [ ] `./scripts/code-quality-check.sh` passes (it does locally)
- [ ] Settings → "Log period start" → pick today → Save → row appears under "Recent onsets" and a "Cycle day 1" card shows
- [ ] Log a new onset N days later → "Cycle day 1" resets, prior days back-counted as cycle 1..N of the previous cycle
- [ ] With ≥9 daily BBTs and an onset on day 0, `Track BBT` → "Current phase" surfaces MENSTRUAL on days 0–4 and OVULATORY / LUTEAL beyond
- [ ] Duress / Delete-all-data wipe destroys `ReproductiveDatabase` including onsets and the derived cycle_day rows
- [ ] FHIR export still skips WOMENS_HEALTH by default (no clinician leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)