### PR TITLE
feat(engine): expose HRV LF + HF band powers alongside the ratio

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt
@@ -42,6 +42,7 @@ object HrvAnalyzer {
         val pnn50 = computePnn50(clean)
         val meanIbi = clean.average()
         val meanHr = 60_000.0 / meanIbi
+        val powers = Spectral.lfHfPowers(clean)
 
         return HrvResult(
             rmssd = rmssd,
@@ -49,7 +50,9 @@ object HrvAnalyzer {
             pnn50 = pnn50,
             lnRmssd = if (rmssd > 0.0) ln(rmssd) else 0.0,
             stressIndex = computeStressIndex(clean),
-            lfHfRatio = Spectral.lfHfRatio(clean),
+            lfHfRatio = powers.ratio,
+            lfPowerMs2 = powers.lfMs2,
+            hfPowerMs2 = powers.hfMs2,
             meanIbiMs = meanIbi,
             meanHrBpm = meanHr,
             cleanIbiCount = clean.size,
@@ -188,6 +191,21 @@ object HrvAnalyzer {
          * degenerate, or the HF band carries no power.
          */
         val lfHfRatio: Double,
+        /**
+         * Absolute power in the LF band (0.04–0.15 Hz), in ms². Useful as
+         * an engine input for cross-correlation patterns where the ratio
+         * alone is ambiguous (sympathetic *up* and parasympathetic *down*
+         * can produce the same ratio). Zero in the same degenerate cases
+         * as [lfHfRatio]. (Task Force 1996, Shaffer & Ginsberg 2017.)
+         */
+        val lfPowerMs2: Double,
+        /**
+         * Absolute power in the HF band (0.15–0.40 Hz), in ms². Strong
+         * vagal-tone correlate; tracks respiratory sinus arrhythmia.
+         * Zero in the same degenerate cases as [lfHfRatio]. (Task Force
+         * 1996, Shaffer & Ginsberg 2017.)
+         */
+        val hfPowerMs2: Double,
         /** Mean inter-beat interval (ms). */
         val meanIbiMs: Double,
         /** Mean heart rate derived from IBIs (bpm). */

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -53,6 +53,8 @@ object MetricCoverageRegistry {
         derived(MetricType.PARASYMPATHETIC_TONE),
         derived(MetricType.STRESS_SCORE),
         derived(MetricType.LF_HF_RATIO),
+        derived(MetricType.HRV_LF_POWER),
+        derived(MetricType.HRV_HF_POWER),
 
         // -- Blood pressure (cuff measurement, slower-moving) --
         MetricCoverageSpec(

--- a/android/app/src/main/java/com/bios/app/engine/Spectral.kt
+++ b/android/app/src/main/java/com/bios/app/engine/Spectral.kt
@@ -50,17 +50,31 @@ internal object Spectral {
     const val MIN_DURATION_SEC = 60.0
 
     /**
-     * Compute the LF/HF ratio from a list of inter-beat intervals (ms).
-     * Returns 0.0 when the recording is too short for spectral analysis,
-     * when the series is degenerate (constant or near-constant IBIs), or
-     * when the HF band contains no power.
+     * Band powers (ms²) over the LF and HF bands plus the LF/HF ratio,
+     * computed in a single pass over the FFT spectrum. Returning the
+     * three together makes the relationship lf / hf = ratio observable in
+     * tests, and saves callers a second FFT for the powers.
+     *
+     * Every field falls to 0.0 in the same degenerate cases [lfHfRatio]
+     * does: recording shorter than [MIN_DURATION_SEC], near-constant IBI
+     * series, or an HF band with no power (which would otherwise divide
+     * by zero in the ratio).
      */
-    fun lfHfRatio(ibisMs: List<Double>): Double {
-        if (ibisMs.size < 4) return 0.0
+    data class LfHfPowers(val lfMs2: Double, val hfMs2: Double, val ratio: Double) {
+        companion object {
+            val ZERO = LfHfPowers(0.0, 0.0, 0.0)
+        }
+    }
 
-        // Build beat-time axis in seconds. The first sample lives at the
-        // end of the first interval; the canonical convention places it
-        // at t = IBI_1 (Task Force 1996 Fig. 3).
+    /**
+     * Compute LF and HF band powers (ms²) and their ratio from a list of
+     * inter-beat intervals (ms). Same pipeline as [lfHfRatio]; preserved
+     * separately so callers needing only the ratio don't pay for the
+     * extra fields. See [lfHfRatio] KDoc for the full algorithm.
+     */
+    fun lfHfPowers(ibisMs: List<Double>): LfHfPowers {
+        if (ibisMs.size < 4) return LfHfPowers.ZERO
+
         val timesSec = DoubleArray(ibisMs.size)
         var cumulative = 0.0
         for (i in ibisMs.indices) {
@@ -68,11 +82,10 @@ internal object Spectral {
             timesSec[i] = cumulative
         }
         val durationSec = timesSec.last() - timesSec.first()
-        if (durationSec < MIN_DURATION_SEC) return 0.0
+        if (durationSec < MIN_DURATION_SEC) return LfHfPowers.ZERO
 
-        // Resample uniformly at RESAMPLE_HZ via linear interpolation.
         val sampleCount = (durationSec * RESAMPLE_HZ).toInt()
-        if (sampleCount < 8) return 0.0
+        if (sampleCount < 8) return LfHfPowers.ZERO
         val nfft = nextPowerOfTwo(sampleCount)
         val signal = DoubleArray(nfft)
         val tStart = timesSec.first()
@@ -80,28 +93,23 @@ internal object Spectral {
             val t = tStart + i / RESAMPLE_HZ
             signal[i] = interpolateLinear(timesSec, ibisMs, t)
         }
-        // Tail samples (sampleCount..nfft-1) stay at zero — zero-padding.
 
-        // Detrend by subtracting the mean of the populated region.
         var sum = 0.0
         for (i in 0 until sampleCount) sum += signal[i]
         val mean = sum / sampleCount
         for (i in 0 until sampleCount) signal[i] -= mean
 
-        // Hann window over the populated region.
         var windowEnergy = 0.0
         for (i in 0 until sampleCount) {
             val w = 0.5 - 0.5 * cos(2.0 * PI * i / (sampleCount - 1).coerceAtLeast(1))
             signal[i] *= w
             windowEnergy += w * w
         }
-        if (windowEnergy <= 0.0) return 0.0
+        if (windowEnergy <= 0.0) return LfHfPowers.ZERO
 
-        // Radix-2 FFT in place.
         val imag = DoubleArray(nfft)
         fftInPlace(signal, imag)
 
-        // One-sided PSD (Welch-style normalization for a single segment).
         val psdScale = 1.0 / (RESAMPLE_HZ * windowEnergy)
         val df = RESAMPLE_HZ / nfft
         var lfPower = 0.0
@@ -109,7 +117,6 @@ internal object Spectral {
         val halfN = nfft / 2
         for (k in 0..halfN) {
             val mag2 = signal[k] * signal[k] + imag[k] * imag[k]
-            // Double everything except DC and Nyquist for the one-sided PSD.
             val onesidedScale = if (k == 0 || k == halfN) 1.0 else 2.0
             val psd = mag2 * psdScale * onesidedScale
             val f = k * df
@@ -118,9 +125,20 @@ internal object Spectral {
                 f >= LF_HIGH_HZ && f <= HF_HIGH_HZ -> hfPower += psd * df
             }
         }
-        if (hfPower <= 0.0) return 0.0
-        return lfPower / hfPower
+        if (hfPower <= 0.0) return LfHfPowers(lfPower, hfPower, 0.0)
+        return LfHfPowers(lfPower, hfPower, lfPower / hfPower)
     }
+
+    /**
+     * Compute the LF/HF ratio from a list of inter-beat intervals (ms).
+     * Returns 0.0 when the recording is too short for spectral analysis,
+     * when the series is degenerate (constant or near-constant IBIs), or
+     * when the HF band contains no power.
+     *
+     * Equivalent to `lfHfPowers(ibisMs).ratio`; preserved as a public
+     * surface for callers that don't need the individual band powers.
+     */
+    fun lfHfRatio(ibisMs: List<Double>): Double = lfHfPowers(ibisMs).ratio
 
     private fun nextPowerOfTwo(n: Int): Int {
         var p = 1

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -379,6 +379,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.EVENT -> "{event}"
     MetricUnit.LUX -> "lx"
     MetricUnit.YEARS -> "a"
+    MetricUnit.MS_SQUARED -> "ms2"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -216,6 +216,22 @@ class CameraPpgAdapter(private val context: Context) {
                     durationSec = durSec,
                     sourceId = sourceId,
                     confidence = ConfidenceTier.LOW.level
+                ),
+                MetricReading(
+                    metricType = MetricType.HRV_LF_POWER.key,
+                    value = hrv.lfPowerMs2,
+                    timestamp = timestamp,
+                    durationSec = durSec,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.LOW.level
+                ),
+                MetricReading(
+                    metricType = MetricType.HRV_HF_POWER.key,
+                    value = hrv.hfPowerMs2,
+                    timestamp = timestamp,
+                    durationSec = durSec,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.LOW.level
                 )
             )
             return CaptureResult(

--- a/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
@@ -126,6 +126,22 @@ class DirectSensorAdapter(context: Context) {
                 durationSec = duration,
                 sourceId = sourceId,
                 confidence = ConfidenceTier.LOW.level
+            ),
+            MetricReading(
+                metricType = MetricType.HRV_LF_POWER.key,
+                value = hrv.lfPowerMs2,
+                timestamp = now,
+                durationSec = duration,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.LOW.level
+            ),
+            MetricReading(
+                metricType = MetricType.HRV_HF_POWER.key,
+                value = hrv.hfPowerMs2,
+                timestamp = now,
+                durationSec = duration,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.LOW.level
             )
         )
     }

--- a/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/CameraPpgAdapterTest.kt
@@ -38,6 +38,8 @@ class CameraPpgAdapterTest {
             lnRmssd = kotlin.math.ln(18.5),
             stressIndex = 120.0,
             lfHfRatio = 1.7,
+            lfPowerMs2 = 340.0,
+            hfPowerMs2 = 200.0,
             meanIbiMs = 815.0,
             meanHrBpm = 73.6,
             cleanIbiCount = 5,
@@ -47,7 +49,8 @@ class CameraPpgAdapterTest {
         val result = CameraPpgAdapter.toResult(ppg, hrv, sourceId, now)
 
         assertTrue(result.accepted)
-        assertEquals(5, result.readings.size)
+        // 5 original + HRV_LF_POWER + HRV_HF_POWER (#29).
+        assertEquals(7, result.readings.size)
 
         val hr = result.readings.single { it.metricType == MetricType.HEART_RATE.key }
         assertEquals(73.6, hr.value, 0.01)
@@ -71,6 +74,11 @@ class CameraPpgAdapterTest {
         val lfHfR = result.readings.single { it.metricType == MetricType.LF_HF_RATIO.key }
         assertEquals(1.7, lfHfR.value, 1e-9)
         assertEquals(ConfidenceTier.LOW.level, lfHfR.confidence)
+
+        val lfP = result.readings.single { it.metricType == MetricType.HRV_LF_POWER.key }
+        assertEquals(340.0, lfP.value, 1e-9)
+        val hfP = result.readings.single { it.metricType == MetricType.HRV_HF_POWER.key }
+        assertEquals(200.0, hfP.value, 1e-9)
     }
 
     @Test
@@ -122,6 +130,8 @@ class CameraPpgAdapterTest {
             lnRmssd = kotlin.math.ln(15.0),
             stressIndex = 95.0,
             lfHfRatio = 1.2,
+            lfPowerMs2 = 280.0,
+            hfPowerMs2 = 230.0,
             meanIbiMs = 805.0, meanHrBpm = 74.5,
             cleanIbiCount = 5, artifactsRejected = 0
         )

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -344,6 +344,7 @@ class FhirExporterTest {
             MetricUnit.EVENT -> "{event}"
             MetricUnit.LUX -> "lx"
             MetricUnit.YEARS -> "a"
+            MetricUnit.MS_SQUARED -> "ms2"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/SpectralTest.kt
+++ b/android/app/src/test/java/com/bios/app/SpectralTest.kt
@@ -143,4 +143,62 @@ class SpectralTest {
         assertTrue("Peak bin should be at k0 or n-k0, got $peakBin",
             peakBin == k0 || peakBin == n - k0)
     }
+
+    // -- lfHfPowers (separate-band exposure for #29) --
+
+    @Test
+    fun `lfHfPowers pure LF concentrates power in the LF band`() {
+        // The frequency-domain decomposition #29 needs to expose both
+        // bands separately so callers can detect "both bands up" vs "HF
+        // collapsed" — the ratio alone is ambiguous between the two.
+        val ibis = ibiSeriesWithFrequency(freqHz = 0.10, durationSec = 180.0)
+        val p = Spectral.lfHfPowers(ibis)
+        assertTrue("LF power should dominate, got lf=${p.lfMs2} hf=${p.hfMs2}",
+            p.lfMs2 > p.hfMs2 * 5.0)
+        assertTrue("HF power should still be non-negative", p.hfMs2 >= 0.0)
+    }
+
+    @Test
+    fun `lfHfPowers pure HF concentrates power in the HF band`() {
+        val ibis = ibiSeriesWithFrequency(freqHz = 0.25, durationSec = 180.0)
+        val p = Spectral.lfHfPowers(ibis)
+        assertTrue("HF power should dominate, got lf=${p.lfMs2} hf=${p.hfMs2}",
+            p.hfMs2 > p.lfMs2 * 5.0)
+        assertTrue("LF power should still be non-negative", p.lfMs2 >= 0.0)
+    }
+
+    @Test
+    fun `lfHfPowers ratio matches lfHfRatio exactly (no second FFT)`() {
+        // Pinning the equivalence so a future micro-optimisation that
+        // splits the two pipelines can't silently drift their answers.
+        val ibis = ibiSeriesWithFrequency(freqHz = 0.10, durationSec = 180.0)
+        val powers = Spectral.lfHfPowers(ibis)
+        val ratio = Spectral.lfHfRatio(ibis)
+        assertEquals(powers.ratio, ratio, 0.0)
+        // And the ratio is consistent with the powers (within fp noise).
+        assertEquals(powers.lfMs2 / powers.hfMs2, ratio, 1e-9)
+    }
+
+    @Test
+    fun `lfHfPowers degenerate cases return zeros (not NaN, not infinity)`() {
+        // Same edge cases the ratio surface guards: too-short recording,
+        // constant series, near-empty inputs. Powers should be 0.0 across
+        // the board, never NaN or infinity — engines downstream multiply
+        // these values into z-scores.
+        val cases = listOf(
+            emptyList<Double>(),
+            List(3) { meanIbiMs },                     // < 4 samples
+            List(56) { meanIbiMs + (it % 2) * 5.0 },   // < 60 sec window
+            List(360) { meanIbiMs },                   // constant
+        )
+        for (ibis in cases) {
+            val p = Spectral.lfHfPowers(ibis)
+            assertTrue("lf must be finite for size ${ibis.size}", p.lfMs2.isFinite())
+            assertTrue("hf must be finite for size ${ibis.size}", p.hfMs2.isFinite())
+            assertTrue("ratio must be finite for size ${ibis.size}", p.ratio.isFinite())
+            assertEquals("lf must be 0 in degenerate case", 0.0, p.lfMs2, 0.0)
+            assertEquals("hf must be 0 in degenerate case", 0.0, p.hfMs2, 0.0)
+            assertEquals("ratio must be 0 in degenerate case", 0.0, p.ratio, 0.0)
+        }
+    }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -27,6 +27,8 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     LF_HF_RATIO("lf_hf_ratio", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
+    HRV_LF_POWER("hrv_lf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
+    HRV_HF_POWER("hrv_hf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
@@ -171,7 +173,8 @@ enum class MetricUnit(val symbol: String) {
     SCORE(""),
     EVENT(""),
     LUX("lx"),
-    YEARS("yr")
+    YEARS("yr"),
+    MS_SQUARED("ms²")
 }
 
 enum class MetricDomain {

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -32,6 +32,8 @@ class MetricTypeKeysSnapshotTest {
         "parasympathetic_tone",
         "stress_score",
         "lf_hf_ratio",
+        "hrv_lf_power",
+        "hrv_hf_power",
         "resting_heart_rate",
         "blood_pressure_systolic",
         "blood_pressure_diastolic",


### PR DESCRIPTION
## Summary

Closes #29. Same shape as the sleep-derivation work in #116: `Spectral` already computed LF/HF spectral powers internally to produce the ratio; only the ratio was reaching the bus. This exposes the two band powers as their own `MetricType` keys.

**Why both bands and not just the ratio**: the ratio collapses information. *Sympathetic up* and *parasympathetic down* produce the same LF/HF change with opposite interventions. Engines that want to discriminate need the absolute powers.

## What landed

**[bios-contracts](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt)**

- `MetricUnit.MS_SQUARED` (`ms²` display, `ms2` UCUM) — the conventional PSD unit for HRV band powers.
- `HRV_LF_POWER` (0.04–0.15 Hz) and `HRV_HF_POWER` (0.15–0.40 Hz) on the `CARDIOVASCULAR` domain.
- Snapshot test extended with both keys.

**[Spectral.kt](android/app/src/main/java/com/bios/app/engine/Spectral.kt)**

- New `lfHfPowers(ibisMs)` returning `LfHfPowers(lfMs2, hfMs2, ratio)` in one pass over the spectrum — keeps the three values arithmetically consistent.
- `lfHfRatio` refactored to delegate (`= lfHfPowers(ibisMs).ratio`); public surface unchanged.
- Degenerate cases return `LfHfPowers.ZERO` rather than NaN/infinity — engines downstream multiply these into z-scores.

**[HrvAnalyzer.HrvResult](android/app/src/main/java/com/bios/app/engine/HrvAnalyzer.kt)**

- Two new fields, `lfPowerMs2` + `hfPowerMs2`, populated from the same `Spectral.lfHfPowers` call. The three values can never drift.

**Adapters with raw-IBI access**

- [DirectSensorAdapter](android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt) + [CameraPpgAdapter](android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt) emit two additional `MetricReading`s alongside the existing `LF_HF_RATIO` row.
- RMSSD-only adapters (Oura, HC, Polar, WHOOP, Withings, Garmin) don't expose raw IBIs and stay unchanged — frequency-domain HRV requires the inter-beat series.

**Other**

- [FhirExporter](android/app/src/main/java/com/bios/app/export/FhirExporter.kt): UCUM mapping for `MS_SQUARED` → `ms2`. Mirror in `FhirExporterTest`.
- [MetricCoverageRegistry](android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt): both keys registered as `derived(...)` alongside the existing HRV derivations.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` green. 4 new `SpectralTest` cases for `lfHfPowers` (pure-LF concentration, pure-HF concentration, arithmetic consistency with `lfHfRatio`, all-zero degenerate cases). `CameraPpgAdapterTest` updated for the larger reading set.
- [x] `:bios-contracts:test` green — snapshot test passes with the two new keys.
- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build).
- [ ] On-device sanity (post-merge): trigger a camera-PPG capture; confirm 7 readings land (HR, HRV/RMSSD, parasympathetic tone, stress score, LF/HF ratio, LF power, HF power); FHIR export carries `ms2` UCUM code on the two new keys.

## Out of scope

- Total power / VLF / very-low-frequency bands — beyond what Task Force 1996 anchors as the LF/HF clinical pair.
- Adapter expansion to RMSSD-only sources — they don't expose raw IBIs. If a future Polar / Oura API endpoint surfaces R-R intervals, the wiring is one new MetricReading per adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)