### PR TITLE
docs: sync Phase 7 + 8 status now that 8.3 and 8.5 are shipped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Bios shares LETHE's protection philosophy:
 - See docs/PRIVACY_ARCHITECTURE.md for privacy/encryption details
 - See docs/CONSUMER_API.md for the `BiosHealthProvider` ContentProvider contract (read by W2F, future companions)
 - See docs/ECOSYSTEM_BOUNDARIES.md for what belongs in Bios vs. companion apps (Fil, W2F, Virgil, SoulRadio)
-- See docs/ROADMAP.md for the owner-protection roadmap (Phases 1-6 complete; Phase 7 effectively complete except 7.5 SoulRadio inbound, deferred on manifesto grounds; Phase 8 perimeter completion in flight — see ROADMAP for per-item status)
+- See docs/ROADMAP.md for the owner-protection roadmap (Phases 1-8 complete except 7.5 SoulRadio inbound, deferred on manifesto grounds; Phase 9 companions explicitly deferred — see ROADMAP for per-item status)
 
 ## Code Conventions
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,7 +84,7 @@ the-loop review, localization (6 regions), and detection latency SLOs.
 
 ---
 
-## Phase 7: Companion Ecosystem — Open the metric bus to sibling apps [IN PROGRESS]
+## Phase 7: Companion Ecosystem — Open the metric bus to sibling apps [COMPLETE EXCEPT 7.5 (DEFERRED)]
 
 > Bios is the suite hub: W2F (mood/bipolar) already reads sensors and writes
 > three MENTAL_HEALTH keys back; Virgil (solo-living safety) has discrete
@@ -249,7 +249,7 @@ See also: [Smokeless/docs/ECOSYSTEM.md](../../Smokeless/docs/ECOSYSTEM.md).
 
 ---
 
-## Phase 8: Perimeter completion — close the bio-hacking coverage gaps [PLANNED]
+## Phase 8: Perimeter completion — close the bio-hacking coverage gaps [COMPLETE]
 
 > A gap audit across the five-app suite (Bios, W2F, Smokeless, Virgil,
 > SoulRadio) surfaced canonical signals that the schema either reserves


### PR DESCRIPTION
## Summary
- Phase 7 and Phase 8 headings in ROADMAP.md still claimed `[IN PROGRESS]` / `[PLANNED]`, but every sub-item underneath is shipped. Only 7.5 SoulRadio inbound remains, and it's deferred on manifesto grounds.
- CLAUDE.md's one-line roadmap summary updated to match.
- Also deleted the stale local `feat/withings-body-fat-pct` branch (commit superseded by merged PR #77). No remote action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)