### PR TITLE
feat(biomarker): wire source-file URI capture for lab reports

### DIFF
--- a/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
+++ b/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
@@ -1,6 +1,7 @@
 package com.bios.app.platform
 
 import android.content.Context
+import android.content.Intent
 import android.util.Log
 import androidx.work.WorkManager
 import com.bios.app.data.BiosDatabase
@@ -54,6 +55,14 @@ object DataDestroyer {
 
         // 0.6. Unregister push and destroy push state
         PushRegistrationManager.destroyAll(context)
+
+        // 0.7. Release every persistable URI permission we hold (lab-report
+        // PDFs / photos attached to biomarker entries — see BiomarkerContext
+        // .sourceUri). Done *before* the DB key is destroyed so the wipe is
+        // observable from outside Bios too: source apps no longer see us in
+        // their "shared with" list. The system would garbage-collect these
+        // on next reboot anyway, but explicit release is the polite move.
+        releaseAllPersistableUriPermissions(context)
 
         // 1. Destroy encryption key (makes DB unreadable even if file survives)
         destroyEncryptionKey(context)
@@ -156,6 +165,26 @@ object DataDestroyer {
             Log.d(TAG, "Notifications cleared")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to clear notifications", e)
+        }
+    }
+
+    private fun releaseAllPersistableUriPermissions(context: Context) {
+        try {
+            val resolver = context.contentResolver
+            val held = resolver.persistedUriPermissions
+            for (perm in held) {
+                val flags = (if (perm.isReadPermission) Intent.FLAG_GRANT_READ_URI_PERMISSION else 0) or
+                    (if (perm.isWritePermission) Intent.FLAG_GRANT_WRITE_URI_PERMISSION else 0)
+                if (flags == 0) continue
+                try {
+                    resolver.releasePersistableUriPermission(perm.uri, flags)
+                } catch (_: SecurityException) {
+                    // Provider revoked the grant under us. Treat as already-released.
+                }
+            }
+            Log.d(TAG, "Released ${held.size} persistable URI permission(s)")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to release persistable URI permissions", e)
         }
     }
 

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryRows.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryRows.kt
@@ -1,0 +1,134 @@
+package com.bios.app.ui.biomarkers
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Row for a single recent biomarker entry. Fetches its
+ * [com.bios.app.data.BiomarkerContext] lazily so the parent doesn't have
+ * to materialise every reading's payload up front. When the entry has an
+ * attached lab-report URI, a "View source" affordance opens it via
+ * [Intent.ACTION_VIEW]; if the source app is gone or the file was
+ * deleted, the fallback message states that — Bios is the index, not the
+ * archive.
+ *
+ * Extracted from [BiomarkerEntryScreen] so the parent file stays under
+ * the 500-line cap.
+ */
+@Composable
+internal fun RecentBiomarkerRow(reading: MetricReading, repo: BiomarkerEntryRepo) {
+    val metric = MetricType.fromKey(reading.metricType)
+    val context = LocalContext.current
+    var sourceUri by remember(reading.id) { mutableStateOf<String?>(null) }
+    var openFailed by remember(reading.id) { mutableStateOf(false) }
+
+    LaunchedEffect(reading.id) {
+        sourceUri = repo.fetchContext(reading.id).sourceUri?.takeIf { it.isNotBlank() }
+    }
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Text(
+                metric?.readableName ?: reading.metricType,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "${formatBiomarkerValue(reading.value)} ${metric?.unit?.symbol.orEmpty()}  ·  " +
+                    formatBiomarkerDate(reading.timestamp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            reading.note?.takeIf { it.isNotBlank() }?.let {
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    "“$it”",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            sourceUri?.let { uri ->
+                Spacer(Modifier.height(2.dp))
+                if (openFailed) {
+                    // Honest fallback: Bios is the index, not the archive.
+                    // If the source file is gone, the row says so rather
+                    // than claiming a working link.
+                    Text(
+                        "Source file not available — was it moved or deleted?",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    TextButton(
+                        onClick = { openFailed = !openSourceUri(context, uri) },
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 0.dp),
+                    ) { Text("View source") }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Opens [uriString] in whichever app the device routes the MIME type to.
+ * Returns `true` when the chooser actually fires; `false` for a missing
+ * resolver or a revoked persistable permission (the source app could have
+ * been uninstalled, or the file could have been moved off whichever
+ * provider granted the URI).
+ */
+internal fun openSourceUri(context: Context, uriString: String): Boolean {
+    val uri = try { Uri.parse(uriString) } catch (_: Exception) { return false }
+    val mime = context.contentResolver.getType(uri) ?: "*/*"
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(uri, mime)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    return try {
+        context.startActivity(intent)
+        true
+    } catch (_: ActivityNotFoundException) {
+        false
+    } catch (_: SecurityException) {
+        false
+    }
+}
+
+private val biomarkerRowDateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
+
+internal fun formatBiomarkerDate(millis: Long): String = biomarkerRowDateFormat.format(Date(millis))
+
+internal fun formatBiomarkerValue(value: Double): String =
+    if (value == value.toLong().toDouble()) value.toLong().toString()
+    else "%.2f".format(value)

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
@@ -1,5 +1,7 @@
 package com.bios.app.ui.biomarkers
 
+import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -52,15 +54,11 @@ import androidx.compose.foundation.layout.Row
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.export.FhirImportSummary
 import com.bios.app.export.FhirImporter
-import com.bios.app.model.MetricReading
 import com.bios.app.model.Specimen
 import com.bios.app.ui.AppViewModel
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -83,10 +81,34 @@ fun BiomarkerEntryScreen(
     var specimen by remember { mutableStateOf<Specimen?>(null) }
     var specimenExpanded by remember { mutableStateOf(false) }
     var note by remember { mutableStateOf("") }
+    var sourceUri by remember { mutableStateOf<Uri?>(null) }
     var showContext by remember { mutableStateOf(false) }
     val recent by viewModel.recentBiomarkers.collectAsState()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    val labReportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { picked ->
+        // OpenDocument returns a content:// URI. Take a persistable read
+        // permission so the URI survives reboots and the source app's
+        // lifecycle. Without this, the URI works for the current process
+        // only and is dead after the next launch.
+        if (picked != null) {
+            try {
+                context.contentResolver.takePersistableUriPermission(
+                    picked, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+                sourceUri = picked
+            } catch (_: SecurityException) {
+                // Some providers (e.g. cached images) won't grant persistable
+                // permission. Keep the URI in-memory only; the entry still
+                // saves, but won't survive a reboot. Better than silently
+                // dropping the owner's pick.
+                sourceUri = picked
+            }
+        }
+    }
 
     val fhirLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocument()
@@ -189,7 +211,7 @@ fun BiomarkerEntryScreen(
                         onClick = { showDatePicker = true },
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text("Drawn on: ${formatDate(selectedDate)}")
+                        Text("Drawn on: ${formatBiomarkerDate(selectedDate)}")
                     }
 
                     TextButton(
@@ -274,6 +296,33 @@ fun BiomarkerEntryScreen(
                             label = { Text("Note (for your recall)") },
                             modifier = Modifier.fillMaxWidth()
                         )
+
+                        Text(
+                            "Lab report (PDF or photo)",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedButton(
+                                onClick = { labReportLauncher.launch(LAB_REPORT_MIME_TYPES) },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(if (sourceUri == null) "Attach…" else "Replace")
+                            }
+                            if (sourceUri != null) {
+                                TextButton(onClick = {
+                                    sourceUri?.let { releasePersistableRead(context, it) }
+                                    sourceUri = null
+                                }) { Text("Remove") }
+                            }
+                        }
+                        sourceUri?.let {
+                            Text(
+                                "Attached: ${it.lastPathSegment ?: it.toString()}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
 
                     OutlinedButton(
@@ -282,6 +331,7 @@ fun BiomarkerEntryScreen(
                                 labName = labName.ifBlank { null },
                                 fasting = fasting,
                                 specimen = specimen,
+                                sourceUri = sourceUri?.toString(),
                                 note = note.ifBlank { null }
                             )
                             viewModel.addManualBiomarker(selected, parsed!!, selectedDate, bioContext)
@@ -290,6 +340,7 @@ fun BiomarkerEntryScreen(
                             fasting = null
                             specimen = null
                             note = ""
+                            sourceUri = null
                         },
                         enabled = isValid,
                         modifier = Modifier.fillMaxWidth()
@@ -335,7 +386,7 @@ fun BiomarkerEntryScreen(
                     contentPadding = PaddingValues(vertical = 4.dp)
                 ) {
                     items(recent, key = { it.id }) { reading ->
-                        RecentBiomarkerRow(reading)
+                        RecentBiomarkerRow(reading, viewModel.biomarkerEntryRepo)
                     }
                 }
             }
@@ -412,40 +463,27 @@ private fun FhirImportSummaryDialog(summary: FhirImportSummary, onDismiss: () ->
     )
 }
 
-@Composable
-private fun RecentBiomarkerRow(reading: MetricReading) {
-    val metric = MetricType.fromKey(reading.metricType)
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-            Text(
-                metric?.readableName ?: reading.metricType,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium
-            )
-            Spacer(Modifier.height(2.dp))
-            Text(
-                "${formatValue(reading.value)} ${metric?.unit?.symbol.orEmpty()}  ·  ${formatDate(reading.timestamp)}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            reading.note?.takeIf { it.isNotBlank() }?.let {
-                Spacer(Modifier.height(2.dp))
-                Text(
-                    "“$it”",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+/**
+ * MIME types the lab-report picker is restricted to. The owner's archive
+ * (Files / Drive / camera roll) typically delivers labs as one of these:
+ * scanned PDFs from a portal, JPEG/PNG photos from the device camera.
+ * Restricting the picker keeps random "PDF or photo or anything else"
+ * accidents off the entry surface.
+ */
+internal val LAB_REPORT_MIME_TYPES: Array<String> = arrayOf(
+    "image/jpeg",
+    "image/png",
+    "application/pdf",
+)
+
+private fun releasePersistableRead(context: android.content.Context, uri: Uri) {
+    try {
+        context.contentResolver.releasePersistableUriPermission(
+            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+    } catch (_: SecurityException) {
+        // Permission was never persisted (some providers don't allow it),
+        // or it has already been revoked. Either way, nothing to release.
     }
 }
 
-private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
-private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))
-
-private fun formatValue(value: Double): String =
-    if (value == value.toLong().toDouble()) value.toLong().toString()
-    else "%.2f".format(value)

--- a/android/app/src/test/java/com/bios/app/BiomarkerSourceUriTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerSourceUriTest.kt
@@ -1,0 +1,75 @@
+package com.bios.app
+
+import com.bios.app.data.BiomarkerPayloadKeys
+import com.bios.app.ui.biomarkers.LAB_REPORT_MIME_TYPES
+import com.bios.app.ui.biomarkers.formatBiomarkerDate
+import com.bios.app.ui.biomarkers.formatBiomarkerValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.TimeZone
+
+/**
+ * Pure-logic tests for the source-URI capture surface (#106).
+ *
+ *  - The lab-report MIME policy (PDF, JPEG, PNG) is the picker's only
+ *    contract with the rest of the OS — pin the literal so it can't drift
+ *    silently and silently widen what the entry surface accepts.
+ *  - [BiomarkerPayloadKeys.SOURCE_URI] is the storage key — pinning it
+ *    here catches accidental renames that would orphan every existing
+ *    attached lab on upgrade.
+ *  - Row-side formatters (extracted into BiomarkerEntryRows.kt) round-trip
+ *    representative values cleanly.
+ *
+ * The capture-side `takePersistableUriPermission` flow and the wipe-side
+ * `releaseAllPersistableUriPermissions` paths both require an Android
+ * `ContentResolver` and are covered by build-and-eyeball, not unit tests.
+ */
+class BiomarkerSourceUriTest {
+
+    init {
+        // Pin dates so format assertions pass in every CI timezone.
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
+    @Test
+    fun `LAB_REPORT_MIME_TYPES is exactly PDF + JPEG + PNG`() {
+        // What the picker accepts is part of the entry-surface contract.
+        // Widening (e.g. "*/*") would let the owner accidentally attach a
+        // .docx, .heic, or .zip and then hit a viewer-not-found wall at
+        // open time. Narrowing (e.g. dropping PNG) would silently break
+        // every PNG attached on a previous version.
+        assertEquals(
+            setOf("application/pdf", "image/jpeg", "image/png"),
+            LAB_REPORT_MIME_TYPES.toSet(),
+        )
+        assertEquals("No duplicates", LAB_REPORT_MIME_TYPES.size, LAB_REPORT_MIME_TYPES.toSet().size)
+    }
+
+    @Test
+    fun `source URI payload key is the stable string declared in BiomarkerContext`() {
+        // Renaming this key would orphan every attached lab on upgrade —
+        // the row would still be in event_payloads but `rowsToContext`
+        // wouldn't find it. Pin the literal so a refactor can't slip past.
+        assertEquals("source_uri", BiomarkerPayloadKeys.SOURCE_URI)
+    }
+
+    @Test
+    fun `formatBiomarkerValue collapses whole numbers and keeps two decimals otherwise`() {
+        // Whole numbers (HbA1c lab integers, platelet counts) shouldn't
+        // drag a trailing ".0" through every row.
+        assertEquals("5", formatBiomarkerValue(5.0))
+        assertEquals("200", formatBiomarkerValue(200.0))
+        assertEquals("5.40", formatBiomarkerValue(5.4))
+        assertEquals("0.85", formatBiomarkerValue(0.85))
+    }
+
+    @Test
+    fun `formatBiomarkerDate renders human-readable date`() {
+        // 2026-01-15 00:00:00 UTC → "Jan 15, 2026"
+        val rendered = formatBiomarkerDate(1768435200000L)
+        assertTrue("Expected human-readable date, got '$rendered'", rendered.contains("2026"))
+        assertTrue(rendered.contains("Jan"))
+        assertTrue(rendered.contains("15"))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #106 — wires the `BiomarkerPayloadKeys.SOURCE_URI` field PR #103 reserved into a real capture surface. Owners can attach the original lab report (PDF or photo) to a biomarker entry; future-them can tap "View source" on the row to pull the original up. Bios stores the URI only — the file content stays wherever the owner put it (Files, Drive, camera roll).

Closes the loop the PDF round-trip (#105) opened: the FHIR exporter explicitly scrubbed `sourceUri` because the entry surface didn't populate it. Now it does.

## What landed

**Capture ([BiomarkerEntryScreen.kt](android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt))**

- New "Lab report (PDF or photo)" picker inside the existing context section. Restricted to PDF + JPEG + PNG via `ActivityResultContracts.OpenDocument` (`LAB_REPORT_MIME_TYPES`).
- On pick, `contentResolver.takePersistableUriPermission(uri, FLAG_GRANT_READ_URI_PERMISSION)` so the URI survives reboot and the source app's lifecycle. Providers that refuse persistable permission still attach in-memory rather than silently dropping — owner's tradeoff to make.
- "Remove" affordance releases the persistable read before clearing the field.

**Recent rows ([BiomarkerEntryRows.kt](android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryRows.kt) — new sibling file)**

- `RecentBiomarkerRow` extracted from the screen so the parent file stays under the 500-line cap. The row asks the repo for its `BiomarkerContext` via a `LaunchedEffect`, and when `sourceUri` is set, surfaces "View source" → `Intent.ACTION_VIEW`.
- Fallback when the URI is dead (moved, deleted, revoked): "Source file not available — was it moved or deleted?" Bios is the index, not the archive.

**Wipe ([DataDestroyer.kt](android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt))**

- New step 0.7 in `destroyAll`: walk `contentResolver.persistedUriPermissions` and release every grant we hold, *before* destroying the DB key. The system would clean these up on next reboot anyway, but explicit release means the wipe is observable from outside Bios — source apps no longer see us in their "shared with" list.

**Tests ([BiomarkerSourceUriTest.kt](android/app/src/test/java/com/bios/app/BiomarkerSourceUriTest.kt) — new file)**

- Pin `LAB_REPORT_MIME_TYPES` to exactly `{application/pdf, image/jpeg, image/png}` — picker contract regression guard.
- Pin `BiomarkerPayloadKeys.SOURCE_URI` to `"source_uri"` — accidental renames would orphan every previously-attached lab.
- Format helpers (extracted to the new row file) round-trip representative values.

## Manifesto check

Bios stores the URI only, not the file content. If the source file is deleted, the URI resolves to "file not found" — that's correct behavior under the index-not-archive framing. The View-source affordance just routes through `Intent.ACTION_VIEW`; the owner stays in control of what app opens it.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build).
- [x] `:app:testStandaloneDebugUnitTest` passes — full suite green; new `BiomarkerSourceUriTest` covers the picker contract + payload-key stability + row-formatter behavior.
- [ ] On-device sanity (post-merge):
   - Add HbA1c → "Add context" → "Attach…" → pick a PDF from Files → see "Attached: …" → Save → row shows "View source" → tap opens the PDF.
   - Pick a JPEG photo from the camera roll → same path works.
   - Reboot device → row's "View source" still works (persistable permission survived).
   - "Delete all data" in Settings → confirm via `adb shell dumpsys content` that the persistable URI grant is gone (source app no longer lists Bios under "shared with").

## Out of scope

- Per-row delete UI for a single biomarker entry — there's no existing delete-one path, and #106 doesn't ask for it. When/if it lands, the persistable-read release belongs on that path too; the `releasePersistableRead` helper in `BiomarkerEntryScreen.kt` is ready to be reused.
- Bios storing a copy of the file content. Explicitly not the design — Bios is the index, the owner's archive holds the bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)