### PR TITLE
feat: epigenetic age clock keys (DunedinPACE, GrimAge, PhenoAge, Horvath) — #33 PR 1

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -283,6 +283,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.CATEGORY -> "{category}"
     MetricUnit.EVENT -> "{event}"
     MetricUnit.LUX -> "lx"
+    MetricUnit.YEARS -> "a"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -38,6 +38,11 @@ class BiomarkerEntrySelectorsTest {
             MetricType.TSH, MetricType.FREE_T4, MetricType.FREE_T3,
             MetricType.HEMOGLOBIN, MetricType.HEMATOCRIT,
             MetricType.WBC, MetricType.RBC, MetricType.PLATELETS,
+            // Epigenetic age clocks (slow-rolling, lab-imported).
+            MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
+            MetricType.EPIGENETIC_AGE_GRIM,
+            MetricType.EPIGENETIC_AGE_PHENO,
+            MetricType.EPIGENETIC_AGE_HORVATH,
         )
         val actual = MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }.toSet()
         assertEquals(expected, actual)

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -343,6 +343,7 @@ class FhirExporterTest {
             MetricUnit.CATEGORY -> "{category}"
             MetricUnit.EVENT -> "{event}"
             MetricUnit.LUX -> "lx"
+            MetricUnit.YEARS -> "a"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
@@ -15,8 +15,14 @@ class FhirImporterTest {
 
     @Test
     fun `reverse LOINC table is the inverse of FhirExporter loincCode for every biomarker`() {
-        val biomarkers = MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }
-        // Every shipped biomarker has a LOINC mapping on the export side.
+        // Epigenetic-age clocks (TruDiagnostic / similar) lack widely-adopted
+        // standardized LOINC codes, so their FHIR mapping is intentionally
+        // deferred. Filter them out of this round-trip check — for every
+        // biomarker that *does* have a LOINC mapping, the reverse table must
+        // be its inverse.
+        val biomarkers = MetricType.entries
+            .filter { it.domain == MetricDomain.BIOMARKER }
+            .filter { com.bios.app.export.loincCode(it) != null }
         for (type in biomarkers) {
             val pair = com.bios.app.export.loincCode(type)
             assertNotNull("${type.key} should have a LOINC mapping", pair)

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -86,6 +86,15 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER),
     PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
 
+    // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
+    // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
+    // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age
+    // score" from these (manifesto: never evaluate the person).
+    EPIGENETIC_AGE_DUNEDIN_PACE("epigenetic_age_dunedin_pace", MetricUnit.SCORE, MetricDomain.BIOMARKER),
+    EPIGENETIC_AGE_GRIM("epigenetic_age_grim", MetricUnit.YEARS, MetricDomain.BIOMARKER),
+    EPIGENETIC_AGE_PHENO("epigenetic_age_pheno", MetricUnit.YEARS, MetricDomain.BIOMARKER),
+    EPIGENETIC_AGE_HORVATH("epigenetic_age_horvath", MetricUnit.YEARS, MetricDomain.BIOMARKER),
+
     // Companion signals (injected by W2F via ContentProvider).
     // typing_cadence requires the AccessibilityService capture surface;
     // mood_drift_score is a domain-specific ADA-1/HDA-1 composite. Both
@@ -145,7 +154,8 @@ enum class MetricUnit(val symbol: String) {
     TERA_PER_L("10¹²/L"),
     SCORE(""),
     EVENT(""),
-    LUX("lx")
+    LUX("lx"),
+    YEARS("yr")
 }
 
 enum class MetricDomain {

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -183,6 +183,27 @@ class MetricTypeTest {
     }
 
     @Test
+    fun epigenetic_age_clocks_are_biomarkers() {
+        // GrimAge, PhenoAge, Horvath report biological age in years.
+        for (t in setOf(
+            MetricType.EPIGENETIC_AGE_GRIM,
+            MetricType.EPIGENETIC_AGE_PHENO,
+            MetricType.EPIGENETIC_AGE_HORVATH,
+        )) {
+            assertEquals(MetricDomain.BIOMARKER, t.domain)
+            assertEquals(MetricUnit.YEARS, t.unit)
+        }
+        // DunedinPACE is years-of-aging-per-year, a dimensionless ratio.
+        assertEquals(MetricDomain.BIOMARKER, MetricType.EPIGENETIC_AGE_DUNEDIN_PACE.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.EPIGENETIC_AGE_DUNEDIN_PACE.unit)
+    }
+
+    @Test
+    fun years_unit_symbol_is_yr() {
+        assertEquals("yr", MetricUnit.YEARS.symbol)
+    }
+
+    @Test
     fun health_contract_authority_is_stable() {
         assertEquals("com.bios.app.health", BiosHealthContract.AUTHORITY)
     }

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -94,7 +94,21 @@ cycle_phase                 -- enum: menstrual | follicular | ovulatory | luteal
 // Environment
 ambient_light               -- lux                           [planned — phone sensor]
 ambient_noise               -- dB                            [planned — microphone adapter]
+
+// Epigenetic age clocks (slow-rolling, user-imported from labs like TruDiagnostic)
+epigenetic_age_dunedin_pace -- ratio (1.0 = aging at normal rate)  [implemented — manual entry]
+epigenetic_age_grim         -- years (biological age)              [implemented — manual entry]
+epigenetic_age_pheno        -- years (biological age)              [implemented — manual entry]
+epigenetic_age_horvath      -- years (biological age)              [implemented — manual entry]
 ```
+
+#### Epigenetic age clocks — manifesto guard
+
+The four clocks above are imported as standalone biomarkers and displayed
+alongside HBA1C / ApoB / etc. in the lab-value surface. Bios **does not**
+compose them into a derived "Bios biological age" or "pace of aging" score
+— evaluating the person is explicitly out of scope. Owners see each clock's
+reading on its own; interpretation is the lab's job, not Bios's.
 
 **Summary:** 17 of 34 metric types are implemented. The remaining 17 are defined for future adapter expansion.
 


### PR DESCRIPTION
## Summary

PR 1 of 2 for [#33](https://github.com/thdelmas/Bios/issues/33). Adds four user-importable epigenetic-age clock keys as biomarkers, plus a new `YEARS` unit. The biomarker entry screen auto-discovers the new keys via its existing BIOMARKER-domain filter — **zero UI code** needed.

- `EPIGENETIC_AGE_DUNEDIN_PACE` — SCORE (dimensionless ratio, 1.0 = aging at normal rate)
- `EPIGENETIC_AGE_GRIM` — YEARS
- `EPIGENETIC_AGE_PHENO` — YEARS
- `EPIGENETIC_AGE_HORVATH` — YEARS

Readings are tagged `SELF_REPORTED` so they appear in trends + FHIR export but are skipped by baselines/anomaly detection (lab values are diagnostic, not streaming — per `SELF_REPORTED_DATA_HOME.md` decision 3).

**Manifesto guard:** Bios does not compose these into a derived "biological age" or "pace of aging" score. Owners see each clock's reading on its own; interpretation is the lab's job. Documented in `DATA_MODEL.md`.

## What's deferred to PR 2

- Report-metadata payload fields (lab date, clock version, sample method) — depends on [PR #93 (composite event payloads)](https://github.com/thdelmas/Bios/pull/93) merging first.
- Organ-age clocks (heart, liver, kidney, brain, immune) — they're newer, narrower coverage; reserved for PR 2.
- LOINC mappings — TruDiagnostic uses vendor-specific codes; standardized LOINC for these clocks isn't widely adopted yet. `FhirImporterTest` was updated to filter the round-trip assertion to biomarkers that *have* a LOINC mapping (the clocks intentionally don't).

## Test plan

- [x] CI green: lint + assembleDebug + unit tests (passes locally via `code-quality-check.sh`)
- [x] `MetricTypeTest.epigenetic_age_clocks_are_biomarkers` pins the 4 new keys' domain + unit
- [x] `MetricTypeTest.years_unit_symbol_is_yr` pins the new unit
- [x] `BiomarkerEntrySelectorsTest.biomarker_domain_filter_includes_every_shipped_biomarker_key` updated — the picker now includes all 4 clocks
- [ ] Manual: install build, open "Add lab value", confirm 4 new clocks appear in the dropdown, save a DunedinPACE = 1.05 and a GrimAge = 47.3, verify both appear in "Recent entries" with correct units

Part of #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)