### PR TITLE
chore: sweep AlertContentPolicy header for new evaluation framing

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt
@@ -1,18 +1,35 @@
 package com.bios.app.alerts
 
 /**
- * Enforces the "never evaluate the person" principle on alert text.
+ * Enforces the **push-side unsolicited-judgment ban** on alert text.
  *
- * All condition pattern text (title, explanation, suggestedAction, earlyDetection,
- * prevention, healing, risks) must pass this policy. Violations fail in CI tests.
+ * This is the code-level enforcement point for Manifesto Principle 7
+ * ("instrument, not coach"). Per the framing in [MANIFESTO.md] and
+ * docs/PRIVACY_ARCHITECTURE.md "Alert Content Policy," Bios distinguishes:
  *
- * Prohibited patterns:
+ *  - **Push side** — alerts and notifications Bios raises on its own,
+ *    unsolicited. This is what the policy here constrains. Unsolicited
+ *    judgment is what the manifesto prohibits, and `ConditionPattern`
+ *    text is exactly that surface: the owner didn't ask for it, Bios is
+ *    surfacing it.
+ *  - **Pull side** — screens the owner navigates into, biomarker context
+ *    they annotate themselves, comparisons they explicitly ask for. The
+ *    owner is doing the evaluation; Bios is the instrument they read.
+ *    These surfaces are **not** constrained by this policy and may use
+ *    language this policy bans.
+ *
+ * All condition pattern text (title, explanation, suggestedAction,
+ * earlyDetection, prevention, healing, risks) must pass this policy.
+ * Violations fail in CI tests. New push-side surfaces should pass
+ * through `validate()` or its sibling check in tests.
+ *
+ * Prohibited on the push side:
  * - Second-person lifestyle judgments ("you should exercise", "you need to sleep more")
  * - Wellness scores or grade language ("your health score is", "grade: B")
  * - Guilt mechanics ("you haven't", "you missed", "you failed")
  * - Gamification ("streak", "achievement", "level up", "points")
  *
- * Allowed:
+ * Allowed on the push side:
  * - Data statements ("resting HR +2σ", "sleep duration 5.2h")
  * - Questions ("have you felt unwell?")
  * - Professional referrals ("discuss with your healthcare provider")


### PR DESCRIPTION
## Summary

Closes #108. Comment-only sweep — no code change. The `AlertContentPolicy` *code* is correct under the new framing (it only ever validated `ConditionPattern` text, which is the push surface). What was stale was the file header still citing *"never evaluate the person"* as the principle it enforces.

The rewritten header:

- Names the policy what it actually is: the **push-side unsolicited-judgment ban** (Manifesto Principle 7, "instrument, not coach").
- Spells out the push / pull distinction so future contributors don't try to validate pull-side surfaces (biomarker context the owner annotates, comparisons they explicitly request, etc.) against the same banlist.
- Cross-references [`MANIFESTO.md`](MANIFESTO.md) and [`docs/PRIVACY_ARCHITECTURE.md`](docs/PRIVACY_ARCHITECTURE.md) so the rationale is one click away.
- Keeps the existing **Prohibited** / **Allowed** lists verbatim — both still accurately describe what the policy enforces on push-side text.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes — no source-code changes, only KDoc.
- [ ] Reviewer eyeballs the new header at [AlertContentPolicy.kt:3-35](android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt#L3-L35) and confirms the push/pull distinction reads correctly.

## What's not changing

- The `PROHIBITED_PHRASES` list — still correct for push-side enforcement.
- `validate()` / `validateAll()` — the surface being validated is unchanged.
- Any other call site or test — `AlertContentPolicyTest` continues to gate condition patterns the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)