### PR TITLE
feat: manual sleep duration entry

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
@@ -1,0 +1,56 @@
+package com.bios.app.data
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.DataSource
+import com.bios.app.model.MetricReading
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+
+/**
+ * Persistence path for manually logged sleep duration when the owner has
+ * no wearable / Health Connect feeding the metric (or wants to override a
+ * gap on a given night).
+ *
+ * Like [BiomarkerEntryRepo], rows are tagged with the shared SELF_REPORTED
+ * [DataSource] + [ReadingKind.SELF_REPORTED] so the baseline engine ignores
+ * them while they still surface in trends, coverage, and FHIR export.
+ */
+class SleepEntryRepo(private val db: BiosDatabase) {
+
+    /** Physiological cap (24h). Anything above is a data-entry error. */
+    private val maxDurationSeconds = 24L * 3600L
+
+    suspend fun add(durationSeconds: Long, timestamp: Long) {
+        require(durationSeconds in 1..maxDurationSeconds) {
+            "Sleep duration $durationSeconds s is outside the 1..$maxDurationSeconds range"
+        }
+        val sourceId = getOrCreateSelfReportedSource()
+        db.metricReadingDao().insert(
+            MetricReading(
+                metricType = MetricType.SLEEP_DURATION.key,
+                value = durationSeconds.toDouble(),
+                timestamp = timestamp,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        )
+    }
+
+    suspend fun fetchRecent(limit: Int = 20): List<MetricReading> =
+        db.metricReadingDao().fetchLatest(MetricType.SLEEP_DURATION.key, limit)
+
+    private suspend fun getOrCreateSelfReportedSource(): String {
+        val dao = db.dataSourceDao()
+        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
+        val source = DataSource(
+            sourceType = SourceType.SELF_REPORTED.key,
+            deviceName = "Self-reported",
+            sensorType = SensorType.DERIVED.name,
+            readingKind = ReadingKind.SELF_REPORTED.name
+        )
+        dao.insert(source)
+        return source.id
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
@@ -85,7 +85,7 @@ object MetricCoverageEngine {
             kind = kind,
             displayName = "Manual entry",
             isConfigured = true,  // always available
-            deepLink = "biomarker_entry"
+            deepLink = manualEntryDeepLink(metric)
         )
         CoverageRouteKind.FHIR_IMPORT -> CoverageRoute(
             kind = kind,
@@ -93,6 +93,14 @@ object MetricCoverageEngine {
             isConfigured = true,
             deepLink = "biomarker_entry"
         )
+    }
+
+    /** Route a MANUAL_ENTRY chip to the right entry screen. Sleep has its
+     *  own form; everything else lands on the biomarker entry surface (which
+     *  is also the FHIR import host). */
+    private fun manualEntryDeepLink(metric: MetricType): String = when (metric) {
+        MetricType.SLEEP_DURATION -> "sleep_entry"
+        else -> "biomarker_entry"
     }
 
     /** Pick the API adapter most likely to provide a given metric. The

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -72,9 +72,16 @@ object MetricCoverageRegistry {
         wearable(MetricType.SKIN_TEMPERATURE_DEVIATION),
 
         // -- Sleep (after waking) --
+        // SLEEP_DURATION is the only sleep metric that accepts self-reported
+        // entry — the stage-derived metrics (latency, efficiency, fragmentation)
+        // need per-minute stage data that a human can't reasonably produce.
         MetricCoverageSpec(
             MetricType.SLEEP_DURATION, 36 * H,
-            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+            listOf(
+                CoverageRouteKind.HEALTH_CONNECT,
+                CoverageRouteKind.API_ADAPTER,
+                CoverageRouteKind.MANUAL_ENTRY
+            )
         ),
         MetricCoverageSpec(
             MetricType.SLEEP_LATENCY, 36 * H,

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -301,6 +301,7 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
                     onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
                     onNavigateToPeriodEntry = { navController.navigate("period_entry") },
+                    onNavigateToSleepEntry = { navController.navigate("sleep_entry") },
                     onNavigateToDataCoverage = { navController.navigate("data_coverage") }
                 )
             }
@@ -328,6 +329,12 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("period_entry") {
                 com.bios.app.ui.period.PeriodEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable("sleep_entry") {
+                com.bios.app.ui.sleep.SleepEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -34,6 +34,7 @@ fun SettingsScreen(
     onNavigateToBiomarkerEntry: () -> Unit = {},
     onNavigateToBbtEntry: () -> Unit = {},
     onNavigateToPeriodEntry: () -> Unit = {},
+    onNavigateToSleepEntry: () -> Unit = {},
     onNavigateToDataCoverage: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -120,6 +121,8 @@ fun SettingsScreen(
 
                 Spacer(Modifier.height(8.dp))
                 SettingsActionButton("Add Lab Values", onNavigateToBiomarkerEntry)
+                Spacer(Modifier.height(4.dp))
+                SettingsActionButton("Log sleep", onNavigateToSleepEntry)
                 Spacer(Modifier.height(4.dp))
                 SettingsActionButton("Track BBT", onNavigateToBbtEntry)
                 Spacer(Modifier.height(4.dp))

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepEntryScreen.kt
@@ -1,0 +1,224 @@
+package com.bios.app.ui.sleep
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.SleepEntryRepo
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepEntryScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit
+) {
+    val repo = remember(viewModel) { SleepEntryRepo(viewModel.db) }
+    val scope = rememberCoroutineScope()
+
+    var hoursText by remember { mutableStateOf("") }
+    var minutesText by remember { mutableStateOf("") }
+    var selectedDate by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var recent by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
+
+    suspend fun refresh() {
+        recent = repo.fetchRecent()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
+
+    val hours = hoursText.toIntOrNull() ?: 0
+    val minutes = minutesText.toIntOrNull() ?: 0
+    val totalSeconds = hours * 3600L + minutes * 60L
+    val isValid = totalSeconds in 1..(24L * 3600L) &&
+        hours in 0..24 && minutes in 0..59
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Log Sleep") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Sleep duration", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(
+                        "Log the total time you slept. Self-reported entries fill gaps when no " +
+                            "wearable or Health Connect provider is feeding the metric. Stays on " +
+                            "device and is excluded from baseline learning so it can't skew " +
+                            "anomaly detection.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        OutlinedTextField(
+                            value = hoursText,
+                            onValueChange = { hoursText = it.filter { c -> c.isDigit() }.take(2) },
+                            label = { Text("Hours") },
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                keyboardType = KeyboardType.Number
+                            ),
+                            singleLine = true,
+                            modifier = Modifier.weight(1f)
+                        )
+                        OutlinedTextField(
+                            value = minutesText,
+                            onValueChange = { minutesText = it.filter { c -> c.isDigit() }.take(2) },
+                            label = { Text("Minutes") },
+                            keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(
+                                keyboardType = KeyboardType.Number
+                            ),
+                            singleLine = true,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+
+                    OutlinedButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Night of: ${formatDate(selectedDate)}")
+                    }
+
+                    OutlinedButton(
+                        onClick = {
+                            if (!isValid) return@OutlinedButton
+                            scope.launch {
+                                repo.add(totalSeconds, selectedDate)
+                                refresh()
+                            }
+                            hoursText = ""
+                            minutesText = ""
+                        },
+                        enabled = isValid,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Save")
+                    }
+                }
+            }
+
+            Text("Recent entries", style = MaterialTheme.typography.titleSmall)
+            if (recent.isEmpty()) {
+                Text(
+                    "No sleep entries yet.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    contentPadding = PaddingValues(vertical = 4.dp)
+                ) {
+                    items(recent, key = { it.id }) { reading ->
+                        RecentSleepRow(reading)
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { selectedDate = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+
+@Composable
+private fun RecentSleepRow(reading: MetricReading) {
+    val seconds = reading.value.toLong()
+    val h = seconds / 3600
+    val m = (seconds % 3600) / 60
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Text(
+                "${h}h ${m}m",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                formatDate(reading.timestamp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
+private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))

--- a/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
@@ -194,6 +194,31 @@ class MetricCoverageEngineTest {
     }
 
     @Test
+    fun `sleep duration offers manual entry routed to the sleep entry screen`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        val sleep = rows.single { it.metricType == MetricType.SLEEP_DURATION }
+        val manual = sleep.routes.single { it.kind == CoverageRouteKind.MANUAL_ENTRY }
+        assertTrue(manual.isConfigured)
+        assertEquals("sleep_entry", manual.deepLink)
+    }
+
+    @Test
+    fun `biomarker manual entry still routes to the biomarker entry screen`() = runTest {
+        val rows = MetricCoverageEngine.compute(
+            readiness = noReadiness,
+            nowMillis = now,
+            lastTimestampFor = { null }
+        )
+        val hba1c = rows.single { it.metricType == MetricType.HBA1C }
+        val manual = hba1c.routes.single { it.kind == CoverageRouteKind.MANUAL_ENTRY }
+        assertEquals("biomarker_entry", manual.deepLink)
+    }
+
+    @Test
     fun `last timestamp survives onto the produced row`() = runTest {
         val ts = now - 3 * H
         val rows = MetricCoverageEngine.compute(


### PR DESCRIPTION
## Summary
- Adds a self-reported sleep entry surface for nights when no wearable or Health Connect provider feeds `SLEEP_DURATION` (or to override a gap on a given night)
- New `SleepEntryRepo` persists entries tagged `SELF_REPORTED` so the baseline engine ignores them while they still surface in trends, coverage, and FHIR export — mirrors `BiomarkerEntryRepo`
- New `SleepEntryScreen`: hours/minutes input, date picker for "night of", recent entries list, validated against the 1s..24h physiological cap
- `MetricCoverageRegistry` adds `MANUAL_ENTRY` only for `SLEEP_DURATION` (latency, efficiency, fragmentation need per-minute stage data a human can't reasonably produce)
- `MetricCoverageEngine` routes the sleep manual chip to a dedicated `"sleep_entry"` deep link; biomarker manual entry still lands on `"biomarker_entry"`
- Wires the route in `MainActivity` and adds a "Log sleep" button to the manual-entry section of `SettingsScreen`

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (file lengths, no secrets, lint, build, unit tests)
- [x] New tests cover both routing branches in `MetricCoverageEngine` (sleep → `sleep_entry`, biomarker → `biomarker_entry`)
- [ ] Manual: open Settings → "Log sleep" → enter 7h 30m on yesterday → save → entry appears in recent list
- [ ] Manual: open Data Coverage → SLEEP_DURATION row offers a MANUAL_ENTRY chip that opens the sleep entry screen
- [ ] Manual: open Data Coverage → HBA1C row's MANUAL_ENTRY chip still opens the biomarker entry screen (regression check)
- [ ] Manual: enter 0h 0m → Save button disabled
- [ ] Manual: confirm entries are tagged SELF_REPORTED (not feeding baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)