### PR TITLE
feat(export): single-page PDF summary for cross-doctor handoff

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/PdfReportExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/PdfReportExporter.kt
@@ -1,0 +1,418 @@
+package com.bios.app.export
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.pdf.PdfDocument
+import com.bios.app.config.BiomarkerBand
+import com.bios.app.config.BiomarkerBands
+import com.bios.app.config.RegionConfigProvider
+import com.bios.app.data.BiosDatabase
+import com.bios.app.model.MetricReading
+import com.bios.app.model.PersonalBaseline
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Renders a single-page A4 PDF the owner can share with a doctor before or
+ * after a consult. Designed to be readable in ~30 seconds. Generated on the
+ * device, written to `context.cacheDir`, shared via the standard share sheet
+ * (`FileProvider` + `ACTION_SEND`) — same pattern as the other exporters.
+ *
+ * Manifesto context (PR #103). Bios renders structured data the owner
+ * already has access to. Cells are coloured against published clinical
+ * reference ranges from [RegionConfigProvider] (ADA/NCEP/AHA/etc.), not
+ * Bios's evaluation — the bands are the ones a doctor would apply. The
+ * owner picks the focal metric and may attach a free-text note; the system
+ * never picks for them. This surface is pull-side: invoked by the owner,
+ * shown to a person of the owner's choosing.
+ *
+ * Excludes WOMENS_HEALTH metrics by construction — those readings live in
+ * the isolated [com.bios.app.data.ReproductiveDatabase]. Including them in
+ * a default summary would collapse the isolation that DB exists to provide.
+ */
+class PdfReportExporter(
+    private val context: Context,
+    private val db: BiosDatabase,
+) {
+    private val readingDao = db.metricReadingDao()
+    private val baselineDao = db.personalBaselineDao()
+
+    suspend fun exportToPdf(
+        focalMetric: MetricType,
+        windowDays: Int = 30,
+        ownerNote: String? = null,
+    ): File {
+        require(focalMetric.domain != MetricDomain.WOMENS_HEALTH) {
+            "Reproductive metrics live in the isolated DB; PDF export excludes them by design"
+        }
+
+        val endMillis = System.currentTimeMillis()
+        val startMillis = endMillis - windowDays.toLong() * 24 * 3600 * 1000
+
+        val focalReadings = readingDao.fetch(focalMetric.key, startMillis, endMillis)
+        val focalBaseline = baselineDao.fetch(focalMetric.key)
+        val biomarkerLatest = MetricType.entries
+            .filter { it.domain == MetricDomain.BIOMARKER }
+            .mapNotNull { metric ->
+                readingDao.fetchLatest(metric.key, 1).firstOrNull()?.let { metric to it }
+            }
+            .sortedBy { it.first.readableName }
+
+        val bands = RegionConfigProvider.forCurrentLocale().clinicalThresholds.biomarkerBands
+
+        val document = PdfDocument()
+        val pageInfo = PdfDocument.PageInfo.Builder(PAGE_WIDTH_PX, PAGE_HEIGHT_PX, 1).create()
+        val page = document.startPage(pageInfo)
+        renderPage(
+            canvas = page.canvas,
+            focalMetric = focalMetric,
+            focalReadings = focalReadings,
+            focalBaseline = focalBaseline,
+            biomarkerLatest = biomarkerLatest,
+            bands = bands,
+            startMillis = startMillis,
+            endMillis = endMillis,
+            ownerNote = ownerNote,
+            versionName = appVersionName(context),
+            generatedAtMillis = endMillis,
+        )
+        document.finishPage(page)
+
+        val filename = "bios_doctor_summary_${timestampForFile()}.pdf"
+        val file = File(context.cacheDir, filename)
+        file.outputStream().use { document.writeTo(it) }
+        document.close()
+        return file
+    }
+
+    private fun timestampForFile(): String =
+        SimpleDateFormat("yyyy-MM-dd_HHmmss", Locale.US).format(Date())
+
+    companion object {
+        // A4 at 72 DPI.
+        const val PAGE_WIDTH_PX = 595
+        const val PAGE_HEIGHT_PX = 842
+        const val MARGIN_PX = 36
+        const val INNER_WIDTH_PX = PAGE_WIDTH_PX - 2 * MARGIN_PX
+    }
+}
+
+// --- Pure-function layout/format helpers (internal so tests can exercise) ---
+
+internal fun appVersionName(context: Context): String =
+    try {
+        context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "0.0"
+    } catch (_: Exception) {
+        "0.0"
+    }
+
+internal fun formatDateRange(startMillis: Long, endMillis: Long): String {
+    val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    return "${fmt.format(Date(startMillis))} to ${fmt.format(Date(endMillis))}"
+}
+
+internal fun formatGeneratedFooter(generatedAtMillis: Long): String {
+    val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    return "Generated on-device by Bios on ${fmt.format(Date(generatedAtMillis))}. " +
+        "No data left this device during generation."
+}
+
+internal fun formatSummaryStats(
+    metric: MetricType,
+    readings: List<MetricReading>,
+    baseline: PersonalBaseline?,
+): String {
+    if (readings.isEmpty()) {
+        return "No ${metric.readableName.lowercase()} readings in this window."
+    }
+    val current = readings.last().value
+    val mean = readings.map { it.value }.average()
+    val parts = mutableListOf<String>()
+    parts.add("Current: ${fmtValue(current)}${metric.unit.symbol}")
+    parts.add("Window mean: ${fmtValue(mean)}${metric.unit.symbol}")
+    if (baseline != null) {
+        parts.add("Baseline p5–p95: ${fmtValue(baseline.p5)}–${fmtValue(baseline.p95)}${metric.unit.symbol}")
+    }
+    return parts.joinToString("  |  ")
+}
+
+internal fun fmtValue(v: Double): String = when {
+    kotlin.math.abs(v) >= 100 -> String.format(Locale.US, "%.0f", v)
+    else -> String.format(Locale.US, "%.1f", v)
+}
+
+internal fun bandFillColor(band: BiomarkerBand?): Int = when (band) {
+    BiomarkerBand.NORMAL -> 0xFFE6F4EA.toInt()
+    BiomarkerBand.BORDERLINE -> 0xFFFFF4CE.toInt()
+    BiomarkerBand.CONCERNING -> 0xFFFADBD8.toInt()
+    null -> 0xFFF5F5F5.toInt()
+}
+
+internal fun bandTextColor(band: BiomarkerBand?): Int = when (band) {
+    BiomarkerBand.NORMAL -> 0xFF1E4620.toInt()
+    BiomarkerBand.BORDERLINE -> 0xFF6F4F00.toInt()
+    BiomarkerBand.CONCERNING -> 0xFF7A1C1C.toInt()
+    null -> 0xFF333333.toInt()
+}
+
+internal fun bandLabel(band: BiomarkerBand?): String = when (band) {
+    BiomarkerBand.NORMAL -> "normal"
+    BiomarkerBand.BORDERLINE -> "borderline"
+    BiomarkerBand.CONCERNING -> "concerning"
+    null -> "—"
+}
+
+/**
+ * Maps a value into a chart's pixel-Y coordinate (top-left origin). Returns
+ * the y for [value] inside [chartTop, chartBottom] when [value] lies within
+ * [valueMin, valueMax]; clamped at the edges otherwise.
+ */
+internal fun mapY(
+    value: Double,
+    valueMin: Double,
+    valueMax: Double,
+    chartTop: Float,
+    chartBottom: Float,
+): Float {
+    if (valueMax <= valueMin) return chartBottom
+    val clamped = value.coerceIn(valueMin, valueMax)
+    val frac = (clamped - valueMin) / (valueMax - valueMin)
+    return (chartBottom - frac * (chartBottom - chartTop)).toFloat()
+}
+
+/**
+ * Returns the [min, max] value-range for the chart, padded by 5% on each
+ * side so points don't sit on the axes. When a baseline is present, the
+ * p5–p95 band is included in the range so the shaded baseline never spills
+ * off the chart.
+ */
+internal fun chartValueRange(
+    readings: List<MetricReading>,
+    baseline: PersonalBaseline?,
+): Pair<Double, Double> {
+    val values = readings.map { it.value }
+    val baselineMin = baseline?.p5
+    val baselineMax = baseline?.p95
+    val candidates = (values + listOfNotNull(baselineMin, baselineMax))
+    if (candidates.isEmpty()) return 0.0 to 1.0
+    val min = candidates.min()
+    val max = candidates.max()
+    if (max <= min) return min - 1.0 to max + 1.0
+    val pad = (max - min) * 0.05
+    return min - pad to max + pad
+}
+
+// --- Page rendering (file-private, big block — kept off the class) -----------
+
+private fun renderPage(
+    canvas: Canvas,
+    focalMetric: MetricType,
+    focalReadings: List<MetricReading>,
+    focalBaseline: PersonalBaseline?,
+    biomarkerLatest: List<Pair<MetricType, MetricReading>>,
+    bands: Map<MetricType, BiomarkerBands>,
+    startMillis: Long,
+    endMillis: Long,
+    ownerNote: String?,
+    versionName: String,
+    generatedAtMillis: Long,
+) {
+    val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.BLACK
+        textSize = 16f
+        isFakeBoldText = true
+    }
+    val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF444444.toInt(); textSize = 10f
+    }
+    val bodyPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF222222.toInt(); textSize = 11f
+    }
+    val rowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { textSize = 10f }
+    val captionPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF666666.toInt(); textSize = 9f
+    }
+    val bandPaint = Paint().apply { style = Paint.Style.FILL }
+    val baselineBandPaint = Paint().apply {
+        color = 0x33339966
+        style = Paint.Style.FILL
+    }
+    val meanLinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF339966.toInt()
+        strokeWidth = 1f
+        style = Paint.Style.STROKE
+        pathEffect = android.graphics.DashPathEffect(floatArrayOf(4f, 4f), 0f)
+    }
+    val linePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF1F4E79.toInt()
+        strokeWidth = 1.5f
+        style = Paint.Style.STROKE
+    }
+    val pointPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF1F4E79.toInt()
+        style = Paint.Style.FILL
+    }
+    val axisPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFFCCCCCC.toInt()
+        strokeWidth = 0.5f
+        style = Paint.Style.STROKE
+    }
+
+    val left = PdfReportExporter.MARGIN_PX.toFloat()
+    val right = (PdfReportExporter.PAGE_WIDTH_PX - PdfReportExporter.MARGIN_PX).toFloat()
+    var y = PdfReportExporter.MARGIN_PX.toFloat() + 14f
+
+    // --- Header ---
+    canvas.drawText("Bios health summary", left, y, titlePaint)
+    y += 18f
+    canvas.drawText(
+        "Window: ${formatDateRange(startMillis, endMillis)}   |   Bios v$versionName",
+        left, y, labelPaint
+    )
+    y += 14f
+    if (!ownerNote.isNullOrBlank()) {
+        for (line in wrapText(ownerNote.trim(), bodyPaint, (right - left).toInt()).take(2)) {
+            canvas.drawText(line, left, y, bodyPaint)
+            y += 13f
+        }
+    }
+    y += 6f
+
+    // --- Focal metric chart ---
+    val unitSuffix = if (focalMetric.unit.symbol.isNotBlank()) " (${focalMetric.unit.symbol})" else ""
+    canvas.drawText("${focalMetric.readableName}$unitSuffix", left, y, bodyPaint.also { it.isFakeBoldText = true })
+    bodyPaint.isFakeBoldText = false
+    y += 4f
+    val chartTop = y
+    val chartBottom = chartTop + 220f
+    canvas.drawRect(left, chartTop, right, chartBottom, axisPaint)
+
+    val (valueMin, valueMax) = chartValueRange(focalReadings, focalBaseline)
+    if (focalBaseline != null) {
+        val yP95 = mapY(focalBaseline.p95, valueMin, valueMax, chartTop, chartBottom)
+        val yP5 = mapY(focalBaseline.p5, valueMin, valueMax, chartTop, chartBottom)
+        canvas.drawRect(left, yP95, right, yP5, baselineBandPaint)
+        val yMean = mapY(focalBaseline.mean, valueMin, valueMax, chartTop, chartBottom)
+        canvas.drawLine(left, yMean, right, yMean, meanLinePaint)
+    }
+
+    if (focalReadings.isNotEmpty()) {
+        val span = (endMillis - startMillis).coerceAtLeast(1L).toDouble()
+        val path = Path()
+        focalReadings.forEachIndexed { i, r ->
+            val xFrac = ((r.timestamp - startMillis).coerceAtLeast(0L)) / span
+            val x = (left + xFrac * (right - left)).toFloat()
+            val yPt = mapY(r.value, valueMin, valueMax, chartTop, chartBottom)
+            if (i == 0) path.moveTo(x, yPt) else path.lineTo(x, yPt)
+            canvas.drawCircle(x, yPt, 1.5f, pointPaint)
+        }
+        canvas.drawPath(path, linePaint)
+    } else {
+        canvas.drawText(
+            "No readings in this window.",
+            left + 8f, chartTop + 110f, labelPaint
+        )
+    }
+
+    canvas.drawText(fmtValue(valueMax), right + 2f, chartTop + 8f, labelPaint)
+    canvas.drawText(fmtValue(valueMin), right + 2f, chartBottom, labelPaint)
+    y = chartBottom + 16f
+
+    // Summary stats line.
+    canvas.drawText(
+        formatSummaryStats(focalMetric, focalReadings, focalBaseline),
+        left, y, bodyPaint
+    )
+    y += 18f
+
+    // --- Biomarker table ---
+    if (biomarkerLatest.isNotEmpty()) {
+        canvas.drawText("Recent lab biomarkers", left, y, bodyPaint.also { it.isFakeBoldText = true })
+        bodyPaint.isFakeBoldText = false
+        y += 12f
+        canvas.drawText(
+            "Cells coloured against published clinical reference ranges " +
+                "(ADA / NCEP / AHA, etc.) from the in-app reference. Bios does not interpret values.",
+            left, y, captionPaint
+        )
+        y += 12f
+
+        val dateFmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        val colMetricRight = left + 240f
+        val colValueRight = left + 320f
+        val colDateRight = left + 410f
+        val rowHeight = 16f
+
+        // Header row
+        canvas.drawText("Biomarker", left + 4f, y + 10f, labelPaint)
+        canvas.drawText("Value", colMetricRight + 4f, y + 10f, labelPaint)
+        canvas.drawText("Date", colValueRight + 4f, y + 10f, labelPaint)
+        canvas.drawText("Band", colDateRight + 4f, y + 10f, labelPaint)
+        y += rowHeight
+
+        // Body rows — clipped if they'd overrun the footer.
+        val footerTopY = (PdfReportExporter.PAGE_HEIGHT_PX - PdfReportExporter.MARGIN_PX - 28).toFloat()
+        val rowsThatFit = ((footerTopY - y) / rowHeight).toInt().coerceAtLeast(0)
+        val overflow = biomarkerLatest.size - rowsThatFit
+
+        for ((i, pair) in biomarkerLatest.withIndex()) {
+            if (i >= rowsThatFit) break
+            val (metric, reading) = pair
+            val band = bands[metric]?.classify(reading.value)
+            bandPaint.color = bandFillColor(band)
+            canvas.drawRect(left, y, right, y + rowHeight - 2f, bandPaint)
+            rowPaint.color = bandTextColor(band)
+            canvas.drawText(metric.readableName, left + 4f, y + 11f, rowPaint)
+            val valueText = "${fmtValue(reading.value)} ${metric.unit.symbol}".trim()
+            canvas.drawText(valueText, colMetricRight + 4f, y + 11f, rowPaint)
+            canvas.drawText(dateFmt.format(Date(reading.timestamp)), colValueRight + 4f, y + 11f, rowPaint)
+            canvas.drawText(bandLabel(band), colDateRight + 4f, y + 11f, rowPaint)
+            y += rowHeight
+        }
+        if (overflow > 0) {
+            canvas.drawText(
+                "+ $overflow more biomarker${if (overflow == 1) "" else "s"} not shown (one-page MVP).",
+                left, y + 11f, captionPaint
+            )
+        }
+    } else {
+        canvas.drawText(
+            "No lab biomarkers entered yet. Add values via Settings → Add Lab Values.",
+            left, y, labelPaint
+        )
+    }
+
+    // --- Footer ---
+    val footerY = (PdfReportExporter.PAGE_HEIGHT_PX - PdfReportExporter.MARGIN_PX).toFloat()
+    canvas.drawText(formatGeneratedFooter(generatedAtMillis), left, footerY, captionPaint)
+}
+
+/**
+ * Simple word-wrap for the owner note. Returns at most two lines worth of
+ * input width-fitting; the caller can take(2) to clip. Trailing partial
+ * words are appended as their own line so nothing is silently dropped.
+ */
+internal fun wrapText(text: String, paint: Paint, maxWidthPx: Int): List<String> {
+    val words = text.split(' ').filter { it.isNotEmpty() }
+    val lines = mutableListOf<String>()
+    var current = StringBuilder()
+    for (word in words) {
+        val candidate = if (current.isEmpty()) word else "$current $word"
+        if (paint.measureText(candidate) <= maxWidthPx) {
+            if (current.isEmpty()) current.append(word) else { current.append(' '); current.append(word) }
+        } else {
+            if (current.isNotEmpty()) lines.add(current.toString())
+            current = StringBuilder(word)
+        }
+    }
+    if (current.isNotEmpty()) lines.add(current.toString())
+    return lines
+}
+

--- a/android/app/src/main/java/com/bios/app/ui/settings/PdfSummaryButton.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/PdfSummaryButton.kt
@@ -1,0 +1,158 @@
+package com.bios.app.ui.settings
+
+import android.content.Intent
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import com.bios.app.export.PdfReportExporter
+import com.bios.app.ui.AppViewModel
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.launch
+
+/**
+ * Fourth export button alongside JSON / CSV / FHIR. Self-contained so
+ * [SettingsScreen] only needs to call this composable — keeps that file
+ * under the 500-line limit and groups all PDF-summary UI in one place.
+ *
+ * The dialog asks for two owner inputs: a focal metric (the chart axis the
+ * doctor will look at first) and an optional free-text note (one to two
+ * lines, e.g., "Visit on 2026-05-22 — fatigue + palpitations"). Both
+ * mirror the MVP scope in issue #104.
+ */
+@Composable
+fun PdfSummaryButton(
+    viewModel: AppViewModel,
+    enabled: Boolean,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var showDialog by remember { mutableStateOf(false) }
+    var isExporting by remember { mutableStateOf(false) }
+    var focalMetric by remember { mutableStateOf(MetricType.HEART_RATE) }
+    var ownerNote by remember { mutableStateOf("") }
+
+    OutlinedButton(
+        onClick = { showDialog = true },
+        enabled = enabled && !isExporting,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (isExporting) {
+            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(if (isExporting) "Generating PDF…" else "Share PDF summary (for doctors)")
+    }
+
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = { showDialog = false },
+            title = { Text("Share PDF summary") },
+            text = {
+                Column {
+                    Text(
+                        "Pick the metric to feature on the chart and (optionally) " +
+                            "add a short note for the doctor. The PDF is generated " +
+                            "on-device and shared through the standard share sheet.",
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text("Focal metric")
+                    Spacer(Modifier.height(4.dp))
+                    Row(
+                        modifier = Modifier.horizontalScroll(rememberScrollState()),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        PDF_FOCAL_METRICS.forEach { (metric, label) ->
+                            FilterChip(
+                                selected = focalMetric == metric,
+                                onClick = { focalMetric = metric },
+                                label = { Text(label) },
+                            )
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = ownerNote,
+                        onValueChange = { ownerNote = it.take(240) },
+                        label = { Text("Note for the doctor (optional)") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = false,
+                        maxLines = 2,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = !isExporting,
+                    onClick = {
+                        val pickedNote = ownerNote.trim().ifBlank { null }
+                        val pickedMetric = focalMetric
+                        showDialog = false
+                        isExporting = true
+                        scope.launch {
+                            try {
+                                val exporter = PdfReportExporter(context, viewModel.db)
+                                val file = exporter.exportToPdf(
+                                    focalMetric = pickedMetric,
+                                    ownerNote = pickedNote,
+                                )
+                                val uri = FileProvider.getUriForFile(
+                                    context,
+                                    "${context.packageName}.fileprovider",
+                                    file,
+                                )
+                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "application/pdf"
+                                    putExtra(Intent.EXTRA_STREAM, uri)
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+                                context.startActivity(
+                                    Intent.createChooser(shareIntent, "Share summary with your doctor"),
+                                )
+                            } finally {
+                                isExporting = false
+                            }
+                        }
+                    },
+                ) { Text("Generate & share") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDialog = false }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+private val PDF_FOCAL_METRICS = listOf(
+    MetricType.HEART_RATE to "Heart Rate",
+    MetricType.HEART_RATE_VARIABILITY to "HRV",
+    MetricType.RESTING_HEART_RATE to "Resting HR",
+    MetricType.BLOOD_OXYGEN to "SpO2",
+    MetricType.RESPIRATORY_RATE to "Resp. Rate",
+    MetricType.SKIN_TEMPERATURE_DEVIATION to "Skin Temp",
+    MetricType.SLEEP_DURATION to "Sleep",
+    MetricType.STEPS to "Steps",
+)

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -245,6 +245,8 @@ fun SettingsScreen(
                 ) {
                     Text("Export as FHIR Bundle (for doctors)")
                 }
+                Spacer(Modifier.height(4.dp))
+                PdfSummaryButton(viewModel = viewModel, enabled = totalReadings > 0)
             }
         }
 

--- a/android/app/src/test/java/com/bios/app/PdfReportExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/PdfReportExporterTest.kt
@@ -1,0 +1,217 @@
+package com.bios.app
+
+import com.bios.app.config.BiomarkerBand
+import com.bios.app.export.bandFillColor
+import com.bios.app.export.bandLabel
+import com.bios.app.export.bandTextColor
+import com.bios.app.export.chartValueRange
+import com.bios.app.export.fmtValue
+import com.bios.app.export.formatDateRange
+import com.bios.app.export.formatGeneratedFooter
+import com.bios.app.export.formatSummaryStats
+import com.bios.app.export.mapY
+import com.bios.app.model.MetricReading
+import com.bios.app.model.PersonalBaseline
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.TimeZone
+
+/**
+ * Pure-logic tests for [com.bios.app.export.PdfReportExporter]'s
+ * deterministic helpers — formatting, band colouring, chart-coordinate
+ * math. Canvas rendering itself requires android.graphics.Paint at
+ * runtime, so it's covered by build-and-eyeball, not unit tests.
+ */
+class PdfReportExporterTest {
+
+    private val utc: TimeZone = TimeZone.getTimeZone("UTC")
+
+    init {
+        // Pin dates so the test passes in every CI timezone.
+        TimeZone.setDefault(utc)
+    }
+
+    // --- formatDateRange ---
+
+    @Test
+    fun `formatDateRange renders ISO yyyy-MM-dd start to end`() {
+        // 2026-01-15 00:00:00 UTC → epoch 1768435200000
+        val start = 1768435200000L
+        // 2026-02-14 00:00:00 UTC → 30 days later
+        val end = start + 30L * 24 * 3600 * 1000
+        assertEquals("2026-01-15 to 2026-02-14", formatDateRange(start, end))
+    }
+
+    // --- formatGeneratedFooter ---
+
+    @Test
+    fun `footer states on-device generation and zero data egress`() {
+        val footer = formatGeneratedFooter(1768435200000L) // 2026-01-15 UTC
+        assertTrue(
+            "Footer must declare the generation date",
+            footer.contains("2026-01-15"),
+        )
+        assertTrue(
+            "Footer must reassure the doctor & owner that no data left the device",
+            footer.contains("No data left this device"),
+        )
+    }
+
+    // --- formatSummaryStats ---
+
+    @Test
+    fun `summary stats with no readings explains absence rather than printing 0`() {
+        val stats = formatSummaryStats(MetricType.HEART_RATE, emptyList(), baseline(60.0))
+        // Anti-regression: a previous draft rendered "Current: 0bpm" with empty
+        // readings, which would look like a real reading to a doctor.
+        assertTrue(stats.contains("No"))
+        assertTrue(stats.contains("readings"))
+    }
+
+    @Test
+    fun `summary stats include current, mean, and baseline range when all are available`() {
+        val readings = listOf(
+            reading(MetricType.HEART_RATE, 58.0, t = 1L),
+            reading(MetricType.HEART_RATE, 62.0, t = 2L),
+            reading(MetricType.HEART_RATE, 70.0, t = 3L), // current
+        )
+        val stats = formatSummaryStats(MetricType.HEART_RATE, readings, baseline(60.0, p5 = 50.0, p95 = 72.0))
+        // Current uses the last reading (chronologically, given the fetch is ASC).
+        assertTrue("Current must be the last reading", stats.contains("Current: 70"))
+        // Window mean = (58+62+70)/3 = 63.33 → formats as "63.3"
+        assertTrue("Window mean must be present", stats.contains("Window mean: 63.3"))
+        assertTrue("Baseline p5-p95 must be present", stats.contains("Baseline p5–p95: 50.0–72.0"))
+    }
+
+    @Test
+    fun `summary stats omit baseline line when no baseline exists yet`() {
+        val readings = listOf(reading(MetricType.HEART_RATE, 70.0))
+        val stats = formatSummaryStats(MetricType.HEART_RATE, readings, baseline = null)
+        assertTrue(stats.contains("Current"))
+        assertTrue("No baseline → no p5/p95 line", !stats.contains("Baseline"))
+    }
+
+    // --- fmtValue (used to render every numeric stat) ---
+
+    @Test
+    fun `fmtValue chooses 1-decimal under 100 and 0-decimal at-or-above 100`() {
+        // 1 decimal for small numbers (HRV, SpO2, BBT, etc.).
+        assertEquals("70.0", fmtValue(70.0))
+        assertEquals("4.2", fmtValue(4.2))
+        // 0 decimal for big numbers (Steps, etc.) to avoid clutter.
+        assertEquals("100", fmtValue(100.0))
+        assertEquals("8523", fmtValue(8523.4))
+        // Negatives use absolute-value cutoff (e.g., glucose delta).
+        assertEquals("-150", fmtValue(-150.3))
+    }
+
+    // --- band colour / label ---
+
+    @Test
+    fun `every band has a distinct fill and text colour`() {
+        val fills = setOf(
+            bandFillColor(BiomarkerBand.NORMAL),
+            bandFillColor(BiomarkerBand.BORDERLINE),
+            bandFillColor(BiomarkerBand.CONCERNING),
+            bandFillColor(null),
+        )
+        assertEquals("Each band (incl. null) must paint a different cell colour", 4, fills.size)
+
+        val texts = setOf(
+            bandTextColor(BiomarkerBand.NORMAL),
+            bandTextColor(BiomarkerBand.BORDERLINE),
+            bandTextColor(BiomarkerBand.CONCERNING),
+            bandTextColor(null),
+        )
+        assertEquals("Each band must use a distinct text colour", 4, texts.size)
+        // Text colour must contrast with fill — at minimum, not equal.
+        for (band in listOf(BiomarkerBand.NORMAL, BiomarkerBand.BORDERLINE, BiomarkerBand.CONCERNING, null)) {
+            assertNotEquals("Text on a $band fill must differ from the fill", bandFillColor(band), bandTextColor(band))
+        }
+    }
+
+    @Test
+    fun `band label uses an em-dash for null so the column never reads as a band`() {
+        assertEquals("normal", bandLabel(BiomarkerBand.NORMAL))
+        assertEquals("borderline", bandLabel(BiomarkerBand.BORDERLINE))
+        assertEquals("concerning", bandLabel(BiomarkerBand.CONCERNING))
+        assertEquals("—", bandLabel(null))
+    }
+
+    // --- mapY ---
+
+    @Test
+    fun `mapY maps min to chartBottom and max to chartTop`() {
+        // Top-left origin: chartTop has the SMALLEST y, chartBottom the LARGEST.
+        assertEquals(200f, mapY(value = 50.0, valueMin = 50.0, valueMax = 100.0, chartTop = 0f, chartBottom = 200f), 0.01f)
+        assertEquals(0f, mapY(value = 100.0, valueMin = 50.0, valueMax = 100.0, chartTop = 0f, chartBottom = 200f), 0.01f)
+        // Midpoint maps to vertical centre.
+        assertEquals(100f, mapY(value = 75.0, valueMin = 50.0, valueMax = 100.0, chartTop = 0f, chartBottom = 200f), 0.01f)
+    }
+
+    @Test
+    fun `mapY clamps values outside the range so chart points never leave the box`() {
+        val y = mapY(value = 1000.0, valueMin = 50.0, valueMax = 100.0, chartTop = 0f, chartBottom = 200f)
+        assertEquals("Above-range values clamp to chartTop", 0f, y, 0.01f)
+        val yLow = mapY(value = -1.0, valueMin = 50.0, valueMax = 100.0, chartTop = 0f, chartBottom = 200f)
+        assertEquals("Below-range values clamp to chartBottom", 200f, yLow, 0.01f)
+    }
+
+    @Test
+    fun `mapY returns chartBottom when valueMax is not greater than valueMin`() {
+        // Degenerate input — constant series — would otherwise NaN/inf. Drop
+        // to the floor instead so the chart still renders.
+        assertEquals(200f, mapY(value = 70.0, valueMin = 70.0, valueMax = 70.0, chartTop = 0f, chartBottom = 200f), 0.01f)
+    }
+
+    // --- chartValueRange ---
+
+    @Test
+    fun `chartValueRange spans both readings and baseline so the band never spills`() {
+        val readings = listOf(reading(MetricType.HEART_RATE, 60.0), reading(MetricType.HEART_RATE, 80.0))
+        val baseline = baseline(70.0, p5 = 50.0, p95 = 90.0)
+        val (min, max) = chartValueRange(readings, baseline)
+        assertTrue("min must be ≤ smallest baseline edge", min <= 50.0)
+        assertTrue("max must be ≥ largest baseline edge", max >= 90.0)
+    }
+
+    @Test
+    fun `chartValueRange handles empty readings without crashing`() {
+        val (min, max) = chartValueRange(emptyList(), baseline = null)
+        // Caller still draws the chart frame; we just need finite values.
+        assertTrue(min.isFinite())
+        assertTrue(max.isFinite())
+        assertTrue(max > min)
+    }
+
+    @Test
+    fun `chartValueRange pads constant-valued readings so the line is not on the axis`() {
+        val readings = listOf(reading(MetricType.HEART_RATE, 65.0), reading(MetricType.HEART_RATE, 65.0))
+        val (min, max) = chartValueRange(readings, baseline = null)
+        assertTrue("min must sit below the constant value", min < 65.0)
+        assertTrue("max must sit above the constant value", max > 65.0)
+    }
+
+    // --- helpers ---
+
+    private fun reading(metric: MetricType, value: Double, t: Long = 0L): MetricReading =
+        MetricReading(
+            metricType = metric.key,
+            value = value,
+            timestamp = t,
+            sourceId = "src",
+            confidence = 90,
+        )
+
+    private fun baseline(mean: Double, p5: Double = mean - 10.0, p95: Double = mean + 10.0): PersonalBaseline =
+        PersonalBaseline(
+            metricType = MetricType.HEART_RATE.key,
+            mean = mean,
+            stdDev = (p95 - p5) / 4.0,
+            p5 = p5,
+            p95 = p95,
+        )
+}


### PR DESCRIPTION
## Summary

Closes #104 MVP. Fourth export button on the settings screen, alongside JSON / CSV / FHIR. Owner picks a focal metric, optionally types a short note, hits Generate & share — Bios renders an A4 PDF on-device and hands it to the standard Android share sheet.

The PDF carries: header (date range + version + owner note), focal-metric line chart against a shaded baseline p5–p95 band, summary stats, biomarker table coloured against published clinical reference bands ([ADA / NCEP / AHA, etc.](android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt)), footer with "no data left this device" line. Single page, one column, designed to scan in ~30 seconds.

## Manifesto / Principle 7 alignment

PDF export is **pull-side** under PR #103's new framing: owner initiates, owner picks the focal metric, owner writes the note, owner picks the recipient via the share sheet. Cell colouring uses the same clinical bands a doctor would apply (and that `LongevityReferenceScreen` already surfaces) — these are published reference ranges, not Bios's evaluation. The class-level KDoc and the table caption spell that out so the framing is visible to reviewers.

## MVP checkbox coverage

- [x] Header: date range + Bios version + optional owner header note
- [x] Focal metric (owner-picked) trend chart with baseline band + summary stats
- [x] Biomarker table cell-coloured against ref ranges
- [x] Footer line about on-device generation + zero data egress
- [x] Wire to fourth button on [SettingsScreen.kt](android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt)
- [x] `FileProvider` + `ACTION_SEND` chooser, mirroring existing share pattern

Phase 2 items (sparkline grid, drift-vs-baseline section, multi-page overflow, dedicated Doctor-visit screen) intentionally deferred per the issue.

## Decisions worth flagging

- **Chart stack recon**: TrendsScreen ships stat cards + trend arrows only — there is no existing chart code in Bios. So I went with the issue's picked tooling decision (A): bespoke Canvas drawing on top of `PdfDocument`. Zero new deps.
- **WOMENS_HEALTH excluded by construction**: reproductive readings live in the isolated `ReproductiveDatabase` and the main-DB exporter must never read them. Same guard as [FhirExporter.kt:69-79](android/app/src/main/java/com/bios/app/export/FhirExporter.kt#L69-L79).
- **Biomarker table omits lab / fasting / your-note columns**: those fields don't exist on `BiomarkerEntryRepo` yet — that's #105 (FHIR round-trip provenance) and #106 (source-file URI capture). When they land, this exporter can pick them up without a layout change.
- **Settings stays under 500 lines**: the dialog + share logic lives in a new sibling composable [`PdfSummaryButton.kt`](android/app/src/main/java/com/bios/app/ui/settings/PdfSummaryButton.kt) so [SettingsScreen.kt](android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt) only gains one line.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build).
- [x] `:app:testStandaloneDebugUnitTest` passes — [`PdfReportExporterTest`](android/app/src/test/java/com/bios/app/PdfReportExporterTest.kt) covers the deterministic helpers: date / footer formatting, summary stats (with / without readings, with / without baseline), value formatting, band fill / text / label distinctness, mapY clamping + degenerate range, chartValueRange edge cases.
- [ ] On-device sanity (post-merge): with ≥ 30 days of data and at least one biomarker entry, share button → dialog → pick HR → "fatigue and palpitations" note → Generate → file lands at ~50–100 KB, opens in a PDF viewer, baseline band visible, biomarker table coloured per band.

## Out of scope

- A clinician-side FHIR reader (explicitly rejected — see #104).
- Bios-operated relay or server-side rendering — generation stays on-device.
- Personal identifiers on the document by default (filename has timestamp only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)