### PR TITLE
feat: enrich HC exercise sessions with avg_hr_bpm (#38 PR 2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -333,20 +333,28 @@ class HealthConnectAdapter(private val context: Context) {
      * pipeline doesn't yet know how to keep payload rows in sync with a
      * deduped parent.
      *
-     * `avg_hr_bpm` is left null today — enriching from HeartRateRecord in
-     * the same window is a follow-up. RPE isn't in Health Connect's record
-     * shape, so it stays null here.
+     * Enriches each session with `avg_hr_bpm` when HeartRateRecord samples
+     * overlap the session window. Fetches HR samples once for the whole
+     * outer window and intersects per-session — sessions are sparse but
+     * HR samples can be dense, so a single IPC beats N+1 queries.
+     *
+     * RPE isn't in Health Connect's record shape, so it stays null here.
      */
     suspend fun fetchExerciseSessions(
         start: Instant, end: Instant, sourceId: String
     ): List<ExerciseSession> {
-        val response = client.readRecords(
+        val sessionResponse = client.readRecords(
             ReadRecordsRequest(
                 ExerciseSessionRecord::class,
                 timeRangeFilter = TimeRangeFilter.between(start, end)
             )
         )
-        return response.records.map { record ->
+        if (sessionResponse.records.isEmpty()) return emptyList()
+
+        // One HR fetch for the whole window; per-session filtering is local.
+        val hrSamples = fetchHeartRateSamples(start, end)
+
+        return sessionResponse.records.map { record ->
             val startMs = record.startTime.toEpochMilli()
             val endMs = record.endTime.toEpochMilli()
             val durationSec = java.time.Duration.between(
@@ -363,7 +371,7 @@ class HealthConnectAdapter(private val context: Context) {
                 confidence = ConfidenceTier.MEDIUM.level
             )
 
-            val payload = listOf(
+            val payload = mutableListOf(
                 EventPayloadField(
                     readingId = reading.id,
                     fieldKey = ExerciseSessionFields.MODALITY,
@@ -381,9 +389,45 @@ class HealthConnectAdapter(private val context: Context) {
                 ),
             )
 
+            meanHrInWindow(hrSamples, startMs, endMs)?.let { avgHr ->
+                payload += EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.AVG_HR_BPM,
+                    doubleValue = avgHr,
+                )
+            }
+
             ExerciseSession(reading = reading, payload = payload)
         }
     }
+
+    /**
+     * Flattens HeartRateRecord -> (timestamp ms, bpm) samples for the window.
+     * Used as the input to per-session mean-HR computation. Kept private —
+     * the canonical streaming HR ingestion is [fetchHeartRate], which writes
+     * MetricReading rows; this is a denormalized read for session enrichment.
+     */
+    private suspend fun fetchHeartRateSamples(
+        start: Instant, end: Instant
+    ): List<HrSample> {
+        val response = client.readRecords(
+            ReadRecordsRequest(
+                HeartRateRecord::class,
+                timeRangeFilter = TimeRangeFilter.between(start, end)
+            )
+        )
+        return response.records.flatMap { record ->
+            record.samples.map { sample ->
+                HrSample(
+                    timestampMs = sample.time.toEpochMilli(),
+                    bpm = sample.beatsPerMinute.toDouble(),
+                )
+            }
+        }
+    }
+
+    /** Internal time-stamped HR sample for session enrichment. */
+    internal data class HrSample(val timestampMs: Long, val bpm: Double)
 
     companion object {
         /**
@@ -421,5 +465,19 @@ class HealthConnectAdapter(private val context: Context) {
 
                 else -> ExerciseModality.OTHER
             }
+
+        /**
+         * Mean BPM across HR samples that fall in `[startMs, endMs]`,
+         * inclusive at both ends. Returns null when no samples land in
+         * the window — caller should omit the `avg_hr_bpm` payload field
+         * rather than write a misleading zero.
+         */
+        internal fun meanHrInWindow(
+            samples: List<HrSample>, startMs: Long, endMs: Long
+        ): Double? {
+            val inWindow = samples.filter { it.timestampMs in startMs..endMs }
+            if (inWindow.isEmpty()) return null
+            return inWindow.sumOf { it.bpm } / inWindow.size
+        }
     }
 }

--- a/android/app/src/test/java/com/bios/app/HealthConnectMeanHrInWindowTest.kt
+++ b/android/app/src/test/java/com/bios/app/HealthConnectMeanHrInWindowTest.kt
@@ -1,0 +1,63 @@
+package com.bios.app
+
+import com.bios.app.ingest.HealthConnectAdapter
+import com.bios.app.ingest.HealthConnectAdapter.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the mean-HR-in-window helper used to enrich EXERCISE_SESSION
+ * payloads with `avg_hr_bpm`. The helper has to be a pure function so
+ * the per-session intersection is unit-testable without Health Connect.
+ *
+ * Returning null vs. zero is load-bearing — null means "we couldn't
+ * measure this session", zero means "you had no heartbeat", and the
+ * pattern engine reads the difference.
+ */
+class HealthConnectMeanHrInWindowTest {
+
+    @Test
+    fun returns_null_when_no_samples_fall_in_window() {
+        val samples = listOf(
+            HrSample(timestampMs = 1_000L, bpm = 70.0),
+            HrSample(timestampMs = 2_000L, bpm = 72.0),
+        )
+        assertNull(HealthConnectAdapter.meanHrInWindow(samples, 5_000L, 6_000L))
+    }
+
+    @Test
+    fun returns_null_when_input_is_empty() {
+        assertNull(HealthConnectAdapter.meanHrInWindow(emptyList(), 0L, 1_000L))
+    }
+
+    @Test
+    fun computes_arithmetic_mean_for_samples_in_window() {
+        val samples = listOf(
+            HrSample(timestampMs = 100L, bpm = 120.0),
+            HrSample(timestampMs = 200L, bpm = 140.0),
+            HrSample(timestampMs = 300L, bpm = 160.0),
+        )
+        assertEquals(140.0, HealthConnectAdapter.meanHrInWindow(samples, 0L, 1000L)!!, 0.0001)
+    }
+
+    @Test
+    fun ignores_samples_outside_window() {
+        val samples = listOf(
+            HrSample(timestampMs = 50L, bpm = 60.0),    // before
+            HrSample(timestampMs = 150L, bpm = 100.0),  // in
+            HrSample(timestampMs = 250L, bpm = 140.0),  // in
+            HrSample(timestampMs = 350L, bpm = 180.0),  // after
+        )
+        assertEquals(120.0, HealthConnectAdapter.meanHrInWindow(samples, 100L, 300L)!!, 0.0001)
+    }
+
+    @Test
+    fun window_endpoints_are_inclusive() {
+        val samples = listOf(
+            HrSample(timestampMs = 100L, bpm = 100.0),
+            HrSample(timestampMs = 200L, bpm = 200.0),
+        )
+        assertEquals(150.0, HealthConnectAdapter.meanHrInWindow(samples, 100L, 200L)!!, 0.0001)
+    }
+}

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -143,7 +143,7 @@ with the same stability commitment as `MetricType.key` strings.
 | `EXERCISE_SESSION` | `modality` | `string_value` | enum: `CARDIO`, `STRENGTH`, `INTERVAL`, `MOBILITY`, `OTHER` |
 | `EXERCISE_SESSION` | `start_utc` | `long_value` | epoch ms |
 | `EXERCISE_SESSION` | `end_utc` | `long_value` | epoch ms |
-| `EXERCISE_SESSION` | `avg_hr_bpm` | `double_value` | nullable — not every source reports it |
+| `EXERCISE_SESSION` | `avg_hr_bpm` | `double_value` | nullable — mean of HR samples that fall inside the session window; omitted entirely when no samples land in window (null ≠ 0) |
 | `EXERCISE_SESSION` | `rpe` | `long_value` | 1–10, nullable — only populated if the source captured it |
 
 #### When to use the payload table


### PR DESCRIPTION
## Summary

Follow-up to [PR #95](https://github.com/thdelmas/Bios/pull/95). Completes the deferred `avg_hr_bpm` field on EXERCISE_SESSION payloads from Health Connect — for each session, mean HR is computed over `HeartRateRecord` samples that fall inside `[start_utc, end_utc]`.

## Design notes

- **One HR fetch per outer sync window**, not per session. HR samples are dense relative to session count (~few sessions/day vs ~thousands of HR samples/day), so one IPC + local intersection beats N+1.
- **`meanHrInWindow` is a pure function** on `HealthConnectAdapter.Companion` — unit-testable without Health Connect or coroutines.
- **null vs zero is load-bearing.** No samples in window → omit the payload field entirely (null). A misleading zero would imply "no heartbeat" rather than "we couldn't measure this session" — the pattern engine reads the difference.
- **Window endpoints are inclusive** at both ends.

## Test plan

- [x] CI green: lint + both flavor builds + unit tests (passes locally via `code-quality-check.sh`)
- [x] `HealthConnectMeanHrInWindowTest` covers: empty input, no overlap, all-overlap, partial overlap, inclusive endpoints.
- [ ] Manual: device with HC sessions logged + HR data (smartwatch sync'd), run sync, query `event_payloads WHERE field_key='avg_hr_bpm'`, verify reasonable values (90–170 bpm for cardio sessions).
- [ ] Manual: log a session without HR data (e.g., manual strength entry, no watch), verify `avg_hr_bpm` row is absent (not zero).

## Still deferred from #38

- Garmin / WHOOP / Oura session emitters (next PR)
- Cross-adapter session dedupe
- RPE field (HC doesn't capture; depends on source)
- Pattern-engine session-level overtraining / deconditioning detection

Part of #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)