### PR TITLE
feat: deep link into PPG capture (bios://capture/ppg)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -82,6 +82,17 @@
                 <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
             </intent-filter>
 
+            <!-- Companion deep link: bios://capture/ppg lands directly on the
+                 PPG capture screen so companions (W2F's "take a snapshot" CTA)
+                 can offer one-tap entry without a Home detour. See
+                 docs/CAMERA_PPG.md § Deep link. -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="bios" android:host="capture" android:path="/ppg" />
+            </intent-filter>
+
             <meta-data
                 android:name="health_permissions"
                 android:resource="@array/health_permissions" />

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -148,6 +148,21 @@ fun BiosApp(viewModel: AppViewModel) {
         }
     }
 
+    // Deep-link from a companion (e.g. W2F "take a snapshot" CTA): bios://capture/ppg
+    // lands directly on the PPG capture screen. popUpTo home/inclusive empties
+    // the in-app back stack so pressing back from capture finishes the
+    // activity and returns to the calling companion, not Bios Home.
+    LaunchedEffect(Unit) {
+        val activity = context as? android.app.Activity ?: return@LaunchedEffect
+        val data = activity.intent?.data ?: return@LaunchedEffect
+        if (data.scheme == "bios" && data.host == "capture" && data.path == "/ppg") {
+            activity.intent.data = null
+            navController.navigate("ppg_capture") {
+                popUpTo("home") { inclusive = true }
+            }
+        }
+    }
+
     // Show errors as snackbar
     LaunchedEffect(error) {
         error?.let {
@@ -242,7 +257,11 @@ fun BiosApp(viewModel: AppViewModel) {
                 )
             }
             composable("ppg_capture") {
-                PpgCaptureScreen(onBack = { navController.popBackStack() })
+                PpgCaptureScreen(onBack = {
+                    if (!navController.popBackStack()) {
+                        (context as? android.app.Activity)?.finish()
+                    }
+                })
             }
             composable("diagnostics") {
                 DiagnosticsScreen(

--- a/docs/CAMERA_PPG.md
+++ b/docs/CAMERA_PPG.md
@@ -122,6 +122,41 @@ Bios ships a `PpgValidation` utility
 for computing MAE, bias, and range from paired readings. See the unit test
 for the shape of input it expects.
 
+## Deep link
+
+Companions can open the PPG capture screen directly with the URI
+`bios://capture/ppg` — no Home detour. This is the right shape for CTAs
+fired in degraded-executive-function moments (post-stressor, post-bad-
+sleep prompts) where the cost of an extra tap is high.
+
+Behavior:
+
+- Camera permission still runs if not yet granted — the capture screen
+  owns its own permission flow.
+- Recording does **not** auto-start; the owner still confirms in Bios.
+  v1 has no qualifier parameters (no `?reason=`); plain link only.
+- Back from the capture screen finishes the activity and returns to the
+  calling companion (or the system back stack), not Bios Home. The
+  in-app back stack is cleared when entering via deep link.
+
+From Kotlin:
+
+```kotlin
+val intent = Intent(Intent.ACTION_VIEW, Uri.parse("bios://capture/ppg"))
+context.startActivity(intent)
+```
+
+From a shell (testing):
+
+```
+adb shell am start -a android.intent.action.VIEW -d bios://capture/ppg
+```
+
+The intent-filter lives on `MainActivity` in
+[AndroidManifest.xml](../android/app/src/main/AndroidManifest.xml); the
+in-app routing is in
+[MainActivity.kt](../android/app/src/main/java/com/bios/app/ui/MainActivity.kt).
+
 ## Cross-references
 
 - [ARCHITECTURE.md §1](ARCHITECTURE.md) — adapter list


### PR DESCRIPTION
## Summary
- Adds a `bios://capture/ppg` deep link so companions (starting with W2F's "HRV offline → take a snapshot" CTA) can land directly on the PPG capture screen, skipping the Home detour
- Motivated by the contexts where these CTAs fire (post-stressor, post-bad-sleep, anhedonia) — every extra tap is expensive when executive function is degraded
- `AndroidManifest.xml`: VIEW/BROWSABLE intent-filter on `MainActivity` for the URI
- `MainActivity.kt`: handles the deep link in a `LaunchedEffect` that navigates to `ppg_capture` with `popUpTo("home") { inclusive = true }` — empties the in-app back stack so back-from-capture finishes the activity and returns to the calling companion, not Bios Home
- `PpgCaptureScreen` `onBack` falls through to `activity.finish()` when `popBackStack` has nothing to pop
- `docs/CAMERA_PPG.md`: new "Deep link" section so other companions can target the same URI

Closes #74.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (lint, build both flavors, unit tests)
- [ ] Manual cold-start: `adb shell am start -a android.intent.action.VIEW -d bios://capture/ppg` from a state where Bios is not running → lands on PPG capture screen (no Home flash)
- [ ] Manual back: from the capture screen launched via deep link, press back → activity finishes and returns to whatever launched it (or Android launcher), not Bios Home
- [ ] Manual camera permission: revoke CAMERA permission, then deep-link → capture screen still runs its own permission prompt
- [ ] Manual W2F: trigger the W2F "take a snapshot" CTA after it's updated to use this URI → one-tap to capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)