### PR TITLE
instrument, not coach — reframe evaluation constraint + biomarker context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 Bios is a health guardian that detects early signs of illness using wearable sensor data. It exists to protect its owner — their health, their data, and their autonomy over both.
 
-All health data processing happens on-device. The owner decides what leaves the device — nothing does by default. Bios watches, notices patterns the owner might miss, and speaks up when something matters. It never evaluates, scores, or nudges the person — only the data.
+All health data processing happens on-device. The owner decides what leaves the device — nothing does by default. Bios watches, notices patterns the owner might miss, and speaks up when something matters. Bios is the instrument; the owner reads it. It never pushes judgments, scores, or nudges at the person — and it never withholds information the owner looks for. **Evaluation belongs to the owner.**
 
 **Primary platform:** Embedded in [LETHE](~/OSmosis/lethe/) (OSmosis privacy-hardened Android overlay based on LineageOS).
 **Portable to:** Any Android device running API 28+ (Android 9 Pie through Android 15).
@@ -14,7 +14,7 @@ Bios shares LETHE's protection philosophy:
 - **Defense only.** Health data is shielded by encryption, on-device processing, and erasure — never weaponized or monetized
 - **No hidden agendas.** No behavioral nudges, no engagement optimization, no data sold to insurers or advertisers
 - **Silence is a feature.** Bios speaks when something matters, not to fill a feed
-- **Never evaluate the person.** Report "resting HR elevated 2 sigma for 48h" — never "you're unhealthy"
+- **Instrument, not coach.** Bios reports deviations from baseline ("resting HR elevated 2 sigma for 48h"), holds what the owner annotates about themselves, answers when asked. It never pushes lifestyle judgments unsolicited. Evaluation belongs to the owner — Bios is what the owner reads to do it.
 - **Erasure by design.** On LETHE: burner mode and dead man's switch destroy health data alongside the OS. Standalone: instant key destruction on "Delete all data"
 
 ## Tech Stack

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -36,7 +36,7 @@ We **analyze** patterns over time — not just snapshots, but trends. A single e
 
 We **alert** you to anomalies that may indicate the early onset of illness, chronic stress, sleep disorders, cardiovascular irregularities, or other conditions — long before traditional symptoms appear.
 
-We **empower** you with clear, human-readable insights so you can have better conversations with your doctor, make informed lifestyle choices, and take preventive action.
+We **empower** you with clear, human-readable insights so you can have better conversations with your doctor, make informed lifestyle choices, and steer your own course over time — toward maintaining what works and improving what doesn't. Detection is one job. The day-to-day act of staying well and getting better is another, and both belong to the owner.
 
 ## Our Principles
 
@@ -57,8 +57,11 @@ If you would rather not contribute, that is your right. You can pay instead. But
 ### 5. Privacy is the default, not the price tag
 Your health data is the most intimate data that exists. We will never collect it without your explicit, informed consent. We will never sell individual data. We will never share anything that identifies you. Community tier users contribute anonymized, aggregated patterns -- never raw data, never anything traceable back to a person. Paid users contribute nothing at all. Both get the same product.
 
-### 6. Science-grounded, not fear-driven
-We do not exist to make you anxious. Every insight we surface is grounded in validated medical research. We inform, we do not diagnose. We empower, we do not alarm.
+### 6. Science-grounded, never fear-driven
+Bios does not exist to make you anxious. Every insight is grounded in validated medical research. We inform, we do not diagnose. We empower, we do not alarm.
+
+### 7. Instrument, not coach
+Bios is the instrument; the owner reads it. We never push judgments at you, score you, or nudge you toward behaviors we have decided are correct. We also never withhold information you look for. **Evaluation belongs to the owner.** Bios surfaces what is, holds what you note about yourself, and answers when you ask — and stays silent otherwise.
 
 ## The Future We Are Building
 

--- a/android/app/src/main/java/com/bios/app/data/BiomarkerContext.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiomarkerContext.kt
@@ -1,0 +1,43 @@
+package com.bios.app.data
+
+import com.bios.app.model.Specimen
+
+/**
+ * Optional provenance attached to a biomarker reading. Holds the context the
+ * lab report carried that the scalar value alone discards — which lab drew
+ * the sample, whether the owner was fasting, what specimen the assay ran on,
+ * a link to the source artifact, and a free-text note for owner recall.
+ *
+ * Engine-relevant fields (lab, fasting, specimen) ride the existing
+ * `event_payloads` sidecar via [BiomarkerPayloadKeys]. The owner-recall note
+ * rides the `MetricReading.note` column directly. Reasoning split in
+ * docs/SELF_REPORTED_DATA_HOME.md and docs/DATA_MODEL.md.
+ *
+ * All fields are optional. A bare biomarker entry (value + date) leaves
+ * every field null and writes nothing to the sidecar.
+ */
+data class BiomarkerContext(
+    val labName: String? = null,
+    val fasting: Boolean? = null,
+    val specimen: Specimen? = null,
+    val sourceUri: String? = null,
+    val note: String? = null
+) {
+    val isEmpty: Boolean
+        get() = labName.isNullOrBlank() &&
+            fasting == null &&
+            specimen == null &&
+            sourceUri.isNullOrBlank() &&
+            note.isNullOrBlank()
+}
+
+/**
+ * Field keys for biomarker provenance in the `event_payloads` sidecar.
+ * Stability contract: renames are breaking changes — see DATA_MODEL.md.
+ */
+object BiomarkerPayloadKeys {
+    const val LAB_NAME = "lab_name"
+    const val FASTING = "fasting"
+    const val SPECIMEN = "specimen"
+    const val SOURCE_URI = "source_uri"
+}

--- a/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
@@ -2,6 +2,7 @@ package com.bios.app.data
 
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.DataSource
+import com.bios.app.model.EventPayloadField
 import com.bios.app.model.MetricReading
 import com.bios.app.model.ReadingKind
 import com.bios.app.model.SensorType
@@ -17,23 +18,35 @@ import com.bios.contracts.MetricType
  * tagged with [ReadingKind.SELF_REPORTED] so the baseline engine and anomaly
  * detector keep ignoring them (decision 3 in docs/SELF_REPORTED_DATA_HOME.md).
  * They still show up in trends, FHIR export, and condition-pattern displays.
+ *
+ * Optional [BiomarkerContext] carries lab provenance — engine-relevant
+ * fields (lab, fasting, specimen, source URI) ride the existing
+ * `event_payloads` sidecar; the free-text owner-recall note rides the
+ * `metric_readings.note` column directly. Engines never read either.
  */
 class BiomarkerEntryRepo(private val db: BiosDatabase) {
 
-    suspend fun add(metricType: MetricType, value: Double, timestamp: Long) {
+    suspend fun add(
+        metricType: MetricType,
+        value: Double,
+        timestamp: Long,
+        context: BiomarkerContext = BiomarkerContext()
+    ): String {
         require(metricType.domain == MetricDomain.BIOMARKER) {
             "BiomarkerEntryRepo only accepts BIOMARKER metrics; got ${metricType.key}"
         }
         val sourceId = getOrCreateSelfReportedSource()
-        db.metricReadingDao().insert(
-            MetricReading(
-                metricType = metricType.key,
-                value = value,
-                timestamp = timestamp,
-                sourceId = sourceId,
-                confidence = ConfidenceTier.HIGH.level
-            )
+        val reading = MetricReading(
+            metricType = metricType.key,
+            value = value,
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            note = context.note?.takeIf { it.isNotBlank() }
         )
+        db.metricReadingDao().insert(reading)
+        persistPayload(reading.id, context)
+        return reading.id
     }
 
     suspend fun fetchRecent(limit: Int = 20): List<MetricReading> {
@@ -43,6 +56,31 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
             .flatMap { dao.fetchLatest(it.key, limit) }
             .sortedByDescending { it.timestamp }
             .take(limit)
+    }
+
+    suspend fun fetchContext(readingId: String): BiomarkerContext {
+        val rows = db.eventPayloadFieldDao().fetchForReading(readingId)
+        return rowsToContext(rows, note = null)
+    }
+
+    private suspend fun persistPayload(readingId: String, context: BiomarkerContext) {
+        val fields = buildList {
+            context.labName?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, BiomarkerPayloadKeys.LAB_NAME, stringValue = it))
+            }
+            context.fasting?.let {
+                add(EventPayloadField(readingId, BiomarkerPayloadKeys.FASTING, longValue = if (it) 1L else 0L))
+            }
+            context.specimen?.let {
+                add(EventPayloadField(readingId, BiomarkerPayloadKeys.SPECIMEN, stringValue = it.name))
+            }
+            context.sourceUri?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, BiomarkerPayloadKeys.SOURCE_URI, stringValue = it))
+            }
+        }
+        if (fields.isNotEmpty()) {
+            db.eventPayloadFieldDao().insertAll(fields)
+        }
     }
 
     private suspend fun getOrCreateSelfReportedSource(): String {
@@ -56,5 +94,19 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
         )
         dao.insert(source)
         return source.id
+    }
+
+    companion object {
+        internal fun rowsToContext(rows: List<EventPayloadField>, note: String?): BiomarkerContext {
+            val byKey = rows.associateBy { it.fieldKey }
+            return BiomarkerContext(
+                labName = byKey[BiomarkerPayloadKeys.LAB_NAME]?.stringValue,
+                fasting = byKey[BiomarkerPayloadKeys.FASTING]?.longValue?.let { it == 1L },
+                specimen = byKey[BiomarkerPayloadKeys.SPECIMEN]?.stringValue
+                    ?.let { com.bios.app.model.Specimen.fromName(it) },
+                sourceUri = byKey[BiomarkerPayloadKeys.SOURCE_URI]?.stringValue,
+                note = note
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -27,7 +27,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         LoggedEvent::class,
         EventPayloadField::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -66,7 +66,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
                 .build()
         }
 
@@ -252,6 +252,16 @@ abstract class BiosDatabase : RoomDatabase() {
                     "CREATE INDEX IF NOT EXISTS index_logged_events_sourceId " +
                         "ON logged_events(sourceId)"
                 )
+            }
+        }
+
+        // Adds owner-recall `note` column to metric_readings. Never read by
+        // any engine — the manifesto's "instrument, not coach" stance scopes
+        // evaluation to the owner. Used by the biomarker entry surface today;
+        // available to any future surface where the owner annotates a reading.
+        private val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE metric_readings ADD COLUMN note TEXT")
             }
         }
 

--- a/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
@@ -2,6 +2,7 @@ package com.bios.app.export
 
 import android.content.Context
 import android.net.Uri
+import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
@@ -51,7 +52,12 @@ object FhirImporter {
 
         val summary = parse(text)
         for (reading in summary.accepted) {
-            repo.add(reading.metricType, reading.value, reading.timestamp)
+            repo.add(
+                metricType = reading.metricType,
+                value = reading.value,
+                timestamp = reading.timestamp,
+                context = BiomarkerContext(labName = reading.labName)
+            )
         }
         summary
     }
@@ -137,7 +143,18 @@ object FhirImporter {
                 )
             )
 
-        return ParseOutcome.Accepted(AcceptedReading(metric, value, timestamp))
+        val labName = readPerformerDisplay(obs)
+        return ParseOutcome.Accepted(AcceptedReading(metric, value, timestamp, labName))
+    }
+
+    private fun readPerformerDisplay(obs: JSONObject): String? {
+        val performers = obs.optJSONArray("performer") ?: return null
+        for (i in 0 until performers.length()) {
+            val entry = performers.optJSONObject(i) ?: continue
+            val display = entry.optString("display")
+            if (display.isNotBlank()) return display
+        }
+        return null
     }
 
     private fun findLoincCode(coding: JSONArray?): String? {
@@ -184,7 +201,8 @@ object FhirImporter {
 data class AcceptedReading(
     val metricType: MetricType,
     val value: Double,
-    val timestamp: Long
+    val timestamp: Long,
+    val labName: String? = null
 )
 
 data class SkippedObservation(

--- a/android/app/src/main/java/com/bios/app/model/MetricReading.kt
+++ b/android/app/src/main/java/com/bios/app/model/MetricReading.kt
@@ -31,5 +31,10 @@ data class MetricReading(
     val sourceId: String,
     val confidence: Int,        // ConfidenceTier.level
     val isPrimary: Boolean = true,
-    val createdAt: Long = System.currentTimeMillis()
+    val createdAt: Long = System.currentTimeMillis(),
+    // Owner-recall free text, never read by any engine. Reserved for surfaces
+    // where the owner annotates their own reading (biomarker entry, manual
+    // sleep duration). Engines must not query this column; the manifesto's
+    // "instrument, not coach" stance scopes evaluation to the owner.
+    val note: String? = null
 )

--- a/android/app/src/main/java/com/bios/app/model/Specimen.kt
+++ b/android/app/src/main/java/com/bios/app/model/Specimen.kt
@@ -1,0 +1,19 @@
+package com.bios.app.model
+
+/**
+ * Specimen the lab assay ran on. Matters for some biomarkers (serum vs
+ * plasma vs whole blood gives different reference ranges and, for a few
+ * assays, different absolute values). Persisted as the enum name in the
+ * `event_payloads` sidecar.
+ */
+enum class Specimen(val readable: String) {
+    SERUM("Serum"),
+    PLASMA("Plasma"),
+    WHOLE_BLOOD("Whole blood"),
+    OTHER("Other");
+
+    companion object {
+        fun fromName(name: String?): Specimen? =
+            entries.firstOrNull { it.name.equals(name, ignoreCase = true) }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -21,6 +21,7 @@ import com.bios.app.ingest.OuraApiAdapter
 import com.bios.app.ingest.OuraTokenStore
 import com.bios.app.ingest.PhoneSensorAdapter
 import com.bios.app.ingest.WithingsApiAdapter
+import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.app.model.ActionItem
 import com.bios.app.model.Anomaly
@@ -485,13 +486,13 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long) {
+    fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long, context: BiomarkerContext = BiomarkerContext()) {
         if (metricType.domain != MetricDomain.BIOMARKER) {
             _error.value = "Manual entry is only supported for biomarker metrics."
             return
         }
         viewModelScope.launch {
-            biomarkerEntryRepo.add(metricType, value, timestamp)
+            biomarkerEntryRepo.add(metricType, value, timestamp, context)
             _recentBiomarkers.value = biomarkerEntryRepo.fetchRecent(20)
         }
     }

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
@@ -47,9 +47,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.FilterChip
+import androidx.compose.foundation.layout.Row
+import com.bios.app.data.BiomarkerContext
 import com.bios.app.export.FhirImportSummary
 import com.bios.app.export.FhirImporter
 import com.bios.app.model.MetricReading
+import com.bios.app.model.Specimen
 import com.bios.app.ui.AppViewModel
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
@@ -74,6 +78,12 @@ fun BiomarkerEntryScreen(
     var showDatePicker by remember { mutableStateOf(false) }
     var importing by remember { mutableStateOf(false) }
     var importSummary by remember { mutableStateOf<FhirImportSummary?>(null) }
+    var labName by remember { mutableStateOf("") }
+    var fasting by remember { mutableStateOf<Boolean?>(null) }
+    var specimen by remember { mutableStateOf<Specimen?>(null) }
+    var specimenExpanded by remember { mutableStateOf(false) }
+    var note by remember { mutableStateOf("") }
+    var showContext by remember { mutableStateOf(false) }
     val recent by viewModel.recentBiomarkers.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -182,10 +192,104 @@ fun BiomarkerEntryScreen(
                         Text("Drawn on: ${formatDate(selectedDate)}")
                     }
 
+                    TextButton(
+                        onClick = { showContext = !showContext },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(if (showContext) "Hide context" else "Add context (lab, fasting, specimen, note)")
+                    }
+
+                    if (showContext) {
+                        OutlinedTextField(
+                            value = labName,
+                            onValueChange = { labName = it },
+                            label = { Text("Lab / facility") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+
+                        Text(
+                            "Fasting",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            FilterChip(
+                                selected = fasting == true,
+                                onClick = { fasting = if (fasting == true) null else true },
+                                label = { Text("Yes") }
+                            )
+                            FilterChip(
+                                selected = fasting == false,
+                                onClick = { fasting = if (fasting == false) null else false },
+                                label = { Text("No") }
+                            )
+                            FilterChip(
+                                selected = fasting == null,
+                                onClick = { fasting = null },
+                                label = { Text("Unknown") }
+                            )
+                        }
+
+                        ExposedDropdownMenuBox(
+                            expanded = specimenExpanded,
+                            onExpandedChange = { specimenExpanded = it }
+                        ) {
+                            OutlinedTextField(
+                                value = specimen?.readable ?: "—",
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text("Specimen") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = specimenExpanded) },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                            )
+                            ExposedDropdownMenu(
+                                expanded = specimenExpanded,
+                                onDismissRequest = { specimenExpanded = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("—") },
+                                    onClick = {
+                                        specimen = null
+                                        specimenExpanded = false
+                                    }
+                                )
+                                Specimen.entries.forEach { s ->
+                                    DropdownMenuItem(
+                                        text = { Text(s.readable) },
+                                        onClick = {
+                                            specimen = s
+                                            specimenExpanded = false
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        OutlinedTextField(
+                            value = note,
+                            onValueChange = { note = it },
+                            label = { Text("Note (for your recall)") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
                     OutlinedButton(
                         onClick = {
-                            viewModel.addManualBiomarker(selected, parsed!!, selectedDate)
+                            val bioContext = BiomarkerContext(
+                                labName = labName.ifBlank { null },
+                                fasting = fasting,
+                                specimen = specimen,
+                                note = note.ifBlank { null }
+                            )
+                            viewModel.addManualBiomarker(selected, parsed!!, selectedDate, bioContext)
                             valueText = ""
+                            labName = ""
+                            fasting = null
+                            specimen = null
+                            note = ""
                         },
                         enabled = isValid,
                         modifier = Modifier.fillMaxWidth()
@@ -327,6 +431,14 @@ private fun RecentBiomarkerRow(reading: MetricReading) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            reading.note?.takeIf { it.isNotBlank() }?.let {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    "“$it”",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiomarkerContextTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerContextTest.kt
@@ -1,0 +1,98 @@
+package com.bios.app
+
+import com.bios.app.data.BiomarkerContext
+import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.app.data.BiomarkerPayloadKeys
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.Specimen
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-data tests for biomarker provenance round-tripping through the
+ * `event_payloads` sidecar. The actual DB write path is exercised by the
+ * existing biomarker entry surface + integration of the FhirImporter; this
+ * test guards the key vocabulary and the rowsToContext mapping in
+ * isolation.
+ */
+class BiomarkerContextTest {
+
+    @Test
+    fun `BiomarkerContext is empty when every field is null or blank`() {
+        assertTrue(BiomarkerContext().isEmpty)
+        assertTrue(BiomarkerContext(labName = "", note = "").isEmpty)
+    }
+
+    @Test
+    fun `BiomarkerContext is not empty when any field is populated`() {
+        assertFalse(BiomarkerContext(labName = "Synlab Madrid").isEmpty)
+        assertFalse(BiomarkerContext(fasting = false).isEmpty)
+        assertFalse(BiomarkerContext(specimen = Specimen.SERUM).isEmpty)
+        assertFalse(BiomarkerContext(sourceUri = "content://x").isEmpty)
+        assertFalse(BiomarkerContext(note = "post-flu").isEmpty)
+    }
+
+    @Test
+    fun `rowsToContext recovers every field round-trip`() {
+        val readingId = "r1"
+        val rows = listOf(
+            EventPayloadField(readingId, BiomarkerPayloadKeys.LAB_NAME, stringValue = "Synlab Madrid"),
+            EventPayloadField(readingId, BiomarkerPayloadKeys.FASTING, longValue = 1L),
+            EventPayloadField(readingId, BiomarkerPayloadKeys.SPECIMEN, stringValue = "SERUM"),
+            EventPayloadField(readingId, BiomarkerPayloadKeys.SOURCE_URI, stringValue = "content://x")
+        )
+        val ctx = BiomarkerEntryRepo.rowsToContext(rows, note = "post-flu")
+        assertEquals("Synlab Madrid", ctx.labName)
+        assertEquals(true, ctx.fasting)
+        assertEquals(Specimen.SERUM, ctx.specimen)
+        assertEquals("content://x", ctx.sourceUri)
+        assertEquals("post-flu", ctx.note)
+    }
+
+    @Test
+    fun `fasting long 0 maps to false, 1 maps to true`() {
+        val rid = "r"
+        val fastingFalse = BiomarkerEntryRepo.rowsToContext(
+            listOf(EventPayloadField(rid, BiomarkerPayloadKeys.FASTING, longValue = 0L)),
+            note = null
+        )
+        assertEquals(false, fastingFalse.fasting)
+
+        val fastingTrue = BiomarkerEntryRepo.rowsToContext(
+            listOf(EventPayloadField(rid, BiomarkerPayloadKeys.FASTING, longValue = 1L)),
+            note = null
+        )
+        assertEquals(true, fastingTrue.fasting)
+    }
+
+    @Test
+    fun `unknown specimen name resolves to null without crashing`() {
+        val ctx = BiomarkerEntryRepo.rowsToContext(
+            listOf(EventPayloadField("r", BiomarkerPayloadKeys.SPECIMEN, stringValue = "BOGUS")),
+            note = null
+        )
+        assertNull(ctx.specimen)
+    }
+
+    @Test
+    fun `Specimen fromName is case-insensitive`() {
+        assertEquals(Specimen.SERUM, Specimen.fromName("serum"))
+        assertEquals(Specimen.PLASMA, Specimen.fromName("PLASMA"))
+        assertEquals(Specimen.WHOLE_BLOOD, Specimen.fromName("Whole_Blood"))
+        assertNull(Specimen.fromName(null))
+        assertNull(Specimen.fromName("nonsense"))
+    }
+
+    @Test
+    fun `field key vocabulary is stable`() {
+        // These strings are persisted into event_payloads.fieldKey on every
+        // biomarker entry. Renaming any of them is a breaking schema change.
+        assertEquals("lab_name", BiomarkerPayloadKeys.LAB_NAME)
+        assertEquals("fasting", BiomarkerPayloadKeys.FASTING)
+        assertEquals("specimen", BiomarkerPayloadKeys.SPECIMEN)
+        assertEquals("source_uri", BiomarkerPayloadKeys.SOURCE_URI)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
@@ -237,6 +237,47 @@ class FhirImporterTest {
         assertTrue(summary.fileError!!.contains("Bundle or Observation"))
     }
 
+    // -- Provenance: performer display becomes labName --
+
+    @Test
+    fun `performer display populates labName on AcceptedReading`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "4548-4" }]
+              },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4 },
+              "performer": [
+                { "display": "Synlab Madrid" }
+              ]
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals("Synlab Madrid", summary.accepted.single().labName)
+    }
+
+    @Test
+    fun `missing performer leaves labName null`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "4548-4" }]
+              },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4 }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertNull(summary.accepted.single().labName)
+    }
+
     // -- Fixture helpers --
 
     private fun observation(loinc: String, value: Double, instant: String) = """

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -145,6 +145,10 @@ with the same stability commitment as `MetricType.key` strings.
 | `EXERCISE_SESSION` | `end_utc` | `long_value` | epoch ms |
 | `EXERCISE_SESSION` | `avg_hr_bpm` | `double_value` | nullable — mean of HR samples that fall inside the session window; omitted entirely when no samples land in window (null ≠ 0) |
 | `EXERCISE_SESSION` | `rpe` | `long_value` | 1–10, nullable — only populated if the source captured it |
+| *(any `BIOMARKER`)* | `lab_name` | `string_value` | Free-text lab/facility name. Provenance only — cross-lab calibration drift on assays like HbA1c, hsCRP, ApoB makes lab identity load-bearing for trend interpretation. |
+| *(any `BIOMARKER`)* | `fasting` | `long_value` | 0 = non-fasting, 1 = fasting. Omitted entirely when unknown (null ≠ 0). Required to interpret glucose, triglycerides, insulin meaningfully. |
+| *(any `BIOMARKER`)* | `specimen` | `string_value` | enum: `SERUM`, `PLASMA`, `WHOLE_BLOOD`, `OTHER`. Some assays differ measurably across specimen types. |
+| *(any `BIOMARKER`)* | `source_uri` | `string_value` | Content URI to the original PDF/photo of the lab report — owner-attached, for retrieval; never parsed. |
 
 #### When to use the payload table
 
@@ -156,10 +160,20 @@ Use a payload row when **all** of:
    require ad-hoc parsing on every read.
 
 Do **not** use it for:
-- Owner-private notes — those go in `LoggedEvent.note`.
+- Owner-private free-text notes — those go in `LoggedEvent.note` (for
+  event-shaped data) or `MetricReading.note` (for biomarker/manual-entry
+  surfaces). The sidecar table is queryable by engines; owner-recall text
+  isn't.
 - Vendor-specific raw blobs — those belong in the raw-payload field on
   `MetricReading` (debug surface, never read by the engine).
 - Re-encoding the scalar that already fits in `value`.
+
+**Note on scalar metrics:** the "scalar metrics never use this table" rule
+applies to the *value itself* (don't denormalize `value` into the sidecar).
+A scalar metric *may* still attach structured provenance via the sidecar —
+biomarker readings are the canonical example: the value is a scalar that
+lives in `MetricReading.value`, but the lab/fasting/specimen context is
+queryable structured data that lives here.
 
 ### DataSource
 

--- a/docs/PRIVACY_ARCHITECTURE.md
+++ b/docs/PRIVACY_ARCHITECTURE.md
@@ -8,7 +8,7 @@ This is not a privacy policy — it is an architectural constraint. Every design
 
 - Health data stays on-device because that protects the owner from data brokers, insurers, advertisers, and legal compulsion
 - Detection runs on-device because that protects the owner from cloud outages, surveillance, and vendor lock-in
-- Alerts are factual, never judgmental, because that protects the owner's autonomy and mental health
+- Unsolicited alerts are factual, never judgmental, because that protects the owner's autonomy and mental health. Evaluation belongs to the owner — the system answers when asked and stays silent otherwise
 - The owner decides what leaves the device — nothing does by default
 
 ### Alignment with LETHE
@@ -19,7 +19,7 @@ On LETHE, Bios is not an app running on a phone — it is part of the phone's im
 |---|---|
 | The user is final | Owner controls alert thresholds, data retention, what to share, and when to delete — Bios advises, never overrides |
 | Defense by encryption and erasure | SQLCipher AES-256, hardware-backed keystore, instant key destruction, LETHE burner/dead-man's-switch integration |
-| Never evaluate the person | Report deviations from baseline ("resting HR +2σ for 48h"), never lifestyle judgments ("you're unhealthy") |
+| Instrument, not coach — evaluation belongs to the owner | Report deviations from baseline ("resting HR +2σ for 48h"), hold what the owner annotates about themselves, answer when asked. Never push lifestyle judgments ("you're unhealthy") unsolicited |
 | Silence is a feature | Bios speaks when something matters, not to fill a feed or drive engagement |
 | No hidden agendas | No behavioral nudges, no engagement metrics, no data sold to anyone, no dark patterns |
 | Each instance is sovereign | Health data belongs to this device and this owner — no cross-device aggregation without explicit opt-in |
@@ -396,11 +396,12 @@ The owner should know what they're accumulating. On a device that could be seize
 
 ## Alert Content Policy
 
-The `AlertContentPolicy` enforces the "never evaluate the person" principle at the code level:
-- Prohibited: second-person lifestyle judgments ("you should", "you need to"), guilt mechanics ("you haven't", "you missed"), gamification ("streak", "achievement", "leaderboard")
-- Allowed: data statements ("resting HR +2σ"), questions ("have you felt unwell?"), professional referrals ("discuss with your healthcare provider")
+The `AlertContentPolicy` enforces the **unsolicited-judgment ban** at the code level. It governs the push surface — alerts and notifications Bios raises on its own. Pull-side surfaces (screens the owner navigates into, biomarker context they annotate themselves, comparisons they ask for) are owner-driven and not constrained by this policy.
+
+- Prohibited (push side): second-person lifestyle judgments ("you should", "you need to"), guilt mechanics ("you haven't", "you missed"), gamification ("streak", "achievement", "leaderboard")
+- Allowed (push side): data statements ("resting HR +2σ"), questions ("have you felt unwell?"), professional referrals ("discuss with your healthcare provider")
 - All 12 condition patterns are validated against this policy
-- Future patterns must pass the same check in CI
+- Future push-side patterns must pass the same check in CI
 
 ## Coercion Resistance
 
@@ -463,7 +464,8 @@ The `SafeMode` provides protection under duress:
 |    - Health data in analytics or crash reports         |
 |    - Individual data sold to anyone                   |
 |    - Data tied to an identity shared with partners    |
-|    - Lifestyle judgments, wellness scores, or          |
-|      behavioral nudges targeting the owner             |
+|    - Unsolicited lifestyle judgments, pushed          |
+|      wellness scores, or behavioral nudges            |
+|      targeting the owner                              |
 +------------------------------------------------------+
 ```


### PR DESCRIPTION
## Summary

Two-commit PR. First commit reframes a foundational manifesto constraint that was blocking the actual ecosystem goal. Second commit lands the first downstream product change.

- **docs (`bf5400c`)** — "Never evaluate the person" was authored under a reactive-prevention frame and was conflating three distinct commitments: (1) no unsolicited judgment, (2) no system-side evaluation as engine input, (3) refusing to hold the owner's own annotations. (1) and (2) are load-bearing. (3) is paternalism and was blocking maintain/improve workflows that the ecosystem actually exists to support. Reformulated to **"instrument, not coach — evaluation belongs to the owner."** Push side (unsolicited alerts, `AlertContentPolicy`) keeps its judgment ban; pull side (owner-driven surfaces) is unconstrained.
- **feat (`01d4bb8`)** — The biomarker entry surface now captures lab provenance (lab name, fasting state, specimen type) and a free-text owner-recall note alongside the value. Lab name is also extracted from FHIR `performer[].display` on import. Engine-relevant context rides the existing `event_payloads` sidecar (from #93); owner-recall note rides a new `metric_readings.note` column (MIGRATION_9_10). Engines never read either by design.

## Why this matters

The biomarker entry surface previously discarded everything the lab report carried except the scalar value and date — meaning a 5.4% HbA1c at Synlab Madrid (fasting) and a 5.4% HbA1c at Hospital X (non-fasting, post-flu) were indistinguishable in the trend view. Cross-lab calibration drift on assays like HbA1c, hsCRP, ApoB is well-documented; without lab identity, the trend is misleading by construction. This PR closes that gap.

## Test plan

- [x] `./scripts/code-quality-check.sh` — file length OK, no secrets, `assembleDebug` succeeds (run twice across the two commits)
- [x] Pure-data unit tests pass (`BiomarkerContextTest` × 7, `FhirImporterTest` extended with 2 performer-display cases)
- [ ] Manual: open `BiomarkerEntryScreen` on device, save a reading with full context, verify it round-trips on relaunch
- [ ] Manual: import a FHIR Bundle with a `performer[].display` field, verify the lab name lands in the recent row
- [ ] Manual: migration 9→10 on an existing install with biomarker readings — note column null-defaults cleanly

## Intentionally deferred (tracked, not lost)

- `FhirExporter` round-trip emission of lab/fasting/specimen back into outgoing FHIR — asymmetric today
- `source_uri` UI capture (file picker + `takePersistableUriPermission`) — vocabulary reserved, screen field not wired
- FHIR fasting (LOINC `49541-6` component) + Specimen resource resolution on import
- Audit-doc revisit (`ECOSYSTEM_BOUNDARIES.md`, `SELF_REPORTED_DATA_HOME.md`) — still downstream of the old frame. Friction now visible in the docs; revisit deliberately, not silently.
- `AlertContentPolicy.kt` header comment sweep — code is fine (push-side only by construction), just the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)