### PR TITLE
feat: show live camera preview + steadiness coaching during PPG capture

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt
@@ -1,0 +1,81 @@
+package com.bios.app.engine
+
+import kotlin.math.abs
+
+/**
+ * Real-time placement / motion classifier for the ongoing camera-PPG capture.
+ *
+ * The full [PpgSignalProcessor] only runs *after* the 60-second recording —
+ * by then the owner has already wasted a minute if their finger drifted or
+ * the lens picked up room light. This classifier looks at the most recent
+ * second of luminance frames and produces an enum the UI surfaces as a
+ * coloured indicator + coaching message, so the owner gets immediate
+ * feedback while they're still in a position to fix it.
+ *
+ * Heuristics, ordered most-to-least specific:
+ *  1. **WAITING** — not enough frames yet for a stable classification. First
+ *     ~1 second of capture, while the auto-exposure settles and the flash
+ *     warms up.
+ *  2. **FINGER_OFF** — mean luminance is too high (room light reaching the
+ *     sensor) or variance is near zero (no PPG modulation because no
+ *     contact). Aligns with the offline [PpgSignalProcessor] checks for
+ *     INSUFFICIENT_SIGNAL and SATURATION.
+ *  3. **MOTION** — large frame-to-frame jumps in luminance over the last
+ *     half-second. Heart-beat amplitude is small (~5–20 Y units); motion
+ *     and pressure changes are typically >25 units.
+ *  4. **STEADY** — the finger is on the lens and the frame is calm. The
+ *     only state where the eventual offline analysis is likely to accept
+ *     the recording.
+ *
+ * Thresholds are eyeball-tuned for 8-bit Y values at ~30 fps with the
+ * device flash on. They may need calibration as field data accumulates;
+ * keeping them as named consts so a future PR can promote them to a
+ * device-specific profile.
+ */
+enum class CaptureQuality(val message: String, val isGood: Boolean) {
+    WAITING("Hold the camera. Reading starting…", false),
+    FINGER_OFF("Cover the rear camera and flash fully with your fingertip.", false),
+    MOTION("Hold still — motion is interfering with the signal.", false),
+    STEADY("Signal looks good. Keep holding.", true);
+
+    companion object {
+        /** Below this we say WAITING — not enough frames to classify. */
+        const val MIN_FRAMES_FOR_CLASSIFICATION = 8
+
+        /** Mean Y above this means room light is reaching the sensor. */
+        const val FINGER_OFF_BRIGHT_MEAN = 200.0
+
+        /** Variance below this means there's no PPG modulation at all. */
+        const val FINGER_OFF_MIN_VARIANCE = 0.5
+
+        /** Max frame-to-frame Y jump above which we flag motion. */
+        const val MOTION_MAX_JUMP_Y = 25.0
+
+        /** Window for the motion check (seconds). */
+        const val MOTION_WINDOW_SEC = 0.5
+
+        /**
+         * Classify the most recent frames. [window] is mean-Y values oldest
+         * first; [samplingRateHz] is the analyzer's current frame rate.
+         */
+        fun classify(window: List<Double>, samplingRateHz: Double): CaptureQuality {
+            if (window.size < MIN_FRAMES_FOR_CLASSIFICATION) return WAITING
+
+            val mean = window.average()
+            if (mean > FINGER_OFF_BRIGHT_MEAN) return FINGER_OFF
+
+            val variance = window.sumOf { (it - mean) * (it - mean) } / window.size
+            if (variance < FINGER_OFF_MIN_VARIANCE) return FINGER_OFF
+
+            val recentSpan =
+                (samplingRateHz * MOTION_WINDOW_SEC).toInt().coerceAtLeast(3)
+            val recentDiffs = window
+                .takeLast(recentSpan + 1)
+                .zipWithNext { a, b -> abs(b - a) }
+            val maxJump = recentDiffs.maxOrNull() ?: 0.0
+            if (maxJump > MOTION_MAX_JUMP_Y) return MOTION
+
+            return STEADY
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.concurrent.futures.await
 import androidx.lifecycle.LifecycleOwner
+import com.bios.app.engine.CaptureQuality
 import com.bios.app.engine.HrvAnalyzer
 import com.bios.app.engine.PpgResult
 import com.bios.app.engine.PpgSignalProcessor
@@ -16,6 +19,7 @@ import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
 import java.util.Collections
@@ -44,11 +48,22 @@ class CameraPpgAdapter(private val context: Context) {
      * Capture a fingertip-PPG snapshot for [durationSec] seconds. Blocks the
      * calling coroutine until capture completes. Returns a [CaptureResult]
      * with either a HR + HRV reading pair or a rejection reason.
+     *
+     * Optional real-time feedback channels:
+     *  - [surfaceProvider] — when non-null, a `Preview` use case is bound to
+     *    it so the UI can show the live lens view. This is placement-only
+     *    feedback (a finger fully on the lens looks dark red); no metric
+     *    values are streamed, per the no-streaming design rule.
+     *  - [qualityFlow] — when non-null, [CaptureQuality] classifications
+     *    are pushed during capture so the UI can coach the owner if the
+     *    finger drifts or motion is detected. Updates ~2 Hz.
      */
     suspend fun capture(
         lifecycleOwner: LifecycleOwner,
         durationSec: Int,
-        sourceId: String
+        sourceId: String,
+        surfaceProvider: Preview.SurfaceProvider? = null,
+        qualityFlow: MutableStateFlow<CaptureQuality>? = null
     ): CaptureResult = withContext(Dispatchers.Main) {
         val provider = try {
             ProcessCameraProvider.getInstance(context).await()
@@ -58,6 +73,7 @@ class CameraPpgAdapter(private val context: Context) {
 
         val luminance = Collections.synchronizedList(mutableListOf<Double>())
         val executor = Executors.newSingleThreadExecutor()
+        val frameCounter = java.util.concurrent.atomic.AtomicInteger(0)
         val analysis = ImageAnalysis.Builder()
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
             .build()
@@ -65,14 +81,29 @@ class CameraPpgAdapter(private val context: Context) {
                 it.setAnalyzer(executor) { image ->
                     luminance.add(yPlaneMean(image))
                     image.close()
+
+                    val n = frameCounter.incrementAndGet()
+                    if (qualityFlow != null && n % QUALITY_UPDATE_EVERY_N_FRAMES == 0) {
+                        val window = synchronized(luminance) {
+                            luminance.takeLast(QUALITY_WINDOW_FRAMES)
+                        }
+                        qualityFlow.value = CaptureQuality.classify(
+                            window, ASSUMED_SAMPLING_HZ
+                        )
+                    }
                 }
             }
 
+        val preview = surfaceProvider?.let { sp ->
+            Preview.Builder().build().also { it.setSurfaceProvider(sp) }
+        }
+
         val selector = CameraSelector.DEFAULT_BACK_CAMERA
         val startMs = System.currentTimeMillis()
+        val useCases: Array<UseCase> = listOfNotNull(analysis, preview).toTypedArray()
 
         try {
-            val camera = provider.bindToLifecycle(lifecycleOwner, selector, analysis)
+            val camera = provider.bindToLifecycle(lifecycleOwner, selector, *useCases)
             if (camera.cameraInfo.hasFlashUnit()) {
                 camera.cameraControl.enableTorch(true)
             }
@@ -99,6 +130,17 @@ class CameraPpgAdapter(private val context: Context) {
     }
 
     companion object {
+        /** Approximate analyzer frame rate, used by the real-time quality
+         *  classifier. Actual rate is measured offline; this is just the
+         *  scale for the motion-window heuristic. */
+        private const val ASSUMED_SAMPLING_HZ = 20.0
+
+        /** Push a quality update every N frames (~2 Hz at 20 fps). */
+        private const val QUALITY_UPDATE_EVERY_N_FRAMES = 10
+
+        /** Window of recent frames the classifier inspects (~1 sec). */
+        private const val QUALITY_WINDOW_FRAMES = 24
+
         /**
          * Pure mapping from processor + HRV output to a [CaptureResult]. On
          * the companion so tests can exercise it without instantiating the

--- a/android/app/src/main/java/com/bios/app/ui/ppg/PpgCaptureScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/ppg/PpgCaptureScreen.kt
@@ -4,11 +4,15 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
@@ -46,12 +51,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.bios.app.engine.CaptureQuality
 import com.bios.app.engine.RejectionReason
 import com.bios.app.ingest.CaptureResult
 import com.bios.contracts.MetricType
@@ -104,15 +113,21 @@ fun PpgCaptureScreen(
                 .padding(16.dp),
             contentAlignment = Alignment.Center
         ) {
+            val quality by viewModel.quality.collectAsState()
             when {
                 !hasCameraPermission -> PermissionPrompt(
                     onRequest = { permissionLauncher.launch(Manifest.permission.CAMERA) }
                 )
                 uiState is PpgUiState.Idle -> IdleView(
-                    onStart = { viewModel.startCapture(lifecycleOwner) }
+                    onStart = { viewModel.requestCapture() }
                 )
                 uiState is PpgUiState.Capturing -> CapturingView(
-                    totalSec = (uiState as PpgUiState.Capturing).totalSec
+                    totalSec = (uiState as PpgUiState.Capturing).totalSec,
+                    quality = quality,
+                    lifecycleOwner = lifecycleOwner,
+                    onPreviewReady = { surfaceProvider ->
+                        viewModel.bindCamera(lifecycleOwner, surfaceProvider)
+                    }
                 )
                 uiState is PpgUiState.Complete -> ResultView(
                     result = (uiState as PpgUiState.Complete).result,
@@ -199,7 +214,12 @@ private fun InstructionRow(marker: String, text: String) {
 }
 
 @Composable
-private fun CapturingView(totalSec: Int) {
+private fun CapturingView(
+    totalSec: Int,
+    quality: CaptureQuality,
+    lifecycleOwner: LifecycleOwner,
+    onPreviewReady: (androidx.camera.core.Preview.SurfaceProvider) -> Unit
+) {
     var elapsed by remember { mutableIntStateOf(0) }
     LaunchedEffect(totalSec) {
         elapsed = 0
@@ -211,32 +231,101 @@ private fun CapturingView(totalSec: Int) {
     val remaining = (totalSec - elapsed).coerceAtLeast(0)
     val progress = elapsed.toFloat() / totalSec.coerceAtLeast(1)
 
+    val previewReady = remember { mutableStateOf(false) }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxWidth()
     ) {
+        // Live camera preview — mostly dark red when the finger is on the
+        // lens; useful for confirming placement, not for showing biometric
+        // values. Borders flip colour with the steadiness classification.
         Box(
-            modifier = Modifier.size(160.dp),
+            modifier = Modifier
+                .fillMaxWidth(0.55f)
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(16.dp))
+                .border(3.dp, quality.borderColor(), RoundedCornerShape(16.dp))
+                .background(Color.Black),
+            contentAlignment = Alignment.Center
+        ) {
+            AndroidView(
+                factory = { ctx ->
+                    PreviewView(ctx).apply {
+                        scaleType = PreviewView.ScaleType.FILL_CENTER
+                        implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+                    }.also { view ->
+                        if (!previewReady.value) {
+                            previewReady.value = true
+                            onPreviewReady(view.surfaceProvider)
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        // Steadiness coaching: colour matches the preview border so the
+        // signal is double-coded (border + chip + text).
+        SteadinessChip(quality)
+
+        Box(
+            modifier = Modifier.size(120.dp),
             contentAlignment = Alignment.Center
         ) {
             CircularProgressIndicator(
                 progress = { progress },
                 modifier = Modifier.fillMaxSize(),
-                strokeWidth = 8.dp
+                strokeWidth = 6.dp
             )
             Text(
                 text = "$remaining",
-                style = MaterialTheme.typography.displayMedium,
+                style = MaterialTheme.typography.displaySmall,
                 fontWeight = FontWeight.Light
             )
         }
-        Text("Keep your fingertip still", style = MaterialTheme.typography.titleMedium)
+    }
+}
+
+@Composable
+private fun SteadinessChip(quality: CaptureQuality) {
+    val container = quality.containerColor()
+    val onContainer = quality.onContainerColor()
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(container)
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+    ) {
         Text(
-            "The flash is on. Don't move your hand until the countdown ends.",
+            text = quality.message,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            fontWeight = FontWeight.Medium,
+            color = onContainer
         )
     }
+}
+
+@Composable
+private fun CaptureQuality.borderColor(): Color = when (this) {
+    CaptureQuality.STEADY -> MaterialTheme.colorScheme.primary
+    CaptureQuality.WAITING -> MaterialTheme.colorScheme.outline
+    CaptureQuality.FINGER_OFF, CaptureQuality.MOTION -> MaterialTheme.colorScheme.error
+}
+
+@Composable
+private fun CaptureQuality.containerColor(): Color = when (this) {
+    CaptureQuality.STEADY -> MaterialTheme.colorScheme.primaryContainer
+    CaptureQuality.WAITING -> MaterialTheme.colorScheme.surfaceVariant
+    CaptureQuality.FINGER_OFF, CaptureQuality.MOTION -> MaterialTheme.colorScheme.errorContainer
+}
+
+@Composable
+private fun CaptureQuality.onContainerColor(): Color = when (this) {
+    CaptureQuality.STEADY -> MaterialTheme.colorScheme.onPrimaryContainer
+    CaptureQuality.WAITING -> MaterialTheme.colorScheme.onSurfaceVariant
+    CaptureQuality.FINGER_OFF, CaptureQuality.MOTION -> MaterialTheme.colorScheme.onErrorContainer
 }
 
 @Composable

--- a/android/app/src/main/java/com/bios/app/ui/ppg/PpgCaptureViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/ppg/PpgCaptureViewModel.kt
@@ -1,16 +1,19 @@
 package com.bios.app.ui.ppg
 
 import android.app.Application
+import androidx.camera.core.Preview
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.CaptureQuality
 import com.bios.app.ingest.CameraPpgAdapter
 import com.bios.app.ingest.CaptureResult
 import com.bios.app.model.DataSource
 import com.bios.app.model.SensorType
 import com.bios.app.model.SourceType
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,7 +23,15 @@ import kotlinx.coroutines.withContext
 /**
  * State machine for a camera-PPG HRV snapshot. Owns the [CameraPpgAdapter]
  * and persists accepted readings via the Room DAO. The screen observes
- * [uiState] and calls [startCapture] / [reset] in response to user input.
+ * [uiState] + [quality] and calls [requestCapture] / [bindCamera] / [reset]
+ * in response to user input and PreviewView lifecycle.
+ *
+ * Capture is two-phase so the UI can show the live lens view:
+ *   1. [requestCapture] transitions to [PpgUiState.Capturing]; the screen
+ *      then renders its `PreviewView`.
+ *   2. Once the PreviewView's `Preview.SurfaceProvider` is available, the
+ *      screen calls [bindCamera], which actually binds CameraX and runs
+ *      the analyzer for the countdown.
  */
 class PpgCaptureViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -30,18 +41,35 @@ class PpgCaptureViewModel(application: Application) : AndroidViewModel(applicati
     private val _uiState = MutableStateFlow<PpgUiState>(PpgUiState.Idle)
     val uiState: StateFlow<PpgUiState> = _uiState.asStateFlow()
 
-    /**
-     * Launch a capture for [durationSec] seconds. The screen must hold CAMERA
-     * permission and pass its [LifecycleOwner] so CameraX can bind.
-     */
-    fun startCapture(lifecycleOwner: LifecycleOwner, durationSec: Int = DEFAULT_DURATION_SEC) {
+    private val _quality = MutableStateFlow(CaptureQuality.WAITING)
+    val quality: StateFlow<CaptureQuality> = _quality.asStateFlow()
+
+    private var captureJob: Job? = null
+
+    /** User tapped Start. Transition to [PpgUiState.Capturing] without
+     *  binding the camera yet — the screen will call [bindCamera] once its
+     *  PreviewView is composed and has a surface provider. */
+    fun requestCapture(durationSec: Int = DEFAULT_DURATION_SEC) {
         if (_uiState.value is PpgUiState.Capturing) return
+        _quality.value = CaptureQuality.WAITING
+        _uiState.value = PpgUiState.Capturing(durationSec)
+    }
 
-        viewModelScope.launch {
-            _uiState.value = PpgUiState.Capturing(durationSec)
+    /** Called by the screen once its PreviewView has a [surfaceProvider].
+     *  Idempotent — extra calls during the same Capturing state are no-ops. */
+    fun bindCamera(lifecycleOwner: LifecycleOwner, surfaceProvider: Preview.SurfaceProvider) {
+        val state = _uiState.value as? PpgUiState.Capturing ?: return
+        if (captureJob?.isActive == true) return
 
+        captureJob = viewModelScope.launch {
             val sourceId = getOrCreateCameraSource()
-            val result = adapter.capture(lifecycleOwner, durationSec, sourceId)
+            val result = adapter.capture(
+                lifecycleOwner = lifecycleOwner,
+                durationSec = state.totalSec,
+                sourceId = sourceId,
+                surfaceProvider = surfaceProvider,
+                qualityFlow = _quality
+            )
 
             if (result.accepted && result.readings.isNotEmpty()) {
                 withContext(Dispatchers.IO) {
@@ -50,6 +78,7 @@ class PpgCaptureViewModel(application: Application) : AndroidViewModel(applicati
             }
 
             _uiState.value = PpgUiState.Complete(result)
+            _quality.value = CaptureQuality.WAITING
         }
     }
 
@@ -57,6 +86,7 @@ class PpgCaptureViewModel(application: Application) : AndroidViewModel(applicati
     fun reset() {
         if (_uiState.value !is PpgUiState.Capturing) {
             _uiState.value = PpgUiState.Idle
+            _quality.value = CaptureQuality.WAITING
         }
     }
 

--- a/android/app/src/test/java/com/bios/app/CaptureQualityTest.kt
+++ b/android/app/src/test/java/com/bios/app/CaptureQualityTest.kt
@@ -1,0 +1,65 @@
+package com.bios.app
+
+import com.bios.app.engine.CaptureQuality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CaptureQualityTest {
+
+    private val fs = 20.0  // ASSUMED_SAMPLING_HZ used by the adapter
+
+    @Test
+    fun `too few frames classifies as WAITING`() {
+        val window = listOf(50.0, 51.0, 50.5)
+        assertEquals(CaptureQuality.WAITING, CaptureQuality.classify(window, fs))
+    }
+
+    @Test
+    fun `empty window classifies as WAITING`() {
+        assertEquals(CaptureQuality.WAITING, CaptureQuality.classify(emptyList(), fs))
+    }
+
+    @Test
+    fun `bright frames classify as FINGER_OFF`() {
+        // Mean luminance > 200 → room light is reaching the sensor.
+        val window = List(24) { 220.0 + (it % 3) }
+        assertEquals(CaptureQuality.FINGER_OFF, CaptureQuality.classify(window, fs))
+    }
+
+    @Test
+    fun `flat low-variance frames classify as FINGER_OFF`() {
+        // Finger loosely on lens but no PPG modulation at all → no contact.
+        val window = List(24) { 60.0 }
+        assertEquals(CaptureQuality.FINGER_OFF, CaptureQuality.classify(window, fs))
+    }
+
+    @Test
+    fun `large frame-to-frame jumps classify as MOTION`() {
+        // Heart-rate PPG amplitude is ~5-20 Y units; a 40-unit step is motion.
+        val window = (0 until 24).map { i ->
+            60.0 + (if (i == 22) 40.0 else if (i % 3 == 0) 1.0 else 0.0)
+        }
+        assertEquals(CaptureQuality.MOTION, CaptureQuality.classify(window, fs))
+    }
+
+    @Test
+    fun `a clean PPG-shaped signal classifies as STEADY`() {
+        // ~1 Hz heart-beat (60 bpm) with 10 Y-unit amplitude on a 60 mean.
+        val window = (0 until 24).map { i ->
+            val t = i / fs
+            60.0 + 10.0 * kotlin.math.sin(2.0 * kotlin.math.PI * 1.0 * t)
+        }
+        assertEquals(CaptureQuality.STEADY, CaptureQuality.classify(window, fs))
+    }
+
+    @Test
+    fun `messages are non-empty and isGood matches STEADY only`() {
+        for (q in CaptureQuality.entries) {
+            assert(q.message.isNotBlank()) { "$q has a blank message" }
+        }
+        assertEquals(true, CaptureQuality.STEADY.isGood)
+        assertEquals(false, CaptureQuality.WAITING.isGood)
+        assertEquals(false, CaptureQuality.MOTION.isGood)
+        assertEquals(false, CaptureQuality.FINGER_OFF.isGood)
+    }
+}


### PR DESCRIPTION
## Summary
- The 60-second HRV snapshot was a black countdown — any finger drift or motion was only surfaced after the full minute, in the rejection message. Now the screen shows the live camera frame and a colour-coded steadiness chip that updates ~2 Hz, so the owner can correct placement while it still matters.
- New `engine/CaptureQuality.kt`: pure WAITING / FINGER_OFF / MOTION / STEADY classifier. Thresholds aligned to the offline `PpgSignalProcessor` checks (mean-luminance bound for room light, variance floor for contact, frame-to-frame jump cap for motion). Honours the existing "no streaming, no live HR" rule — only placement feedback, never metric values.
- `CameraPpgAdapter.capture` gains optional `surfaceProvider` (binds a CameraX `Preview` use case) and `qualityFlow` (analyzer pushes a classification every 10 frames).
- `PpgCaptureViewModel` becomes two-phase: `requestCapture` flips state; `bindCamera` runs the adapter once the UI's `PreviewView` has a `SurfaceProvider`. Idempotent.
- UI signal is triple-coded (border, chip background, text) — works without colour. `CaptureQualityTest` covers all five branches plus enum invariants.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes
- [ ] On device: start a capture without a finger → chip turns red, "Cover the rear camera and flash" appears
- [ ] With finger on lens, hold still → chip turns primary-coloured, "Signal looks good"
- [ ] Jiggle the finger → chip flips back to red, "Hold still" message
- [ ] Completing the full 60 s with STEADY most of the time still saves the reading; rejection message still surfaces when the offline processor rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)