### PR TITLE
feat: add lf_hf_ratio autonomic derivation via FFT on IBI tachogram

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -65,6 +65,7 @@ class BaselineEngine(
     private val TRACKED_METRICS = listOf(
         MetricType.HEART_RATE,
         MetricType.HEART_RATE_VARIABILITY,
+        MetricType.LF_HF_RATIO,
         MetricType.RESTING_HEART_RATE,
         MetricType.BLOOD_OXYGEN,
         MetricType.RESPIRATORY_RATE,
@@ -80,6 +81,7 @@ class BaselineEngine(
             val metricsToBaseline = listOf(
                 MetricType.HEART_RATE,
                 MetricType.HEART_RATE_VARIABILITY,
+                MetricType.LF_HF_RATIO,
                 MetricType.RESTING_HEART_RATE,
                 MetricType.BLOOD_OXYGEN,
                 MetricType.RESPIRATORY_RATE,

--- a/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
@@ -49,6 +49,7 @@ object HrvAnalyzer {
             pnn50 = pnn50,
             lnRmssd = if (rmssd > 0.0) ln(rmssd) else 0.0,
             stressIndex = computeStressIndex(clean),
+            lfHfRatio = Spectral.lfHfRatio(clean),
             meanIbiMs = meanIbi,
             meanHrBpm = meanHr,
             cleanIbiCount = clean.size,
@@ -176,6 +177,17 @@ object HrvAnalyzer {
          * constant-IBI case (Baevsky & Berseneva 2008).
          */
         val stressIndex: Double,
+        /**
+         * LF/HF ratio — power in the low-frequency band (0.04–0.15 Hz)
+         * divided by power in the high-frequency band (0.15–0.40 Hz),
+         * computed via FFT on the IBI tachogram resampled at 4 Hz with
+         * a Hann window (Task Force 1996, Shaffer & Ginsberg 2017).
+         * Reflects sympathovagal balance: typical resting range 0.5–2.0,
+         * values >5 indicate sympathetic dominance. Zero when the
+         * recording is shorter than 60 seconds, the series is
+         * degenerate, or the HF band carries no power.
+         */
+        val lfHfRatio: Double,
         /** Mean inter-beat interval (ms). */
         val meanIbiMs: Double,
         /** Mean heart rate derived from IBIs (bpm). */

--- a/android/app/src/main/java/com/bios/app/engine/Spectral.kt
+++ b/android/app/src/main/java/com/bios/app/engine/Spectral.kt
@@ -1,0 +1,204 @@
+package com.bios.app.engine
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Minimal spectral-analysis surface used by [HrvAnalyzer] to compute the
+ * `lf_hf_ratio` autonomic derivation. Pure functions, no Android deps —
+ * lives next to the time-domain HRV math and is exercised by the same
+ * unit-test suite.
+ *
+ * The implementation is the textbook IBI-tachogram pipeline (ESC/NASPE
+ * Task Force 1996, Shaffer & Ginsberg 2017):
+ *
+ *   1. Build the beat-time axis t_n = cumulative sum of IBI_1..IBI_n.
+ *   2. Resample the IBI series at a uniform 4 Hz via linear interpolation
+ *      — the IBI series is naturally non-uniform (each sample lives at
+ *      its own beat instant), and direct FFT on non-uniform data is
+ *      meaningless.
+ *   3. Subtract the mean (detrend) so the DC bin doesn't dominate.
+ *   4. Apply a Hann window to suppress spectral leakage.
+ *   5. Zero-pad to the next power of two and run a radix-2 Cooley-Tukey
+ *      FFT.
+ *   6. Compute the one-sided power spectral density.
+ *   7. Sum power in LF (0.04–0.15 Hz) and HF (0.15–0.4 Hz) and return
+ *      the ratio. A degenerate denominator (constant IBI, near-zero
+ *      HF) returns 0.0 — the caller treats that as "no autonomic
+ *      signal to interpret" rather than infinity.
+ *
+ * The minimum useful recording length is roughly 60 seconds (one full
+ * LF-band cycle plus headroom). Shorter inputs return 0.0 — LF/HF over
+ * a few seconds is not clinically defensible.
+ */
+internal object Spectral {
+
+    /** Lower edge of the LF band (Hz), per Task Force 1996. */
+    const val LF_LOW_HZ = 0.04
+
+    /** Boundary between LF and HF bands (Hz). */
+    const val LF_HIGH_HZ = 0.15
+
+    /** Upper edge of the HF band (Hz). */
+    const val HF_HIGH_HZ = 0.40
+
+    /** Resampling rate of the IBI tachogram (Hz). 4 Hz is the standard. */
+    const val RESAMPLE_HZ = 4.0
+
+    /** Minimum recording duration for a defensible LF/HF estimate (sec). */
+    const val MIN_DURATION_SEC = 60.0
+
+    /**
+     * Compute the LF/HF ratio from a list of inter-beat intervals (ms).
+     * Returns 0.0 when the recording is too short for spectral analysis,
+     * when the series is degenerate (constant or near-constant IBIs), or
+     * when the HF band contains no power.
+     */
+    fun lfHfRatio(ibisMs: List<Double>): Double {
+        if (ibisMs.size < 4) return 0.0
+
+        // Build beat-time axis in seconds. The first sample lives at the
+        // end of the first interval; the canonical convention places it
+        // at t = IBI_1 (Task Force 1996 Fig. 3).
+        val timesSec = DoubleArray(ibisMs.size)
+        var cumulative = 0.0
+        for (i in ibisMs.indices) {
+            cumulative += ibisMs[i] / 1000.0
+            timesSec[i] = cumulative
+        }
+        val durationSec = timesSec.last() - timesSec.first()
+        if (durationSec < MIN_DURATION_SEC) return 0.0
+
+        // Resample uniformly at RESAMPLE_HZ via linear interpolation.
+        val sampleCount = (durationSec * RESAMPLE_HZ).toInt()
+        if (sampleCount < 8) return 0.0
+        val nfft = nextPowerOfTwo(sampleCount)
+        val signal = DoubleArray(nfft)
+        val tStart = timesSec.first()
+        for (i in 0 until sampleCount) {
+            val t = tStart + i / RESAMPLE_HZ
+            signal[i] = interpolateLinear(timesSec, ibisMs, t)
+        }
+        // Tail samples (sampleCount..nfft-1) stay at zero — zero-padding.
+
+        // Detrend by subtracting the mean of the populated region.
+        var sum = 0.0
+        for (i in 0 until sampleCount) sum += signal[i]
+        val mean = sum / sampleCount
+        for (i in 0 until sampleCount) signal[i] -= mean
+
+        // Hann window over the populated region.
+        var windowEnergy = 0.0
+        for (i in 0 until sampleCount) {
+            val w = 0.5 - 0.5 * cos(2.0 * PI * i / (sampleCount - 1).coerceAtLeast(1))
+            signal[i] *= w
+            windowEnergy += w * w
+        }
+        if (windowEnergy <= 0.0) return 0.0
+
+        // Radix-2 FFT in place.
+        val imag = DoubleArray(nfft)
+        fftInPlace(signal, imag)
+
+        // One-sided PSD (Welch-style normalization for a single segment).
+        val psdScale = 1.0 / (RESAMPLE_HZ * windowEnergy)
+        val df = RESAMPLE_HZ / nfft
+        var lfPower = 0.0
+        var hfPower = 0.0
+        val halfN = nfft / 2
+        for (k in 0..halfN) {
+            val mag2 = signal[k] * signal[k] + imag[k] * imag[k]
+            // Double everything except DC and Nyquist for the one-sided PSD.
+            val onesidedScale = if (k == 0 || k == halfN) 1.0 else 2.0
+            val psd = mag2 * psdScale * onesidedScale
+            val f = k * df
+            when {
+                f >= LF_LOW_HZ && f < LF_HIGH_HZ -> lfPower += psd * df
+                f >= LF_HIGH_HZ && f <= HF_HIGH_HZ -> hfPower += psd * df
+            }
+        }
+        if (hfPower <= 0.0) return 0.0
+        return lfPower / hfPower
+    }
+
+    private fun nextPowerOfTwo(n: Int): Int {
+        var p = 1
+        while (p < n) p = p shl 1
+        return p
+    }
+
+    /**
+     * Linear interpolation of values defined at [timesSec] onto a single
+     * query time [t]. The series is monotonic (cumulative IBI sums), so
+     * a binary search over the indexing is enough.
+     */
+    private fun interpolateLinear(
+        timesSec: DoubleArray,
+        values: List<Double>,
+        t: Double
+    ): Double {
+        if (t <= timesSec.first()) return values.first()
+        if (t >= timesSec.last()) return values.last()
+        var lo = 0
+        var hi = timesSec.size - 1
+        while (lo < hi - 1) {
+            val mid = (lo + hi) ushr 1
+            if (timesSec[mid] <= t) lo = mid else hi = mid
+        }
+        val span = timesSec[hi] - timesSec[lo]
+        if (span <= 0.0) return values[lo]
+        val frac = (t - timesSec[lo]) / span
+        return values[lo] + frac * (values[hi] - values[lo])
+    }
+
+    /**
+     * In-place radix-2 Cooley-Tukey FFT. [real] and [imag] must have the
+     * same length and that length must be a power of two.
+     */
+    internal fun fftInPlace(real: DoubleArray, imag: DoubleArray) {
+        val n = real.size
+        require(n == imag.size && n > 0 && (n and (n - 1)) == 0) {
+            "FFT length must be a positive power of two; got $n"
+        }
+        // Bit-reversal permutation.
+        var j = 0
+        for (i in 0 until n - 1) {
+            if (i < j) {
+                val tr = real[i]; real[i] = real[j]; real[j] = tr
+                val ti = imag[i]; imag[i] = imag[j]; imag[j] = ti
+            }
+            var k = n shr 1
+            while (k in 1..j) { j -= k; k = k shr 1 }
+            j += k
+        }
+        // Butterflies.
+        var size = 2
+        while (size <= n) {
+            val half = size shr 1
+            val angleStep = -2.0 * PI / size
+            val wStepR = cos(angleStep)
+            val wStepI = sin(angleStep)
+            var start = 0
+            while (start < n) {
+                var wR = 1.0
+                var wI = 0.0
+                for (k in 0 until half) {
+                    val a = start + k
+                    val b = a + half
+                    val tR = wR * real[b] - wI * imag[b]
+                    val tI = wR * imag[b] + wI * real[b]
+                    real[b] = real[a] - tR
+                    imag[b] = imag[a] - tI
+                    real[a] = real[a] + tR
+                    imag[a] = imag[a] + tI
+                    val newR = wR * wStepR - wI * wStepI
+                    wI = wR * wStepI + wI * wStepR
+                    wR = newR
+                }
+                start += size
+            }
+            size = size shl 1
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -164,6 +164,14 @@ class CameraPpgAdapter(private val context: Context) {
                     durationSec = durSec,
                     sourceId = sourceId,
                     confidence = ConfidenceTier.LOW.level
+                ),
+                MetricReading(
+                    metricType = MetricType.LF_HF_RATIO.key,
+                    value = hrv.lfHfRatio,
+                    timestamp = timestamp,
+                    durationSec = durSec,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.LOW.level
                 )
             )
             return CaptureResult(

--- a/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
@@ -118,6 +118,14 @@ class DirectSensorAdapter(context: Context) {
                 durationSec = duration,
                 sourceId = sourceId,
                 confidence = ConfidenceTier.LOW.level
+            ),
+            MetricReading(
+                metricType = MetricType.LF_HF_RATIO.key,
+                value = hrv.lfHfRatio,
+                timestamp = now,
+                durationSec = duration,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.LOW.level
             )
         )
     }

--- a/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
@@ -37,6 +37,7 @@ class CameraPpgAdapterTest {
             pnn50 = 10.0,
             lnRmssd = kotlin.math.ln(18.5),
             stressIndex = 120.0,
+            lfHfRatio = 1.7,
             meanIbiMs = 815.0,
             meanHrBpm = 73.6,
             cleanIbiCount = 5,
@@ -46,7 +47,7 @@ class CameraPpgAdapterTest {
         val result = CameraPpgAdapter.toResult(ppg, hrv, sourceId, now)
 
         assertTrue(result.accepted)
-        assertEquals(4, result.readings.size)
+        assertEquals(5, result.readings.size)
 
         val hr = result.readings.single { it.metricType == MetricType.HEART_RATE.key }
         assertEquals(73.6, hr.value, 0.01)
@@ -66,6 +67,10 @@ class CameraPpgAdapterTest {
         val stressR = result.readings.single { it.metricType == MetricType.STRESS_SCORE.key }
         assertEquals(120.0, stressR.value, 1e-9)
         assertEquals(ConfidenceTier.LOW.level, stressR.confidence)
+
+        val lfHfR = result.readings.single { it.metricType == MetricType.LF_HF_RATIO.key }
+        assertEquals(1.7, lfHfR.value, 1e-9)
+        assertEquals(ConfidenceTier.LOW.level, lfHfR.confidence)
     }
 
     @Test
@@ -116,6 +121,7 @@ class CameraPpgAdapterTest {
             rmssd = 15.0, sdnn = 22.0, pnn50 = 5.0,
             lnRmssd = kotlin.math.ln(15.0),
             stressIndex = 95.0,
+            lfHfRatio = 1.2,
             meanIbiMs = 805.0, meanHrBpm = 74.5,
             cleanIbiCount = 5, artifactsRejected = 0
         )

--- a/android/app/src/test/java/com/bios/app/SpectralTest.kt
+++ b/android/app/src/test/java/com/bios/app/SpectralTest.kt
@@ -1,0 +1,146 @@
+package com.bios.app
+
+import com.bios.app.engine.Spectral
+import org.junit.Assert.*
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Synthetic-signal coverage for the FFT-based LF/HF spectral derivation.
+ *
+ * Two design constraints anchor these tests:
+ *  - Each "test" IBI series must respect the Malik 20% successive-change
+ *    threshold so [HrvAnalyzer.rejectArtifacts] doesn't truncate it — we
+ *    keep the perturbation amplitude well below 0.2 × mean IBI.
+ *  - The frequency we want to inject (in Hz) is a property of the
+ *    *time* axis. We build the IBIs against a uniform 4 Hz time axis,
+ *    then convert back into an IBI series whose cumulative sums recover
+ *    that time axis to within numerical noise.
+ */
+class SpectralTest {
+
+    private val meanIbiMs = 800.0  // 75 bpm rest
+
+    /**
+     * Build an IBI series whose *values* oscillate at the requested
+     * frequency when indexed by their actual cumulative beat time. The
+     * spectral derivation rebuilds that same time axis from the IBIs,
+     * so a sinusoid at frequency f here lands at frequency f in the
+     * FFT.
+     */
+    private fun ibiSeriesWithFrequency(
+        freqHz: Double,
+        durationSec: Double,
+        amplitudeMs: Double = 30.0
+    ): List<Double> {
+        val meanSec = meanIbiMs / 1000.0
+        val beatCount = (durationSec / meanSec).toInt()
+        val ibis = ArrayList<Double>(beatCount)
+        var tSec = 0.0
+        for (i in 0 until beatCount) {
+            val ibi = meanIbiMs + amplitudeMs * sin(2.0 * PI * freqHz * tSec)
+            ibis.add(ibi)
+            tSec += ibi / 1000.0
+        }
+        return ibis
+    }
+
+    @Test
+    fun `pure 0_1 Hz oscillation lands almost entirely in the LF band`() {
+        // 0.1 Hz sits in LF (0.04–0.15 Hz); HF (0.15–0.40 Hz) should be empty.
+        val ibis = ibiSeriesWithFrequency(freqHz = 0.10, durationSec = 180.0)
+        val ratio = Spectral.lfHfRatio(ibis)
+        assertTrue("LF/HF should be >> 1 for a pure LF signal, got $ratio", ratio > 5.0)
+    }
+
+    @Test
+    fun `pure 0_25 Hz oscillation lands almost entirely in the HF band`() {
+        // 0.25 Hz sits in HF; LF should be empty.
+        val ibis = ibiSeriesWithFrequency(freqHz = 0.25, durationSec = 180.0)
+        val ratio = Spectral.lfHfRatio(ibis)
+        assertTrue("LF/HF should be << 1 for a pure HF signal, got $ratio", ratio < 0.2)
+    }
+
+    @Test
+    fun `constant IBI series produces zero LF over HF`() {
+        val ibis = List(360) { meanIbiMs }  // 4+ minutes of perfectly regular beats
+        assertEquals(0.0, Spectral.lfHfRatio(ibis), 0.0)
+    }
+
+    @Test
+    fun `recordings shorter than 60 seconds return zero`() {
+        // 45 seconds at 75 bpm is ~56 beats. Below the minimum LF window.
+        val ibis = List(56) { meanIbiMs + (if (it % 2 == 0) 5.0 else -5.0) }
+        assertEquals(0.0, Spectral.lfHfRatio(ibis), 0.0)
+    }
+
+    @Test
+    fun `equal-amplitude LF plus HF produces a finite positive ratio`() {
+        // Mixed 0.10 + 0.25 Hz at equal amplitude → both bands have power.
+        val meanSec = meanIbiMs / 1000.0
+        val durationSec = 180.0
+        val beatCount = (durationSec / meanSec).toInt()
+        val ibis = ArrayList<Double>(beatCount)
+        var tSec = 0.0
+        for (i in 0 until beatCount) {
+            val perturb = 15.0 * (sin(2.0 * PI * 0.10 * tSec) + sin(2.0 * PI * 0.25 * tSec))
+            val ibi = meanIbiMs + perturb
+            ibis.add(ibi)
+            tSec += ibi / 1000.0
+        }
+        val ratio = Spectral.lfHfRatio(ibis)
+        assertTrue("Mixed-band ratio should be finite and positive, got $ratio",
+            ratio.isFinite() && ratio > 0.0)
+        // With matching amplitudes the two integrated band powers come out
+        // within ~3× of each other (Hann windowing, band-width asymmetry).
+        assertTrue("Mixed-band ratio should sit roughly in [0.2, 5], got $ratio",
+            ratio in 0.2..5.0)
+    }
+
+    @Test
+    fun `lfHfRatio never returns NaN or infinity`() {
+        // Sanity check across a few short, noisy series.
+        val cases = listOf(
+            List(80) { meanIbiMs },                              // constant
+            List(80) { meanIbiMs + (it % 7) * 1.0 },             // small ramp
+            (0 until 400).map { meanIbiMs + 20 * sin(it * 0.3) } // long & jittery
+        )
+        for (ibis in cases) {
+            val r = Spectral.lfHfRatio(ibis)
+            assertTrue("ratio must be finite for series of size ${ibis.size}, got $r",
+                r.isFinite())
+            assertTrue("ratio must be >= 0, got $r", r >= 0.0)
+        }
+    }
+
+    // -- FFT itself --
+
+    @Test
+    fun `fft of a complex impulse produces uniform magnitude`() {
+        val n = 16
+        val real = DoubleArray(n).also { it[0] = 1.0 }
+        val imag = DoubleArray(n)
+        Spectral.fftInPlace(real, imag)
+        // FFT of a unit impulse is a constant-magnitude 1 across all bins.
+        for (k in 0 until n) {
+            val mag = real[k] * real[k] + imag[k] * imag[k]
+            assertEquals(1.0, mag, 1e-12)
+        }
+    }
+
+    @Test
+    fun `fft of a pure tone concentrates power at the expected bin`() {
+        val n = 64
+        val k0 = 5  // target bin
+        val real = DoubleArray(n) { i -> cos(2.0 * PI * k0 * i / n) }
+        val imag = DoubleArray(n)
+        Spectral.fftInPlace(real, imag)
+        // For a real cosine at bin k0, magnitude peaks at bins k0 and n - k0.
+        val mag = DoubleArray(n) { real[it] * real[it] + imag[it] * imag[it] }
+        val peakBin = mag.indices.maxByOrNull { mag[it] }!!
+        assertTrue("Peak bin should be at k0 or n-k0, got $peakBin",
+            peakBin == k0 || peakBin == n - k0)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -17,6 +17,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
+    LF_HF_RATIO("lf_hf_ratio", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -59,6 +59,12 @@ class MetricTypeTest {
     }
 
     @Test
+    fun lf_hf_ratio_is_cardiovascular_score() {
+        assertEquals(MetricDomain.CARDIOVASCULAR, MetricType.LF_HF_RATIO.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.LF_HF_RATIO.unit)
+    }
+
+    @Test
     fun cycle_phase_is_womens_health_category() {
         assertEquals(MetricDomain.WOMENS_HEALTH, MetricType.CYCLE_PHASE.domain)
         assertEquals(MetricUnit.CATEGORY, MetricType.CYCLE_PHASE.unit)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -281,23 +281,23 @@ violating SoulRadio's manifesto (Bios derives, SoulRadio doesn't consume).
 
 `BODY_MASS` + `BODY_FAT_PCT` (`METABOLIC` domain) emit from `WithingsApiAdapter.fetchMeasures` (types 1, 6); wired into `IngestManager` alongside Oura. Settings → Withings pastes an OAuth access token (full OAuth dance is a future PR — needs a registered Withings dev app). Both keys baseline (14-day) + bounded (mass 20–300 kg; fat 3–60 %). `DataDestroyer` wipes via `ApiTokenStore.clearAll()`; LOINC 41982-0 ships in `FhirExporter`.
 
-### 8.3 HRV decomposition (autonomic-tone derivations) [PARTIAL — parasympathetic shipped, LF/HF deferred]
+### 8.3 HRV decomposition (autonomic-tone derivations) [COMPLETE]
 
-Raw HRV is canonical but the clinically useful numbers (LF/HF ratio,
-parasympathetic tone) aren't. Resolves the "raw HRV present, no
-autonomic surface" finding from the audit.
+Raw HRV was canonical but the clinically useful numbers (LF/HF ratio,
+parasympathetic tone) weren't — closes the "raw HRV, no autonomic surface" audit finding.
 
-- `parasympathetic_tone` (CARDIOVASCULAR, SCORE) — **shipped.** Computed
-  as `ln(RMSSD)` in `HrvAnalyzer.HrvResult.lnRmssd` and emitted by both
-  PPG and direct-sensor adapters alongside `HEART_RATE_VARIABILITY`.
-  `ln(RMSSD)` is the standard time-domain proxy for HF spectral power
-  (Shaffer & Ginsberg 2017, Kleiger 2005) — correlates ~0.9 with `ln(HF)`
-  in healthy adults and is approximately normally distributed across
-  individuals.
-- `lf_hf_ratio` (CARDIOVASCULAR) — **deferred.** Requires real spectral
-  analysis (FFT or Lomb-Scargle over the IBI tachogram); no time-domain
-  proxy is clinically defensible. Worth its own PR with a vetted FFT
-  implementation and synthetic-signal test coverage.
+- `parasympathetic_tone` (CARDIOVASCULAR, SCORE) — **shipped.** `ln(RMSSD)`
+  in `HrvAnalyzer.HrvResult.lnRmssd`, emitted by both PPG and direct-
+  sensor adapters alongside `HEART_RATE_VARIABILITY`. The standard time-
+  domain proxy for HF spectral power (Shaffer & Ginsberg 2017, Kleiger
+  2005) — correlates ~0.9 with `ln(HF)` and is approximately normally
+  distributed across individuals.
+- `lf_hf_ratio` (CARDIOVASCULAR, SCORE) — **shipped.** `engine/Spectral.kt`
+  resamples the IBI tachogram to 4 Hz, detrends, Hann-windows, runs a
+  radix-2 FFT, then integrates one-sided PSD over LF (0.04–0.15 Hz) and
+  HF (0.15–0.40 Hz) (Task Force 1996; Shaffer & Ginsberg 2017). Returns
+  0.0 under 60 s, on constant-IBI series, and on zero-HF-power. Emitted
+  by both adapters alongside the other HRV derivations and baselined.
 
 ### 8.4 Sleep derivations: latency + components [LATENCY + COMPONENTS SHIPPED]
 


### PR DESCRIPTION
## Summary
- Closes ROADMAP §8.3's deferred `lf_hf_ratio`: new `engine/Spectral.kt` runs the textbook IBI-tachogram pipeline (Task Force 1996, Shaffer & Ginsberg 2017) — cumulative beat times, 4 Hz linear-interpolation resample, detrend, Hann window, radix-2 FFT, one-sided PSD, integrate LF (0.04–0.15 Hz) and HF (0.15–0.40 Hz).
- `HrvAnalyzer.HrvResult` gains `lfHfRatio`; both `CameraPpgAdapter` and `DirectSensorAdapter` emit `LF_HF_RATIO` alongside the other HRV derivations; `BaselineEngine` tracks + baselines it.
- New `SpectralTest` covers pure-LF, pure-HF, constant-IBI, sub-60 s, and mixed-band synthetic signals, plus direct FFT correctness checks (impulse spectrum, pure-tone bin).

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (build + 602 unit tests + lint)
- [ ] Capture a 60 s+ PPG sample on device → `LF_HF_RATIO` row written to DB, finite + non-negative
- [ ] Capture < 60 s → `LF_HF_RATIO = 0.0` (no fabricated ratio)
- [ ] After two weeks of captures, baseline appears under TRACKED_METRICS coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)