### PR TITLE
feat(engine): port circadian-phase-shift engine into Bios (Phase 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/CircadianCalculator.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CircadianCalculator.kt
@@ -1,0 +1,149 @@
+package com.bios.app.engine
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Computes circadian rhythm features from sleep timing data.
+ *
+ * Based on the Seoul National University npj Digital Medicine 2024 paper:
+ * "Accurately predicting mood episodes using wearable sleep and circadian rhythm features".
+ * Key insight: phase advance correlates with mania prodrome, phase delay with
+ * depression prodrome. Sleep midpoint shift is the strongest single predictor.
+ *
+ * Hoisted from W2F's domain layer per the producer-by-capture-surface rule
+ * (docs/ECOSYSTEM_BOUNDARIES.md): chronobiology math is universal, not mood-
+ * specific, so it belongs in Bios. W2F becomes a read-side consumer.
+ *
+ * All time values use circular statistics to handle midnight wraparound
+ * (e.g., 23:30 and 00:30 are 1h apart, not 23h).
+ */
+object CircadianCalculator {
+
+    private const val PERIOD = 24.0
+    private const val TWO_PI = 2.0 * Math.PI
+    private const val MIN_SAMPLES_PHASE_SHIFT = 3
+    private const val MIN_SAMPLES_REGULARITY = 7
+
+    /**
+     * One night of sleep summary, keyed by the wake-day local-calendar date.
+     *
+     * `sleepOnsetHour` is the local-clock decimal hour the sleep period began
+     * (e.g. 23.5 for 23:30); `sleepHours` is duration in decimal hours. Either
+     * may be null when an adapter only reports one side (e.g. manual sleep
+     * entry with a duration but no onset).
+     */
+    data class DailySleepSummary(
+        val date: String,
+        val sleepOnsetHour: Double?,
+        val sleepHours: Double?,
+    )
+
+    /**
+     * `phaseShift`: hours. Positive = phase advance (earlier bedtime, mania
+     * signal). Negative = phase delay (later bedtime, depression signal).
+     * Null when fewer than 3 reference midpoints are available, or today's
+     * onset / duration is missing.
+     *
+     * `sleepRegularity`: circular std of onset times over the input. Lower =
+     * more regular schedule. Null when fewer than 7 onset samples exist.
+     */
+    data class CircadianFeatures(
+        val phaseShift: Double?,
+        val sleepRegularity: Double?,
+    )
+
+    /**
+     * Compute circadian features from recent daily summaries.
+     *
+     * @param recent oldest→newest list of summaries
+     * @param todayOnsetHour today's sleep onset hour (decimal, e.g. 23.5);
+     *   pass separately because today's data may not yet be in [recent]
+     */
+    fun calculate(
+        recent: List<DailySleepSummary>,
+        todayOnsetHour: Double?,
+    ): CircadianFeatures {
+        val onsetHours = recent.mapNotNull { it.sleepOnsetHour }
+        val sleepDurations = recent.mapNotNull { it.sleepHours }
+
+        val midpoints = recent.mapNotNull { m ->
+            val onset = m.sleepOnsetHour ?: return@mapNotNull null
+            val duration = m.sleepHours ?: return@mapNotNull null
+            wrapHour(onset + duration / 2.0)
+        }
+
+        val phaseShift = computePhaseShift(midpoints, todayOnsetHour, sleepDurations.lastOrNull())
+        val sleepRegularity = computeSleepRegularity(onsetHours)
+
+        return CircadianFeatures(phaseShift, sleepRegularity)
+    }
+
+    /**
+     * How far today's sleep midpoint deviates from the recent 7-day circular mean.
+     * Positive = advance (earlier), negative = delay (later). Sign is inverted
+     * from raw circular diff because earlier bedtime is a *negative* clock shift
+     * but a *positive* phase advance in chronobiology convention.
+     */
+    private fun computePhaseShift(
+        midpoints: List<Double>,
+        todayOnset: Double?,
+        todaySleepHours: Double?,
+    ): Double? {
+        if (midpoints.size < MIN_SAMPLES_PHASE_SHIFT) return null
+        if (todayOnset == null || todaySleepHours == null) return null
+
+        val todayMidpoint = wrapHour(todayOnset + todaySleepHours / 2.0)
+        val referenceMean = circularMean(midpoints.takeLast(7))
+
+        return -circularDiff(todayMidpoint, referenceMean)
+    }
+
+    private fun computeSleepRegularity(onsetHours: List<Double>): Double? {
+        if (onsetHours.size < MIN_SAMPLES_REGULARITY) return null
+        return circularStd(onsetHours)
+    }
+
+    // ---- Circular statistics (handle midnight wraparound) ----
+
+    /** e.g. circularMean([23.0, 1.0]) = 0.0 (midnight), not 12.0. */
+    internal fun circularMean(hours: List<Double>): Double {
+        val n = hours.size
+        var sinSum = 0.0
+        var cosSum = 0.0
+        for (h in hours) {
+            val rad = h * TWO_PI / PERIOD
+            sinSum += sin(rad)
+            cosSum += cos(rad)
+        }
+        val meanRad = atan2(sinSum / n, cosSum / n)
+        return ((meanRad * PERIOD / TWO_PI) % PERIOD + PERIOD) % PERIOD
+    }
+
+    /** std = sqrt(-2 * ln R) * (period / 2π), where R is the mean resultant length. */
+    internal fun circularStd(hours: List<Double>): Double {
+        val n = hours.size
+        var sinSum = 0.0
+        var cosSum = 0.0
+        for (h in hours) {
+            val rad = h * TWO_PI / PERIOD
+            sinSum += sin(rad)
+            cosSum += cos(rad)
+        }
+        val r = sqrt((sinSum / n) * (sinSum / n) + (cosSum / n) * (cosSum / n))
+        if (r >= 1.0) return 0.0
+        return sqrt(-2.0 * ln(r)) * PERIOD / TWO_PI
+    }
+
+    /** Signed circular difference wrapped to [-12, +12]. */
+    internal fun circularDiff(phiNew: Double, phiOld: Double): Double {
+        var diff = phiNew - phiOld
+        diff = ((diff + PERIOD / 2) % PERIOD + PERIOD) % PERIOD - PERIOD / 2
+        return diff
+    }
+
+    private fun wrapHour(h: Double): Double = ((h % PERIOD) + PERIOD) % PERIOD
+}

--- a/android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt
@@ -1,0 +1,126 @@
+package com.bios.app.engine
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.CircadianCalculator.DailySleepSummary
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Reads recent `SLEEP_DURATION` rows off the bus, builds per-night summaries,
+ * and emits a `CIRCADIAN_PHASE_SHIFT` reading via [CircadianCalculator].
+ *
+ * Inputs are SLEEP_DURATION only (universal across adapters) — `timestamp` is
+ * the wake instant, `durationSec` is total time-in-bed, `value` is time-asleep
+ * in seconds. From those three we derive both the local-clock sleep-onset hour
+ * (wake − time-in-bed) and the sleep-hours figure the calculator needs. This
+ * keeps the engine source-agnostic: Health Connect, Oura, Withings, and the
+ * manual-entry path all feed it without special-casing.
+ *
+ * Idempotency: skips emission when a CIRCADIAN_PHASE_SHIFT reading already
+ * exists at or after today's wake instant. The append-only readings table makes
+ * a "have we already written today?" check the simplest correct gate.
+ *
+ * Cadence: invoked once per sync. The calculator returns null until at least
+ * 3 days of reference history exist, so early-install runs are silent by
+ * design rather than producing noisy zero-history estimates.
+ */
+class CircadianEngine(
+    private val readingDao: MetricReadingDao,
+    private val zoneId: ZoneId = ZoneId.systemDefault(),
+) {
+
+    suspend fun derive(now: Instant = Instant.now()): MetricReading? {
+        val windowStart = now.minus(LOOKBACK_DAYS.toLong(), ChronoUnit.DAYS)
+        val sleepRows = readingDao.fetch(
+            metricType = MetricType.SLEEP_DURATION.key,
+            startMillis = windowStart.toEpochMilli(),
+            endMillis = now.toEpochMilli(),
+        )
+        if (sleepRows.isEmpty()) return null
+
+        val summaries = toDailySummaries(sleepRows, zoneId)
+        if (summaries.size < MIN_SUMMARIES_TO_EMIT) return null
+
+        val today = summaries.last()
+        val history = summaries.dropLast(1)
+
+        val lastEmitted = readingDao.lastTimestampFor(MetricType.CIRCADIAN_PHASE_SHIFT.key)
+        if (lastEmitted != null && lastEmitted >= today.wakeEpochMillis) return null
+
+        val features = CircadianCalculator.calculate(
+            recent = history.map { it.summary },
+            todayOnsetHour = today.summary.sleepOnsetHour,
+        )
+        val phaseShift = features.phaseShift ?: return null
+
+        return MetricReading(
+            metricType = MetricType.CIRCADIAN_PHASE_SHIFT.key,
+            value = phaseShift,
+            timestamp = today.wakeEpochMillis,
+            sourceId = today.sourceId,
+            confidence = today.confidence,
+        )
+    }
+
+    internal data class DatedSummary(
+        val date: LocalDate,
+        val summary: DailySleepSummary,
+        val wakeEpochMillis: Long,
+        val sourceId: String,
+        val confidence: Int,
+    )
+
+    companion object {
+        private const val LOOKBACK_DAYS = 30
+
+        // Need at least 4 nights total: 3 for the reference history + today.
+        // Matches CircadianCalculator.MIN_SAMPLES_PHASE_SHIFT = 3 on `recent`.
+        internal const val MIN_SUMMARIES_TO_EMIT = 4
+
+        private const val SECONDS_PER_HOUR = 3600.0
+
+        /**
+         * Groups SLEEP_DURATION rows by local wake-date. Multiple adapters can
+         * report the same night; the highest-confidence row per date wins, so
+         * a watch-derived session beats a manual entry and the emitted
+         * CIRCADIAN_PHASE_SHIFT inherits the strongest available source.
+         */
+        internal fun toDailySummaries(
+            rows: List<MetricReading>,
+            zoneId: ZoneId,
+        ): List<DatedSummary> {
+            val byDate = rows
+                .filter { it.durationSec != null && it.durationSec > 0 }
+                .groupBy { LocalDate.ofInstant(Instant.ofEpochMilli(it.timestamp), zoneId) }
+
+            return byDate.entries
+                .map { (date, sameDate) ->
+                    val best = sameDate.maxBy { it.confidence }
+                    val wakeInstant = Instant.ofEpochMilli(best.timestamp)
+                    val inBedMs = best.durationSec!!.toLong() * 1000L
+                    val onsetInstant = wakeInstant.minusMillis(inBedMs)
+                    DatedSummary(
+                        date = date,
+                        summary = DailySleepSummary(
+                            date = date.toString(),
+                            sleepOnsetHour = localHourOf(onsetInstant, zoneId),
+                            sleepHours = best.value / SECONDS_PER_HOUR,
+                        ),
+                        wakeEpochMillis = best.timestamp,
+                        sourceId = best.sourceId,
+                        confidence = best.confidence,
+                    )
+                }
+                .sortedBy { it.date }
+        }
+
+        private fun localHourOf(instant: Instant, zoneId: ZoneId): Double {
+            val ldt = instant.atZone(zoneId).toLocalDateTime()
+            return ldt.hour + ldt.minute / 60.0 + ldt.second / 3600.0
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt
@@ -95,7 +95,11 @@ class CircadianEngine(
         ): List<DatedSummary> {
             val byDate = rows
                 .filter { it.durationSec != null && it.durationSec > 0 }
-                .groupBy { LocalDate.ofInstant(Instant.ofEpochMilli(it.timestamp), zoneId) }
+                .groupBy {
+                    // LocalDate.ofInstant is API 34; build the equivalent via
+                    // ZonedDateTime so we stay compatible with minSdk 28.
+                    Instant.ofEpochMilli(it.timestamp).atZone(zoneId).toLocalDate()
+                }
 
             return byDate.entries
                 .map { (date, sameDate) ->

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -1,6 +1,7 @@
 package com.bios.app.ingest
 
 import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.CircadianEngine
 import com.bios.app.engine.DetectionLatencyTracker
 import com.bios.app.engine.PipelineStage
 import com.bios.app.engine.SignalQualityFilter
@@ -45,6 +46,7 @@ class IngestManager(
     private val readingDao = db.metricReadingDao()
     private val sourceDao = db.dataSourceDao()
     private val payloadDao = db.eventPayloadFieldDao()
+    private val circadianEngine = CircadianEngine(readingDao)
 
     private val _lastSyncTime = MutableStateFlow<Long?>(null)
     val lastSyncTime: StateFlow<Long?> = _lastSyncTime
@@ -196,6 +198,8 @@ class IngestManager(
                 ingestBlock()
             }
 
+            deriveCircadianPhaseShift()
+
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {
@@ -248,12 +252,24 @@ class IngestManager(
                 _syncProgress.value = completedDays / totalDays
             }
 
+            deriveCircadianPhaseShift()
+
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {
             _isSyncing.value = false
             _syncProgress.value = 1f
         }
+    }
+
+    /**
+     * Run the circadian-phase-shift derivation against the readings now in DB.
+     * Self-skips when fewer than 4 days of SLEEP_DURATION exist or when today's
+     * shift has already been emitted, so this is safe to call on every sync.
+     */
+    private suspend fun deriveCircadianPhaseShift() {
+        val reading = circadianEngine.derive() ?: return
+        readingDao.insert(reading)
     }
 
     // MARK: - Derivations

--- a/android/app/src/test/java/com/bios/app/CircadianCalculatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/CircadianCalculatorTest.kt
@@ -1,0 +1,145 @@
+package com.bios.app
+
+import com.bios.app.engine.CircadianCalculator
+import com.bios.app.engine.CircadianCalculator.DailySleepSummary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioral parity port of W2F's `CircadianCalculatorTest`. The math is
+ * universal — sleep-onset timing → phase shift / regularity — and now lives
+ * in Bios per the producer-by-capture-surface rule. Keeping the test set
+ * shape-identical (per the migration plan in issue #88) lets us verify that
+ * the hoist preserves W2F's existing behavior before W2F switches to reading
+ * from Bios.
+ */
+class CircadianCalculatorTest {
+
+    // ---- Circular mean ----
+
+    @Test
+    fun `circularMean handles midnight wraparound`() {
+        val mean = CircadianCalculator.circularMean(listOf(23.0, 1.0))
+        assertTrue("Expected near 0.0 (midnight), got $mean", mean < 1.0 || mean > 23.0)
+    }
+
+    @Test
+    fun `circularMean of identical values returns that value`() {
+        val mean = CircadianCalculator.circularMean(listOf(22.5, 22.5, 22.5))
+        assertEquals(22.5, mean, 0.01)
+    }
+
+    @Test
+    fun `circularMean of afternoon values works normally`() {
+        val mean = CircadianCalculator.circularMean(listOf(14.0, 16.0))
+        assertEquals(15.0, mean, 0.01)
+    }
+
+    // ---- Circular std ----
+
+    @Test
+    fun `circularStd of identical values is 0`() {
+        val std = CircadianCalculator.circularStd(listOf(23.0, 23.0, 23.0))
+        assertEquals(0.0, std, 0.01)
+    }
+
+    @Test
+    fun `circularStd of spread values is positive`() {
+        val std = CircadianCalculator.circularStd(listOf(21.0, 22.0, 23.0, 0.0, 1.0))
+        assertTrue("Expected positive std, got $std", std > 0.0)
+    }
+
+    // ---- Circular diff ----
+
+    @Test
+    fun `circularDiff handles simple cases`() {
+        assertEquals(2.0, CircadianCalculator.circularDiff(14.0, 12.0), 0.01)
+        assertEquals(-2.0, CircadianCalculator.circularDiff(12.0, 14.0), 0.01)
+    }
+
+    @Test
+    fun `circularDiff handles midnight wraparound`() {
+        assertEquals(2.0, CircadianCalculator.circularDiff(1.0, 23.0), 0.01)
+        assertEquals(-2.0, CircadianCalculator.circularDiff(23.0, 1.0), 0.01)
+    }
+
+    // ---- Phase shift ----
+
+    @Test
+    fun `phase shift is null with insufficient data`() {
+        val summaries = listOf(
+            summary("2026-04-10", onset = 23.0, hours = 7.0),
+            summary("2026-04-11", onset = 23.5, hours = 7.0),
+        )
+        val result = CircadianCalculator.calculate(summaries, todayOnsetHour = 23.0)
+        assertNull("Should be null with < 3 samples", result.phaseShift)
+    }
+
+    @Test
+    fun `phase shift detects advance when going to bed earlier`() {
+        val summaries = (1..7).map { d ->
+            summary("2026-04-%02d".format(d), onset = 23.5, hours = 7.0)
+        }
+        val result = CircadianCalculator.calculate(summaries, todayOnsetHour = 21.0)
+        assertNotNull(result.phaseShift)
+        assertTrue(
+            "Earlier bedtime should report a positive phase shift, got ${result.phaseShift}",
+            result.phaseShift!! > 0.0,
+        )
+    }
+
+    @Test
+    fun `phase shift detects delay when going to bed later`() {
+        val summaries = (1..7).map { d ->
+            summary("2026-04-%02d".format(d), onset = 23.0, hours = 7.0)
+        }
+        val result = CircadianCalculator.calculate(summaries, todayOnsetHour = 2.0)
+        assertNotNull(result.phaseShift)
+        assertTrue(
+            "Later bedtime should report a negative phase shift, got ${result.phaseShift}",
+            result.phaseShift!! < 0.0,
+        )
+    }
+
+    @Test
+    fun `no phase shift when consistent schedule`() {
+        val summaries = (1..7).map { d ->
+            summary("2026-04-%02d".format(d), onset = 23.0, hours = 7.5)
+        }
+        val result = CircadianCalculator.calculate(summaries, todayOnsetHour = 23.0)
+        assertNotNull(result.phaseShift)
+        assertEquals(0.0, result.phaseShift!!, 0.5)
+    }
+
+    // ---- Sleep regularity ----
+
+    @Test
+    fun `high regularity when consistent bedtime`() {
+        val summaries = (1..14).map { d ->
+            summary("2026-04-%02d".format(d), onset = 23.0, hours = 7.0)
+        }
+        val result = CircadianCalculator.calculate(summaries, 23.0)
+        assertNotNull(result.sleepRegularity)
+        assertEquals(0.0, result.sleepRegularity!!, 0.1)
+    }
+
+    @Test
+    fun `low regularity when erratic bedtime`() {
+        val onsets = listOf(20.0, 2.0, 22.0, 4.0, 21.0, 3.0, 23.0, 1.0, 20.0, 3.0, 22.0, 4.0, 21.0, 2.0)
+        val summaries = onsets.mapIndexed { i, onset ->
+            summary("2026-04-%02d".format(i + 1), onset = onset, hours = 6.0)
+        }
+        val result = CircadianCalculator.calculate(summaries, 2.0)
+        assertNotNull(result.sleepRegularity)
+        assertTrue(
+            "Erratic bedtime should produce high circular std, got ${result.sleepRegularity}",
+            result.sleepRegularity!! > 1.0,
+        )
+    }
+
+    private fun summary(date: String, onset: Double?, hours: Double?) =
+        DailySleepSummary(date = date, sleepOnsetHour = onset, sleepHours = hours)
+}

--- a/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
@@ -1,0 +1,228 @@
+package com.bios.app
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.CircadianEngine
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Exercises the orchestration around [CircadianCalculator]: SLEEP_DURATION rows
+ * are read off the bus, grouped by local wake-date, fed to the calculator, and
+ * emitted as a CIRCADIAN_PHASE_SHIFT reading.
+ *
+ * Math parity with W2F lives in [CircadianCalculatorTest]; this file covers the
+ * Bios-specific wiring: per-night grouping, multi-adapter confidence tie-break,
+ * the "insufficient history" silent path, and idempotent re-emission.
+ */
+class CircadianEngineTest {
+
+    private val utc = ZoneOffset.UTC
+
+    @Test
+    fun `no SLEEP_DURATION rows returns null`() = runBlocking {
+        val dao = FakeMetricReadingDao(rows = emptyList())
+        val engine = CircadianEngine(dao, zoneId = utc)
+        assertNull(engine.derive(now = "2026-04-10T12:00:00Z".asInstant()))
+    }
+
+    @Test
+    fun `fewer than four nights returns null`() = runBlocking {
+        // The calculator needs 3 history nights + today; anything less is silent
+        // by design rather than producing a noisy zero-history phase shift.
+        val rows = (1..3).map { d ->
+            sleepRow(wake = "2026-04-%02dT07:00:00Z".format(d).asInstant(), inBedHours = 7.5)
+        }
+        val dao = FakeMetricReadingDao(rows = rows)
+        val engine = CircadianEngine(dao, zoneId = utc)
+        assertNull(engine.derive(now = "2026-04-04T12:00:00Z".asInstant()))
+    }
+
+    @Test
+    fun `consistent schedule emits a near-zero phase shift`() = runBlocking {
+        // 7 nights of identical onset/duration — the math should agree the
+        // phase didn't shift.
+        val rows = (1..7).map { d ->
+            sleepRow(wake = "2026-04-%02dT06:30:00Z".format(d).asInstant(), inBedHours = 7.5)
+        }
+        val dao = FakeMetricReadingDao(rows = rows)
+        val engine = CircadianEngine(dao, zoneId = utc)
+        val emitted = engine.derive(now = "2026-04-07T12:00:00Z".asInstant())
+        assertNotNull(emitted)
+        assertEquals(MetricType.CIRCADIAN_PHASE_SHIFT.key, emitted!!.metricType)
+        assertEquals(0.0, emitted.value, 0.5)
+    }
+
+    @Test
+    fun `later bedtime emits a negative phase shift`() = runBlocking {
+        // Six baseline nights with a 23:00 onset, then a much later onset on
+        // night seven — that's a phase delay, depression signal.
+        val baseline = (1..6).map { d ->
+            sleepRow(wake = "2026-04-%02dT06:00:00Z".format(d).asInstant(), inBedHours = 7.0)
+        }
+        val lateNight = sleepRow(
+            wake = "2026-04-07T09:00:00Z".asInstant(),
+            inBedHours = 7.0,
+        )
+        val dao = FakeMetricReadingDao(rows = baseline + lateNight)
+        val engine = CircadianEngine(dao, zoneId = utc)
+        val emitted = engine.derive(now = "2026-04-07T12:00:00Z".asInstant())
+        assertNotNull(emitted)
+        assertTrue(
+            "Phase delay should produce a negative shift, got ${emitted!!.value}",
+            emitted.value < 0.0,
+        )
+    }
+
+    @Test
+    fun `re-emission for the same wake instant is skipped`() = runBlocking {
+        // Calling derive twice on identical inputs should produce a reading then
+        // null — the second call sees the prior wake timestamp in the DAO and
+        // bails. Prevents the once-per-sync invocation from stacking duplicates.
+        val rows = (1..7).map { d ->
+            sleepRow(wake = "2026-04-%02dT06:30:00Z".format(d).asInstant(), inBedHours = 7.5)
+        }
+        val dao = FakeMetricReadingDao(rows = rows)
+        val engine = CircadianEngine(dao, zoneId = utc)
+
+        val first = engine.derive(now = "2026-04-07T12:00:00Z".asInstant())
+        assertNotNull(first)
+        dao.recordPhaseShift(first!!.timestamp)
+
+        val second = engine.derive(now = "2026-04-07T13:00:00Z".asInstant())
+        assertNull("Second derive should skip — already wrote this night", second)
+    }
+
+    @Test
+    fun `multi-adapter same night picks highest confidence`() = runBlocking {
+        // Two adapters cover night 7 — a watch (HIGH) and a manual entry (LOW).
+        // The watch row should provide the source attribution and confidence
+        // for the emitted CIRCADIAN_PHASE_SHIFT reading.
+        val baseline = (1..6).map { d ->
+            sleepRow(wake = "2026-04-%02dT06:00:00Z".format(d).asInstant(), inBedHours = 7.0)
+        }
+        val manual = sleepRow(
+            wake = "2026-04-07T08:00:00Z".asInstant(),
+            inBedHours = 7.0,
+            sourceId = "manual",
+            confidence = ConfidenceTier.LOW.level,
+        )
+        val watch = sleepRow(
+            wake = "2026-04-07T06:00:00Z".asInstant(),
+            inBedHours = 7.0,
+            sourceId = "watch",
+            confidence = ConfidenceTier.HIGH.level,
+        )
+        val dao = FakeMetricReadingDao(rows = baseline + manual + watch)
+        val engine = CircadianEngine(dao, zoneId = utc)
+        val emitted = engine.derive(now = "2026-04-07T12:00:00Z".asInstant())
+        assertNotNull(emitted)
+        assertEquals("watch", emitted!!.sourceId)
+        assertEquals(ConfidenceTier.HIGH.level, emitted.confidence)
+    }
+
+    // ---- Pure grouping ----
+
+    @Test
+    fun `toDailySummaries skips rows missing durationSec`() {
+        val rows = listOf(
+            sleepRow(wake = "2026-04-01T06:00:00Z".asInstant(), inBedHours = 7.0),
+            // No durationSec → can't reconstruct onset, must be skipped
+            MetricReading(
+                metricType = MetricType.SLEEP_DURATION.key,
+                value = 25_200.0,
+                timestamp = "2026-04-02T06:00:00Z".asInstant().toEpochMilli(),
+                durationSec = null,
+                sourceId = "x",
+                confidence = ConfidenceTier.MEDIUM.level,
+            ),
+        )
+        val summaries = CircadianEngine.toDailySummaries(rows, utc)
+        assertEquals(1, summaries.size)
+        assertEquals(LocalDate.of(2026, 4, 1), summaries[0].date)
+    }
+
+    @Test
+    fun `toDailySummaries computes onset hour as wake minus in-bed time`() {
+        // Wake 06:30 UTC, in bed for 7.5h → onset at 23:00 the previous day.
+        val rows = listOf(
+            sleepRow(wake = "2026-04-01T06:30:00Z".asInstant(), inBedHours = 7.5),
+        )
+        val summaries = CircadianEngine.toDailySummaries(rows, utc)
+        assertEquals(1, summaries.size)
+        assertEquals(23.0, summaries[0].summary.sleepOnsetHour!!, 0.01)
+        assertEquals(7.5, summaries[0].summary.sleepHours!!, 0.01)
+    }
+
+    // ---- Helpers ----
+
+    private fun sleepRow(
+        wake: java.time.Instant,
+        inBedHours: Double,
+        sourceId: String = "source1",
+        confidence: Int = ConfidenceTier.MEDIUM.level,
+    ): MetricReading {
+        val inBedSec = (inBedHours * 3600).toInt()
+        return MetricReading(
+            metricType = MetricType.SLEEP_DURATION.key,
+            // value is "asleep seconds"; for the engine's onset math we only
+            // need durationSec (in-bed) and timestamp (wake). Set value = inBed
+            // for simplicity — it only affects sleepHours, which is fine.
+            value = inBedSec.toDouble(),
+            timestamp = wake.toEpochMilli(),
+            durationSec = inBedSec,
+            sourceId = sourceId,
+            confidence = confidence,
+        )
+    }
+
+    private fun String.asInstant(): java.time.Instant = java.time.Instant.parse(this)
+}
+
+/**
+ * Minimal in-memory MetricReadingDao for [CircadianEngineTest]. Implements the
+ * two methods CircadianEngine actually calls (`fetch` and `lastTimestampFor`);
+ * the rest are not exercised here and throw if hit.
+ */
+private class FakeMetricReadingDao(
+    private val rows: List<MetricReading>,
+) : MetricReadingDao {
+
+    private var lastPhaseShiftTimestamp: Long? = null
+
+    fun recordPhaseShift(timestamp: Long) {
+        lastPhaseShiftTimestamp = timestamp
+    }
+
+    override suspend fun fetch(metricType: String, startMillis: Long, endMillis: Long): List<MetricReading> =
+        rows.filter {
+            it.metricType == metricType && it.timestamp in startMillis..endMillis
+        }
+
+    override suspend fun lastTimestampFor(metricType: String): Long? =
+        if (metricType == MetricType.CIRCADIAN_PHASE_SHIFT.key) lastPhaseShiftTimestamp else null
+
+    override suspend fun insertAll(readings: List<MetricReading>): Unit = notUsed()
+    override suspend fun insert(reading: MetricReading): Unit = notUsed()
+    override suspend fun fetchValues(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun fetchLatest(metricType: String, limit: Int): List<MetricReading> = notUsed()
+    override suspend fun count(metricType: String): Int = notUsed()
+    override suspend fun countAll(): Int = notUsed()
+    override suspend fun countInRange(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): Int = notUsed()
+    override suspend fun fetchBucketedMeans(metricType: String, startMillis: Long, endMillis: Long, bucketMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun oldestTimestamp(): Long? = notUsed()
+    override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
+    override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
+    override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteAll(): Unit = notUsed()
+
+    private fun <T> notUsed(): T = error("FakeMetricReadingDao: method not exercised by CircadianEngineTest")
+}


### PR DESCRIPTION
## Summary

Hoists the circadian-phase-shift math out of W2F into Bios per the producer-by-capture-surface rule. Chronobiology from sleep-onset timing is universal — not mood-specific — so the producer belongs in Bios with W2F as a read-side consumer in the follow-up phases.

Phase 1 of #88.

## What lands

**Two-class split:**

- [`CircadianCalculator`](android/app/src/main/java/com/bios/app/engine/CircadianCalculator.kt) — pure math, line-for-line port of W2F's `CircadianCalculator`. Circular statistics (mean/std/diff with midnight wraparound), phase-shift and regularity computations. Same constants, same sign convention (positive = phase advance = earlier bedtime).
- [`CircadianEngine`](android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt) — DB-aware orchestrator. Reads SLEEP_DURATION rows over the last 30 days, groups by local wake-date (highest-confidence wins per night across adapters), derives per-night `(sleep_onset_hour, sleep_hours)` from `timestamp − durationSec`, and emits one CIRCADIAN_PHASE_SHIFT reading. Idempotent — skips when today's wake already has an emitted shift, so once-per-sync calls are safe.

**Wiring:** invoked at the tail of both `IngestManager.syncRecentData()` and `syncHistoricalData()`. Engine self-skips on insufficient history (<4 nights), so early-install runs are silent rather than noisy.

**Tests:**

- [`CircadianCalculatorTest`](android/app/src/test/java/com/bios/app/CircadianCalculatorTest.kt) — direct port of W2F's `CircadianCalculatorTest` (renaming inputs to Bios's `DailySleepSummary`). Locks math parity before W2F switches to reading from Bios.
- [`CircadianEngineTest`](android/app/src/test/java/com/bios/app/CircadianEngineTest.kt) — wiring: empty input, insufficient nights, consistent schedule (≈zero shift), phase delay detection, idempotent re-emission, multi-adapter confidence tie-break, plus pure `toDailySummaries` cases (skip rows missing durationSec, onset = wake − in-bed-time).

## Out of scope (Phases 2/3 of #88)

- W2F switches its `CircadianCalculator` to read from `BiosHealthProvider` instead of computing locally.
- Bios revokes `circadian_phase_shift` from W2F's writable-metrics whitelist in `CompanionContract`.
- The transition note in `MetricType.kt` for `CIRCADIAN_PHASE_SHIFT` is removed.

The companion-write path stays open so W2F's current writes don't break during the cross-repo migration window.

## Test plan

- [x] `./scripts/code-quality-check.sh` green (file-length, secrets, lint, debug build, unit tests)
- [x] `CircadianCalculatorTest` passes all 12 cases ported from W2F
- [x] `CircadianEngineTest` covers wiring + grouping + idempotency
- [x] Lint clean — `LocalDate.ofInstant` (API 34) was caught and replaced with `Instant.atZone().toLocalDate()` (API 28+ via java.time)
- [ ] Manual on-device verification: with ≥4 nights of HC sleep history, trigger a sync, confirm a CIRCADIAN_PHASE_SHIFT row appears with `timestamp = today's wake instant` and a plausible signed hours value
- [ ] Manual verification: on a fresh install with <4 nights of sleep data, no CIRCADIAN_PHASE_SHIFT row is written
- [ ] Manual verification: a second sync without new sleep data doesn't double-write today's phase shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)