### PR TITLE
docs: revisit Blueprint audit decisions under the new evaluation frame

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt
@@ -8,10 +8,20 @@ package com.bios.app.alerts
  * docs/PRIVACY_ARCHITECTURE.md "Alert Content Policy," Bios distinguishes:
  *
  *  - **Push side** — alerts and notifications Bios raises on its own,
- *    unsolicited. This is what the policy here constrains. Unsolicited
- *    judgment is what the manifesto prohibits, and `ConditionPattern`
- *    text is exactly that surface: the owner didn't ask for it, Bios is
- *    surfacing it.
+ *    unsolicited. The push side splits into three sub-categories:
+ *      1. **Person-evaluative push** — "your sleep is degrading,"
+ *         "you're unhealthy." This is what the policy here constrains.
+ *         Unsolicited judgment of the person is what the manifesto
+ *         prohibits, and `ConditionPattern` text is exactly that surface.
+ *      2. **Person-factual push** — "RHR +2σ for 48h," daily digest.
+ *         Admissible — what the existing banlist explicitly allows.
+ *      3. **Bios-state push** — "Oura hasn't synced in 5 days. Reconnect?"
+ *         Admissible. Not about the owner at all; Bios reporting on its
+ *         own plumbing. "Silence is a feature" was always about the
+ *         owner — silent system failure isn't silence, it's failure.
+ *         Bios-state pushes follow the same factual-only content rules
+ *         as category 2, but the banlist below targets person-judgment
+ *         patterns specifically and doesn't apply by construction.
  *  - **Pull side** — screens the owner navigates into, biomarker context
  *    they annotate themselves, comparisons they explicitly ask for. The
  *    owner is doing the evaluation; Bios is the instrument they read.

--- a/docs/ECOSYSTEM_BOUNDARIES.md
+++ b/docs/ECOSYSTEM_BOUNDARIES.md
@@ -319,12 +319,12 @@ feature) and the second-consumer rule were the load-bearing principles.
 
 | Topic | Verdict | Principle |
 |---|---|---|
-| Food / macro / calorie log (#36) | ❌ Out of scope — permanently | Inherently evaluative (deficit/surplus, "good food"). Violates "never evaluate the person" + "no behavioral nudges". |
-| Intervention log — sauna / NIR / HBOT / cold (#39) | ❌ Out of scope | Quantified-self self-experimentation framing ("did X improve my recovery?") is exactly the optimization framing the manifesto rejects. |
+| Food / macro / calorie log (#36) | ❌ Out of scope — permanently | Inherently evaluative (deficit/surplus, "good food"). Violates "never evaluate the person" + "no behavioral nudges". *(Reasoning revised 2026-05 manifesto-frame revisit — verdict stands, but on operational not philosophical grounds. See subsection below.)* |
+| Intervention log — sauna / NIR / HBOT / cold (#39) | ❌ Out of scope | Quantified-self self-experimentation framing ("did X improve my recovery?") is exactly the optimization framing the manifesto rejects. *(Superseded by 2026-05 manifesto-frame revisit — verdict now ✅ in scope as a pull-side event log. See subsection below.)* |
 | Self-exam / fertility self-report (#42) | ❌ Out of scope | Self-exam reminders are habit-tracker territory, not health-guardian. Involuntary fertility signal (BBT) already covered by #32. Privacy bar too high for marginal pattern benefit. |
 | Hydration logging (`HYDRATION_ML`) | ❌ Out of scope | Manual entry drifts into "are you drinking enough?" behavioral judgment. |
 | Water quality / TDS / mineralization | ❌ Out of scope | Blueprint-style optimization, no Bios pattern consumes it. |
-| Supplement / medication adherence (#37) | ⏸ Deferred — second-consumer rule | No Bios pattern needs adherence input today. Re-evaluate when a concrete consumer emerges (likely: future migraine / chronic-condition companion). If reserved, mirror Smokeless posture exactly (timestamp + opaque event-id, no substance names). |
+| Supplement / medication adherence (#37) | ⏸ Deferred — second-consumer rule | No Bios pattern needs adherence input today. Re-evaluate when a concrete consumer emerges (likely: future migraine / chronic-condition companion). If reserved, mirror Smokeless posture exactly (timestamp + opaque event-id, no substance names). *(Superseded by 2026-05 manifesto-frame revisit — verdict now ✅ in scope, pull-side only. See subsection below.)* |
 | Grip strength `GRIP_STRENGTH_KG` (#41) | ⏸ Deferred — second-consumer rule | Re-evaluate when Fil (or a physical-tests companion) ships an active grip test AND a second Bios-side consumer exists. |
 | Additional cognitive keys — `N_BACK`, `STROOP`, `DIGIT_SPAN_*`, `PROCESSING_SPEED_SCORE` (#40) | ⏸ Deferred — second-consumer rule | Unlike `REACTION_TIME_MS`, these have only Fil as a consumer. Reserve when Fil's active-test surface ships. |
 | `REACTION_TIME_MS` (#40) | ✅ Keep reserved | Two named consumers across two domains: Fil produces (active micro-tests); W2F reads as a cross-check on its passive psychomotor-acceleration signal. Documented producer + reader satisfies the second-consumer rule. |
@@ -364,6 +364,61 @@ in scope, surfaces that produce companion-owned keys are not.
 | Hypothetical SDMT / tapping / contrast micro-test | ❌ Companion (Fil) | Produces Fil-owned cognitive scores. Domain-specific active test. |
 | Hypothetical keystroke-cadence capture UI | ❌ Companion (W2F) | Produces `typing_cadence` — W2F-owned. AccessibilityService surface, mood-specific consumer. |
 | Hypothetical grip-strength dynamometer test | ❌ Companion (physical-tests) | Produces an active-test key with no canonical Bios producer. |
+
+### 2026-05 — Manifesto-frame revisit (post-PR #103)
+
+[MANIFESTO.md](../MANIFESTO.md) Principle 7 ("instrument, not coach") replaced
+the earlier "never evaluate the person" load-bearing constraint with a
+push/pull distinction: **unsolicited push-side evaluation is prohibited;
+owner-pulled / owner-driven surfaces are not.** The 2026-05 Blueprint audit
+above made two rejections on grounds that no longer hold — both cited the
+old framing's "the manifesto rejects optimization" reasoning, which the new
+manifesto explicitly authorizes ("steer your own course over time — toward
+maintaining what works and improving what doesn't").
+
+Verdict revisions:
+
+| Topic | Old verdict | New verdict | Reasoning |
+|---|---|---|---|
+| Food / macro / calorie log (#36) | ❌ "inherently evaluative" | ❌ unchanged — **reasoning rewritten** | The new frame doesn't disqualify "inherently evaluative" on its own. Real disqualifiers are operational: multi-meal-per-day capture surfaces have well-documented abandonment curves, and the sensor stack (glucose variability via Dexcom, post-meal HR/HRV) already produces the metabolic signal without owner typing. |
+| Intervention log — sauna / NIR / HBOT / cold (#39) | ❌ "optimization framing the manifesto rejects" | ✅ **in scope as a pull-side event log** | The old rejection cited a frame the manifesto no longer holds. Surface is admissible under the new principle. Constraint rides on the design rule below. |
+| Supplement / medication adherence (#37) | ⏸ deferred — second-consumer rule | ✅ **in scope, pull-side only** | The owner-pulled correlation IS the second consumer when the owner asks "did I take the magnesium on the nights I slept poorly?" The trigger fires as soon as the owner navigates into that comparison. Storage shape per the original Smokeless posture (timestamp + opaque event-id, no substance names) still right. |
+
+Decisions the frame change does **not** move (unchanged from above): #41
+Grip strength (still gated on the producer + second-consumer rule, both
+independent of push/pull); #42 self-exam (habit-tracker territory
+regardless of frame); hydration (the behavioral-judgment slippery slope is
+a push-side concern, still applies); water quality (no Bios consumer in
+either direction); the other "in scope / affirmed" rows.
+
+### Design rule for owner-driven pull-side logs
+
+When a manual logging surface is admitted under the new frame
+(intervention log, supplement/medication adherence, future analogous
+surfaces), the **firewall lives in the UI design line, not the feature
+line.** The surface must not host engagement-app DNA. Specifically:
+
+- **No streak counters, no completeness percentages, no daily-goal gauges.**
+- **No "you haven't logged today" empty states or daily-reminder UI.**
+- **No "log everything to see results" prompts.** Sparse logging is
+  expected and treated as a first-class state.
+- **Empty state reads what's true** — "no interventions logged in this
+  window" — full stop, no nudge.
+- **Correlation surfaces show what's there**, say nothing about what's
+  missing. Sparse log → sparse chart → honest insight.
+- **Bios does not ask for data.** It works with whatever the owner gives.
+
+These rules apply to pull surfaces because pull-side absolutism alone
+doesn't prevent engagement loops — empty boxes pull at people, "did X
+improve my recovery?" charts re-create the optimization pathology even
+without a single notification firing. The defence is structural: don't
+build the pieces engagement apps use to drive sessions.
+
+The rule does **not** apply to:
+- Bios-state pushes (the third push category — "Oura hasn't synced in 5
+  days") — those are about Bios's plumbing, not the owner.
+- Pull surfaces that don't host owner-typed event data (Data Coverage,
+  trends, alerts review) — these were never at risk of the loop.
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — Bios system components
 - [CONSUMER_API.md](CONSUMER_API.md) — `BiosHealthProvider` contract

--- a/docs/SELF_REPORTED_DATA_HOME.md
+++ b/docs/SELF_REPORTED_DATA_HOME.md
@@ -82,15 +82,24 @@ meaningful.
 
 **Why:** A baseline of self-reported sleep is a baseline of *perception*,
 not physiology — statistically meaningless to mix. Beyond statistics,
-running anomaly detection on self-reports crosses the alignment principle:
-"your reported mood is 1.5σ below baseline" *is* evaluating the person,
-which Bios explicitly does not do.
+running anomaly detection on self-reports and pushing the result —
+"your reported mood is 1.5σ below baseline" — is **unsolicited
+push-side evaluation of the person**, which `AlertContentPolicy`
+explicitly bans (see [MANIFESTO.md](../MANIFESTO.md) Principle 7 and
+the push/pull distinction in
+[PRIVACY_ARCHITECTURE.md](PRIVACY_ARCHITECTURE.md) "Alert Content
+Policy"). The mechanical guarantees here (`BaselineEngine` skips
+`kind != SENSOR`; `SignalQualityFilter` same) implement that prohibition
+at the code level.
 
 Self-reports and events are: **displayable** (transparency),
 **correlatable** as context for sensor-derived alerts (HRV down + user
 reports poor sleep = stronger signal than HRV alone), and
 **pattern-detectable** with descriptive language only ("you've logged poor
-sleep 4 nights in a row" — never "your sleep is degrading").
+sleep 4 nights in a row" — never "your sleep is degrading"). Owner-pulled
+comparison surfaces — where the owner navigates in and asks "did I sleep
+better after starting magnesium?" — are not constrained by this rule;
+the firewall is push-side only.
 
 ### 4. Structured symptom taxonomy as Bios canon
 
@@ -128,11 +137,31 @@ applies to *executing* tests. *Results* are data, and data with multiple
 consumers belongs on the bus. The boundaries doc gets a sentence to that
 effect alongside this PR.
 
-### 6. Bios is a consumer, never the entry point — period.
+### 6. Bios hosts only the entry points its own canonical data needs.
 
-Codified above as the principle. Called out as a separate decision because
-future asks of "let me log sleep directly in Bios" will be plausible and
-worth refusing every time.
+Originally framed as *"Bios is a consumer, never the entry point —
+period."* That absolute is now wrong-as-written: since then, BBT manual
+entry (`BbtEntryRepo`), biomarker entry (`BiomarkerEntryRepo`), manual
+sleep duration, and lab-report attachment (PR #106) have all shipped as
+legitimate Bios-hosted entry surfaces.
+
+The corrected rule — which all four shipped surfaces already satisfy —
+is the same producer-by-capture-surface line codified in
+[ECOSYSTEM_BOUNDARIES.md](ECOSYSTEM_BOUNDARIES.md) ("No domain-specific
+active tests in Bios"). **Bios hosts an entry point if and only if the
+data being entered is a canonical Bios-owned key with no other producer
+available.** Biomarkers are typed because no sensor draws blood; BBT is
+typed because no wearable on the owner's wrist measures basal body
+temperature; manual sleep is typed when Health Connect / Oura / Gadgetbridge
+are all silent. Bios is *not* the entry point for data a companion
+uniquely owns — typing cadence belongs in W2F, SDMT in Fil, fall-event
+in Virgil.
+
+The "future asks of 'let me log sleep directly in Bios'" line from the
+old wording was directionally right but the verdict's been wrong: the
+manual-sleep-entry surface that landed in the meantime is the right
+shape, and refusing it would have left a real gap. The rule above is
+what we apply going forward.
 
 ## Open questions (decide before implementing)
 


### PR DESCRIPTION
## Summary

Closes #107. PR #103 reformulated the load-bearing evaluation constraint from *"never evaluate the person"* to *"instrument, not coach — unsolicited push-side evaluation is prohibited; owner-pulled / owner-driven surfaces are not."* Two of the 2026-05 Blueprint audit's rejections cited the old framing's reasoning, which the new manifesto no longer holds. This is the doc-only revisit.

Verdict signoff was reached over the [#107 comment thread](https://github.com/thdelmas/Bios/issues/107#issuecomment-4477338112) — two genuine flips (#37 and #39), one reasoning rewrite (#36), four "no change."

## Verdict table

| Decision | Old verdict | New verdict |
|---|---|---|
| #36 Food log | ❌ "inherently evaluative" | ❌ unchanged — **reasoning rewritten** (operational, not philosophical) |
| #37 Supplement adherence | ⏸ deferred | ✅ **in scope, pull-side only** |
| #39 Intervention log | ❌ "manifesto rejects optimization" | ✅ **in scope as a pull-side event log** |
| #41 Grip strength | ⏸ deferred | ⏸ unchanged (frame doesn't move it) |
| #42, hydration, water quality | ❌ | unchanged |
| SRDH Decision 3 | "evaluating the person" | rule unchanged, reasoning sharpened to push-side |
| SRDH Decision 6 | "never the entry point — period" | rewritten to producer-by-capture-surface rule |
| AlertContentPolicy header | one push category | names three sub-categories explicitly |

## What landed

**[`docs/ECOSYSTEM_BOUNDARIES.md`](docs/ECOSYSTEM_BOUNDARIES.md)**

- New *"2026-05 — Manifesto-frame revisit (post-PR #103)"* subsection appended to the scope-decisions log. Original 2026-05 audit table entries get inline supersession notes pointing to the new subsection rather than rewriting history (the audit log's own rule: *"Append new decisions; do not rewrite history"*).
- New *"Design rule for owner-driven pull-side logs"* sub-section codifying the load-bearing firewall that lets #37 and #39 flip without dragging in engagement-app DNA: no streak counters, no completeness gauges, no nag empty states, sparse logging treated as first-class, correlation surfaces show what's there without commenting on what's missing.

**[`docs/SELF_REPORTED_DATA_HOME.md`](docs/SELF_REPORTED_DATA_HOME.md)**

- Decision 3 (Engine isolation by kind): rule mechanically unchanged, reasoning sharpened from *"evaluating the person"* to *"unsolicited push-side evaluation of the person, which AlertContentPolicy explicitly bans."* Cross-references Principle 7 and the push/pull section.
- Decision 6: the absolute *"never the entry point — period"* is wrong as written — four entry surfaces have shipped since (BBT, biomarker, manual sleep, lab-report attachment via #111). Rewrite to the corrected rule all four already satisfy: Bios hosts an entry point iff the data being entered is a canonical Bios-owned key with no other producer.

**[`AlertContentPolicy.kt`](android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt) header**

- Expanded the push-side framing to name three sub-categories: person-evaluative (banned), person-factual (admissible — what the banlist allows), and a third — **Bios-state push** ("Oura hasn't synced in 5 days"). The third was implicit before; the #108 sweep framed "the push surface" as a single thing. Code untouched.

## The hidden architectural insight

The conversation that produced this also surfaced a third push category I hadn't named explicitly: **Bios reporting on Bios, not on the owner.** "Oura hasn't synced in 5 days" is system reporting on its own plumbing, not judgment of the owner. The banlist doesn't apply to it by construction.

This is what lets us answer "how do we surface disconnected data sources under the silence rule?" — silence is a feature about the owner; silent system failure is just failure. **#113 is the implementation ticket** for the actual catastrophic-disconnect push feature. This PR just lands the architectural acknowledgement in docs and the policy header.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build — comment + doc changes only).
- [ ] Reviewer reads the new ECOSYSTEM_BOUNDARIES "Manifesto-frame revisit" section ([from line ~370](docs/ECOSYSTEM_BOUNDARIES.md#L370)) and confirms each verdict matches their sign-off in the issue thread.
- [ ] Reviewer reads SRDH Decision 6 ([line ~131](docs/SELF_REPORTED_DATA_HOME.md#L131)) and confirms the rewrite captures the four shipped entry surfaces correctly.
- [ ] Reviewer reads the AlertContentPolicy.kt header ([line ~3](android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt#L3)) and confirms the three-category framing reads correctly.

## Out of scope

- Implementing the catastrophic-disconnect push — filed as #113.
- Implementing intervention-log / supplement-adherence UIs — verdicts are now ✅ but no surfaces are being built in this PR. When they ship, the design-rule sub-section in ECOSYSTEM_BOUNDARIES.md governs what they may and may not include.
- Reopening other Blueprint audit decisions whose reasoning didn't cite the old frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)