### PR TITLE
feat(fhir): round-trip biomarker provenance (export + import)

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -1,10 +1,13 @@
 package com.bios.app.export
 
 import android.content.Context
+import com.bios.app.data.BiomarkerContext
+import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.app.data.BiosDatabase
 import com.bios.app.model.Anomaly
 import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
+import com.bios.app.model.Specimen
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
@@ -46,6 +49,7 @@ class FhirExporter(
     private val sourceDao = db.dataSourceDao()
     private val anomalyDao = db.anomalyDao()
     private val baselineDao = db.personalBaselineDao()
+    private val payloadDao = db.eventPayloadFieldDao()
 
     /**
      * Export all Bios data as a FHIR R4 Bundle (JSON).
@@ -77,9 +81,19 @@ class FhirExporter(
             // reproductive data" opt-in would query ReproductiveDatabase
             // explicitly; today's default is hard-skip.
             if (metricType.domain == MetricDomain.WOMENS_HEALTH) continue
+            val isBiomarker = metricType.domain == MetricDomain.BIOMARKER
             val readings = readingDao.fetch(metricType.key, thirtyDaysAgo, Long.MAX_VALUE)
             for (reading in readings.take(500)) {
-                entries.put(bundleEntry(buildObservationResource(reading, metricType)))
+                // Biomarker readings carry optional provenance (lab name,
+                // fasting status, specimen type) in the event-payload sidecar.
+                // The owner-recall note in MetricReading.note is intentionally
+                // *not* exported — it's owner-recall only, never shared by
+                // default. See issue #105.
+                val context = if (isBiomarker) {
+                    val rows = payloadDao.fetchForReading(reading.id)
+                    BiomarkerEntryRepo.rowsToContext(rows, note = null)
+                } else null
+                entries.put(bundleEntry(buildObservationResource(reading, metricType, context)))
             }
         }
 
@@ -138,7 +152,8 @@ internal fun buildDeviceResource(source: DataSource): JSONObject = JSONObject().
 
 internal fun buildObservationResource(
     reading: MetricReading,
-    metricType: MetricType
+    metricType: MetricType,
+    context: BiomarkerContext? = null,
 ): JSONObject = JSONObject().apply {
     put("resourceType", "Observation")
     put("id", reading.id)
@@ -170,6 +185,86 @@ internal fun buildObservationResource(
     })
     put("device", JSONObject().apply {
         put("reference", "Device/${reading.sourceId}")
+    })
+
+    // Biomarker provenance: emit when context is non-null and any of the
+    // shareable fields is populated. Owner-recall note is intentionally not
+    // emitted (BiomarkerContext.note is engine-irrelevant and stays local).
+    // Source URI is also not emitted — it's a local content://, useless to
+    // a remote reader and trades nothing for a privacy risk.
+    if (context != null) {
+        context.labName?.takeIf { it.isNotBlank() }?.let { lab ->
+            put("performer", JSONArray().put(JSONObject().apply {
+                put("display", lab)
+            }))
+        }
+        context.fasting?.let { fasting ->
+            // LOINC 49541-6 "Fasting status - Reported" on a component, with
+            // the boolean as valueBoolean — the simplest FHIR-R4 encoding that
+            // round-trips cleanly with Bios's Boolean? storage. Clinical
+            // systems that emit valueCodeableConcept with LA33-6 / LA32-8 are
+            // also parsed by FhirImporter.
+            val components = optJSONArray("component") ?: JSONArray().also { put("component", it) }
+            components.put(JSONObject().apply {
+                put("code", JSONObject().apply {
+                    put("coding", JSONArray().put(JSONObject().apply {
+                        put("system", "http://loinc.org")
+                        put("code", "49541-6")
+                        put("display", "Fasting status - Reported")
+                    }))
+                })
+                put("valueBoolean", fasting)
+            })
+        }
+        context.specimen?.let { specimen ->
+            val containedId = "specimen-${reading.id}"
+            val contained = optJSONArray("contained") ?: JSONArray().also { put("contained", it) }
+            contained.put(buildSpecimenResource(containedId, specimen))
+            put("specimen", JSONObject().apply {
+                put("reference", "#$containedId")
+            })
+        }
+    }
+}
+
+/**
+ * Builds a contained Specimen resource that names a [Specimen] enum value
+ * using SNOMED CT concept codes — what clinical systems index against.
+ * `OTHER` falls back to text-only so the receiving system at least gets the
+ * Bios label rather than nothing.
+ */
+internal fun buildSpecimenResource(id: String, specimen: Specimen): JSONObject = JSONObject().apply {
+    put("resourceType", "Specimen")
+    put("id", id)
+    put("status", "available")
+    put("type", JSONObject().apply {
+        when (specimen) {
+            Specimen.SERUM -> {
+                put("coding", JSONArray().put(JSONObject().apply {
+                    put("system", "http://snomed.info/sct")
+                    put("code", "119364003")
+                    put("display", "Serum specimen")
+                }))
+                put("text", specimen.readable)
+            }
+            Specimen.PLASMA -> {
+                put("coding", JSONArray().put(JSONObject().apply {
+                    put("system", "http://snomed.info/sct")
+                    put("code", "119361006")
+                    put("display", "Plasma specimen")
+                }))
+                put("text", specimen.readable)
+            }
+            Specimen.WHOLE_BLOOD -> {
+                put("coding", JSONArray().put(JSONObject().apply {
+                    put("system", "http://snomed.info/sct")
+                    put("code", "258580003")
+                    put("display", "Whole blood specimen")
+                }))
+                put("text", specimen.readable)
+            }
+            Specimen.OTHER -> put("text", specimen.readable)
+        }
     })
 }
 

--- a/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.app.model.Specimen
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import kotlinx.coroutines.Dispatchers
@@ -56,7 +57,11 @@ object FhirImporter {
                 metricType = reading.metricType,
                 value = reading.value,
                 timestamp = reading.timestamp,
-                context = BiomarkerContext(labName = reading.labName)
+                context = BiomarkerContext(
+                    labName = reading.labName,
+                    fasting = reading.fasting,
+                    specimen = reading.specimen,
+                )
             )
         }
         summary
@@ -71,9 +76,9 @@ object FhirImporter {
         }
 
         val resourceType = root.optString("resourceType")
-        val observations = when (resourceType) {
-            "Bundle" -> extractBundleObservations(root)
-            "Observation" -> listOf(root)
+        val (observations, bundleSpecimens) = when (resourceType) {
+            "Bundle" -> extractBundleObservations(root) to extractBundleSpecimens(root)
+            "Observation" -> listOf(root) to emptyMap()
             else -> return FhirImportSummary.fileError(
                 "Unsupported resourceType \"$resourceType\" — expected Bundle or Observation"
             )
@@ -82,7 +87,7 @@ object FhirImporter {
         val accepted = mutableListOf<AcceptedReading>()
         val skipped = mutableListOf<SkippedObservation>()
         for (obs in observations) {
-            when (val outcome = parseObservation(obs)) {
+            when (val outcome = parseObservation(obs, bundleSpecimens)) {
                 is ParseOutcome.Accepted -> accepted += outcome.reading
                 is ParseOutcome.Skipped -> skipped += outcome.skipped
             }
@@ -100,7 +105,28 @@ object FhirImporter {
         return out
     }
 
-    private fun parseObservation(obs: JSONObject): ParseOutcome {
+    /**
+     * Index any `Specimen` resources in the Bundle by id so an Observation's
+     * `specimen.reference = "Specimen/<id>"` can resolve back to the type
+     * coding. Contained specimens on the Observation itself are handled
+     * inline in [parseObservation] and do not need to live here.
+     */
+    private fun extractBundleSpecimens(bundle: JSONObject): Map<String, JSONObject> {
+        val entries = bundle.optJSONArray("entry") ?: return emptyMap()
+        val out = mutableMapOf<String, JSONObject>()
+        for (i in 0 until entries.length()) {
+            val resource = entries.optJSONObject(i)?.optJSONObject("resource") ?: continue
+            if (resource.optString("resourceType") != "Specimen") continue
+            val id = resource.optString("id").takeIf { it.isNotBlank() } ?: continue
+            out[id] = resource
+        }
+        return out
+    }
+
+    private fun parseObservation(
+        obs: JSONObject,
+        bundleSpecimens: Map<String, JSONObject>,
+    ): ParseOutcome {
         val loinc = findLoincCode(obs.optJSONObject("code")?.optJSONArray("coding"))
             ?: return ParseOutcome.Skipped(
                 SkippedObservation("No LOINC coding on Observation", loincCode = null)
@@ -144,7 +170,116 @@ object FhirImporter {
             )
 
         val labName = readPerformerDisplay(obs)
-        return ParseOutcome.Accepted(AcceptedReading(metric, value, timestamp, labName))
+        val fasting = readFastingComponent(obs)
+        val specimen = readSpecimen(obs, bundleSpecimens)
+        return ParseOutcome.Accepted(
+            AcceptedReading(metric, value, timestamp, labName, fasting, specimen)
+        )
+    }
+
+    /**
+     * Reads a fasting-status component on the Observation. LOINC `49541-6`
+     * "Fasting status - Reported" is what clinical systems emit. We accept
+     * three encodings of the answer:
+     *   - `valueBoolean` (FHIR-simple, what Bios's own exporter writes)
+     *   - `valueCodeableConcept.coding[].code` matching LOINC answer list
+     *     `LL1815-1`: `LA33-6` = Yes / `LA32-8` = No (clinical-systems form)
+     *   - `valueCodeableConcept.text` matching "yes" / "no" (text fallback)
+     * Returns `null` (i.e., "unknown") when the component is absent or
+     * encodes an unrecognised answer. Doesn't trip on `LA46-7` (Don't know).
+     */
+    private fun readFastingComponent(obs: JSONObject): Boolean? {
+        val components = obs.optJSONArray("component") ?: return null
+        for (i in 0 until components.length()) {
+            val component = components.optJSONObject(i) ?: continue
+            val coding = component.optJSONObject("code")?.optJSONArray("coding") ?: continue
+            if (findLoincCode(coding) != "49541-6") continue
+            if (component.has("valueBoolean")) {
+                return component.optBoolean("valueBoolean")
+            }
+            val cc = component.optJSONObject("valueCodeableConcept")
+            cc?.optJSONArray("coding")?.let { codings ->
+                for (j in 0 until codings.length()) {
+                    val c = codings.optJSONObject(j)?.optString("code")
+                    when (c) {
+                        "LA33-6" -> return true
+                        "LA32-8" -> return false
+                    }
+                }
+            }
+            cc?.optString("text")?.lowercase()?.let { text ->
+                when {
+                    text.startsWith("yes") || text == "fasting" -> return true
+                    text.startsWith("no") || text == "non-fasting" -> return false
+                }
+            }
+            return null
+        }
+        return null
+    }
+
+    /**
+     * Resolves the Observation's `specimen.reference` to a [Specimen] enum.
+     * Tries, in order: `contained` resources on the Observation itself, then
+     * the Bundle-level Specimen index. Returns `null` when the reference is
+     * absent, the target can't be found, or its type doesn't match a Bios
+     * specimen enum.
+     */
+    private fun readSpecimen(
+        obs: JSONObject,
+        bundleSpecimens: Map<String, JSONObject>,
+    ): Specimen? {
+        val reference = obs.optJSONObject("specimen")?.optString("reference") ?: return null
+        if (reference.isBlank()) return null
+
+        val specimenResource = if (reference.startsWith("#")) {
+            findContainedSpecimen(obs, reference.removePrefix("#"))
+        } else {
+            val id = reference.substringAfter("Specimen/").substringAfter("/")
+            bundleSpecimens[id]
+        } ?: return null
+
+        return mapSpecimenType(specimenResource.optJSONObject("type"))
+    }
+
+    private fun findContainedSpecimen(obs: JSONObject, id: String): JSONObject? {
+        val contained = obs.optJSONArray("contained") ?: return null
+        for (i in 0 until contained.length()) {
+            val r = contained.optJSONObject(i) ?: continue
+            if (r.optString("resourceType") == "Specimen" && r.optString("id") == id) return r
+        }
+        return null
+    }
+
+    /**
+     * Maps a FHIR `Specimen.type` CodeableConcept to our enum. Prefers SCT
+     * coding (the standard); falls back to free-text matching so labs that
+     * skip the codings — common in EU public-system exports — still resolve.
+     */
+    private fun mapSpecimenType(type: JSONObject?): Specimen? {
+        if (type == null) return null
+        type.optJSONArray("coding")?.let { codings ->
+            for (i in 0 until codings.length()) {
+                val c = codings.optJSONObject(i) ?: continue
+                val system = c.optString("system")
+                val code = c.optString("code")
+                if (system == "http://snomed.info/sct") {
+                    when (code) {
+                        "119364003" -> return Specimen.SERUM
+                        "119361006" -> return Specimen.PLASMA
+                        "258580003" -> return Specimen.WHOLE_BLOOD
+                    }
+                }
+            }
+        }
+        val text = type.optString("text").lowercase()
+        return when {
+            "serum" in text -> Specimen.SERUM
+            "plasma" in text -> Specimen.PLASMA
+            "whole blood" in text -> Specimen.WHOLE_BLOOD
+            text.isNotBlank() -> Specimen.OTHER
+            else -> null
+        }
     }
 
     private fun readPerformerDisplay(obs: JSONObject): String? {
@@ -202,7 +337,9 @@ data class AcceptedReading(
     val metricType: MetricType,
     val value: Double,
     val timestamp: Long,
-    val labName: String? = null
+    val labName: String? = null,
+    val fasting: Boolean? = null,
+    val specimen: Specimen? = null,
 )
 
 data class SkippedObservation(

--- a/android/app/src/test/java/com/bios/app/FhirProvenanceRoundTripTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirProvenanceRoundTripTest.kt
@@ -1,0 +1,423 @@
+package com.bios.app
+
+import com.bios.app.data.BiomarkerContext
+import com.bios.app.export.FhirImporter
+import com.bios.app.export.buildBundleResource
+import com.bios.app.export.buildObservationResource
+import com.bios.app.export.bundleEntry
+import com.bios.app.model.MetricReading
+import com.bios.app.model.Specimen
+import com.bios.contracts.MetricType
+import org.json.JSONArray
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Round-trip + asymmetric coverage for biomarker provenance (#105).
+ *
+ *  - Exporter side: every shape `BiomarkerContext` can express must encode
+ *    the right FHIR R4 elements (performer.display, fasting component on
+ *    LOINC 49541-6, contained Specimen with SCT type) and, critically,
+ *    must *not* leak the owner-recall `note` or local `sourceUri`.
+ *  - Importer side: every shape we accept from real lab exports
+ *    (`valueBoolean`, LOINC answer codes, free text; contained / Bundle /
+ *    text-only Specimens; dangling references) must resolve to the
+ *    expected `BiomarkerContext` fields.
+ *  - Round trip: Bios-emitted Bundle → `FhirImporter.parse` → context
+ *    fields survive intact. Guards against export and import drifting
+ *    apart even if each side stays internally consistent.
+ *
+ * Split out of `FhirImporterTest` / `FhirExporterTest` to keep both
+ * companion files under the 500-line file-length cap.
+ */
+class FhirProvenanceRoundTripTest {
+
+    // --- Exporter: empty / missing context emits a clean Observation ---
+
+    @Test
+    fun `biomarker Observation with null context emits no performer, component, or specimen`() {
+        // Anti-regression: a missing context must produce a clean Observation
+        // identical to the pre-#105 shape. Otherwise existing FHIR consumers
+        // start seeing empty performer arrays or stub specimens, both invalid.
+        val obs = buildObservationResource(hba1c(), MetricType.HBA1C, context = null)
+        assertFalse(obs.has("performer"))
+        assertFalse(obs.has("component"))
+        assertFalse(obs.has("specimen"))
+        assertFalse(obs.has("contained"))
+    }
+
+    @Test
+    fun `empty context emits nothing (matches null-context shape)`() {
+        // BiomarkerContext.isEmpty owners — value + date only — produce the
+        // same clean Observation. Don't emit empty arrays.
+        val obs = buildObservationResource(hba1c(), MetricType.HBA1C, context = BiomarkerContext())
+        assertFalse(obs.has("performer"))
+        assertFalse(obs.has("component"))
+        assertFalse(obs.has("specimen"))
+    }
+
+    // --- Exporter: each context field maps to the right FHIR element ---
+
+    @Test
+    fun `lab name populates performer display`() {
+        val obs = buildObservationResource(
+            hba1c(),
+            MetricType.HBA1C,
+            context = BiomarkerContext(labName = "Synlab Madrid"),
+        )
+        val performers = obs.optJSONArray("performer")!!
+        assertEquals(1, performers.length())
+        assertEquals("Synlab Madrid", performers.getJSONObject(0).optString("display"))
+        // Lab name alone — fasting/specimen stay off.
+        assertFalse(obs.has("component"))
+        assertFalse(obs.has("specimen"))
+    }
+
+    @Test
+    fun `fasting=true emits LOINC 49541-6 component with valueBoolean`() {
+        val obs = buildObservationResource(
+            hba1c(),
+            MetricType.HBA1C,
+            context = BiomarkerContext(fasting = true),
+        )
+        val components = obs.optJSONArray("component")!!
+        assertEquals(1, components.length())
+        val first = components.getJSONObject(0)
+        val coding = first.getJSONObject("code").getJSONArray("coding").getJSONObject(0)
+        assertEquals("http://loinc.org", coding.getString("system"))
+        assertEquals("49541-6", coding.getString("code"))
+        assertEquals(true, first.getBoolean("valueBoolean"))
+    }
+
+    @Test
+    fun `specimen emits a contained Specimen with the matching SCT code`() {
+        val obs = buildObservationResource(
+            hba1c(id = "obs-1"),
+            MetricType.HBA1C,
+            context = BiomarkerContext(specimen = Specimen.SERUM),
+        )
+        // Observation.specimen is a reference into contained — never a
+        // dangling pointer.
+        val reference = obs.getJSONObject("specimen").getString("reference")
+        assertEquals("#specimen-obs-1", reference)
+        val contained = obs.getJSONArray("contained")
+        assertEquals(1, contained.length())
+        val resource = contained.getJSONObject(0)
+        assertEquals("Specimen", resource.getString("resourceType"))
+        assertEquals("specimen-obs-1", resource.getString("id"))
+        val typeCoding = resource.getJSONObject("type").getJSONArray("coding").getJSONObject(0)
+        assertEquals("http://snomed.info/sct", typeCoding.getString("system"))
+        assertEquals("119364003", typeCoding.getString("code"))
+    }
+
+    // --- Exporter: shareability filter — note and sourceUri stay local ---
+
+    @Test
+    fun `note field is intentionally not emitted (owner-recall only)`() {
+        // PR #103 framing: the free-text note is owner-recall, never shared.
+        // Even when context.note is populated, no Observation field carries it.
+        val obs = buildObservationResource(
+            hba1c(),
+            MetricType.HBA1C,
+            context = BiomarkerContext(note = "Had coffee 7am, possibly broke fast"),
+        )
+        assertFalse(obs.has("note"))
+        assertFalse(obs.toString().contains("Had coffee"))
+    }
+
+    @Test
+    fun `source URI is intentionally not emitted (local URI, useless remotely)`() {
+        // A content:// or file:// URI from BiomarkerContext.sourceUri only
+        // resolves on the source device. Emitting it would trade a privacy
+        // smell for zero remote utility.
+        val obs = buildObservationResource(
+            hba1c(),
+            MetricType.HBA1C,
+            context = BiomarkerContext(sourceUri = "content://com.bios.app/labs/123.pdf"),
+        )
+        assertFalse(obs.toString().contains("content://"))
+    }
+
+    // --- Importer: fasting in every encoding clinical systems emit ---
+
+    @Test
+    fun `fasting valueBoolean true populates fasting=true`() {
+        // What Bios's own exporter emits — the simplest FHIR encoding that
+        // round-trips Boolean storage cleanly.
+        val summary = FhirImporter.parse(observationWithFastingValueBoolean(true))
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(true, summary.accepted.single().fasting)
+    }
+
+    @Test
+    fun `fasting valueBoolean false populates fasting=false`() {
+        val summary = FhirImporter.parse(observationWithFastingValueBoolean(false))
+        assertEquals(java.lang.Boolean.FALSE, summary.accepted.single().fasting)
+    }
+
+    @Test
+    fun `fasting valueCodeableConcept LA33-6 maps to true (clinical-systems form)`() {
+        val summary = FhirImporter.parse(observationWithFastingCoding("LA33-6"))
+        assertEquals(true, summary.accepted.single().fasting)
+    }
+
+    @Test
+    fun `fasting valueCodeableConcept LA32-8 maps to false`() {
+        assertEquals(
+            java.lang.Boolean.FALSE,
+            FhirImporter.parse(observationWithFastingCoding("LA32-8")).accepted.single().fasting,
+        )
+    }
+
+    @Test
+    fun `fasting LA46-7 (Don't know) leaves fasting null rather than guessing`() {
+        // The "Don't know" answer in LOINC LL1815-1. We don't bias toward
+        // either truth value when the source explicitly said it didn't know.
+        assertNull(FhirImporter.parse(observationWithFastingCoding("LA46-7")).accepted.single().fasting)
+    }
+
+    @Test
+    fun `fasting text 'Yes' falls through codings to give true`() {
+        // Some EU public-system exports skip the LOINC answer code and use
+        // free text on valueCodeableConcept.text. Match the human answer.
+        assertEquals(true, FhirImporter.parse(observationWithFastingText("Yes, fasting > 8 hrs")).accepted.single().fasting)
+    }
+
+    @Test
+    fun `missing fasting component leaves fasting null`() {
+        assertNull(FhirImporter.parse(plainHbA1c()).accepted.single().fasting)
+    }
+
+    // --- Importer: specimen across contained / Bundle / text-only / dangling ---
+
+    @Test
+    fun `specimen reference to contained SCT-coded Specimen maps to enum`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4 },
+              "contained": [{
+                "resourceType": "Specimen",
+                "id": "spec-1",
+                "type": {
+                  "coding": [{
+                    "system": "http://snomed.info/sct",
+                    "code": "119364003",
+                    "display": "Serum specimen"
+                  }]
+                }
+              }],
+              "specimen": { "reference": "#spec-1" }
+            }
+        """.trimIndent()
+        assertEquals(Specimen.SERUM, FhirImporter.parse(json).accepted.single().specimen)
+    }
+
+    @Test
+    fun `Bundle-level Specimen referenced by Observation maps to enum`() {
+        // External Specimen resource in the same Bundle — common shape from
+        // clinical lab systems that don't use contained resources.
+        val json = """
+            {
+              "resourceType": "Bundle",
+              "type": "collection",
+              "entry": [
+                {
+                  "resource": {
+                    "resourceType": "Specimen",
+                    "id": "plasma-ref",
+                    "type": {
+                      "coding": [{
+                        "system": "http://snomed.info/sct",
+                        "code": "119361006"
+                      }]
+                    }
+                  }
+                },
+                {
+                  "resource": {
+                    "resourceType": "Observation",
+                    "status": "final",
+                    "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+                    "effectiveDateTime": "2024-12-01T08:30:00Z",
+                    "valueQuantity": { "value": 5.4 },
+                    "specimen": { "reference": "Specimen/plasma-ref" }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+        assertEquals(Specimen.PLASMA, FhirImporter.parse(json).accepted.single().specimen)
+    }
+
+    @Test
+    fun `Specimen with no codings falls back to type text matching`() {
+        // EU public-system exports often skip the coding[] and put the
+        // specimen type in free text only.
+        assertEquals(
+            Specimen.WHOLE_BLOOD,
+            FhirImporter.parse(observationWithSpecimenText("Whole blood, EDTA tube")).accepted.single().specimen,
+        )
+    }
+
+    @Test
+    fun `Specimen with unrecognised text falls back to OTHER rather than null`() {
+        // Preserves the fact that *some* specimen was reported — better than
+        // collapsing to "unknown" silently.
+        assertEquals(
+            Specimen.OTHER,
+            FhirImporter.parse(observationWithSpecimenText("Cerebrospinal fluid")).accepted.single().specimen,
+        )
+    }
+
+    @Test
+    fun `dangling specimen reference resolves to null without crashing`() {
+        // Reference points at an id that doesn't exist anywhere in the
+        // Bundle or contained list. Don't fabricate a specimen.
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+              "effectiveDateTime": "2024-12-01T08:30:00Z",
+              "valueQuantity": { "value": 5.4 },
+              "specimen": { "reference": "Specimen/does-not-exist" }
+            }
+        """.trimIndent()
+        assertNull(FhirImporter.parse(json).accepted.single().specimen)
+    }
+
+    @Test
+    fun `missing specimen reference leaves specimen null`() {
+        assertNull(FhirImporter.parse(plainHbA1c()).accepted.single().specimen)
+    }
+
+    // --- Round trip: Bios-emitted Bundle → FhirImporter.parse → context recovered ---
+
+    @Test
+    fun `full-context Observation survives export then reimport`() {
+        // Wraps the Observation in a Bundle so the importer's parse() path
+        // exercises the same code that processes real lab exports.
+        val obs = buildObservationResource(
+            hba1c(id = "rt-obs"),
+            MetricType.HBA1C,
+            context = BiomarkerContext(
+                labName = "Quest Diagnostics",
+                fasting = true,
+                specimen = Specimen.PLASMA,
+            ),
+        )
+        val bundle = buildBundleResource(JSONArray().put(bundleEntry(obs))).toString()
+
+        val summary = FhirImporter.parse(bundle)
+        assertEquals(0, summary.skippedCount)
+        assertEquals(1, summary.acceptedCount)
+        val recovered = summary.accepted.single()
+        assertEquals(MetricType.HBA1C, recovered.metricType)
+        assertEquals(5.4, recovered.value, 0.0)
+        assertEquals("Quest Diagnostics", recovered.labName)
+        assertEquals(true, recovered.fasting)
+        assertEquals(Specimen.PLASMA, recovered.specimen)
+    }
+
+    @Test
+    fun `empty-context Observation survives export then reimport with all context null`() {
+        // Regression guard for the bare-entry shape — value + date only
+        // round-trips cleanly without inventing context.
+        val obs = buildObservationResource(hba1c(id = "rt-empty"), MetricType.HBA1C, context = null)
+        val bundle = buildBundleResource(JSONArray().put(bundleEntry(obs))).toString()
+
+        val summary = FhirImporter.parse(bundle)
+        assertEquals(0, summary.skippedCount)
+        val recovered = summary.accepted.single()
+        assertNull(recovered.labName)
+        assertNull(recovered.fasting)
+        assertNull(recovered.specimen)
+    }
+
+    // --- Fixtures ---
+
+    private fun hba1c(id: String = "test-id"): MetricReading = MetricReading(
+        id = id,
+        metricType = MetricType.HBA1C.key,
+        value = 5.4,
+        timestamp = 1_733_044_200_000L, // 2024-12-01T08:30:00Z
+        sourceId = "source-1",
+        confidence = 90,
+    )
+
+    private fun plainHbA1c(): String = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+          "effectiveDateTime": "2024-12-01T08:30:00Z",
+          "valueQuantity": { "value": 5.4 }
+        }
+    """.trimIndent()
+
+    private fun observationWithFastingValueBoolean(fasting: Boolean): String = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+          "effectiveDateTime": "2024-12-01T08:30:00Z",
+          "valueQuantity": { "value": 5.4 },
+          "component": [{
+            "code": { "coding": [{ "system": "http://loinc.org", "code": "49541-6" }] },
+            "valueBoolean": $fasting
+          }]
+        }
+    """.trimIndent()
+
+    private fun observationWithFastingCoding(code: String): String = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+          "effectiveDateTime": "2024-12-01T08:30:00Z",
+          "valueQuantity": { "value": 5.4 },
+          "component": [{
+            "code": { "coding": [{ "system": "http://loinc.org", "code": "49541-6" }] },
+            "valueCodeableConcept": {
+              "coding": [{ "system": "http://loinc.org", "code": "$code" }]
+            }
+          }]
+        }
+    """.trimIndent()
+
+    private fun observationWithFastingText(text: String): String = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+          "effectiveDateTime": "2024-12-01T08:30:00Z",
+          "valueQuantity": { "value": 5.4 },
+          "component": [{
+            "code": { "coding": [{ "system": "http://loinc.org", "code": "49541-6" }] },
+            "valueCodeableConcept": { "text": "$text" }
+          }]
+        }
+    """.trimIndent()
+
+    private fun observationWithSpecimenText(text: String): String = """
+        {
+          "resourceType": "Observation",
+          "status": "final",
+          "code": { "coding": [{ "system": "http://loinc.org", "code": "4548-4" }] },
+          "effectiveDateTime": "2024-12-01T08:30:00Z",
+          "valueQuantity": { "value": 5.4 },
+          "contained": [{
+            "resourceType": "Specimen",
+            "id": "spec-text",
+            "type": { "text": "$text" }
+          }],
+          "specimen": { "reference": "#spec-text" }
+        }
+    """.trimIndent()
+}


### PR DESCRIPTION
## Summary

Closes #105. Closes the asymmetric I/O gap PR #103 left in place: the importer now extracts `fasting` and `specimen` from incoming Bundles, and the exporter emits `performer.display` / fasting `component` / contained `Specimen` from every BIOMARKER-domain Observation.

Net effect: "Add Lab Values" → "Share FHIR Bundle with your doctor" → re-import on another device now preserves what the owner typed in, end-to-end. Same pipeline a clinical lab uses to round-trip these fields.

## Manifesto / Principle 7 alignment

Two fields are deliberately *not* emitted:

- **`note`** — the free-text "what to remember about this lab" owner-recall field. Engine-irrelevant by construction, owner-recall only, never shared by default. PR #103 framing.
- **`sourceUri`** — a `content://` or `file://` URI that only resolves on the source device. Emitting it would trade a privacy smell for zero remote utility.

Both have dedicated regression tests that grep the serialized Observation for the sentinels.

## Coverage

**Importer ([FhirImporter.kt](android/app/src/main/java/com/bios/app/export/FhirImporter.kt))**

- Component LOINC `49541-6` → `BiomarkerContext.fasting`, parsing all three encodings clinical systems emit:
  - `valueBoolean` (FHIR-simple, Bios's own form)
  - `valueCodeableConcept.coding[].code` matching LOINC answer-list `LL1815-1` (`LA33-6` Yes, `LA32-8` No)
  - Free-text `valueCodeableConcept.text` fallback (EU public-system exports)
  - `LA46-7` "Don't know" → leaves field null rather than guessing
- `Observation.specimen.reference` → resolves against `contained[]` first, then a Bundle-level Specimen index. SCT codes 119364003 / 119361006 / 258580003 map to `SERUM` / `PLASMA` / `WHOLE_BLOOD`. Text-only fallback covers the EU public-system case; unknown text falls back to `OTHER` so the fact-of-specimen survives. Dangling references resolve to null without crashing.

**Exporter ([FhirExporter.kt](android/app/src/main/java/com/bios/app/export/FhirExporter.kt))**

- BIOMARKER-domain readings fold their sidecar payload (via the existing `BiomarkerEntryRepo.rowsToContext`) into a `BiomarkerContext` and pass it into `buildObservationResource`. Non-biomarker observations are unaffected.
- Emits `performer[{display}]`, LOINC 49541-6 `component` with `valueBoolean`, contained `Specimen` with SCT type. Observation references the contained specimen by `"#specimen-<observation-id>"` — never a dangling pointer.

**Tests ([FhirProvenanceRoundTripTest.kt](android/app/src/test/java/com/bios/app/FhirProvenanceRoundTripTest.kt) — new file)**

- Exporter-side: null and empty context produce a clean Observation (anti-regression for existing consumers); each populated field maps to the right FHIR element in isolation; `note` + `sourceUri` are scrubbed even when present.
- Importer-side: every fasting encoding; specimen via contained / Bundle / text / dangling / missing.
- Round trip: full-context Bundle (lab + fasting + PLASMA) and empty-context Bundle both survive a `buildObservationResource` → `buildBundleResource` → `FhirImporter.parse` round-trip with the right fields recovered.

Tests live in a new sibling file because both companion test files were near the 500-line cap; either would have spilled with the new coverage.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build).
- [x] `:app:testStandaloneDebugUnitTest` passes — new `FhirProvenanceRoundTripTest` (22 tests) + the existing `FhirImporterTest` / `FhirExporterTest` / `BiomarkerContextTest` suites all green.
- [ ] On-device sanity (post-merge): enter an HbA1c with lab + fasting + specimen → "Share FHIR Bundle" → re-import the same file → confirm all three fields land back in `BiomarkerContext`.

## Out of scope

- `Specimen.OTHER` → SCT code mapping. The receiving system gets the text label; that's what FHIR expects when no concept code applies.
- `sourceUri` propagation through FHIR — local URIs are non-portable. #106 may revisit if a portable representation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)