### PR TITLE
feat(schema): composite event payloads for multi-field metrics

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -24,9 +24,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         UserFeedback::class,
         ProfessionalReview::class,
         CompanionGrant::class,
-        LoggedEvent::class
+        LoggedEvent::class,
+        EventPayloadField::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -42,6 +43,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun professionalReviewDao(): ProfessionalReviewDao
     abstract fun companionGrantDao(): CompanionGrantDao
     abstract fun loggedEventDao(): LoggedEventDao
+    abstract fun eventPayloadFieldDao(): EventPayloadFieldDao
 
     companion object {
         @Volatile
@@ -64,7 +66,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
                 .build()
         }
 
@@ -249,6 +251,29 @@ abstract class BiosDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS index_logged_events_sourceId " +
                         "ON logged_events(sourceId)"
+                )
+            }
+        }
+
+        // Sidecar table for composite event payloads. Each row is one field
+        // of a structured event attached to a parent MetricReading row.
+        // See docs/DATA_MODEL.md for the field-key vocabulary.
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS event_payloads (
+                        readingId TEXT NOT NULL,
+                        fieldKey TEXT NOT NULL,
+                        stringValue TEXT,
+                        doubleValue REAL,
+                        longValue INTEGER,
+                        PRIMARY KEY (readingId, fieldKey),
+                        FOREIGN KEY (readingId) REFERENCES metric_readings(id) ON DELETE CASCADE
+                    )
+                """)
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS index_event_payloads_readingId " +
+                        "ON event_payloads(readingId)"
                 )
             }
         }

--- a/android/app/src/main/java/com/bios/app/data/dao/EventPayloadFieldDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/EventPayloadFieldDao.kt
@@ -1,0 +1,29 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.bios.app.model.EventPayloadField
+
+@Dao
+interface EventPayloadFieldDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(fields: List<EventPayloadField>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(field: EventPayloadField)
+
+    @Query("SELECT * FROM event_payloads WHERE readingId = :readingId")
+    suspend fun fetchForReading(readingId: String): List<EventPayloadField>
+
+    @Query("SELECT * FROM event_payloads WHERE readingId IN (:readingIds)")
+    suspend fun fetchForReadings(readingIds: List<String>): List<EventPayloadField>
+
+    @Query("DELETE FROM event_payloads WHERE readingId = :readingId")
+    suspend fun deleteForReading(readingId: String)
+
+    @Query("DELETE FROM event_payloads")
+    suspend fun deleteAll()
+}

--- a/android/app/src/main/java/com/bios/app/model/EventPayloadField.kt
+++ b/android/app/src/main/java/com/bios/app/model/EventPayloadField.kt
@@ -1,0 +1,45 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// Sidecar table for composite event payloads. Each row is one field of a
+// structured event attached to a parent MetricReading row.
+//
+// Scalar metrics (heart_rate, hba1c, …) never touch this table — they keep
+// their full meaning in MetricReading.value. Composite metrics (e.g.
+// EXERCISE_SESSION with {modality, start, end, avg_hr, rpe}) land one
+// MetricReading row plus N EventPayloadField rows.
+//
+// Field keys are part of the contract. They are namespaced per MetricType
+// and documented in docs/DATA_MODEL.md alongside the metric they describe.
+// Treat them with the same stability commitment as MetricType.key strings —
+// renames are breaking changes for every reader.
+//
+// Each row carries exactly one typed value; the other two columns are null.
+// Three typed columns (vs. one stringly-typed) keeps SQL queries useful:
+// "find sessions where avg_hr_bpm > 140" stays a numeric comparison rather
+// than a string-cast.
+@Entity(
+    tableName = "event_payloads",
+    primaryKeys = ["readingId", "fieldKey"],
+    foreignKeys = [
+        ForeignKey(
+            entity = MetricReading::class,
+            parentColumns = ["id"],
+            childColumns = ["readingId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index("readingId")
+    ]
+)
+data class EventPayloadField(
+    val readingId: String,
+    val fieldKey: String,
+    val stringValue: String? = null,
+    val doubleValue: Double? = null,
+    val longValue: Long? = null,
+)

--- a/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
+++ b/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.runBlocking
  *   content://com.bios.app.health/baselines/{metricType}
  *   content://com.bios.app.health/status                  — one row per known metricType
  *   content://com.bios.app.health/status/{metricType}     — one row for that metricType
+ *   content://com.bios.app.health/payload/{readingId}     — composite-event fields
  *
  * Write URI (companion signals only):
  *   content://com.bios.app.health/companion/{metricType}
@@ -52,6 +53,7 @@ class BiosHealthProvider : ContentProvider() {
         private const val COMPANION_WRITE = 4
         private const val STATUS_ALL = 5
         private const val STATUS_TYPE = 6
+        private const val PAYLOAD = 7
 
         private const val DAY_MILLIS = 24L * 60L * 60L * 1000L
 
@@ -62,11 +64,13 @@ class BiosHealthProvider : ContentProvider() {
             addURI(AUTHORITY, "${BiosHealthContract.PATH_COMPANION}/*", COMPANION_WRITE)
             addURI(AUTHORITY, BiosHealthContract.PATH_STATUS, STATUS_ALL)
             addURI(AUTHORITY, "${BiosHealthContract.PATH_STATUS}/*", STATUS_TYPE)
+            addURI(AUTHORITY, "${BiosHealthContract.PATH_PAYLOAD}/*", PAYLOAD)
         }
 
         val READING_COLUMNS = BiosHealthContract.READING_COLUMNS
         val BASELINE_COLUMNS = BiosHealthContract.BASELINE_COLUMNS
         val STATUS_COLUMNS = BiosHealthContract.STATUS_COLUMNS
+        val PAYLOAD_COLUMNS = BiosHealthContract.PAYLOAD_COLUMNS
     }
 
     private lateinit var db: BiosDatabase
@@ -129,6 +133,7 @@ class BiosHealthProvider : ContentProvider() {
             BASELINE_TYPE -> queryBaselines(uri.lastPathSegment)
             STATUS_ALL -> queryStatus(null)
             STATUS_TYPE -> queryStatus(uri.lastPathSegment)
+            PAYLOAD -> queryPayload(uri.lastPathSegment)
             else -> null
         }
     }
@@ -244,6 +249,27 @@ class BiosHealthProvider : ContentProvider() {
                 row?.lastTimestamp ?: 0L,
                 row?.count24h ?: 0,
                 row?.countTotal ?: 0,
+            ))
+        }
+        return cursor
+    }
+
+    /**
+     * Returns the composite payload fields for a parent reading. Scalar
+     * metrics carry no payload; in that case the cursor is empty rather than
+     * null, so callers always get the same shape back.
+     */
+    private fun queryPayload(readingId: String?): Cursor {
+        val fields = if (readingId.isNullOrEmpty()) {
+            emptyList()
+        } else {
+            runBlocking { db.eventPayloadFieldDao().fetchForReading(readingId) }
+        }
+
+        val cursor = MatrixCursor(PAYLOAD_COLUMNS, fields.size)
+        for (f in fields) {
+            cursor.addRow(arrayOf(
+                f.readingId, f.fieldKey, f.stringValue, f.doubleValue, f.longValue
             ))
         }
         return cursor

--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -186,4 +186,24 @@ class BiosHealthProviderContractTest {
         assertEquals(ReadingKind.DERIVED, w2f.defaultReadingKind)
         assertEquals(ReadingKind.DERIVED, virgil.defaultReadingKind)
     }
+
+    @Test
+    fun `payload path constant matches the documented URI shape`() {
+        // Companions that read composite events build URIs by appending the
+        // parent reading id to PATH_PAYLOAD. Renames break every reader.
+        assertEquals("payload", com.bios.contracts.BiosHealthContract.PATH_PAYLOAD)
+    }
+
+    @Test
+    fun `payload column projection exposes the three typed value columns`() {
+        val cols = com.bios.contracts.BiosHealthContract.PAYLOAD_COLUMNS
+        assertEquals(5, cols.size)
+        assertTrue("reading_id" in cols)
+        assertTrue("field_key" in cols)
+        // Three typed columns — readers query the one matching the field's
+        // documented type rather than parsing a stringly-typed blob.
+        assertTrue("string_value" in cols)
+        assertTrue("double_value" in cols)
+        assertTrue("long_value" in cols)
+    }
 }

--- a/android/app/src/test/java/com/bios/app/EventPayloadFieldTest.kt
+++ b/android/app/src/test/java/com/bios/app/EventPayloadFieldTest.kt
@@ -1,0 +1,69 @@
+package com.bios.app
+
+import com.bios.app.model.EventPayloadField
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the EventPayloadField entity shape so the composite-event sidecar
+ * doesn't drift. Field renames here are breaking changes — Bios's own
+ * pattern engines and (eventually) companion readers compile against this
+ * class via the Room-generated DAO and the BiosHealthProvider /payload
+ * cursor columns.
+ */
+class EventPayloadFieldTest {
+
+    @Test
+    fun `single-field payload exposes the typed value and nulls for the others`() {
+        val stringField = EventPayloadField(
+            readingId = "reading-1",
+            fieldKey = "modality",
+            stringValue = "CARDIO",
+        )
+        assertEquals("CARDIO", stringField.stringValue)
+        assertNull(stringField.doubleValue)
+        assertNull(stringField.longValue)
+
+        val doubleField = EventPayloadField(
+            readingId = "reading-1",
+            fieldKey = "avg_hr_bpm",
+            doubleValue = 138.0,
+        )
+        assertNull(doubleField.stringValue)
+        assertEquals(138.0, doubleField.doubleValue!!, 0.0)
+        assertNull(doubleField.longValue)
+
+        val longField = EventPayloadField(
+            readingId = "reading-1",
+            fieldKey = "end_utc",
+            longValue = 1_700_000_900_000L,
+        )
+        assertNull(longField.stringValue)
+        assertNull(longField.doubleValue)
+        assertEquals(1_700_000_900_000L, longField.longValue)
+    }
+
+    @Test
+    fun `optional fields default to null`() {
+        val field = EventPayloadField(readingId = "reading-1", fieldKey = "rpe")
+        assertNull(field.stringValue)
+        assertNull(field.doubleValue)
+        assertNull(field.longValue)
+    }
+
+    @Test
+    fun `composite key is (readingId, fieldKey)`() {
+        // The primary key shape is asserted by Room's compile-time check on
+        // the entity; this test exercises that two fields under the same
+        // reading can coexist as distinct data-class instances.
+        val a = EventPayloadField(readingId = "reading-1", fieldKey = "modality",
+            stringValue = "CARDIO")
+        val b = EventPayloadField(readingId = "reading-1", fieldKey = "avg_hr_bpm",
+            doubleValue = 138.0)
+        assertEquals("reading-1", a.readingId)
+        assertEquals("reading-1", b.readingId)
+        assertEquals("modality", a.fieldKey)
+        assertEquals("avg_hr_bpm", b.fieldKey)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/BiosHealthContract.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/BiosHealthContract.kt
@@ -15,6 +15,7 @@ package com.bios.contracts
  *   content://com.bios.app.health/baselines/{metricType}
  *   content://com.bios.app.health/status
  *   content://com.bios.app.health/status/{metricType}
+ *   content://com.bios.app.health/payload/{readingId}
  *
  * ### Writes (companion signals only)
  *   content://com.bios.app.health/companion/{metricType}
@@ -29,6 +30,7 @@ object BiosHealthContract {
     const val PATH_BASELINES = "baselines"
     const val PATH_STATUS = "status"
     const val PATH_COMPANION = "companion"
+    const val PATH_PAYLOAD = "payload"
 
     /** Reading-row column names returned by `/readings/{metricType}` queries. */
     val READING_COLUMNS = arrayOf(
@@ -45,6 +47,15 @@ object BiosHealthContract {
     /** Status-row column names returned by `/status[/...]` queries. */
     val STATUS_COLUMNS = arrayOf(
         "metric_type", "last_ingested_at", "reading_count_24h", "reading_count_total"
+    )
+
+    /**
+     * Payload-row column names returned by `/payload/{readingId}` queries.
+     * Exactly one of `string_value`, `double_value`, `long_value` is non-null
+     * per row. Field-key vocabulary lives in `docs/DATA_MODEL.md`.
+     */
+    val PAYLOAD_COLUMNS = arrayOf(
+        "reading_id", "field_key", "string_value", "double_value", "long_value"
     )
 
     /** ContentValues keys accepted on `/companion/{metricType}` inserts. */

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -98,6 +98,54 @@ ambient_noise               -- dB                            [planned — microp
 
 **Summary:** 17 of 34 metric types are implemented. The remaining 17 are defined for future adapter expansion.
 
+### EventPayloadField
+
+Sidecar to `MetricReading` for composite events that don't fit in a single
+scalar. Each row is one named field of a structured event attached to a
+parent reading. Scalar metrics never use this table — only multi-field
+composites do.
+
+```
+EventPayloadField {
+    reading_id:     UUID                -- FK to MetricReading.id; CASCADE on delete
+    field_key:      String              -- field name within the event (e.g. "modality")
+    string_value:   String?             -- exactly one of these three is non-null
+    double_value:   Float64?
+    long_value:     Int64?
+}
+                                        -- composite PK: (reading_id, field_key)
+```
+
+#### Field-key vocabulary
+
+Field keys are part of the public contract — companions and the pattern
+engine compile against them. Renames are breaking changes. New field keys
+land in this document alongside the metric type they describe; treat them
+with the same stability commitment as `MetricType.key` strings.
+
+| Metric type | Field key | Typed column | Notes |
+|---|---|---|---|
+| `EXERCISE_SESSION` *(planned, #38)* | `modality` | `string_value` | enum: `CARDIO`, `STRENGTH`, `INTERVAL`, `MOBILITY`, `OTHER` |
+| `EXERCISE_SESSION` *(planned, #38)* | `start_utc` | `long_value` | epoch ms |
+| `EXERCISE_SESSION` *(planned, #38)* | `end_utc` | `long_value` | epoch ms |
+| `EXERCISE_SESSION` *(planned, #38)* | `avg_hr_bpm` | `double_value` | nullable — not every source reports it |
+| `EXERCISE_SESSION` *(planned, #38)* | `rpe` | `long_value` | 1–10, nullable — only populated if the source captured it |
+
+#### When to use the payload table
+
+Use a payload row when **all** of:
+1. The metric needs more than one structured value per reading.
+2. Pattern-engine code or a companion reader needs to query individual
+   fields (`WHERE modality = 'CARDIO' AND avg_hr_bpm > 140`).
+3. Stuffing the data into `MetricReading.value` + a convention would
+   require ad-hoc parsing on every read.
+
+Do **not** use it for:
+- Owner-private notes — those go in `LoggedEvent.note`.
+- Vendor-specific raw blobs — those belong in the raw-payload field on
+  `MetricReading` (debug surface, never read by the engine).
+- Re-encoding the scalar that already fits in `value`.
+
 ### DataSource
 
 Tracks where a reading came from.


### PR DESCRIPTION
## Summary

- Adds a sidecar `EventPayloadField` table for composite events with structured per-field data (parent `MetricReading` + N field rows)
- Three typed nullable columns (`stringValue`, `doubleValue`, `longValue`) so SQL filters stay typed — readers can do `WHERE field_key = 'avg_hr_bpm' AND double_value > 140` without parsing
- New ContentProvider route `/payload/{readingId}` so companions and the pattern engine can read the structured part of a reading
- Field-key vocabulary documented in `DATA_MODEL.md` and treated with the same stability commitment as `MetricType.key` strings

Unblocks #38 (EXERCISE_SESSION needs `{modality, start, end, avg_hr, rpe}`) and clears the path for #33's full epigenetic-age report metadata.

Closes #89.

## Test plan

- [ ] CI green: lint + assembleDebug + unit tests (already passing locally via `code-quality-check.sh`)
- [ ] Manual: install Bios on a device, confirm Room migration 8→9 succeeds (no data loss; existing scalar metrics unaffected)
- [ ] Manual: with a debug build, insert a composite reading + payload fields, query `content://com.bios.app.health/payload/{readingId}`, verify cursor shape matches `PAYLOAD_COLUMNS`
- [ ] Follow-up issue (#38): wire the first real consumer (`EXERCISE_SESSION` from `HealthConnectAdapter`) — that's where the round-trip really gets exercised in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)