### PR TITLE
feat: Data Coverage screen — surface missing and stale metrics with CTAs

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
@@ -1,0 +1,78 @@
+package com.bios.app.engine
+
+import com.bios.contracts.MetricType
+
+/**
+ * Status of the owner's coverage for a single [MetricType] — does Bios
+ * have data, is it fresh, and what routes can fill the gap.
+ *
+ * Surfaced by [MetricCoverageEngine] to the Data Coverage screen so the
+ * owner can spot missing or stale metrics at a glance and act on them.
+ */
+data class MetricCoverage(
+    val metricType: MetricType,
+    val status: MetricCoverageStatus,
+    /** Epoch millis of the most recent reading, or null if none exists. */
+    val lastTimestamp: Long?,
+    /** Routes that could deliver this metric — adapters, manual entry, etc.
+     *  Each route carries its own configured/unconfigured state so the UI
+     *  can mark them as either CTAs (tap to connect / add) or
+     *  acknowledgements (already set up). */
+    val routes: List<CoverageRoute>
+)
+
+enum class MetricCoverageStatus {
+    /** Fresh data within the metric's staleness budget. */
+    LIVE,
+
+    /** Has data, but the most recent reading is older than the budget. */
+    STALE,
+
+    /** No reading has ever been recorded for this metric. */
+    MISSING
+}
+
+/**
+ * One way the owner can register a metric. Routes are *what could deliver
+ * this metric*, regardless of whether the owner has set the route up.
+ * `isConfigured` distinguishes "ready to receive" from "needs setup".
+ */
+data class CoverageRoute(
+    val kind: CoverageRouteKind,
+    val displayName: String,
+    val isConfigured: Boolean,
+    /** Optional in-app navigation route to take on tap (Compose nav). Null
+     *  for routes that don't lead anywhere actionable (e.g. an external
+     *  device that's already paired and we're just informing the owner). */
+    val deepLink: String? = null
+)
+
+enum class CoverageRouteKind {
+    HEALTH_CONNECT,
+    API_ADAPTER,    // Oura, Withings, Polar, Dexcom, etc.
+    DIRECT_SENSOR,
+    PHONE_SENSOR,
+    PPG_CAPTURE,
+    MANUAL_ENTRY,
+    FHIR_IMPORT,
+}
+
+/**
+ * Snapshot of which data-source surfaces the app currently has set up.
+ * Built by the ViewModel from `AppViewModel` / `IngestManager` flags and
+ * passed into [MetricCoverageEngine] so the engine stays pure (no Android
+ * deps, no permissions checks).
+ */
+data class AdapterReadiness(
+    val healthConnectGranted: Boolean,
+    val ouraConfigured: Boolean,
+    val withingsConfigured: Boolean,
+    val polarConfigured: Boolean,
+    val dexcomConfigured: Boolean,
+    val directSensorAvailable: Boolean,
+    val phoneSensorAvailable: Boolean,
+    /** The PPG-camera capture path is always available on a phone with a
+     *  rear camera + flash — kept here so the engine doesn't have to
+     *  assume the hardware exists. */
+    val ppgCaptureAvailable: Boolean
+)

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
@@ -1,0 +1,140 @@
+package com.bios.app.engine
+
+import com.bios.contracts.MetricType
+
+/**
+ * Pure runtime classifier for [MetricCoverage]. Decoupled from Room / the
+ * Application context so it can be exercised by unit tests with a fake
+ * [lastTimestampFor] function.
+ *
+ * The engine takes:
+ *  - a [readiness] snapshot of which adapter surfaces are currently
+ *    configured (Health Connect granted, Oura token present, etc.),
+ *  - a [lastTimestampFor] callback that returns the most recent reading
+ *    timestamp for a given metric key (null if none), and
+ *  - the current wall-clock time (so tests can freeze it).
+ *
+ * It walks [MetricCoverageRegistry.specs], compares last-reading times
+ * against each spec's staleness budget, and assembles a list of
+ * actionable [CoverageRoute] entries from the spec's route kinds + the
+ * readiness flags.
+ */
+object MetricCoverageEngine {
+
+    suspend fun compute(
+        readiness: AdapterReadiness,
+        nowMillis: Long,
+        lastTimestampFor: suspend (String) -> Long?
+    ): List<MetricCoverage> {
+        return MetricCoverageRegistry.specs.map { spec ->
+            val lastTs = lastTimestampFor(spec.metricType.key)
+            val status = classifyStatus(lastTs, nowMillis, spec.stalenessBudgetMs)
+            val routes = spec.routeKinds.map { kind ->
+                routeFor(kind, spec.metricType, readiness)
+            }
+            MetricCoverage(
+                metricType = spec.metricType,
+                status = status,
+                lastTimestamp = lastTs,
+                routes = routes
+            )
+        }
+    }
+
+    internal fun classifyStatus(
+        lastTs: Long?,
+        nowMillis: Long,
+        stalenessBudgetMs: Long
+    ): MetricCoverageStatus = when {
+        lastTs == null -> MetricCoverageStatus.MISSING
+        (nowMillis - lastTs) <= stalenessBudgetMs -> MetricCoverageStatus.LIVE
+        else -> MetricCoverageStatus.STALE
+    }
+
+    internal fun routeFor(
+        kind: CoverageRouteKind,
+        metric: MetricType,
+        readiness: AdapterReadiness
+    ): CoverageRoute = when (kind) {
+        CoverageRouteKind.HEALTH_CONNECT -> CoverageRoute(
+            kind = kind,
+            displayName = "Health Connect",
+            isConfigured = readiness.healthConnectGranted,
+            deepLink = null
+        )
+        CoverageRouteKind.API_ADAPTER -> apiAdapterRoute(metric, readiness)
+        CoverageRouteKind.DIRECT_SENSOR -> CoverageRoute(
+            kind = kind,
+            displayName = "On-device sensor",
+            isConfigured = readiness.directSensorAvailable,
+            deepLink = null
+        )
+        CoverageRouteKind.PHONE_SENSOR -> CoverageRoute(
+            kind = kind,
+            displayName = "Phone sensor",
+            isConfigured = readiness.phoneSensorAvailable,
+            deepLink = null
+        )
+        CoverageRouteKind.PPG_CAPTURE -> CoverageRoute(
+            kind = kind,
+            displayName = "Fingertip-PPG snapshot",
+            isConfigured = readiness.ppgCaptureAvailable,
+            deepLink = "ppg_capture"
+        )
+        CoverageRouteKind.MANUAL_ENTRY -> CoverageRoute(
+            kind = kind,
+            displayName = "Manual entry",
+            isConfigured = true,  // always available
+            deepLink = "biomarker_entry"
+        )
+        CoverageRouteKind.FHIR_IMPORT -> CoverageRoute(
+            kind = kind,
+            displayName = "FHIR file import",
+            isConfigured = true,
+            deepLink = "biomarker_entry"
+        )
+    }
+
+    /** Pick the API adapter most likely to provide a given metric. The
+     *  registry's route list only says "an API adapter can help"; this
+     *  function names which one based on what the adapters actually emit. */
+    private fun apiAdapterRoute(metric: MetricType, readiness: AdapterReadiness): CoverageRoute {
+        // (adapter display name, isConfigured)
+        val candidates: List<Pair<String, Boolean>> = when (metric) {
+            MetricType.BODY_MASS,
+            MetricType.BODY_FAT_PCT,
+            MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC ->
+                listOf("Withings" to readiness.withingsConfigured)
+
+            MetricType.BLOOD_GLUCOSE ->
+                listOf("Dexcom" to readiness.dexcomConfigured)
+
+            MetricType.RECOVERY_SCORE ->
+                listOf("Oura" to readiness.ouraConfigured)
+
+            else -> listOf(
+                "Oura" to readiness.ouraConfigured,
+                "Polar" to readiness.polarConfigured,
+            )
+        }
+        // Prefer to show a configured adapter; otherwise show all candidate
+        // names so the UI can suggest any of them.
+        val configured = candidates.firstOrNull { it.second }
+        return if (configured != null) {
+            CoverageRoute(
+                kind = CoverageRouteKind.API_ADAPTER,
+                displayName = configured.first,
+                isConfigured = true,
+                deepLink = null
+            )
+        } else {
+            CoverageRoute(
+                kind = CoverageRouteKind.API_ADAPTER,
+                displayName = candidates.joinToString(" or ") { it.first },
+                isConfigured = false,
+                deepLink = "settings"
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -1,0 +1,180 @@
+package com.bios.app.engine
+
+import com.bios.contracts.MetricType
+
+/**
+ * Static description of how Bios expects each [MetricType] to be filled.
+ *
+ * Each spec carries:
+ *  - a *staleness budget* — how recent a reading must be for the coverage
+ *    engine to call it LIVE — anchored in clinical or wearable conventions
+ *    rather than UX preference; and
+ *  - the set of *route kinds* that could deliver this metric, which the
+ *    runtime engine matches against [AdapterReadiness] to produce
+ *    actionable [CoverageRoute] entries.
+ *
+ * Out of scope for this registry:
+ *  - Companion-provided metrics (TYPING_CADENCE, MOOD_DRIFT_SCORE,
+ *    FALL_EVENT, TOBACCO_USE, etc.) — those need an "install companion"
+ *    flow which is its own design problem.
+ *  - Reproductive metrics (BASAL_BODY_TEMPERATURE, CYCLE_PHASE, CYCLE_DAY,
+ *    MENSTRUATION_ONSET) — those live in the isolated `ReproductiveDatabase`
+ *    behind their own entry surface and aren't part of the general health
+ *    coverage view.
+ */
+data class MetricCoverageSpec(
+    val metricType: MetricType,
+    val stalenessBudgetMs: Long,
+    val routeKinds: List<CoverageRouteKind>
+)
+
+object MetricCoverageRegistry {
+
+    private const val H = 60L * 60_000L                  // 1 hour
+    private const val D = 24L * H                        // 1 day
+    private const val W = 7L * D                         // 1 week
+    private const val MONTH = 30L * D                    // 30 days
+    private const val SIX_MONTHS = 6L * MONTH
+
+    /**
+     * The set of metrics surfaced by the Data Coverage feature. Adding a
+     * new wearable / biomarker is a matter of adding an entry here — the
+     * UI and engine pick it up automatically.
+     */
+    val specs: List<MetricCoverageSpec> = listOf(
+        // -- Cardiovascular (continuous wearable) --
+        wearable(MetricType.HEART_RATE),
+        wearable(MetricType.HEART_RATE_VARIABILITY, alsoFromPpgCapture = true),
+        wearable(MetricType.RESTING_HEART_RATE),
+        wearable(MetricType.BLOOD_OXYGEN),
+
+        // HRV-derived metrics — only produced by the same paths that yield
+        // HEART_RATE_VARIABILITY (PPG-camera capture + direct sensor).
+        derived(MetricType.PARASYMPATHETIC_TONE),
+        derived(MetricType.STRESS_SCORE),
+        derived(MetricType.LF_HF_RATIO),
+
+        // -- Blood pressure (cuff measurement, slower-moving) --
+        MetricCoverageSpec(
+            MetricType.BLOOD_PRESSURE_SYSTOLIC, W,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.BLOOD_PRESSURE_DIASTOLIC, W,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+
+        // -- Respiratory --
+        wearable(MetricType.RESPIRATORY_RATE),
+
+        // -- Temperature --
+        wearable(MetricType.SKIN_TEMPERATURE),
+        wearable(MetricType.SKIN_TEMPERATURE_DEVIATION),
+
+        // -- Sleep (after waking) --
+        MetricCoverageSpec(
+            MetricType.SLEEP_DURATION, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.SLEEP_LATENCY, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.SLEEP_EFFICIENCY, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.SLEEP_FRAGMENTATION_INDEX, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+
+        // -- Activity --
+        MetricCoverageSpec(
+            MetricType.STEPS, D,
+            listOf(
+                CoverageRouteKind.HEALTH_CONNECT,
+                CoverageRouteKind.API_ADAPTER,
+                CoverageRouteKind.PHONE_SENSOR
+            )
+        ),
+        MetricCoverageSpec(
+            MetricType.ACTIVE_MINUTES, D,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.ACTIVE_CALORIES, D,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+
+        // -- Metabolic --
+        MetricCoverageSpec(
+            MetricType.BLOOD_GLUCOSE, 4 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.BODY_MASS, MONTH,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.BODY_FAT_PCT, MONTH,
+            listOf(CoverageRouteKind.API_ADAPTER)
+        ),
+
+        // -- Recovery --
+        MetricCoverageSpec(
+            MetricType.RECOVERY_SCORE, D,
+            listOf(CoverageRouteKind.API_ADAPTER)
+        ),
+
+        // -- Environment --
+        MetricCoverageSpec(
+            MetricType.AMBIENT_LIGHT, H,
+            listOf(CoverageRouteKind.PHONE_SENSOR)
+        ),
+
+        // -- Biomarkers (clinical re-test cadence ≈ 6 months) --
+        biomarker(MetricType.HBA1C),
+        biomarker(MetricType.HSCRP),
+        biomarker(MetricType.TOTAL_CHOLESTEROL),
+        biomarker(MetricType.LDL_CHOLESTEROL),
+        biomarker(MetricType.HDL_CHOLESTEROL),
+        biomarker(MetricType.TRIGLYCERIDES),
+        biomarker(MetricType.APO_B),
+        biomarker(MetricType.VITAMIN_D_25OH),
+        biomarker(MetricType.TSH),
+        biomarker(MetricType.FREE_T4),
+        biomarker(MetricType.FREE_T3),
+        biomarker(MetricType.HEMOGLOBIN),
+        biomarker(MetricType.HEMATOCRIT),
+        biomarker(MetricType.WBC),
+        biomarker(MetricType.RBC),
+        biomarker(MetricType.PLATELETS),
+    )
+
+    val byMetric: Map<MetricType, MetricCoverageSpec> = specs.associateBy { it.metricType }
+
+    private fun wearable(
+        metric: MetricType,
+        alsoFromPpgCapture: Boolean = false
+    ): MetricCoverageSpec {
+        val routes = buildList {
+            add(CoverageRouteKind.HEALTH_CONNECT)
+            add(CoverageRouteKind.API_ADAPTER)
+            add(CoverageRouteKind.DIRECT_SENSOR)
+            if (alsoFromPpgCapture) add(CoverageRouteKind.PPG_CAPTURE)
+        }
+        return MetricCoverageSpec(metric, D, routes)
+    }
+
+    /** HRV-derived autonomic scores: same paths as HEART_RATE_VARIABILITY. */
+    private fun derived(metric: MetricType) = MetricCoverageSpec(
+        metric, D,
+        listOf(CoverageRouteKind.PPG_CAPTURE, CoverageRouteKind.DIRECT_SENSOR)
+    )
+
+    private fun biomarker(metric: MetricType) = MetricCoverageSpec(
+        metric, SIX_MONTHS,
+        listOf(CoverageRouteKind.MANUAL_ENTRY, CoverageRouteKind.FHIR_IMPORT)
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -300,7 +300,18 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToCompanions = { navController.navigate("companions") },
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
                     onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
-                    onNavigateToPeriodEntry = { navController.navigate("period_entry") }
+                    onNavigateToPeriodEntry = { navController.navigate("period_entry") },
+                    onNavigateToDataCoverage = { navController.navigate("data_coverage") }
+                )
+            }
+            composable("data_coverage") {
+                val coverageVm = remember(viewModel) {
+                    com.bios.app.ui.coverage.DataCoverageViewModel(viewModel)
+                }
+                com.bios.app.ui.coverage.DataCoverageScreen(
+                    viewModel = coverageVm,
+                    onBack = { navController.popBackStack() },
+                    onNavigate = { route -> navController.navigate(route) }
                 )
             }
             composable("biomarker_entry") {

--- a/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageScreen.kt
@@ -1,0 +1,255 @@
+package com.bios.app.ui.coverage
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.CoverageRoute
+import com.bios.app.engine.CoverageRouteKind
+import com.bios.app.engine.MetricCoverage
+import com.bios.app.engine.MetricCoverageStatus
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Per-metric coverage view: lists every metric Bios cares about along
+ * with a LIVE / STALE / MISSING badge, the last-seen timestamp, and the
+ * routes that could fill the gap (Connect Oura, Add Lab Values, etc.).
+ *
+ * Sort order surfaces problems first: MISSING → STALE → LIVE, so the
+ * owner's attention lands on the gaps without scrolling.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataCoverageScreen(
+    viewModel: DataCoverageViewModel,
+    onBack: () -> Unit,
+    onNavigate: (route: String) -> Unit
+) {
+    val coverage by viewModel.coverage.collectAsState()
+    val sorted = remember(coverage) { coverage.sortedWith(StatusComparator) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Data Coverage") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (sorted.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Text("Loading coverage…", style = MaterialTheme.typography.bodyMedium)
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            item { OverviewBanner(sorted) }
+            items(sorted, key = { it.metricType.key }) { entry ->
+                CoverageRow(entry, onNavigate = onNavigate)
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverviewBanner(rows: List<MetricCoverage>) {
+    val missing = rows.count { it.status == MetricCoverageStatus.MISSING }
+    val stale = rows.count { it.status == MetricCoverageStatus.STALE }
+    val live = rows.count { it.status == MetricCoverageStatus.LIVE }
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Snapshot", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.size(4.dp))
+            Text(
+                "$live live · $stale stale · $missing missing",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                "Stale and missing metrics show suggested routes below — tap a chip to set it up or register the data.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun CoverageRow(
+    entry: MetricCoverage,
+    onNavigate: (String) -> Unit
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                StatusDot(entry.status)
+                Spacer(Modifier.size(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        entry.metricType.readableName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        timestampLabel(entry),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                StatusBadge(entry.status)
+            }
+
+            if (entry.status != MetricCoverageStatus.LIVE) {
+                Spacer(Modifier.size(8.dp))
+                RouteChips(entry.routes, onNavigate)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusDot(status: MetricCoverageStatus) {
+    val color = when (status) {
+        MetricCoverageStatus.LIVE -> MaterialTheme.colorScheme.primary
+        MetricCoverageStatus.STALE -> MaterialTheme.colorScheme.tertiary
+        MetricCoverageStatus.MISSING -> MaterialTheme.colorScheme.error
+    }
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .clip(CircleShape)
+            .background(color)
+    )
+}
+
+@Composable
+private fun StatusBadge(status: MetricCoverageStatus) {
+    val (label, color) = when (status) {
+        MetricCoverageStatus.LIVE -> "Live" to MaterialTheme.colorScheme.primary
+        MetricCoverageStatus.STALE -> "Stale" to MaterialTheme.colorScheme.tertiary
+        MetricCoverageStatus.MISSING -> "Missing" to MaterialTheme.colorScheme.error
+    }
+    Text(
+        label,
+        color = color,
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun RouteChips(routes: List<CoverageRoute>, onNavigate: (String) -> Unit) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        // Unconfigured routes first (they're the actionable CTAs); already-
+        // configured routes go last as a confirmation that the path is set
+        // up and Bios is waiting on a sync.
+        for (route in routes.sortedBy { it.isConfigured }) {
+            val label = if (route.isConfigured) "✓ ${route.displayName}" else route.actionLabel()
+            AssistChip(
+                onClick = { route.deepLink?.let(onNavigate) },
+                enabled = route.deepLink != null || route.isConfigured,
+                label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+                colors = if (route.isConfigured) {
+                    AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    AssistChipDefaults.assistChipColors()
+                }
+            )
+        }
+    }
+}
+
+private fun CoverageRoute.actionLabel(): String = when (kind) {
+    CoverageRouteKind.HEALTH_CONNECT -> "Enable Health Connect"
+    CoverageRouteKind.API_ADAPTER -> "Connect $displayName"
+    CoverageRouteKind.DIRECT_SENSOR -> "Pair a wearable"
+    CoverageRouteKind.PHONE_SENSOR -> "Allow phone sensor"
+    CoverageRouteKind.PPG_CAPTURE -> "Take HRV snapshot"
+    CoverageRouteKind.MANUAL_ENTRY -> "Add value manually"
+    CoverageRouteKind.FHIR_IMPORT -> "Import FHIR file"
+}
+
+private val dateFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)
+private fun timestampLabel(entry: MetricCoverage): String {
+    val ts = entry.lastTimestamp ?: return "Never recorded"
+    return "Last reading: ${dateFormat.format(Date(ts))}"
+}
+
+/** Stable ordering: MISSING first, then STALE, then LIVE; ties broken by
+ *  metric key for determinism across recompositions. */
+private object StatusComparator : Comparator<MetricCoverage> {
+    override fun compare(a: MetricCoverage, b: MetricCoverage): Int {
+        val byStatus = statusRank(a.status).compareTo(statusRank(b.status))
+        return if (byStatus != 0) byStatus else a.metricType.key.compareTo(b.metricType.key)
+    }
+
+    private fun statusRank(s: MetricCoverageStatus): Int = when (s) {
+        MetricCoverageStatus.MISSING -> 0
+        MetricCoverageStatus.STALE -> 1
+        MetricCoverageStatus.LIVE -> 2
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
@@ -1,0 +1,59 @@
+package com.bios.app.ui.coverage
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bios.app.engine.AdapterReadiness
+import com.bios.app.engine.MetricCoverage
+import com.bios.app.engine.MetricCoverageEngine
+import com.bios.app.ingest.DexcomApiAdapter
+import com.bios.app.ingest.PolarApiAdapter
+import com.bios.app.ingest.WithingsApiAdapter
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Surface-level ViewModel for the Data Coverage screen. Snapshots adapter
+ * readiness from [AppViewModel] and asks [MetricCoverageEngine] for the
+ * per-metric status + routes; re-snapshots on demand via [refresh].
+ *
+ * Plain `ViewModel` (not AndroidViewModel) — the data sources it needs
+ * live on the shared [AppViewModel] instance the caller passes in.
+ */
+class DataCoverageViewModel(
+    private val app: AppViewModel
+) : ViewModel() {
+
+    private val _coverage = MutableStateFlow<List<MetricCoverage>>(emptyList())
+    val coverage: StateFlow<List<MetricCoverage>> = _coverage.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    init { refresh() }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val readiness = AdapterReadiness(
+                healthConnectGranted = app.hasPermissions.value,
+                ouraConfigured = app.ouraTokenStore.hasToken(),
+                withingsConfigured = app.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY),
+                polarConfigured = app.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY),
+                dexcomConfigured = app.apiTokenStore.hasToken(DexcomApiAdapter.PROVIDER_KEY),
+                directSensorAvailable = app.directSensorAdapter.hasAnySensor,
+                phoneSensorAvailable = app.phoneSensorAdapter.hasAccelerometer,
+                ppgCaptureAvailable = true,  // any phone with a rear camera + flash
+            )
+            val dao = app.db.metricReadingDao()
+            _coverage.value = MetricCoverageEngine.compute(
+                readiness = readiness,
+                nowMillis = System.currentTimeMillis(),
+                lastTimestampFor = { dao.lastTimestampFor(it) }
+            )
+            _isLoading.value = false
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -33,7 +33,8 @@ fun SettingsScreen(
     onNavigateToCompanions: () -> Unit = {},
     onNavigateToBiomarkerEntry: () -> Unit = {},
     onNavigateToBbtEntry: () -> Unit = {},
-    onNavigateToPeriodEntry: () -> Unit = {}
+    onNavigateToPeriodEntry: () -> Unit = {},
+    onNavigateToDataCoverage: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -118,26 +119,13 @@ fun SettingsScreen(
                 )
 
                 Spacer(Modifier.height(8.dp))
-                OutlinedButton(
-                    onClick = onNavigateToBiomarkerEntry,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Add Lab Values")
-                }
+                SettingsActionButton("Add Lab Values", onNavigateToBiomarkerEntry)
                 Spacer(Modifier.height(4.dp))
-                OutlinedButton(
-                    onClick = onNavigateToBbtEntry,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Track BBT")
-                }
+                SettingsActionButton("Track BBT", onNavigateToBbtEntry)
                 Spacer(Modifier.height(4.dp))
-                OutlinedButton(
-                    onClick = onNavigateToPeriodEntry,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Log period start")
-                }
+                SettingsActionButton("Log period start", onNavigateToPeriodEntry)
+                Spacer(Modifier.height(4.dp))
+                SettingsActionButton("Data coverage", onNavigateToDataCoverage)
             }
         }
 
@@ -491,6 +479,11 @@ fun SettingsScreen(
             onDismiss = { showWithingsDialog = false }
         )
     }
+}
+
+@Composable
+private fun SettingsActionButton(label: String, onClick: () -> Unit) {
+    OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) { Text(label) }
 }
 
 private fun saveTier(context: Context, tier: PrivacyTier) {

--- a/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
@@ -1,0 +1,209 @@
+package com.bios.app
+
+import com.bios.app.engine.AdapterReadiness
+import com.bios.app.engine.CoverageRouteKind
+import com.bios.app.engine.MetricCoverageEngine
+import com.bios.app.engine.MetricCoverageRegistry
+import com.bios.app.engine.MetricCoverageStatus
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MetricCoverageEngineTest {
+
+    private val noReadiness = AdapterReadiness(
+        healthConnectGranted = false,
+        ouraConfigured = false,
+        withingsConfigured = false,
+        polarConfigured = false,
+        dexcomConfigured = false,
+        directSensorAvailable = false,
+        phoneSensorAvailable = false,
+        ppgCaptureAvailable = true,
+    )
+
+    private val now = 1_700_000_000_000L
+    private val H = 60L * 60_000L
+    private val D = 24L * H
+
+    @Test
+    fun `null timestamp classifies MISSING regardless of budget`() {
+        assertEquals(
+            MetricCoverageStatus.MISSING,
+            MetricCoverageEngine.classifyStatus(null, now, D)
+        )
+    }
+
+    @Test
+    fun `reading within budget classifies LIVE`() {
+        assertEquals(
+            MetricCoverageStatus.LIVE,
+            MetricCoverageEngine.classifyStatus(now - H, now, D)
+        )
+    }
+
+    @Test
+    fun `reading older than budget classifies STALE`() {
+        assertEquals(
+            MetricCoverageStatus.STALE,
+            MetricCoverageEngine.classifyStatus(now - 2 * D, now, D)
+        )
+    }
+
+    @Test
+    fun `reading exactly at the budget edge is still LIVE`() {
+        assertEquals(
+            MetricCoverageStatus.LIVE,
+            MetricCoverageEngine.classifyStatus(now - D, now, D)
+        )
+    }
+
+    @Test
+    fun `engine produces a row for every spec in the registry`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        assertEquals(MetricCoverageRegistry.specs.size, rows.size)
+        // Every spec is represented by exactly one row.
+        for (spec in MetricCoverageRegistry.specs) {
+            assertTrue(
+                "expected a row for ${spec.metricType.key}",
+                rows.any { it.metricType == spec.metricType }
+            )
+        }
+    }
+
+    @Test
+    fun `all rows are MISSING when the DB is empty`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        assertTrue(rows.all { it.status == MetricCoverageStatus.MISSING })
+        assertTrue(rows.all { it.lastTimestamp == null })
+    }
+
+    @Test
+    fun `fresh hr reading classifies LIVE and stale one classifies STALE`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { key ->
+                when (key) {
+                    MetricType.HEART_RATE.key -> now - 2 * H              // fresh
+                    MetricType.SLEEP_DURATION.key -> now - 5 * D          // very stale
+                    else -> null
+                }
+            }
+        )
+        val hr = rows.single { it.metricType == MetricType.HEART_RATE }
+        val sleep = rows.single { it.metricType == MetricType.SLEEP_DURATION }
+        assertEquals(MetricCoverageStatus.LIVE, hr.status)
+        assertEquals(MetricCoverageStatus.STALE, sleep.status)
+    }
+
+    @Test
+    fun `oura route flips to configured when its token is present`() = runTest {
+        val ouraReady = noReadiness.copy(ouraConfigured = true)
+        val rows = MetricCoverageEngine.compute(
+            readiness = ouraReady,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        val hr = rows.single { it.metricType == MetricType.HEART_RATE }
+        val apiRoute = hr.routes.single { it.kind == CoverageRouteKind.API_ADAPTER }
+        assertTrue(apiRoute.isConfigured)
+        assertEquals("Oura", apiRoute.displayName)
+    }
+
+    @Test
+    fun `withings is the API route surfaced for body composition`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        val mass = rows.single { it.metricType == MetricType.BODY_MASS }
+        val apiRoute = mass.routes.single { it.kind == CoverageRouteKind.API_ADAPTER }
+        assertTrue("Withings" in apiRoute.displayName)
+        assertEquals(false, apiRoute.isConfigured)
+    }
+
+    @Test
+    fun `biomarker rows offer manual entry and FHIR import as configured`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        val hba1c = rows.single { it.metricType == MetricType.HBA1C }
+        val manual = hba1c.routes.single { it.kind == CoverageRouteKind.MANUAL_ENTRY }
+        val fhir = hba1c.routes.single { it.kind == CoverageRouteKind.FHIR_IMPORT }
+        assertTrue(manual.isConfigured)
+        assertTrue(fhir.isConfigured)
+        assertNotNull(manual.deepLink)
+        assertNotNull(fhir.deepLink)
+    }
+
+    @Test
+    fun `reproductive metrics are deliberately not in the registry`() {
+        // BBT / cycle data live in the isolated ReproductiveDatabase behind
+        // their own entry surface, so the general coverage view skips them.
+        val present = MetricCoverageRegistry.byMetric.keys
+        assertTrue(MetricType.BASAL_BODY_TEMPERATURE !in present)
+        assertTrue(MetricType.CYCLE_PHASE !in present)
+        assertTrue(MetricType.CYCLE_DAY !in present)
+        assertTrue(MetricType.MENSTRUATION_ONSET !in present)
+    }
+
+    @Test
+    fun `companion-provided metrics are deliberately not in the registry`() {
+        // No install-companion flow yet — surfacing those metrics here would
+        // just be noise without an actionable CTA.
+        val present = MetricCoverageRegistry.byMetric.keys
+        assertTrue(MetricType.TYPING_CADENCE !in present)
+        assertTrue(MetricType.MOOD_DRIFT_SCORE !in present)
+        assertTrue(MetricType.FALL_EVENT !in present)
+        assertTrue(MetricType.TOBACCO_USE !in present)
+    }
+
+    @Test
+    fun `every wearable spec lists health connect and a named api adapter`() {
+        // Routes-shape sanity: a continuous-wear metric should always offer
+        // both Health Connect and an API adapter so the engine can render
+        // either CTA depending on what's already set up.
+        val sample = MetricCoverageRegistry.byMetric.getValue(MetricType.HEART_RATE)
+        assertTrue(CoverageRouteKind.HEALTH_CONNECT in sample.routeKinds)
+        assertTrue(CoverageRouteKind.API_ADAPTER in sample.routeKinds)
+    }
+
+    @Test
+    fun `manual entry routes have no API-adapter sibling for biomarkers`() {
+        val sample = MetricCoverageRegistry.byMetric.getValue(MetricType.HSCRP)
+        assertEquals(
+            listOf(CoverageRouteKind.MANUAL_ENTRY, CoverageRouteKind.FHIR_IMPORT),
+            sample.routeKinds
+        )
+    }
+
+    @Test
+    fun `last timestamp survives onto the produced row`() = runTest {
+        val ts = now - 3 * H
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { if (it == MetricType.HEART_RATE.key) ts else null }
+        )
+        val hr = rows.single { it.metricType == MetricType.HEART_RATE }
+        assertEquals(ts, hr.lastTimestamp)
+        // Other rows still null.
+        assertNull(rows.single { it.metricType == MetricType.SLEEP_DURATION }.lastTimestamp)
+    }
+}


### PR DESCRIPTION
## Summary
Settings → Data coverage lists every metric Bios cares about with a LIVE / STALE / MISSING badge, the last-seen timestamp, and the routes that could fill the gap. Sorted MISSING-first so gaps surface immediately.

- `engine/MetricCoverageRegistry.kt` declares per-MetricType staleness budgets and the route kinds that could deliver each (Health Connect, named API adapter, on-device sensor, phone sensor, PPG capture, manual entry, FHIR import).
- `engine/MetricCoverageEngine.kt` is the pure runtime classifier — takes an `AdapterReadiness` snapshot + a `lastTimestampFor` callback + a clock, returns the per-metric coverage list. Names the right API adapter per metric (Withings for body composition + BP, Dexcom for glucose, Oura for recovery, Oura/Polar for the rest).
- `ui/coverage/DataCoverageScreen.kt` + ViewModel render the list. Configured routes appear as ✓ acknowledgement chips; unconfigured ones as actionable CTAs ("Connect Oura", "Add value manually", "Take HRV snapshot") that deep-link into Settings / BiomarkerEntry / PpgCapture.
- Deliberately out of scope: companion-provided metrics (no install-companion flow yet) and reproductive metrics (already behind the isolated ReproductiveDatabase entry surface). Both guarded by tests so future code can't accidentally surface them.

Side cleanup: extracted a 3-line `SettingsActionButton` helper to keep `SettingsScreen` under the 500-line cap while adding the new entry.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes — 13 new tests cover status classification, registry shape, adapter-readiness flips, last-timestamp passthrough, exclusion of companion + reproductive metrics
- [ ] On device with no adapter connected: Data Coverage opens, every metric shows MISSING, each row offers "Connect Oura" / "Add value manually" / etc. CTAs
- [ ] After taking a PPG snapshot: HEART_RATE, HRV, LF_HF_RATIO, PARASYMPATHETIC_TONE, STRESS_SCORE flip to LIVE
- [ ] After 24 hours without a wearable sync: those rows flip to STALE

🤖 Generated with [Claude Code](https://claude.com/claude-code)