### PR TITLE
chore: migrate deprecated Material icons to AutoMirrored variants

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -159,9 +161,9 @@ fun BiosApp(viewModel: AppViewModel) {
 
     val tabs = listOf(
         Triple("home", "Home", Icons.Default.FavoriteBorder),
-        Triple("trends", "Trends", Icons.Default.ShowChart),
+        Triple("trends", "Trends", Icons.AutoMirrored.Filled.ShowChart),
         Triple("alerts", "Alerts", Icons.Default.Notifications),
-        Triple("timeline", "Journal", Icons.Default.MenuBook),
+        Triple("timeline", "Journal", Icons.AutoMirrored.Filled.MenuBook),
         Triple("settings", "Settings", Icons.Default.Settings)
     )
 

--- a/android/app/src/main/java/com/bios/app/ui/alerts/ProfessionalReviewScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/alerts/ProfessionalReviewScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -41,7 +42,7 @@ fun ProfessionalReviewScreen(
             title = { Text("Professional Review") },
             navigationIcon = {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                 }
             }
         )

--- a/android/app/src/main/java/com/bios/app/ui/companions/CompanionsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/companions/CompanionsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -44,7 +44,7 @@ fun CompanionsScreen(viewModel: AppViewModel, onBack: () -> Unit) {
                 title = { Text("Companion Apps") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
                 }
             )

--- a/android/app/src/main/java/com/bios/app/ui/components/HealthEventCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/HealthEventCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.StickyNote2
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -226,7 +227,7 @@ fun eventTypeIcon(type: HealthEventType): ImageVector {
         HealthEventType.DOCTOR_VISIT -> Icons.Default.LocalHospital
         HealthEventType.DIAGNOSIS -> Icons.Default.MedicalServices
         HealthEventType.TREATMENT -> Icons.Default.Healing
-        HealthEventType.NOTE -> Icons.Default.StickyNote2
+        HealthEventType.NOTE -> Icons.AutoMirrored.Filled.StickyNote2
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -40,7 +41,7 @@ fun ConditionDetailScreen(
             title = { Text(pattern?.title ?: "Condition Details") },
             navigationIcon = {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                 }
             }
         )

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -129,7 +130,7 @@ fun DiagnosticCard(result: DiagnosticResult, onNavigateToDetail: (String) -> Uni
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Icon(
-                            Icons.Default.MenuBook,
+                            Icons.AutoMirrored.Filled.MenuBook,
                             contentDescription = null,
                             modifier = Modifier.size(16.dp)
                         )

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticsScreen.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.LibraryBooks
 import androidx.compose.material.icons.filled.HourglassBottom
-import androidx.compose.material.icons.filled.LibraryBooks
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -39,7 +39,7 @@ fun DiagnosticsScreen(
             title = { Text("Health Diagnostics") },
             navigationIcon = {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                 }
             },
             actions = {
@@ -47,7 +47,7 @@ fun DiagnosticsScreen(
                     Icon(Icons.Default.Speed, contentDescription = "Pipeline health")
                 }
                 IconButton(onClick = onNavigateToReference) {
-                    Icon(Icons.Default.LibraryBooks, contentDescription = "Longevity reference")
+                    Icon(Icons.AutoMirrored.Filled.LibraryBooks, contentDescription = "Longevity reference")
                 }
             }
         )

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/PipelineHealthScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/PipelineHealthScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
@@ -38,7 +38,7 @@ fun PipelineHealthScreen(
             title = { Text("Pipeline Health") },
             navigationIcon = {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                 }
             }
         )

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -7,6 +7,9 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -213,10 +216,10 @@ fun HomeScreen(
 
         val metrics = listOf(
             Triple(MetricType.HEART_RATE, "Heart Rate", Icons.Default.Favorite),
-            Triple(MetricType.HEART_RATE_VARIABILITY, "HRV", Icons.Default.ShowChart),
+            Triple(MetricType.HEART_RATE_VARIABILITY, "HRV", Icons.AutoMirrored.Filled.ShowChart),
             Triple(MetricType.BLOOD_OXYGEN, "SpO2", Icons.Default.Air),
             Triple(MetricType.RESPIRATORY_RATE, "Resp. Rate", Icons.Default.Air),
-            Triple(MetricType.STEPS, "Steps", Icons.Default.DirectionsWalk),
+            Triple(MetricType.STEPS, "Steps", Icons.AutoMirrored.Filled.DirectionsWalk),
             Triple(MetricType.SKIN_TEMPERATURE_DEVIATION, "Skin Temp", Icons.Default.Thermostat),
             Triple(MetricType.SLEEP_DURATION, "Sleep", Icons.Default.Bedtime),
         )
@@ -391,7 +394,7 @@ fun QuickSymptomCard(onLogSymptom: (String) -> Unit) {
                         enabled = text.isNotBlank()
                     ) {
                         Icon(
-                            Icons.Default.Send,
+                            Icons.AutoMirrored.Filled.Send,
                             contentDescription = "Log symptom",
                             modifier = Modifier.size(16.dp)
                         )

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -31,7 +32,7 @@ fun LongevityReferenceScreen(
             title = { Text("What Longevity Science Tracks") },
             navigationIcon = {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                 }
             }
         )


### PR DESCRIPTION
## Summary
- Migrated 14 call sites across 10 files from the deprecated `Icons.Filled.X` / `Icons.Default.X` (for icons that flip under RTL) to `Icons.AutoMirrored.Filled.X`. Compose has been logging a deprecation warning per site on every build; per the release notes these become hard errors in a future Material release.
- Icons touched: `ArrowBack` ×7, `ShowChart` ×2, `MenuBook` ×2, `LibraryBooks`, `DirectionsWalk`, `Send`, `StickyNote2`.
- No behavior change in LTR; AutoMirrored variants render identically and flip correctly under RTL.
- The two remaining build warnings (`NsdManager.resolveService` and `NsdServiceInfo.host`) in `LocalNetworkTransport.kt` are unrelated Java API deprecations — separate scope.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes
- [x] `./gradlew :app:compileStandaloneDebugKotlin --rerun-tasks` shows zero AutoMirrored warnings
- [ ] Visual smoke: navigate through Home → Trends → Journal → Diagnostics → Companions → LongevityReference to confirm icons still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)