### PR TITLE
feat: ingest exercise sessions from Health Connect (#38 PR 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -7,6 +7,10 @@ import androidx.health.connect.client.records.*
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseModality
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ExerciseSessionFields
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import com.bios.app.model.SleepStage
@@ -316,5 +320,106 @@ class HealthConnectAdapter(private val context: Context) {
                 confidence = ConfidenceTier.MEDIUM.level
             )
         }
+    }
+
+    // MARK: - Composite event: exercise sessions
+
+    /**
+     * Reads `ExerciseSessionRecord`s in the window and returns each one as
+     * a composite [ExerciseSession] — a parent EXERCISE_SESSION MetricReading
+     * plus its EventPayloadField rows. Returned separately from
+     * [fetchReadings] because the result type is structurally different
+     * (parent + payload, not a flat reading list) and the dedupe/quality
+     * pipeline doesn't yet know how to keep payload rows in sync with a
+     * deduped parent.
+     *
+     * `avg_hr_bpm` is left null today — enriching from HeartRateRecord in
+     * the same window is a follow-up. RPE isn't in Health Connect's record
+     * shape, so it stays null here.
+     */
+    suspend fun fetchExerciseSessions(
+        start: Instant, end: Instant, sourceId: String
+    ): List<ExerciseSession> {
+        val response = client.readRecords(
+            ReadRecordsRequest(
+                ExerciseSessionRecord::class,
+                timeRangeFilter = TimeRangeFilter.between(start, end)
+            )
+        )
+        return response.records.map { record ->
+            val startMs = record.startTime.toEpochMilli()
+            val endMs = record.endTime.toEpochMilli()
+            val durationSec = java.time.Duration.between(
+                record.startTime, record.endTime
+            ).seconds.toInt()
+
+            val reading = MetricReading(
+                id = UUID.randomUUID().toString(),
+                metricType = MetricType.EXERCISE_SESSION.key,
+                value = 1.0,
+                timestamp = startMs,
+                durationSec = durationSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level
+            )
+
+            val payload = listOf(
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.MODALITY,
+                    stringValue = mapExerciseTypeToModality(record.exerciseType),
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.START_UTC,
+                    longValue = startMs,
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.END_UTC,
+                    longValue = endMs,
+                ),
+            )
+
+            ExerciseSession(reading = reading, payload = payload)
+        }
+    }
+
+    companion object {
+        /**
+         * Maps a Health Connect `ExerciseSessionRecord.exerciseType` int to
+         * Bios's coarse modality bucket. Unknown / unmapped types fall to
+         * OTHER — that's the right default for the pattern engine, which
+         * cares about aerobic-vs-anaerobic-vs-mixed load buckets rather
+         * than HC's full sport taxonomy.
+         */
+        internal fun mapExerciseTypeToModality(exerciseType: Int): String =
+            when (exerciseType) {
+                ExerciseSessionRecord.EXERCISE_TYPE_RUNNING,
+                ExerciseSessionRecord.EXERCISE_TYPE_RUNNING_TREADMILL,
+                ExerciseSessionRecord.EXERCISE_TYPE_WALKING,
+                ExerciseSessionRecord.EXERCISE_TYPE_HIKING,
+                ExerciseSessionRecord.EXERCISE_TYPE_BIKING,
+                ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY,
+                ExerciseSessionRecord.EXERCISE_TYPE_ELLIPTICAL,
+                ExerciseSessionRecord.EXERCISE_TYPE_ROWING,
+                ExerciseSessionRecord.EXERCISE_TYPE_ROWING_MACHINE,
+                ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_POOL,
+                ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_OPEN_WATER,
+                ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING,
+                ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING_MACHINE -> ExerciseModality.CARDIO
+
+                ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+                ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING,
+                ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS -> ExerciseModality.STRENGTH
+
+                ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING -> ExerciseModality.INTERVAL
+
+                ExerciseSessionRecord.EXERCISE_TYPE_YOGA,
+                ExerciseSessionRecord.EXERCISE_TYPE_PILATES,
+                ExerciseSessionRecord.EXERCISE_TYPE_STRETCHING -> ExerciseModality.MOBILITY
+
+                else -> ExerciseModality.OTHER
+            }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -7,6 +7,7 @@ import com.bios.app.engine.SignalQualityFilter
 import com.bios.app.engine.SleepDerivations
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
+import com.bios.app.model.ExerciseSession
 import com.bios.app.model.MetricReading
 import com.bios.app.model.SensorType
 import com.bios.app.model.SourceType
@@ -43,6 +44,7 @@ class IngestManager(
 ) {
     private val readingDao = db.metricReadingDao()
     private val sourceDao = db.dataSourceDao()
+    private val payloadDao = db.eventPayloadFieldDao()
 
     private val _lastSyncTime = MutableStateFlow<Long?>(null)
     val lastSyncTime: StateFlow<Long?> = _lastSyncTime
@@ -176,6 +178,16 @@ class IngestManager(
                 val derived = deriveAll(quality)
                 readingDao.insertAll(quality + derived)
                 updateLastReadings(quality)
+
+                // Composite events (EXERCISE_SESSION) take a parallel path —
+                // the scalar dedupe/quality filter can't keep payload rows in
+                // sync with a deduped parent today, so sessions skip it and
+                // land directly. Multi-adapter dedupe lands when a second
+                // session-emitting adapter exists.
+                healthConnectSourceId?.let { id ->
+                    val sessions = healthConnect.fetchExerciseSessions(start, end, id)
+                    persistSessions(sessions)
+                }
             }
 
             if (latencyTracker != null) {
@@ -225,6 +237,12 @@ class IngestManager(
                 val derived = deriveAll(quality)
                 readingDao.insertAll(quality + derived)
                 updateLastReadings(quality)
+
+                healthConnectSourceId?.let { id ->
+                    val sessions = healthConnect.fetchExerciseSessions(current, chunkEnd, id)
+                    persistSessions(sessions)
+                }
+
                 current = chunkEnd
                 completedDays++
                 _syncProgress.value = completedDays / totalDays
@@ -275,6 +293,19 @@ class IngestManager(
         }
 
         return seen.values.sortedBy { it.timestamp }
+    }
+
+    /**
+     * Writes composite EXERCISE_SESSION readings + their payload rows.
+     * Insert order matters — the parent reading must exist before its
+     * EventPayloadField rows reference it via FK. Skipped silently if the
+     * source list is empty (the common case when no HC sessions exist
+     * in the window).
+     */
+    private suspend fun persistSessions(sessions: List<ExerciseSession>) {
+        if (sessions.isEmpty()) return
+        readingDao.insertAll(sessions.map { it.reading })
+        payloadDao.insertAll(sessions.flatMap { it.payload })
     }
 
     // MARK: - Helpers

--- a/android/app/src/main/java/com/bios/app/model/ExerciseSession.kt
+++ b/android/app/src/main/java/com/bios/app/model/ExerciseSession.kt
@@ -1,0 +1,44 @@
+package com.bios.app.model
+
+// Composite EXERCISE_SESSION reading bundled with its event-payload fields.
+// Adapters return these from a session-specific fetch path; IngestManager
+// writes the parent row to metric_readings and the payload rows to
+// event_payloads in one logical insert.
+//
+// The reading itself is the canonical parent — the payload follows it by
+// foreign key (CASCADE on delete). Pattern-engine code reads the parent
+// for time/duration and joins on event_payloads.reading_id when it needs
+// modality, avg-HR, or RPE.
+data class ExerciseSession(
+    val reading: MetricReading,
+    val payload: List<EventPayloadField>,
+)
+
+// Modality enum carried in event_payloads.field_key="modality".string_value.
+// Stable string constants — adapters and the pattern engine compile against
+// these; renames break field-key contracts (docs/DATA_MODEL.md).
+//
+// Coarse on purpose. A single CARDIO bucket lumps running, biking, swimming
+// because the cross-system patterns Bios cares about (overtraining,
+// deconditioning) hinge on aerobic-vs-anaerobic-vs-mixed load, not on
+// modality flavor. Fine-grained classification (which sport, indoor vs
+// outdoor) stays in the source's own record and is not promoted to a
+// canonical field.
+object ExerciseModality {
+    const val CARDIO = "CARDIO"
+    const val STRENGTH = "STRENGTH"
+    const val INTERVAL = "INTERVAL"
+    const val MOBILITY = "MOBILITY"
+    const val OTHER = "OTHER"
+}
+
+// Field keys for the EXERCISE_SESSION payload. Centralized so adapters and
+// readers can't drift on spelling. New keys belong in docs/DATA_MODEL.md
+// alongside the metric they describe.
+object ExerciseSessionFields {
+    const val MODALITY = "modality"
+    const val START_UTC = "start_utc"
+    const val END_UTC = "end_utc"
+    const val AVG_HR_BPM = "avg_hr_bpm"
+    const val RPE = "rpe"
+}

--- a/android/app/src/test/java/com/bios/app/ExerciseSessionTest.kt
+++ b/android/app/src/test/java/com/bios/app/ExerciseSessionTest.kt
@@ -1,0 +1,85 @@
+package com.bios.app
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseModality
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ExerciseSessionFields
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the EXERCISE_SESSION composite shape — parent MetricReading plus
+ * a payload list keyed by field. Adapters wire to these names; renames
+ * are breaking changes.
+ */
+class ExerciseSessionTest {
+
+    @Test
+    fun modality_constants_are_the_documented_buckets() {
+        // The stable string values documented in docs/DATA_MODEL.md.
+        // Pattern engine and downstream readers compile against these.
+        assertEquals("CARDIO", ExerciseModality.CARDIO)
+        assertEquals("STRENGTH", ExerciseModality.STRENGTH)
+        assertEquals("INTERVAL", ExerciseModality.INTERVAL)
+        assertEquals("MOBILITY", ExerciseModality.MOBILITY)
+        assertEquals("OTHER", ExerciseModality.OTHER)
+    }
+
+    @Test
+    fun field_keys_match_data_model_vocabulary() {
+        assertEquals("modality", ExerciseSessionFields.MODALITY)
+        assertEquals("start_utc", ExerciseSessionFields.START_UTC)
+        assertEquals("end_utc", ExerciseSessionFields.END_UTC)
+        assertEquals("avg_hr_bpm", ExerciseSessionFields.AVG_HR_BPM)
+        assertEquals("rpe", ExerciseSessionFields.RPE)
+    }
+
+    @Test
+    fun a_session_carries_the_parent_reading_and_payload_together() {
+        val reading = MetricReading(
+            metricType = MetricType.EXERCISE_SESSION.key,
+            value = 1.0,
+            timestamp = 1_700_000_000_000L,
+            durationSec = 1800,
+            sourceId = "src-1",
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+        val payload = listOf(
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = ExerciseSessionFields.MODALITY,
+                stringValue = ExerciseModality.CARDIO,
+            ),
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = ExerciseSessionFields.START_UTC,
+                longValue = 1_700_000_000_000L,
+            ),
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = ExerciseSessionFields.END_UTC,
+                longValue = 1_700_000_000_000L + 1_800_000L,
+            ),
+        )
+        val session = ExerciseSession(reading = reading, payload = payload)
+
+        assertEquals(MetricType.EXERCISE_SESSION.key, session.reading.metricType)
+        assertEquals(1.0, session.reading.value, 0.0)
+        assertEquals(1800, session.reading.durationSec)
+        assertEquals(3, session.payload.size)
+
+        val modalityField = session.payload.first { it.fieldKey == ExerciseSessionFields.MODALITY }
+        assertEquals(ExerciseModality.CARDIO, modalityField.stringValue)
+        assertNull(modalityField.doubleValue)
+        assertNull(modalityField.longValue)
+
+        val startField = session.payload.first { it.fieldKey == ExerciseSessionFields.START_UTC }
+        assertNotNull(startField.longValue)
+        assertNull(startField.stringValue)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/HealthConnectExerciseModalityTest.kt
+++ b/android/app/src/test/java/com/bios/app/HealthConnectExerciseModalityTest.kt
@@ -1,0 +1,105 @@
+package com.bios.app
+
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import com.bios.app.ingest.HealthConnectAdapter
+import com.bios.app.model.ExerciseModality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the Health Connect → ExerciseModality mapping. The bucketing is
+ * coarse on purpose (CARDIO / STRENGTH / INTERVAL / MOBILITY / OTHER) so
+ * the pattern engine can reason about aerobic-vs-anaerobic-vs-mixed load
+ * without depending on HC's full sport taxonomy.
+ *
+ * If HC adds a new exercise type that should map to a non-OTHER bucket,
+ * the test for that bucket goes here. Anything not explicitly mapped
+ * lands in OTHER — that's the correct default (the engine still sees a
+ * session, just without a coarse modality cue).
+ */
+class HealthConnectExerciseModalityTest {
+
+    @Test
+    fun cardio_bucket_covers_endurance_modalities() {
+        val cardio = listOf(
+            ExerciseSessionRecord.EXERCISE_TYPE_RUNNING,
+            ExerciseSessionRecord.EXERCISE_TYPE_RUNNING_TREADMILL,
+            ExerciseSessionRecord.EXERCISE_TYPE_WALKING,
+            ExerciseSessionRecord.EXERCISE_TYPE_HIKING,
+            ExerciseSessionRecord.EXERCISE_TYPE_BIKING,
+            ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY,
+            ExerciseSessionRecord.EXERCISE_TYPE_ELLIPTICAL,
+            ExerciseSessionRecord.EXERCISE_TYPE_ROWING,
+            ExerciseSessionRecord.EXERCISE_TYPE_ROWING_MACHINE,
+            ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_POOL,
+            ExerciseSessionRecord.EXERCISE_TYPE_SWIMMING_OPEN_WATER,
+            ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING,
+            ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING_MACHINE,
+        )
+        for (t in cardio) {
+            assertEquals(
+                "Exercise type $t should map to CARDIO",
+                ExerciseModality.CARDIO,
+                HealthConnectAdapter.mapExerciseTypeToModality(t)
+            )
+        }
+    }
+
+    @Test
+    fun strength_bucket_covers_resistance_modalities() {
+        val strength = listOf(
+            ExerciseSessionRecord.EXERCISE_TYPE_STRENGTH_TRAINING,
+            ExerciseSessionRecord.EXERCISE_TYPE_WEIGHTLIFTING,
+            ExerciseSessionRecord.EXERCISE_TYPE_CALISTHENICS,
+        )
+        for (t in strength) {
+            assertEquals(
+                "Exercise type $t should map to STRENGTH",
+                ExerciseModality.STRENGTH,
+                HealthConnectAdapter.mapExerciseTypeToModality(t)
+            )
+        }
+    }
+
+    @Test
+    fun interval_bucket_covers_hiit() {
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            HealthConnectAdapter.mapExerciseTypeToModality(
+                ExerciseSessionRecord.EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING
+            )
+        )
+    }
+
+    @Test
+    fun mobility_bucket_covers_low_intensity_modalities() {
+        val mobility = listOf(
+            ExerciseSessionRecord.EXERCISE_TYPE_YOGA,
+            ExerciseSessionRecord.EXERCISE_TYPE_PILATES,
+            ExerciseSessionRecord.EXERCISE_TYPE_STRETCHING,
+        )
+        for (t in mobility) {
+            assertEquals(
+                "Exercise type $t should map to MOBILITY",
+                ExerciseModality.MOBILITY,
+                HealthConnectAdapter.mapExerciseTypeToModality(t)
+            )
+        }
+    }
+
+    @Test
+    fun unknown_or_unmapped_exercise_types_fall_to_other() {
+        // EXERCISE_TYPE_OTHER_WORKOUT is the explicit HC catch-all;
+        // 0 is a sentinel that shouldn't show up in real records.
+        assertEquals(
+            ExerciseModality.OTHER,
+            HealthConnectAdapter.mapExerciseTypeToModality(
+                ExerciseSessionRecord.EXERCISE_TYPE_OTHER_WORKOUT
+            )
+        )
+        assertEquals(
+            ExerciseModality.OTHER,
+            HealthConnectAdapter.mapExerciseTypeToModality(0)
+        )
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -47,6 +47,11 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     STEPS("steps", MetricUnit.COUNT, MetricDomain.ACTIVITY),
     ACTIVE_CALORIES("active_calories", MetricUnit.KCAL, MetricDomain.ACTIVITY),
     ACTIVE_MINUTES("active_minutes", MetricUnit.SECONDS, MetricDomain.ACTIVITY),
+    // Composite event: discrete workout/session. value = 1.0 marker,
+    // durationSec = session length. Structured fields (modality, start/end
+    // utc, avg_hr_bpm, rpe) live in event_payloads keyed by reading id —
+    // see docs/DATA_MODEL.md field-key vocabulary.
+    EXERCISE_SESSION("exercise_session", MetricUnit.EVENT, MetricDomain.ACTIVITY),
 
     // Metabolic
     BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -204,6 +204,16 @@ class MetricTypeTest {
     }
 
     @Test
+    fun exercise_session_is_activity_event() {
+        // Composite event: parent row is a MetricReading, structured fields
+        // (modality, start/end utc, avg HR, RPE) live in event_payloads.
+        // ACTIVITY domain alongside steps/active_calories/active_minutes;
+        // EVENT unit matches the marker semantics (value = 1.0).
+        assertEquals(MetricDomain.ACTIVITY, MetricType.EXERCISE_SESSION.domain)
+        assertEquals(MetricUnit.EVENT, MetricType.EXERCISE_SESSION.unit)
+    }
+
+    @Test
     fun health_contract_authority_is_stable() {
         assertEquals("com.bios.app.health", BiosHealthContract.AUTHORITY)
     }

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -66,6 +66,7 @@ sleep_score                 -- 0-100 (vendor-normalized)     [planned — vendor
 steps                       -- count                         [implemented]
 active_calories             -- kcal                          [implemented]
 active_minutes              -- minutes                       [implemented]
+exercise_session            -- event (composite, payload below) [implemented — Health Connect]
 distance                    -- meters                        [planned — GPS-capable adapters]
 vo2_max                     -- mL/kg/min                     [planned — exercise-mode adapters]
 
@@ -139,11 +140,11 @@ with the same stability commitment as `MetricType.key` strings.
 
 | Metric type | Field key | Typed column | Notes |
 |---|---|---|---|
-| `EXERCISE_SESSION` *(planned, #38)* | `modality` | `string_value` | enum: `CARDIO`, `STRENGTH`, `INTERVAL`, `MOBILITY`, `OTHER` |
-| `EXERCISE_SESSION` *(planned, #38)* | `start_utc` | `long_value` | epoch ms |
-| `EXERCISE_SESSION` *(planned, #38)* | `end_utc` | `long_value` | epoch ms |
-| `EXERCISE_SESSION` *(planned, #38)* | `avg_hr_bpm` | `double_value` | nullable — not every source reports it |
-| `EXERCISE_SESSION` *(planned, #38)* | `rpe` | `long_value` | 1–10, nullable — only populated if the source captured it |
+| `EXERCISE_SESSION` | `modality` | `string_value` | enum: `CARDIO`, `STRENGTH`, `INTERVAL`, `MOBILITY`, `OTHER` |
+| `EXERCISE_SESSION` | `start_utc` | `long_value` | epoch ms |
+| `EXERCISE_SESSION` | `end_utc` | `long_value` | epoch ms |
+| `EXERCISE_SESSION` | `avg_hr_bpm` | `double_value` | nullable — not every source reports it |
+| `EXERCISE_SESSION` | `rpe` | `long_value` | 1–10, nullable — only populated if the source captured it |
 
 #### When to use the payload table
 


### PR DESCRIPTION
## Summary

PR 1 of [#38](https://github.com/thdelmas/Bios/issues/38). First consumer of the composite-event-payload schema ([#89](https://github.com/thdelmas/Bios/issues/89) / [#93](https://github.com/thdelmas/Bios/pull/93)): emits `EXERCISE_SESSION` events with structured payload from Health Connect's `ExerciseSessionRecord`.

- `EXERCISE_SESSION` lands in `MetricType` (`ACTIVITY` domain, `EVENT` unit).
- New `ExerciseSession` data class + `ExerciseModality` constants (`CARDIO` / `STRENGTH` / `INTERVAL` / `MOBILITY` / `OTHER`) + `ExerciseSessionFields` field-key constants — all stable contract.
- `HealthConnectAdapter.fetchExerciseSessions()` — reads HC `ExerciseSessionRecord`, maps `exerciseType` → modality, emits parent reading + 3 payload fields (modality, start_utc, end_utc).
- `IngestManager.persistSessions()` — writes parent then payload; called from both `syncRecentData` and `syncHistoricalData`.

## Design notes

- **Sessions skip the scalar dedupe/quality pipeline** for now. The pipeline doesn't yet know how to keep payload rows in sync with a deduped parent. Multi-adapter dedupe lands when a second emitter (Garmin/WHOOP/Oura) exists.
- **`avg_hr_bpm` left null** — enriching from `HeartRateRecord` in the session window is a follow-up.
- **RPE stays null** — Health Connect doesn't capture it.
- **Modality buckets are coarse on purpose.** The pattern engine cares about aerobic-vs-anaerobic-vs-mixed load, not HC's full sport taxonomy.

## Deferred to later PRs of #38

- Garmin, WHOOP, Oura session emitters
- Cross-adapter session dedupe
- Pattern-engine session-level overtraining / deconditioning detection
- HR enrichment

## Test plan

- [x] CI green: lint + both flavor builds + unit tests (passes locally via `code-quality-check.sh`)
- [x] `MetricTypeTest.exercise_session_is_activity_event` pins domain/unit
- [x] `HealthConnectExerciseModalityTest` pins every documented modality bucket + the OTHER fallback
- [x] `ExerciseSessionTest` pins the field-key vocabulary and composite shape
- [ ] Manual: install build on a device with HC sessions logged (Strava/Fit), run a sync, query `metric_readings` for `metric_type='exercise_session'`, verify parent rows exist with matching `event_payloads` (3 rows per session: modality, start_utc, end_utc)
- [ ] Manual: re-run sync, confirm no duplicate parent rows for the same session

Part of #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)