### PR TITLE
docs(contracts): codify forward/backward-compat rules for bios-contracts

### DIFF
--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -10,6 +10,15 @@ package com.bios.contracts
  * Adding a key here does *not* automatically make it writable by companions —
  * see [com.bios.contracts.BiosHealthContract] for the companion-write surface
  * and Bios's `CompanionContract` for the per-package allowlist.
+ *
+ * **Forward/backward-compat rules** (see docs/CONSUMER_API.md →
+ * "Contracts forward/backward compatibility"):
+ *  - Never delete a `key` once it has shipped — annotate with `@Deprecated`
+ *    instead so `fromKey()` keeps resolving it.
+ *  - Never repurpose a `key` string or change the `unit`/`domain` of an
+ *    existing entry — add a new entry.
+ *  - Consumers must call `fromKey()` (not `valueOf`) and tolerate `null` for
+ *    keys their contracts version doesn't know.
  */
 enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricDomain) {
     // Cardiovascular

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -1,0 +1,136 @@
+package com.bios.contracts
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Frozen snapshot of every `MetricType.key` string that has shipped in a
+ * released `bios-contracts` artifact. Out-of-tree companions (W2F, Smokeless,
+ * Virgil, Fil) pin a contracts version and assume these keys keep resolving.
+ *
+ * **How to update this file.**
+ *  - Adding a key: append the new string. That is the only valid edit when
+ *    growing the contract.
+ *  - Deprecating a key: keep the entry here AND keep the enum constant —
+ *    annotate the enum with `@Deprecated`. `fromKey()` keeps resolving it,
+ *    so this test still passes.
+ *  - Removing a key (the entry actually disappears from the enum): do not
+ *    silence this test by trimming the snapshot. Removing a key forces a
+ *    paired release of every companion and is a major-version break of the
+ *    contracts artifact. Coordinate with companion maintainers first, then
+ *    bump the contracts major version, then edit this snapshot.
+ *
+ * See docs/CONSUMER_API.md → "Contracts forward/backward compatibility".
+ */
+class MetricTypeKeysSnapshotTest {
+
+    private val shippedKeys: Set<String> = setOf(
+        // Cardiovascular
+        "heart_rate",
+        "heart_rate_variability",
+        "parasympathetic_tone",
+        "stress_score",
+        "lf_hf_ratio",
+        "resting_heart_rate",
+        "blood_pressure_systolic",
+        "blood_pressure_diastolic",
+        "blood_oxygen",
+        // Respiratory
+        "respiratory_rate",
+        // Temperature
+        "skin_temperature",
+        "skin_temperature_deviation",
+        // Sleep
+        "sleep_stage",
+        "sleep_duration",
+        "sleep_latency",
+        "sleep_efficiency",
+        "sleep_fragmentation_index",
+        "circadian_phase_shift",
+        // Activity
+        "steps",
+        "active_calories",
+        "active_minutes",
+        "exercise_session",
+        // Metabolic
+        "blood_glucose",
+        "body_mass",
+        "body_fat_pct",
+        // Recovery
+        "recovery_score",
+        // Women's Health
+        "basal_body_temperature",
+        "cycle_phase",
+        "menstruation_onset",
+        "cycle_day",
+        // Environment
+        "ambient_light",
+        // Biomarkers
+        "hba1c",
+        "hscrp",
+        "total_cholesterol",
+        "ldl_cholesterol",
+        "hdl_cholesterol",
+        "triglycerides",
+        "apo_b",
+        "vitamin_d_25oh",
+        "tsh",
+        "free_t4",
+        "free_t3",
+        "hemoglobin",
+        "hematocrit",
+        "wbc",
+        "rbc",
+        "platelets",
+        // Epigenetic age clocks
+        "epigenetic_age_dunedin_pace",
+        "epigenetic_age_grim",
+        "epigenetic_age_pheno",
+        "epigenetic_age_horvath",
+        // Companion-written (W2F)
+        "typing_cadence",
+        "mood_drift_score",
+        // Companion-written (Smokeless)
+        "tobacco_use",
+        "tobacco_craving",
+        "cannabis_use",
+        "cannabis_craving",
+        // Companion-written (Virgil)
+        "fall_event",
+        "near_miss_fall",
+        "check_in_miss",
+        // Reserved active-test result
+        "reaction_time_ms",
+    )
+
+    @Test
+    fun every_shipped_key_still_resolves() {
+        for (key in shippedKeys) {
+            assertNotNull(
+                MetricType.fromKey(key),
+                "Shipped key '$key' no longer resolves. Removing a key from " +
+                    "MetricType breaks every companion pinned to an earlier " +
+                    "bios-contracts version. Mark the entry @Deprecated " +
+                    "instead, or bump the contracts major version and " +
+                    "coordinate paired companion releases.",
+            )
+        }
+    }
+
+    @Test
+    fun snapshot_covers_every_current_entry() {
+        // Catches the reverse failure: a new key was added to the enum but
+        // the snapshot was not updated, so future removals of that key
+        // would silently slip past the guard above.
+        val current = MetricType.entries.map { it.key }.toSet()
+        val missingFromSnapshot = current - shippedKeys
+        assertEquals(
+            emptySet<String>(),
+            missingFromSnapshot,
+            "New MetricType keys are not listed in the snapshot. Append " +
+                "them to MetricTypeKeysSnapshotTest.shippedKeys so future " +
+                "removals are caught.",
+        )
+    }
+}

--- a/docs/CONSUMER_API.md
+++ b/docs/CONSUMER_API.md
@@ -217,4 +217,81 @@ underscores, case-sensitive.
 **Safety (Virgil-writable)**: `fall_event`, `near_miss_fall`, `check_in_miss`
 
 The source of truth is `MetricType` in
-[`android/app/src/main/java/com/bios/app/model/Enums.kt`](../android/app/src/main/java/com/bios/app/model/Enums.kt).
+[`android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt`](../android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt).
+
+## Contracts forward/backward compatibility
+
+`MetricType`, `MetricUnit`, and `MetricDomain` ship from the `bios-contracts`
+AAR. Companions (W2F, Smokeless, Virgil, Fil) pin a version of that AAR and
+release on their own cadence, so at any given moment some companion will be
+running against an older — or newer — contracts version than the installed
+Bios. The data plane already tolerates this by accident
+(`MetricReading.metricType` is a `String` end-to-end and `MetricType.fromKey`
+is nullable), but the rules below make the contract explicit.
+
+### Stability commitments (Bios side)
+
+1. **Keys are forever.** Once a `MetricType.key` string ships in a released
+   `bios-contracts` artifact, it is never deleted and never repurposed.
+2. **Domain and unit on an existing key never change.** Renaming
+   `blood_glucose` from `MG_PER_DL` to `MMOL_PER_L`, or moving `circadian_phase_shift`
+   from `SLEEP` to `MENTAL_HEALTH`, would silently corrupt every downstream
+   chart. Add a new key instead.
+3. **Deprecation is in-place.** When a key falls out of favor, annotate the
+   enum entry with `@Deprecated` and leave the entry in the enum so
+   `fromKey()` keeps resolving it. Document the replacement in the
+   `@Deprecated` message.
+4. **Removal is a major-version break.** Actually removing a `MetricType`
+   entry forces every companion to publish a paired release. Bump the
+   `bios-contracts` major version and coordinate releases.
+
+### Companion-side rules
+
+1. **Never call `MetricType.valueOf(...)` on a string from the provider.**
+   It throws `IllegalArgumentException` on any key your contracts version
+   doesn't know about — including keys Bios shipped after your last build.
+2. **Use `MetricType.fromKey(key)` and handle `null`.** The contract is that
+   unknown keys return `null`. The correct response is "skip this row" — not
+   crash, not surface as an error to the owner. Anything that reads the
+   `metric_type` column must tolerate strings outside its enum.
+3. **Never enumerate `MetricType.entries` and assume it covers the provider's
+   output.** A newer Bios may emit keys your build has never heard of. Filter
+   on the keys you actually care about; treat the rest as inert.
+4. **Writes to unknown keys silently no-op.** `CompanionContract.canWrite`
+   rejects keys it doesn't recognize, so a companion that ships a new write
+   key before the matching Bios release will see its inserts return `null`
+   URIs with no exception. Read `/status/{key}` first and gate the write
+   path on a non-empty cursor.
+
+### Rotation flow
+
+A companion can release independently of Bios as long as it follows the
+read-before-write rule and tolerates `fromKey() == null`. Concretely:
+
+- **Reading new keys before Bios ships them.** `/status/{key}` returns an
+  empty cursor for keys Bios doesn't know. Treat that as "this signal is not
+  available on this Bios version yet" and hide the UI path.
+- **Reading new keys after Bios shipped them.** If your contracts version is
+  older than Bios, `fromKey()` returns `null` for the new strings. Same
+  handling — skip the row.
+- **Writing new keys.** Bios must ship support first (key added to
+  `MetricType` and to `CompanionContract.WHITELIST_BY_PACKAGE`), then the
+  companion may publish a release that writes that key. Reverse order leaves
+  the companion writing to a closed door.
+
+### Versioning hygiene
+
+- The `bios-contracts` AAR is published with each Bios release. Add-only
+  changes (new key, new permission constant) bump the patch version; renames
+  or removals bump the major version (see "Stability commitments").
+- Companions pin a minimum-supported `bios-contracts` version in their
+  `build.gradle.kts`. The pinned version is the *contracts the companion
+  was built against* — at runtime it may talk to a Bios that ships a newer
+  contracts version, which is fine because of the rules above.
+- The contracts module includes a snapshot test
+  (`MetricTypeKeysSnapshotTest`) that fails when a previously-published key
+  disappears from the enum, even if its enum constant was renamed. Adding
+  `@Deprecated` to an entry still leaves the key resolvable and passes the
+  test; deleting the entry fails it. Treat a snapshot-test failure as a
+  required code review with the companion maintainers, not a test to fix
+  by editing the snapshot.


### PR DESCRIPTION
## Summary

Closes #91. Companions (W2F, Smokeless, Virgil, Fil) consume `bios-contracts` as an AAR on their own release cadence, so at any given moment one side will be running against an older or newer contracts version than the installed Bios. The data plane already tolerates this by accident (`MetricReading.metricType` is `String` end-to-end; `MetricType.fromKey` is nullable) — what was missing was a written-down policy. This PR is policy + a snapshot test that catches accidental key removal at PR-review time, not at companion-update-runtime time.

- **`docs/CONSUMER_API.md`** — new "Contracts forward/backward compatibility" section covering stability commitments (keys are forever; domain/unit never change on a shipped key; deprecate-in-place), companion-side rules (use `fromKey()` not `valueOf()`, tolerate `null`), rotation flow (read `/status/{key}` before writing new keys; Bios ships key support before companions write it), and versioning hygiene. Also fixes a stale link that pointed at the old `model/Enums.kt` location.
- **`MetricType.kt`** — header KDoc lists the three load-bearing rules inline and points at the doc section, so a contributor adding a key sees the policy without leaving the file.
- **`MetricTypeKeysSnapshotTest.kt`** (new) — frozen snapshot of every shipped key string. Removing a key from the enum fails the test with a message pointing at the deprecation procedure; renaming a key's string literal fails too (resolves to `null`). A reverse check fails if a new enum entry is missing from the snapshot, so future removals of newly-added keys can't slip past either.

## Test plan

- [x] `./gradlew :bios-contracts:testDebugUnitTest --tests "com.bios.contracts.MetricTypeKeysSnapshotTest"` passes
- [x] Full `./scripts/code-quality-check.sh` passes (file lengths, secret scan, lint, build, unit tests)
- [ ] Reviewer sanity-check: try renaming `STEPS("steps", ...)` to `STEPS("step", ...)` locally — both snapshot tests should fail with the documented error messages
- [ ] Reviewer sanity-check: annotating an entry `@Deprecated` should NOT fail the snapshot test (the key still resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)