### PR TITLE
feat(provider): pin companion writes by signing cert

### DIFF
--- a/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
+++ b/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
@@ -11,6 +11,7 @@ import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
 import com.bios.app.model.SensorType
+import com.bios.app.platform.PlatformDetector
 import com.bios.contracts.BiosHealthContract
 import com.bios.contracts.MetricType
 import kotlinx.coroutines.runBlocking
@@ -75,6 +76,8 @@ class BiosHealthProvider : ContentProvider() {
 
     private lateinit var db: BiosDatabase
     private lateinit var gate: CompanionGate
+    private lateinit var certResolver: CallerCertResolver
+    private var bypassCertPin: Boolean = false
     private val ensuredSources = mutableSetOf<String>()
 
     override fun onCreate(): Boolean {
@@ -85,6 +88,11 @@ class BiosHealthProvider : ContentProvider() {
             dao = db.companionGrantDao(),
             onFirstPending = { pkg -> notifier.notifyPending(pkg) }
         )
+        certResolver = PackageManagerCertResolver(ctx.packageManager)
+        // On LETHE the platform key is the trust anchor — companions are
+        // pre-installed system apps signed by the OS. Standalone has no such
+        // anchor, so the SHA-256 pin in CompanionContract becomes load-bearing.
+        bypassCertPin = PlatformDetector.isLethe(ctx)
         return true
     }
 
@@ -157,6 +165,14 @@ class BiosHealthProvider : ContentProvider() {
         val companion = CompanionContract.sourceFor(caller)
         if (companion == null || metricType !in companion.writableMetrics) {
             throw SecurityException("'$caller' may not write '$metricType'")
+        }
+        if (!bypassCertPin && companion.signingCertSha256.isNotEmpty()) {
+            val actualSha = caller?.let { certResolver.signingCertSha256(it) }
+            if (!CompanionContract.verifySigningCert(caller, actualSha)) {
+                throw SecurityException(
+                    "'$caller' presented a signing cert that does not match the pin for ${companion.displayName}"
+                )
+            }
         }
         val cv = values ?: throw IllegalArgumentException("ContentValues required")
         val value = cv.getAsDouble(BiosHealthContract.CompanionInsert.VALUE)

--- a/android/app/src/main/java/com/bios/app/provider/CallerCertResolver.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CallerCertResolver.kt
@@ -1,0 +1,48 @@
+package com.bios.app.provider
+
+import android.content.pm.PackageManager
+import android.os.Build
+import java.security.MessageDigest
+
+/**
+ * Resolves the SHA-256 of an installed package's signing certificate, returned
+ * as lowercase hex. Returns null when the package is uninstalled or unsigned.
+ *
+ * Wrapped behind an interface so [BiosHealthProvider]'s cert-pin path is
+ * testable on the JVM without an Android `PackageManager` — tests inject a
+ * map-backed fake; the production wiring uses [PackageManagerCertResolver].
+ */
+internal interface CallerCertResolver {
+    fun signingCertSha256(packageName: String): String?
+}
+
+internal class PackageManagerCertResolver(
+    private val pm: PackageManager,
+) : CallerCertResolver {
+
+    @Suppress("NewApi") // minSdk 28 = always covered; the version branch keeps lint happy
+    override fun signingCertSha256(packageName: String): String? = try {
+        val info = pm.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+        val signingInfo = info.signingInfo ?: return null
+        // `apkContentsSigners` is the post-rotation v3 result: when a key has
+        // been rotated, this returns the current signer only. Fall back to
+        // `signingCertificateHistory` for builds still using the older
+        // v1/v2-signed-only release flow (no rotation, single cert in history).
+        val signers = signingInfo.apkContentsSigners
+            ?: signingInfo.signingCertificateHistory
+            ?: return null
+        val first = signers.firstOrNull() ?: return null
+        val digest = MessageDigest.getInstance("SHA-256").digest(first.toByteArray())
+        digest.joinToString("") { "%02x".format(it) }
+    } catch (_: PackageManager.NameNotFoundException) {
+        null
+    }
+
+    companion object {
+        // Referenced only to keep Build.VERSION_CODES.P explicitly tied to the
+        // minSdk floor — if minSdk ever drops below 28, the GET_SIGNING_CERTIFICATES
+        // flag and `apkContentsSigners` API need a guarded older-API fallback.
+        @Suppress("unused")
+        private const val REQUIRES_API = Build.VERSION_CODES.P
+    }
+}

--- a/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
@@ -20,6 +20,16 @@ import com.bios.app.model.ReadingKind
  * owner can trace exactly which app wrote any given reading. Without this,
  * everything routes through one source and provenance is lost.
  *
+ * Signing-cert pin: on the standalone flavor, package-name equality is not enough
+ * — any sideloaded APK can declare `<application android:packageName="com.w2f.app">`.
+ * [signingCertSha256] pins the trust to the SHA-256 of the companion's release
+ * signing certificate. An empty set means "no pin published yet" (migration
+ * window) and the package-name check stands alone; once the companion ships a
+ * stable release-signing key, its SHA is added here and impersonators are
+ * rejected at insert time. The check is bypassed on the LETHE flavor where the
+ * platform itself is the trust anchor (companions are pre-installed system apps
+ * signed by the platform key).
+ *
  * Membership rules:
  * - W2F (com.w2f.app) writes MENTAL_HEALTH signals
  * - Smokeless (com.smokless.smokeless) writes INTAKE events (tobacco + cannabis,
@@ -33,13 +43,31 @@ internal object CompanionContract {
     // SELF_REPORTED mood) must split into multiple sourceIds when that
     // ambiguity actually bites — tracked as an open question in
     // docs/SELF_REPORTED_DATA_HOME.md.
+    //
+    // `signingCertSha256`: hex (lowercase) SHA-256 of the companion's release
+    // signing cert(s). Multiple values support a rotation window. Empty set =
+    // not yet pinned — see the migration-window note on the surrounding object.
     data class Companion(
         val packageName: String,
         val displayName: String,
         val sourceId: String,
         val writableMetrics: Set<String>,
         val defaultReadingKind: ReadingKind,
-    )
+        val signingCertSha256: Set<String> = emptySet(),
+    ) {
+        /**
+         * Whether [actualCertSha256] (lowercase hex) matches this companion's pin.
+         * Empty pin → true (migration window, falls back to package-name trust).
+         * Non-empty pin → true iff the actual SHA is in the pinned set, case-
+         * insensitively. A null actual SHA against a non-empty pin reads as
+         * impersonation and returns false.
+         */
+        fun verifySigningCert(actualCertSha256: String?): Boolean {
+            if (signingCertSha256.isEmpty()) return true
+            val actual = actualCertSha256?.lowercase() ?: return false
+            return signingCertSha256.any { it.lowercase() == actual }
+        }
+    }
 
     val PACKAGES: Map<String, Companion> = listOf(
         Companion(
@@ -56,6 +84,11 @@ internal object CompanionContract {
                 "mood_drift_score",
             ),
             defaultReadingKind = ReadingKind.DERIVED,
+            // TODO populate with W2F's release-signing cert SHA-256 before the
+            // first standalone-flavor release. See docs/CONSUMER_API.md cert-
+            // rotation procedure. Until then, the package-name check stands
+            // alone.
+            signingCertSha256 = emptySet(),
         ),
         Companion(
             packageName = "com.smokless.smokeless",
@@ -68,6 +101,7 @@ internal object CompanionContract {
                 "cannabis_craving",
             ),
             defaultReadingKind = ReadingKind.SELF_REPORTED,
+            signingCertSha256 = emptySet(),
         ),
         Companion(
             packageName = "com.virgil.app",
@@ -79,6 +113,7 @@ internal object CompanionContract {
                 "check_in_miss",
             ),
             defaultReadingKind = ReadingKind.DERIVED,
+            signingCertSha256 = emptySet(),
         ),
     ).associateBy { it.packageName }
 
@@ -95,4 +130,17 @@ internal object CompanionContract {
 
     /** Source metadata for a known companion package, or `null` if unknown. */
     fun sourceFor(pkg: String?): Companion? = pkg?.let { PACKAGES[it] }
+
+    /**
+     * Decides whether to accept a write from [pkg] given the calling APK's
+     * actual signing-cert SHA-256 ([actualCertSha256], lowercase hex).
+     *
+     * Unknown package → false. Known package → delegates to the per-companion
+     * [Companion.verifySigningCert]. Callers running on the LETHE flavor should
+     * skip this and trust the platform key instead.
+     */
+    fun verifySigningCert(pkg: String?, actualCertSha256: String?): Boolean {
+        val companion = sourceFor(pkg) ?: return false
+        return companion.verifySigningCert(actualCertSha256)
+    }
 }

--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -206,4 +206,98 @@ class BiosHealthProviderContractTest {
         assertTrue("double_value" in cols)
         assertTrue("long_value" in cols)
     }
+
+    // ---- Cert-SHA pinning (issue #90) ----
+
+    @Test
+    fun `empty cert pin is the current migration-window default`() {
+        // Until each companion ships a release-signing key, the pin stays empty
+        // and the package-name check stands alone. Treat this as a transitional
+        // contract — populate signingCertSha256 before the first standalone
+        // public release.
+        for (c in CompanionContract.PACKAGES.values) {
+            assertTrue(
+                "${c.packageName} unexpectedly has a non-empty cert pin — update test if intentional",
+                c.signingCertSha256.isEmpty()
+            )
+        }
+    }
+
+    @Test
+    fun `empty pin accepts any cert (migration-window fallback)`() {
+        val companion = w2fWithPin(emptySet())
+        assertTrue(companion.verifySigningCert("anything"))
+        assertTrue(companion.verifySigningCert(null))
+        assertTrue(companion.verifySigningCert(""))
+    }
+
+    @Test
+    fun `non-empty pin accepts the matching SHA`() {
+        val sha = "a".repeat(64)
+        val companion = w2fWithPin(setOf(sha))
+        assertTrue(companion.verifySigningCert(sha))
+    }
+
+    @Test
+    fun `non-empty pin rejects a non-matching SHA`() {
+        val pinned = "a".repeat(64)
+        val impostor = "b".repeat(64)
+        val companion = w2fWithPin(setOf(pinned))
+        assertFalse(companion.verifySigningCert(impostor))
+    }
+
+    @Test
+    fun `non-empty pin rejects null caller cert`() {
+        // Null means we couldn't read the caller's signing info — a malicious
+        // unsigned APK is the realistic case. Reject hard.
+        val companion = w2fWithPin(setOf("a".repeat(64)))
+        assertFalse(companion.verifySigningCert(null))
+    }
+
+    @Test
+    fun `cert comparison is case-insensitive`() {
+        val mixed = "AbCdEf" + "0".repeat(58)
+        val companion = w2fWithPin(setOf(mixed))
+        assertTrue(companion.verifySigningCert(mixed.lowercase()))
+        assertTrue(companion.verifySigningCert(mixed.uppercase()))
+    }
+
+    @Test
+    fun `rotation window accepts any of the pinned SHAs`() {
+        val oldKey = "a".repeat(64)
+        val newKey = "b".repeat(64)
+        val companion = w2fWithPin(setOf(oldKey, newKey))
+        assertTrue(companion.verifySigningCert(oldKey))
+        assertTrue(companion.verifySigningCert(newKey))
+        assertFalse(companion.verifySigningCert("c".repeat(64)))
+    }
+
+    @Test
+    fun `verifySigningCert via object lookup rejects unknown packages`() {
+        // Unknown package can't be impersonating any known companion — the
+        // package-name gate already rejects it; the cert path agrees.
+        assertFalse(CompanionContract.verifySigningCert("com.unknown.app", "any"))
+        assertFalse(CompanionContract.verifySigningCert(null, "any"))
+    }
+
+    @Test
+    fun `verifySigningCert via object lookup delegates to the matching companion`() {
+        // With the current empty-pin migration default, every known package
+        // accepts any cert via the object-level entry point.
+        for (pkg in CompanionContract.PACKAGES.keys) {
+            assertTrue(
+                "$pkg should accept under migration-window fallback",
+                CompanionContract.verifySigningCert(pkg, "any")
+            )
+        }
+    }
+
+    private fun w2fWithPin(pin: Set<String>) = CompanionContract.Companion(
+        packageName = "com.w2f.app",
+        displayName = "W2F",
+        sourceId = "companion_w2f",
+        writableMetrics = setOf("typing_cadence"),
+        defaultReadingKind = ReadingKind.DERIVED,
+        signingCertSha256 = pin,
+    )
 }

--- a/docs/CONSUMER_API.md
+++ b/docs/CONSUMER_API.md
@@ -120,6 +120,64 @@ Current allocations:
 - `value` (Double) — required
 - `timestamp` (Long, epoch ms) — optional, defaults to `now`
 
+### Signing-cert pin (standalone flavor)
+
+On the standalone flavor, package-name equality is not enough — any sideloaded
+APK can declare `<application android:packageName="com.w2f.app">`. Each
+companion's release signing cert SHA-256 is pinned alongside its package name
+in `provider.CompanionContract.PACKAGES.signingCertSha256`. Writes from a
+matching package name with a non-matching cert are rejected with
+`SecurityException`.
+
+On the LETHE flavor the pin is bypassed: companions are pre-installed system
+apps signed by the platform key, which is the trust anchor.
+
+**Migration window.** Until a companion publishes a stable release-signing
+key, its `signingCertSha256` is `emptySet()`. In that state the package-name
+check stands alone (current behavior). Once populated, impersonators are
+rejected at insert time.
+
+#### Cert-rotation procedure
+
+When a companion ships its first signed release, or rotates its key, the new
+SHA-256 must be added to its `Companion` entry in `CompanionContract.kt`:
+
+1. **Compute the SHA-256.** From the signed release APK:
+   ```sh
+   apksigner verify --print-certs companion-release.apk \
+     | grep "SHA-256 digest" \
+     | head -1 | awk '{print $NF}' | tr -d ':' | tr 'A-Z' 'a-z'
+   ```
+   Or from a keystore:
+   ```sh
+   keytool -list -keystore release.keystore -alias <alias> \
+     | grep "SHA256" | awk '{print $2}' | tr -d ':' | tr 'A-Z' 'a-z'
+   ```
+
+2. **Add to the pinned set.** Edit the companion's `signingCertSha256` in
+   `CompanionContract.kt`:
+   ```kotlin
+   signingCertSha256 = setOf(
+       "abc123...new-release-key-sha-here...",
+   )
+   ```
+
+3. **Key rotation.** When a companion rotates its release key, keep the *old*
+   SHA in the set for one Bios release cycle. The set tolerates multiple SHAs
+   so users running an older companion version don't lose write access while
+   they update:
+   ```kotlin
+   signingCertSha256 = setOf(
+       "old-key-sha-256",  // remove in Bios N+2
+       "new-key-sha-256",
+   )
+   ```
+
+4. **Ship Bios, then ship companion.** A Bios release with the new SHA must
+   reach users before the companion release signed with the new key, otherwise
+   the companion's writes will start failing on devices that haven't updated
+   Bios yet.
+
 ## First-connection notification
 
 The first time any unknown package calls the provider, Bios fires a


### PR DESCRIPTION
## Summary

Closes the standalone-flavor impersonation hole called out in #90. `CompanionContract.canWrite` previously trusted any package whose `applicationId` appeared in the whitelist — but on stock Android any sideloaded APK can declare `<application android:packageName=\"com.w2f.app\">` and pass the check. A malicious build under that package could then write `mood_drift_score` values that trigger downstream alerts, poison drift baselines, or spoof Smokeless events to corrupt cessation-trajectory patterns.

This PR adds the runtime cert pin called out in Architecture Audit #2 (2026-05) and the keystore-decision memory (Phase 7 Option C).

## What lands

- [`signingCertSha256: Set<String>`](android/app/src/main/java/com/bios/app/provider/CompanionContract.kt) added to `CompanionContract.Companion`. Per-companion `verifySigningCert` is case-insensitive hex; the set supports multiple values for a key-rotation window.
- New [`CallerCertResolver`](android/app/src/main/java/com/bios/app/provider/CallerCertResolver.kt) + `PackageManagerCertResolver` wraps `PackageManager.getPackageInfo(GET_SIGNING_CERTIFICATES)`. Prefers `apkContentsSigners` (post-rotation v3 result) so rotated keys read as the *current* cert, with `signingCertificateHistory` as fallback.
- [`BiosHealthProvider.insert`](android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt) resolves the caller's cert SHA and rejects matching-pkg / non-matching-cert writes with `SecurityException`. **Bypassed on LETHE** — the platform key is the trust anchor since companions are pre-installed system apps signed by the OS.
- [CONSUMER_API.md](docs/CONSUMER_API.md) documents the rotation procedure with `apksigner` / `keytool` one-liners and the "ship Bios then ship companion" rule.

## Migration window

All three current entries (W2F / Smokeless / Virgil) keep `signingCertSha256 = emptySet()`. In that state the package-name check stands alone — current behavior is preserved. The pin becomes load-bearing the moment SHAs are populated, no further code change required. A contract test pins this default so a partial pin trips the build.

## Test plan

- [x] `./scripts/code-quality-check.sh` green (file-length, secrets, lint, debug build, unit tests)
- [x] Migration-window default asserted (`empty cert pin is the current migration-window default`)
- [x] Empty pin accepts any cert (`empty pin accepts any cert`)
- [x] Non-empty pin: matching SHA accepts, mismatched / null rejects
- [x] Case-insensitive hex comparison
- [x] Rotation set with multiple SHAs accepts any pinned value
- [x] Object-level entry point rejects unknown packages
- [ ] Once owner has release-signing certs for W2F / Smokeless / Virgil, populate SHAs and verify on a real device: legit companion APK writes succeed, impersonator APK (same package name, different signing key) is rejected with `SecurityException`

## Out of scope (follow-ups)

- Populating actual release-cert SHAs for W2F / Smokeless / Virgil — requires the project owner's release keystores.
- **Read-side cert pinning.** Today reads only pass through the owner gate (`CompanionGate`). A spoofed package that gets owner-approved can still read. Closing that gap is a larger change and out of #90's scope — flagged for a follow-up.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)