### PR TITLE
feat(engine): WASO + sleep score derivations; strengthen sleep pattern

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -121,8 +121,14 @@ object ConditionPatterns {
         title = "Sleep quality declining",
         category = ConditionCategory.SLEEP,
         signalRules = listOf(
-            SignalRule(MetricType.SLEEP_STAGE, DeviationDirection.BELOW, 1.5, 72, 1.0,
-                ThresholdSource.LITERATURE, "Prather et al. (2015) - sleep efficiency <85% for >5 nights correlates with immune suppression"),
+            // Fragmentation is the most direct sleep-quality signal — number
+            // of post-onset awakenings is a clinical PSG metric, not a
+            // statistical proxy. Bonzini et al. (2020): fragmentation rises
+            // 3-7 days before subjective awareness of poor sleep.
+            SignalRule(MetricType.SLEEP_FRAGMENTATION_INDEX, DeviationDirection.ABOVE, 1.0, 72, 1.0,
+                ThresholdSource.LITERATURE, "Bonzini et al. (2020) — fragmentation index above personal baseline precedes subjective fatigue"),
+            SignalRule(MetricType.SLEEP_EFFICIENCY, DeviationDirection.BELOW, 1.0, 72, 1.0,
+                ThresholdSource.LITERATURE, "Prather et al. (2015) — sleep efficiency <85% for >5 nights correlates with immune suppression"),
             SignalRule(MetricType.HEART_RATE_VARIABILITY, DeviationDirection.BELOW, 1.0, 48, 0.8,
                 ThresholdSource.LITERATURE, "Kim et al. (2018) - sustained low HRV reflects autonomic stress during poor sleep"),
             SignalRule(MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 48, 0.6,

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -95,6 +95,14 @@ object MetricCoverageRegistry {
             MetricType.SLEEP_FRAGMENTATION_INDEX, 36 * H,
             listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
         ),
+        MetricCoverageSpec(
+            MetricType.WAKE_AFTER_SLEEP_ONSET, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.SLEEP_SCORE, 36 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
 
         // -- Activity --
         MetricCoverageSpec(

--- a/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
@@ -133,4 +133,146 @@ object SleepDerivations {
             confidence = stages.first().confidence
         )
     }
+
+    /**
+     * Wake After Sleep Onset (WASO): total seconds spent AWAKE after the first
+     * non-AWAKE stage, before the session ends. Standard polysomnography
+     * metric — distinguishes "couldn't fall asleep" (latency) from "kept
+     * waking up" (WASO). Lower is better.
+     *
+     * Returns null when the session has no stage rows, no sleep onset, or
+     * stages lack a `durationSec` field (some adapters emit point events
+     * instead of duration-bound segments — those don't produce a WASO).
+     */
+    fun deriveWakeAfterSleepOnset(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val stages = readings
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .sortedBy { it.timestamp }
+        if (stages.isEmpty()) return null
+
+        val firstSleepIdx = stages.indexOfFirst { it.value.toInt() != SleepStage.AWAKE.value }
+        if (firstSleepIdx < 0) return null
+
+        val postOnsetAwakeSec = stages.drop(firstSleepIdx)
+            .filter { it.value.toInt() == SleepStage.AWAKE.value }
+            .sumOf { it.durationSec ?: 0 }
+        if (postOnsetAwakeSec == 0) {
+            // No post-onset awakenings → emit a zero rather than null. WASO=0
+            // is a real, meaningful value (uninterrupted sleep); collapsing
+            // it to null would lose that signal.
+            return MetricReading(
+                metricType = MetricType.WAKE_AFTER_SLEEP_ONSET.key,
+                value = 0.0,
+                timestamp = stages.first().timestamp,
+                durationSec = 0,
+                sourceId = sourceId,
+                confidence = stages.first().confidence
+            )
+        }
+
+        return MetricReading(
+            metricType = MetricType.WAKE_AFTER_SLEEP_ONSET.key,
+            value = postOnsetAwakeSec.toDouble(),
+            timestamp = stages.first().timestamp,
+            durationSec = postOnsetAwakeSec,
+            sourceId = sourceId,
+            confidence = stages.first().confidence
+        )
+    }
+
+    /**
+     * Composite sleep score on a 0–100 scale, averaging four sub-scores
+     * (each weighted equally, each clamped to 0–100):
+     *
+     *  - **Duration**: 100 in the 7–9h "recommended" band (Hirshkowitz et al.
+     *    2015 / NSF 2015), drops linearly to 0 at 4h below / 11h above.
+     *  - **Efficiency**: the SLEEP_EFFICIENCY value itself (already 0–100).
+     *  - **Latency**: 100 if ≤ 15 min, drops linearly to 0 at 60 min
+     *    (clinical cut-offs: ≤ 30 min normal, > 45 min abnormal).
+     *  - **Fragmentation**: 100 if 0 post-onset awakenings, drops linearly
+     *    to 0 at 8 awakenings (NSF: < 5 awakenings is normal).
+     *
+     * The score is descriptive, not evaluative — it aggregates published
+     * clinical norms into one number for trending. Bios does not push
+     * judgments on top of this value (AlertContentPolicy unchanged); the
+     * Sleep Disruption ConditionPattern consumes the underlying components
+     * directly, not the score.
+     *
+     * Returns null when any of the four components can't be derived from
+     * the input — partial scores would mis-rank nights with missing
+     * components against complete ones.
+     */
+    fun deriveSleepScore(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val latency = deriveSleepLatency(readings, sourceId) ?: return null
+        val efficiency = deriveSleepEfficiency(readings, sourceId) ?: return null
+        val fragmentation = deriveSleepFragmentation(readings, sourceId) ?: return null
+        val sessionDurationSec = efficiency.durationSec ?: return null
+        if (sessionDurationSec <= 0) return null
+
+        val durationScore = durationSubScore(sessionDurationSec)
+        val efficiencyScore = efficiency.value.coerceIn(0.0, 100.0)
+        val latencyScore = latencySubScore(latency.value)
+        val fragmentationScore = fragmentationSubScore(fragmentation.value)
+
+        val composite = (durationScore + efficiencyScore + latencyScore + fragmentationScore) / 4.0
+
+        return MetricReading(
+            metricType = MetricType.SLEEP_SCORE.key,
+            value = composite,
+            timestamp = latency.timestamp,
+            durationSec = sessionDurationSec,
+            sourceId = sourceId,
+            confidence = efficiency.confidence
+        )
+    }
+
+    private fun durationSubScore(sessionDurationSec: Int): Double {
+        val hours = sessionDurationSec / 3600.0
+        return when {
+            hours in MIN_RECOMMENDED_HOURS..MAX_RECOMMENDED_HOURS -> 100.0
+            hours < MIN_RECOMMENDED_HOURS -> {
+                // 100 at MIN_RECOMMENDED_HOURS, 0 at MIN_DURATION_HOURS_FLOOR.
+                ((hours - MIN_DURATION_HOURS_FLOOR) /
+                    (MIN_RECOMMENDED_HOURS - MIN_DURATION_HOURS_FLOOR) * 100.0)
+                    .coerceIn(0.0, 100.0)
+            }
+            else -> {
+                // 100 at MAX_RECOMMENDED_HOURS, 0 at MAX_DURATION_HOURS_CEIL.
+                ((MAX_DURATION_HOURS_CEIL - hours) /
+                    (MAX_DURATION_HOURS_CEIL - MAX_RECOMMENDED_HOURS) * 100.0)
+                    .coerceIn(0.0, 100.0)
+            }
+        }
+    }
+
+    private fun latencySubScore(latencySec: Double): Double {
+        val minutes = latencySec / 60.0
+        return when {
+            minutes <= LATENCY_OPTIMAL_MIN -> 100.0
+            minutes >= LATENCY_ABNORMAL_MIN -> 0.0
+            else -> ((LATENCY_ABNORMAL_MIN - minutes) /
+                (LATENCY_ABNORMAL_MIN - LATENCY_OPTIMAL_MIN) * 100.0)
+        }
+    }
+
+    private fun fragmentationSubScore(awakenings: Double): Double = when {
+        awakenings <= 0.0 -> 100.0
+        awakenings >= FRAGMENTATION_FLOOR_AWAKENINGS -> 0.0
+        else -> ((FRAGMENTATION_FLOOR_AWAKENINGS - awakenings) /
+            FRAGMENTATION_FLOOR_AWAKENINGS * 100.0)
+    }
+
+    private const val MIN_RECOMMENDED_HOURS = 7.0
+    private const val MAX_RECOMMENDED_HOURS = 9.0
+    private const val MIN_DURATION_HOURS_FLOOR = 4.0
+    private const val MAX_DURATION_HOURS_CEIL = 11.0
+    private const val LATENCY_OPTIMAL_MIN = 15.0
+    private const val LATENCY_ABNORMAL_MIN = 60.0
+    private const val FRAGMENTATION_FLOOR_AWAKENINGS = 8.0
 }

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -285,6 +285,8 @@ class IngestManager(
             SleepDerivations.deriveSleepLatency(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepEfficiency(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepFragmentation(rows, sourceId)?.let { derived += it }
+            SleepDerivations.deriveWakeAfterSleepOnset(rows, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepScore(rows, sourceId)?.let { derived += it }
         }
         return derived
     }

--- a/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
@@ -7,6 +7,7 @@ import com.bios.app.model.SleepStage
 import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SleepDerivationsTest {
@@ -178,4 +179,142 @@ class SleepDerivationsTest {
         )
         assertNull(SleepDerivations.deriveSleepFragmentation(readings, "src"))
     }
+
+    // --- WASO ---
+
+    @Test
+    fun `WASO sums post-onset AWAKE durations only`() {
+        // Initial AWAKE blocks before sleep onset count toward latency, not
+        // WASO. Only awake durations *after* the first non-AWAKE stage do.
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),      // pre-onset, ignored
+            stage(SleepStage.AWAKE, 1_300_000L),      // pre-onset, ignored
+            stage(SleepStage.LIGHT, 1_900_000L),      // onset
+            stage(SleepStage.DEEP, 2_500_000L),
+            stage(SleepStage.AWAKE, 3_100_000L),      // counts: 300s
+            stage(SleepStage.LIGHT, 3_400_000L),
+            stage(SleepStage.AWAKE, 4_000_000L),      // counts: 300s
+            stage(SleepStage.REM, 4_300_000L),
+        )
+        val waso = SleepDerivations.deriveWakeAfterSleepOnset(readings, "src")!!
+        assertEquals(MetricType.WAKE_AFTER_SLEEP_ONSET.key, waso.metricType)
+        assertEquals(600.0, waso.value, 0.0)
+        assertEquals(600, waso.durationSec)
+    }
+
+    @Test
+    fun `WASO is zero (not null) when sleep is uninterrupted`() {
+        // WASO = 0 is a real, meaningful value — collapsing to null would
+        // lose the distinction between "uninterrupted night" and
+        // "couldn't measure."
+        val readings = listOf(
+            stage(SleepStage.LIGHT, 1_000_000L),
+            stage(SleepStage.DEEP, 1_300_000L),
+            stage(SleepStage.REM, 1_600_000L),
+        )
+        val waso = SleepDerivations.deriveWakeAfterSleepOnset(readings, "src")!!
+        assertEquals(0.0, waso.value, 0.0)
+    }
+
+    @Test
+    fun `WASO is null when session never reaches sleep`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+        )
+        assertNull(SleepDerivations.deriveWakeAfterSleepOnset(readings, "src"))
+    }
+
+    @Test
+    fun `WASO is null when readings list is empty`() {
+        assertNull(SleepDerivations.deriveWakeAfterSleepOnset(emptyList(), "src"))
+    }
+
+    // --- Sleep score ---
+
+    @Test
+    fun `sleep score is high for a textbook 8h session with one brief awakening`() {
+        // 8h total, ~5 min latency, 1 brief awakening — should score near
+        // the top of the scale. Test pins the rough ceiling rather than
+        // the exact value to allow sub-score weight tuning later.
+        val readings = textbookNight()
+        val score = SleepDerivations.deriveSleepScore(readings, "src")!!
+        assertEquals(MetricType.SLEEP_SCORE.key, score.metricType)
+        assertTrue("Score for textbook night should be ≥ 85, got ${score.value}", score.value >= 85.0)
+        assertTrue("Score must stay ≤ 100", score.value <= 100.0)
+    }
+
+    @Test
+    fun `sleep score penalises a 4h session vs an 8h session of equal quality`() {
+        // Same efficiency / latency / fragmentation profile, different
+        // duration. The duration sub-score must move the composite.
+        val shortNight = sessionOf(
+            durations = listOf(SleepStage.LIGHT to 3600, SleepStage.DEEP to 3600,
+                SleepStage.REM to 3600, SleepStage.LIGHT to 3600),
+            prefix = listOf(SleepStage.AWAKE to 300),
+        )
+        val fullNight = sessionOf(
+            durations = listOf(SleepStage.LIGHT to 3600, SleepStage.DEEP to 3600,
+                SleepStage.REM to 3600, SleepStage.LIGHT to 3600,
+                SleepStage.DEEP to 3600, SleepStage.REM to 3600,
+                SleepStage.LIGHT to 3600, SleepStage.LIGHT to 3600),
+            prefix = listOf(SleepStage.AWAKE to 300),
+        )
+        val short = SleepDerivations.deriveSleepScore(shortNight, "src")!!
+        val full = SleepDerivations.deriveSleepScore(fullNight, "src")!!
+        assertTrue(
+            "4h session must score lower than 8h: short=${short.value} full=${full.value}",
+            short.value < full.value,
+        )
+    }
+
+    @Test
+    fun `sleep score is null when fragmentation cannot be derived (never reached sleep)`() {
+        // The composite-or-null rule: partial scores would mis-rank
+        // nights with missing components against complete ones.
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.AWAKE, 1_300_000L),
+        )
+        assertNull(SleepDerivations.deriveSleepScore(readings, "src"))
+    }
+
+    // --- Sleep-score fixture helpers ---
+
+    private fun sessionOf(
+        durations: List<Pair<SleepStage, Int>>,
+        prefix: List<Pair<SleepStage, Int>> = emptyList(),
+        startMillis: Long = 1_000_000L,
+    ): List<MetricReading> {
+        val rows = mutableListOf<MetricReading>()
+        var t = startMillis
+        for ((s, dur) in prefix + durations) {
+            rows.add(
+                MetricReading(
+                    metricType = MetricType.SLEEP_STAGE.key,
+                    value = s.value.toDouble(),
+                    timestamp = t,
+                    durationSec = dur,
+                    sourceId = "src",
+                    confidence = ConfidenceTier.MEDIUM.level,
+                )
+            )
+            t += dur * 1000L
+        }
+        return rows
+    }
+
+    private fun textbookNight(): List<MetricReading> = sessionOf(
+        prefix = listOf(SleepStage.AWAKE to 300), // 5 min latency
+        durations = listOf(
+            SleepStage.LIGHT to 3600,
+            SleepStage.DEEP to 3600,
+            SleepStage.REM to 3600,
+            SleepStage.LIGHT to 3600,
+            SleepStage.AWAKE to 120,             // 2 min mid-night awakening
+            SleepStage.DEEP to 3600,
+            SleepStage.REM to 3600,
+            SleepStage.LIGHT to 3360,
+        ),
+    )
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -45,6 +45,8 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_EFFICIENCY("sleep_efficiency", MetricUnit.PERCENT, MetricDomain.SLEEP),
     SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),
+    WAKE_AFTER_SLEEP_ONSET("wake_after_sleep_onset", MetricUnit.SECONDS, MetricDomain.SLEEP),
+    SLEEP_SCORE("sleep_score", MetricUnit.SCORE, MetricDomain.SLEEP),
     // Bios-produced from sleep-onset times via cosinor/DLMO math. Universal
     // chronobiology metric — not mood-specific despite W2F being the primary
     // consumer. See docs/ECOSYSTEM_BOUNDARIES.md producer-by-capture-surface

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -47,6 +47,8 @@ class MetricTypeKeysSnapshotTest {
         "sleep_latency",
         "sleep_efficiency",
         "sleep_fragmentation_index",
+        "wake_after_sleep_onset",
+        "sleep_score",
         "circadian_phase_shift",
         // Activity
         "steps",


### PR DESCRIPTION
## Summary

Closes #30. The latency / efficiency / fragmentation derivations shipped earlier and are wired through `IngestManager.deriveAll`; this fills in the two missing components called out in the issue (**WASO** and **sleep score**) and lets the Sleep Disruption `ConditionPattern` consume the structured signals instead of leaning on a `SLEEP_STAGE` z-score proxy.

## What landed

**MetricType ([bios-contracts](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt))**

- `WAKE_AFTER_SLEEP_ONSET` (`wake_after_sleep_onset`, SECONDS) — standard PSG metric, distinguishes "couldn't fall asleep" (latency) from "kept waking up" (WASO).
- `SLEEP_SCORE` (`sleep_score`, SCORE, 0–100) — composite of four sub-scores.

Snapshot test extended with both keys.

**[SleepDerivations.kt](android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt)**

- `deriveWakeAfterSleepOnset` — sums AWAKE durations after first sleep onset. Emits **0** rather than `null` when sleep was uninterrupted; that's a real, meaningful signal, not "couldn't measure."
- `deriveSleepScore` — equal-weighted average of four sub-scores, each grounded in published clinical norms (Hirshkowitz et al. 2015 / NSF 2015):
  - Duration: 100 in 7–9h band, linear drop to 0 at 4h / 11h.
  - Efficiency: the `SLEEP_EFFICIENCY` value itself (already 0–100).
  - Latency: 100 if ≤ 15 min, linear drop to 0 at 60 min.
  - Fragmentation: 100 if 0 awakenings, linear drop to 0 at 8.
- Returns `null` when any component can't be derived — partial scores would mis-rank nights with missing components against complete ones.

**Manifesto framing.** `SLEEP_SCORE` is **descriptive, not evaluative**. It aggregates published clinical reference points into one trendable number; no push surface emits a judgment on top of it. The Sleep Disruption pattern consumes the underlying components directly, not the score itself.

**[IngestManager.deriveAll](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt)** wires both new derivations into the existing per-source nightly pipeline, alongside the three already-derived metrics.

**[ConditionPatterns.sleepDisruption](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt)**

- Replaces the `SLEEP_STAGE` z-score proxy with the direct `SLEEP_FRAGMENTATION_INDEX` signal — fragmentation rises 3–7 days before subjective awareness of poor sleep (Bonzini et al. 2020).
- Adds `SLEEP_EFFICIENCY` as a corroborating signal — Prather et al. 2015 was cited in the old proxy comment; now driven by the actual metric.
- HRV / RHR corroborators kept; `minActiveSignals = 2` preserved so a single noisy sub-signal can't fire the pattern alone.

**[MetricCoverageRegistry](android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt)** picks up both new keys with the same 36h freshness budget as the other derived sleep metrics.

## Tests

- [x] `:app:testStandaloneDebugUnitTest` green — 7 new cases in `SleepDerivationsTest` (4 WASO, 3 score), existing 19 cases unchanged.
- [x] `:bios-contracts:test` green — `MetricTypeKeysSnapshotTest` updated with the two new keys.
- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build).
- [ ] On-device sanity (post-merge): with an Oura adapter ingesting a night of sleep-stage data, confirm the five derived rows (latency / efficiency / fragmentation / WASO / score) all appear in trends for the morning after.

## Out of scope

- Tuning the sleep-score sub-score weights against owner preference data — equal-weighted is the starting point. The constants are private; flipping them is a one-file change.
- Surfacing the score in a dedicated UI — Trends + Data Coverage already render any MetricType on the bus; no new screen needed.
- Per-stage analytics (REM percentage, deep sleep duration) — separate derivations, not in #30 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)