### PR TITLE
feat(metrics): add VO2_MAX and extract from HC, Garmin, Oura

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -233,7 +233,16 @@ object ConditionPatterns {
             SignalRule(MetricType.HEART_RATE_VARIABILITY, DeviationDirection.BELOW, 1.0, 336, 1.0,
                 ThresholdSource.LITERATURE, "Buchheit (2014) - HRV decline tracks fitness loss during detraining"),
             SignalRule(MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.5, 336, 0.8,
-                ThresholdSource.LITERATURE, "Ross et al. (2016) - activity decline precedes measurable VO2 max loss")
+                ThresholdSource.LITERATURE, "Ross et al. (2016) - activity decline precedes measurable VO2 max loss"),
+            // Direct VO2 max signal — the clinical gold standard that the
+            // explanation paragraph below already names. The earlier
+            // SignalRules pre-dated VO2 ingestion (#26) and used resting
+            // HR + HRV + activity as a proxy triad; with VO2 on the bus
+            // we add it as a corroborator (not a required signal — most
+            // owners' wearables only update VO2 weekly, so a 7-day window
+            // captures one or two re-estimates).
+            SignalRule(MetricType.VO2_MAX, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE, "Ross et al. (2016) — VO2 max decline is the clinical gold standard for cardiorespiratory fitness loss")
         ),
         minActiveSignals = 2,
         explanation = "Your resting heart rate and HRV have shifted over the past two weeks in a direction consistent with cardiorespiratory fitness decline, alongside reduced activity levels.",

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -109,6 +109,11 @@ class BaselineEngine(
             for (metricType in metricsToBaseline) {
                 computeBaseline(metricType)
             }
+            // VO2 max changes slowly (weeks-to-months timescale). Use a
+            // 90-day window so the baseline reflects the genuine fitness
+            // trajectory rather than the noisy weekly Garmin/Oura
+            // re-estimates the default 14-day window would amplify.
+            computeBaseline(MetricType.VO2_MAX, windowDays = 90)
 
             // Reproductive baselines pull from the isolated reproductive DB
             // when it's available; otherwise this is a no-op (the owner

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -55,6 +55,14 @@ object MetricCoverageRegistry {
         derived(MetricType.LF_HF_RATIO),
         derived(MetricType.HRV_LF_POWER),
         derived(MetricType.HRV_HF_POWER),
+        // VO2 max updates roughly weekly (vendor refresh cadence is tied to
+        // the next qualifying outdoor run / fitness test). MONTH freshness
+        // is the right "stale" bar — daily-freshness would flag every
+        // sedentary week as a coverage gap.
+        MetricCoverageSpec(
+            MetricType.VO2_MAX, MONTH,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
 
         // -- Blood pressure (cuff measurement, slower-moving) --
         MetricCoverageSpec(

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -334,6 +334,7 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
     MetricType.BODY_MASS -> "29463-7" to "Body weight"
     MetricType.BODY_FAT_PCT -> "41982-0" to "Percentage of body fat Measured"
+    MetricType.VO2_MAX -> "97090-9" to "Maximum oxygen consumption per unit time per unit body mass"
     MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
     MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
     MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"
@@ -380,6 +381,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.LUX -> "lx"
     MetricUnit.YEARS -> "a"
     MetricUnit.MS_SQUARED -> "ms2"
+    MetricUnit.ML_PER_KG_MIN -> "mL/(kg.min)"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt
@@ -114,6 +114,21 @@ class GarminApiAdapter(
             )
         }
 
+        // Garmin exposes vo2Max on the dailies endpoint when the watch has
+        // a recent fitness estimate (typically refreshed weekly after an
+        // outdoor run). NaN / 0 / absent → skip silently rather than emit
+        // a meaningless reading.
+        val vo2Max = json.optDouble("vo2Max", Double.NaN)
+        if (!vo2Max.isNaN() && vo2Max > 0) {
+            readings += MetricReading(
+                metricType = MetricType.VO2_MAX.key,
+                value = vo2Max,
+                timestamp = start.toEpochMilli(),
+                sourceId = sourceId,
+                confidence = ConfidenceTier.VENDOR_DERIVED.level
+            )
+        }
+
         return readings
     }
 

--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -41,6 +41,7 @@ class HealthConnectAdapter(private val context: Context) {
         HealthPermission.getReadPermission(StepsRecord::class),
         HealthPermission.getReadPermission(ActiveCaloriesBurnedRecord::class),
         HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+        HealthPermission.getReadPermission(Vo2MaxRecord::class),
         // SyncWorker runs in the background; without this the HC service returns
         // only Bios' own written records (none) instead of Google Fit / Fitbit data.
         HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND,
@@ -70,10 +71,26 @@ class HealthConnectAdapter(private val context: Context) {
             async { fetchSkinTemp(startTime, endTime, sourceId) },
             async { fetchSleep(startTime, endTime, sourceId) },
             async { fetchSteps(startTime, endTime, sourceId) },
-            async { fetchActiveCalories(startTime, endTime, sourceId) }
+            async { fetchActiveCalories(startTime, endTime, sourceId) },
+            async { fetchVo2Max(startTime, endTime, sourceId) }
         )
         jobs.awaitAll().flatten()
     }
+
+    // VO2 max from HC is vendor-derived (Garmin / Fitbit / Apple fitness
+    // models, not clinical CPET) — flagged via VENDOR_DERIVED confidence.
+    private suspend fun fetchVo2Max(start: Instant, end: Instant, sourceId: String): List<MetricReading> =
+        client.readRecords(
+            ReadRecordsRequest(Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+        ).records.map { record ->
+            MetricReading(
+                metricType = MetricType.VO2_MAX.key,
+                value = record.vo2MillilitersPerMinuteKilogram,
+                timestamp = record.time.toEpochMilli(),
+                sourceId = sourceId,
+                confidence = ConfidenceTier.VENDOR_DERIVED.level
+            )
+        }
 
     // MARK: - Individual record types
 

--- a/android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt
@@ -53,8 +53,37 @@ class OuraApiAdapter(
         readings += fetchSleep(token, startDate, endDate, sourceId)
         readings += fetchDailyActivity(token, startDate, endDate, sourceId)
         readings += fetchDailyReadiness(token, startDate, endDate, sourceId)
+        readings += fetchCardiovascularAge(token, startDate, endDate, sourceId)
 
         return readings
+    }
+
+    /**
+     * Oura v2 exposes a `cardio_capacity` (their proprietary VO2 max
+     * estimate) on the `/usercollection/cardiovascular_age` endpoint. The
+     * value updates roughly weekly, in mL/kg/min, derived from the user's
+     * resting HR, age, weight, and activity history. Missing endpoint
+     * (legacy Oura plan, ring not paired, no recent run) → empty list.
+     */
+    private suspend fun fetchCardiovascularAge(
+        token: String, startDate: String, endDate: String, sourceId: String
+    ): List<MetricReading> {
+        val json = apiGet(token, "cardiovascular_age", startDate, endDate) ?: return emptyList()
+        val data = json.optJSONArray("data") ?: return emptyList()
+
+        return (0 until data.length()).mapNotNull { i ->
+            val day = data.getJSONObject(i)
+            val vo2 = day.optDouble("vo2_max", Double.NaN)
+            if (vo2.isNaN() || vo2 <= 0.0) return@mapNotNull null
+
+            MetricReading(
+                metricType = MetricType.VO2_MAX.key,
+                value = vo2,
+                timestamp = parseDayTimestamp(day.getString("day")),
+                sourceId = sourceId,
+                confidence = ConfidenceTier.VENDOR_DERIVED.level
+            )
+        }
     }
 
     private suspend fun fetchHeartRate(

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -111,9 +111,9 @@ class FhirExporterTest {
     }
 
     @Test
-    fun `30 metric types have LOINC mappings`() {
+    fun `31 metric types have LOINC mappings`() {
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(30, mapped)
+        assertEquals(31, mapped)
     }
 
     @Test
@@ -265,6 +265,7 @@ class FhirExporterTest {
             MetricType.BASAL_BODY_TEMPERATURE -> "8332-9" to "Oral temperature"
             MetricType.BODY_MASS -> "29463-7" to "Body weight"
             MetricType.BODY_FAT_PCT -> "41982-0" to "Percentage of body fat Measured"
+            MetricType.VO2_MAX -> "97090-9" to "Maximum oxygen consumption per unit time per unit body mass"
             MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
             MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
             MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"
@@ -345,6 +346,7 @@ class FhirExporterTest {
             MetricUnit.LUX -> "lx"
             MetricUnit.YEARS -> "a"
             MetricUnit.MS_SQUARED -> "ms2"
+            MetricUnit.ML_PER_KG_MIN -> "mL/(kg.min)"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/Vo2MaxIntegrationTest.kt
+++ b/android/app/src/test/java/com/bios/app/Vo2MaxIntegrationTest.kt
@@ -1,0 +1,83 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.export.loincCode
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the cross-file wiring for VO2_MAX (#26).
+ *
+ * The adapter HTTP paths (Garmin / Oura `cardiovascular_age`, HC
+ * `Vo2MaxRecord`) require networked or `HealthConnectClient` runtime
+ * fixtures the unit-test layer doesn't provide. What we can pin here
+ * — and what catches the most likely silent regressions — is the
+ * contract surface every adapter has to land on: domain, unit,
+ * LOINC / UCUM mapping, baseline membership, and condition-pattern
+ * consumption.
+ */
+class Vo2MaxIntegrationTest {
+
+    @Test
+    fun `VO2_MAX is registered as a CARDIOVASCULAR metric in mL per kg per minute`() {
+        // Anti-regression: silently moving VO2_MAX to a different domain
+        // would drop it out of the cardiovascular cross-correlation set;
+        // changing the unit would orphan every previously-written row.
+        assertEquals(MetricDomain.CARDIOVASCULAR, MetricType.VO2_MAX.domain)
+        assertEquals(MetricUnit.ML_PER_KG_MIN, MetricType.VO2_MAX.unit)
+        assertEquals("vo2_max", MetricType.VO2_MAX.key)
+    }
+
+    @Test
+    fun `ML_PER_KG_MIN renders the conventional clinical unit symbol`() {
+        // Clinical literature reads mL/kg/min. Slash-separated is the
+        // ESC / AHA / Hirshkowitz / Ross convention; UCUM normalizes
+        // (mL/(kg.min)) for export but the display stays human-readable.
+        assertEquals("mL/kg/min", MetricUnit.ML_PER_KG_MIN.symbol)
+    }
+
+    @Test
+    fun `VO2_MAX has a LOINC code so FHIR export carries it`() {
+        // The "Share FHIR Bundle with your doctor" path round-trips
+        // anything with a loincCode mapping; VO2_MAX is clinically
+        // canonical, so it must be on the table.
+        val mapping = loincCode(MetricType.VO2_MAX)
+        assertNotNull("VO2_MAX needs a LOINC mapping for doctor handoff", mapping)
+        // LOINC 97090-9 — "Maximum oxygen consumption per unit time per
+        // unit body mass." Pin both ends of the pair so a typo in either
+        // half trips the test.
+        assertEquals("97090-9", mapping!!.first)
+        assertTrue(mapping.second.lowercase().contains("oxygen"))
+    }
+
+    @Test
+    fun `cardiorespiratory deconditioning pattern consumes VO2_MAX as a BELOW signal`() {
+        // The pattern's prose ("VO2 max, the clinical gold standard")
+        // pre-existed the ingestion path — adding a SignalRule closes
+        // the loop. Direction BELOW is load-bearing: a VO2 increase is
+        // not a deconditioning signal.
+        val pattern = ConditionPatterns.cardiorespiratoryDeconditioning
+        val vo2Rule = pattern.signalRules.singleOrNull { it.metricType == MetricType.VO2_MAX }
+        assertNotNull(
+            "Cardiorespiratory deconditioning pattern must include a VO2_MAX SignalRule (#26)",
+            vo2Rule,
+        )
+        assertEquals(DeviationDirection.BELOW, vo2Rule!!.direction)
+    }
+
+    @Test
+    fun `VO2_MAX is the only mL per kg per min metric on the contract today`() {
+        // A second metric in that unit might want a different LOINC /
+        // baseline / pattern set; force a fresh decision instead of
+        // letting a future addition inherit VO2_MAX's bindings by
+        // accident.
+        val sharingUnit = MetricType.entries.filter { it.unit == MetricUnit.ML_PER_KG_MIN }
+        assertEquals(listOf(MetricType.VO2_MAX), sharingUnit)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -29,6 +29,7 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     LF_HF_RATIO("lf_hf_ratio", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     HRV_LF_POWER("hrv_lf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     HRV_HF_POWER("hrv_hf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
+    VO2_MAX("vo2_max", MetricUnit.ML_PER_KG_MIN, MetricDomain.CARDIOVASCULAR),
     RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
@@ -174,7 +175,8 @@ enum class MetricUnit(val symbol: String) {
     EVENT(""),
     LUX("lx"),
     YEARS("yr"),
-    MS_SQUARED("ms²")
+    MS_SQUARED("ms²"),
+    ML_PER_KG_MIN("mL/kg/min")
 }
 
 enum class MetricDomain {

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -34,6 +34,7 @@ class MetricTypeKeysSnapshotTest {
         "lf_hf_ratio",
         "hrv_lf_power",
         "hrv_hf_power",
+        "vo2_max",
         "resting_heart_rate",
         "blood_pressure_systolic",
         "blood_pressure_diastolic",


### PR DESCRIPTION
## Summary

Closes #26. Bios had zero VO2 max coverage despite the existing Cardiorespiratory Deconditioning pattern explicitly citing it as the "clinical gold standard" in its `earlyDetection` prose. This wires the metric in from the three adapters that report it natively.

## What landed

**Contract ([bios-contracts](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt))**

- `MetricUnit.ML_PER_KG_MIN` (`mL/kg/min` display, UCUM `mL/(kg.min)`).
- `MetricType.VO2_MAX` on the `CARDIOVASCULAR` domain.
- Snapshot test extended.

**Adapter extraction** (vendor-derived confidence — smartwatch fitness-model projections, not lab CPETs)

- [HealthConnectAdapter](android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt): new `Vo2MaxRecord` permission + `fetchVo2Max`. Broadest path — every HC-backed upstream (Garmin Connect / Fitbit / Samsung / Apple Health bridge) lands here.
- [GarminApiAdapter](android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt): opportunistic `vo2Max` extraction on the dailies endpoint. Garmin watches refresh after qualifying outdoor runs; NaN / 0 / absent → skip silently.
- [OuraApiAdapter](android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt): new `cardiovascular_age` endpoint fetch reading `vo2_max`. Oura v2 updates roughly weekly.

**Skipped on purpose**: WHOOP v1 API doesn't expose VO2 max (Strain is their headline). Polar exposes VO2 only behind a transaction-based physical-info endpoint that's overkill to wire for one field. Both are one-block additions when needed.

**Engine wiring**

- [BaselineEngine](android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt): VO2_MAX gets a **90-day window** per #26 — VO2 changes on weeks-to-months timescale; the default 14-day window would amplify weekly-re-estimate noise rather than reflect the trajectory.
- [Cardiorespiratory Deconditioning pattern](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt#L235): new `SignalRule` on `VO2_MAX BELOW` (1.0σ, 7-day window). The earlier triad (resting HR + HRV + active minutes) stays as proxy corroborators; the pattern can now anchor on the direct signal it always cited.
- [MetricCoverageRegistry](android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt): MONTH freshness — daily-freshness would flag every sedentary week as a coverage gap.

**FHIR plumbing**

- LOINC `97090-9` ("Maximum oxygen consumption per unit time per unit body mass"); UCUM `mL/(kg.min)`. Picked up by the existing `loincToMetricType` reverse index for symmetric import.
- The two existing sweep tests (LOINC count 30 → 31, UCUM-coverage) carry the new entry.

**Tests** ([Vo2MaxIntegrationTest](android/app/src/test/java/com/bios/app/Vo2MaxIntegrationTest.kt))

Pins five load-bearing bindings: domain / unit / key / LOINC mapping / Cardiorespiratory-pattern membership / unit-set singularity (so a future second `mL/kg/min` metric forces a fresh decision instead of inheriting VO2_MAX's wiring by accident). HTTP-path tests remain build-and-eyeball — same convention as the other adapters.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` green.
- [x] `:bios-contracts:test` green — snapshot test updated.
- [x] `./scripts/code-quality-check.sh` passes. `HealthConnectAdapter.kt` sits at 500 / 500 after the addition.
- [ ] On-device sanity (post-merge): with an HC-backed wearable reporting VO2 max, the row appears in Trends after the next sync; "Share FHIR Bundle for doctors" carries LOINC `97090-9` with UCUM `mL/(kg.min)`.

## Out of scope

- Polar physical-info-transactions wire-up (separate endpoint pattern with commit semantics — issue mentions Polar but the architecture for that should land independently).
- A VO2-max-anchored standalone ConditionPattern. The existing Cardiorespiratory Deconditioning pattern now consumes VO2 as a corroborating signal alongside RHR / HRV / active minutes; a single-signal pattern would mostly duplicate it.
- Baseline-engine `windowDays` parameter — already exists on `computeBaseline`, so VO2 just calls it with 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)