### PR TITLE
feat(env): BLE air-quality contract + ESS parser (#43 phase 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -132,7 +132,11 @@ object ConditionPatterns {
             SignalRule(MetricType.HEART_RATE_VARIABILITY, DeviationDirection.BELOW, 1.0, 48, 0.8,
                 ThresholdSource.LITERATURE, "Kim et al. (2018) - sustained low HRV reflects autonomic stress during poor sleep"),
             SignalRule(MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 48, 0.6,
-                ThresholdSource.ENGINEERING)
+                ThresholdSource.ENGINEERING),
+            // Bedroom CO2 above ~1000 ppm corroborates the sleep signals
+            // when an ESS-class BLE sensor (#43) is paired.
+            SignalRule(MetricType.AIR_CO2, DeviationDirection.ABOVE, 1.0, 72, 0.5,
+                ThresholdSource.LITERATURE, "Strom-Tejsen et al. (2016) — bedroom CO2 > 1000 ppm degrades sleep efficiency")
         ),
         minActiveSignals = 2,
         explanation = "Your sleep quality has been declining for several days. Reduced deep sleep combined with physiological stress markers may indicate accumulated fatigue or stress.",

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -102,6 +102,9 @@ class BaselineEngine(
                 MetricType.SLEEP_STAGE,
                 MetricType.SLEEP_DURATION,
                 MetricType.AMBIENT_LIGHT,
+                MetricType.AIR_PM25,
+                MetricType.AIR_VOC,
+                MetricType.AIR_CO2,
                 MetricType.BODY_MASS,
                 MetricType.BODY_FAT_PCT,
             )

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
@@ -55,6 +55,7 @@ enum class CoverageRouteKind {
     PPG_CAPTURE,
     MANUAL_ENTRY,
     FHIR_IMPORT,
+    BLE_PERIPHERAL, // Bluetooth-LE air-quality / future BLE sensors (#43).
 }
 
 /**
@@ -74,5 +75,8 @@ data class AdapterReadiness(
     /** The PPG-camera capture path is always available on a phone with a
      *  rear camera + flash — kept here so the engine doesn't have to
      *  assume the hardware exists. */
-    val ppgCaptureAvailable: Boolean
+    val ppgCaptureAvailable: Boolean,
+    /** True when at least one BLE air-quality peripheral has been paired
+     *  (#43). Default false until the phase-2 pairing UI lands. */
+    val bleAirQualityPaired: Boolean = false,
 )

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
@@ -93,6 +93,13 @@ object MetricCoverageEngine {
             isConfigured = true,
             deepLink = "biomarker_entry"
         )
+        CoverageRouteKind.BLE_PERIPHERAL -> CoverageRoute(
+            kind = kind,
+            displayName = "BLE air-quality sensor",
+            isConfigured = readiness.bleAirQualityPaired,
+            // Deep-link deferred until the phase-2 pairing UI lands (#43-phase-2).
+            deepLink = null,
+        )
     }
 
     /** Route a MANUAL_ENTRY chip to the right entry screen. Sleep has its

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -157,6 +157,21 @@ object MetricCoverageRegistry {
             MetricType.AMBIENT_LIGHT, H,
             listOf(CoverageRouteKind.PHONE_SENSOR)
         ),
+        // BLE air-quality sensors typically notify every 30-60s when active;
+        // an hourly freshness budget treats one connected sensor as live and
+        // anything older as drifted-off (sensor unplugged, BLE link lost).
+        MetricCoverageSpec(
+            MetricType.AIR_PM25, H,
+            listOf(CoverageRouteKind.BLE_PERIPHERAL)
+        ),
+        MetricCoverageSpec(
+            MetricType.AIR_VOC, H,
+            listOf(CoverageRouteKind.BLE_PERIPHERAL)
+        ),
+        MetricCoverageSpec(
+            MetricType.AIR_CO2, H,
+            listOf(CoverageRouteKind.BLE_PERIPHERAL)
+        ),
 
         // -- Biomarkers (clinical re-test cadence ≈ 6 months) --
         biomarker(MetricType.HBA1C),

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -382,6 +382,9 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.YEARS -> "a"
     MetricUnit.MS_SQUARED -> "ms2"
     MetricUnit.ML_PER_KG_MIN -> "mL/(kg.min)"
+    MetricUnit.UG_PER_M3 -> "ug/m3"
+    MetricUnit.PPM -> "[ppm]"
+    MetricUnit.PPB -> "[ppb]"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ingest/EnvironmentalSensingParser.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/EnvironmentalSensingParser.kt
@@ -1,0 +1,135 @@
+package com.bios.app.ingest
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Byte-format parser for the Bluetooth SIG **Environmental Sensing
+ * Service** (ESS, service UUID `0x181A`). The runtime BLE adapter
+ * (deferred to phase 2) hands raw characteristic payloads to these pure
+ * functions; the values come back as canonical [MetricReading]s on
+ * Bios's bus.
+ *
+ * Three characteristics are supported, matching the three [MetricType]s
+ * #43 introduces:
+ *
+ *  - **PM2.5** (`0x2BD4`, "Particulate Matter PM2.5 Concentration") —
+ *    `uint16`, resolution **0.1 µg/m³**. Range 0.0–6553.5 µg/m³.
+ *  - **CO2** (`0x2B8C`, "CO2 Concentration") — `uint16`, **ppm**,
+ *    integer resolution. Range 0–65 535 ppm.
+ *  - **VOC** (`0x2BE7`, "VOC Concentration") — `uint16`, **ppb**,
+ *    integer resolution. Range 0–65 535 ppb.
+ *
+ * All three characteristics use little-endian byte order (Bluetooth
+ * convention). The "not known" sentinel `0xFFFF` from the spec is
+ * surfaced as `null` rather than a 6553.5 / 65 535 reading — it would
+ * pollute baselines if treated as data.
+ *
+ * Lives next to the existing adapters in `ingest/` so its callers (the
+ * future `BleAirQualityAdapter` runtime) can wire it without a
+ * cross-package dependency, but is fully exercise-able in unit tests
+ * without any Android Bluetooth runtime.
+ */
+object EnvironmentalSensingParser {
+
+    /** Bluetooth SIG GATT characteristic UUID for PM2.5 (16-bit form). */
+    const val CHARACTERISTIC_PM25_SHORT = 0x2BD4
+    /** Bluetooth SIG GATT characteristic UUID for CO2 (16-bit form). */
+    const val CHARACTERISTIC_CO2_SHORT = 0x2B8C
+    /** Bluetooth SIG GATT characteristic UUID for VOC (16-bit form). */
+    const val CHARACTERISTIC_VOC_SHORT = 0x2BE7
+
+    /** Bluetooth-spec "value not known" sentinel for uint16 characteristics. */
+    private const val NOT_KNOWN_UINT16: Int = 0xFFFF
+
+    /**
+     * Parse the PM2.5 characteristic payload. The spec stores
+     * concentration as `uint16` with a 0.1 µg/m³ resolution — the raw
+     * value is the concentration multiplied by 10 — so the result is
+     * `raw / 10.0` µg/m³.
+     *
+     * Returns `null` for the "not known" sentinel, for byte arrays
+     * shorter than 2 bytes, or when the converted value would be
+     * negative (defensive — the underlying type is unsigned, but a
+     * caller-supplied JVM `ByteArray` is signed and a malicious /
+     * malformed payload could produce a negative intermediate).
+     */
+    fun parsePm25(bytes: ByteArray, timestamp: Long, sourceId: String): MetricReading? {
+        val raw = readUint16Le(bytes) ?: return null
+        if (raw == NOT_KNOWN_UINT16) return null
+        val ugPerM3 = raw / 10.0
+        if (ugPerM3 < 0.0) return null
+        return MetricReading(
+            metricType = MetricType.AIR_PM25.key,
+            value = ugPerM3,
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    /**
+     * Parse the CO2 characteristic payload. `uint16`, integer ppm.
+     * Returns `null` for the spec sentinel or short payloads.
+     */
+    fun parseCo2(bytes: ByteArray, timestamp: Long, sourceId: String): MetricReading? {
+        val raw = readUint16Le(bytes) ?: return null
+        if (raw == NOT_KNOWN_UINT16) return null
+        return MetricReading(
+            metricType = MetricType.AIR_CO2.key,
+            value = raw.toDouble(),
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    /**
+     * Parse the VOC characteristic payload. `uint16`, integer ppb.
+     * Returns `null` for the spec sentinel or short payloads.
+     */
+    fun parseVoc(bytes: ByteArray, timestamp: Long, sourceId: String): MetricReading? {
+        val raw = readUint16Le(bytes) ?: return null
+        if (raw == NOT_KNOWN_UINT16) return null
+        return MetricReading(
+            metricType = MetricType.AIR_VOC.key,
+            value = raw.toDouble(),
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    /**
+     * Dispatch a raw GATT notification to the correct parser by the
+     * characteristic's 16-bit short UUID. Returns `null` when the UUID
+     * isn't one Bios supports — the caller (runtime BLE adapter) logs
+     * and moves on rather than crashing.
+     */
+    fun parse(
+        characteristicShortUuid: Int,
+        bytes: ByteArray,
+        timestamp: Long,
+        sourceId: String,
+    ): MetricReading? = when (characteristicShortUuid) {
+        CHARACTERISTIC_PM25_SHORT -> parsePm25(bytes, timestamp, sourceId)
+        CHARACTERISTIC_CO2_SHORT -> parseCo2(bytes, timestamp, sourceId)
+        CHARACTERISTIC_VOC_SHORT -> parseVoc(bytes, timestamp, sourceId)
+        else -> null
+    }
+
+    /**
+     * Little-endian uint16 read out of a [ByteArray]. Returns `null`
+     * when the array has fewer than 2 bytes — defensive against
+     * truncated GATT notifications. Bytes after the first two are
+     * ignored; some ESS characteristics carry trailing flags / extra
+     * fields the air-quality keys don't use.
+     */
+    private fun readUint16Le(bytes: ByteArray): Int? {
+        if (bytes.size < 2) return null
+        val low = bytes[0].toInt() and 0xFF
+        val high = bytes[1].toInt() and 0xFF
+        return (high shl 8) or low
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageScreen.kt
@@ -231,6 +231,7 @@ private fun CoverageRoute.actionLabel(): String = when (kind) {
     CoverageRouteKind.PPG_CAPTURE -> "Take HRV snapshot"
     CoverageRouteKind.MANUAL_ENTRY -> "Add value manually"
     CoverageRouteKind.FHIR_IMPORT -> "Import FHIR file"
+    CoverageRouteKind.BLE_PERIPHERAL -> "Pair air-quality sensor"
 }
 
 private val dateFormat = SimpleDateFormat("MMM d, HH:mm", Locale.US)

--- a/android/app/src/test/java/com/bios/app/EnvironmentalSensingParserTest.kt
+++ b/android/app/src/test/java/com/bios/app/EnvironmentalSensingParserTest.kt
@@ -1,0 +1,179 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.ingest.EnvironmentalSensingParser
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Deterministic byte-format coverage for the Bluetooth SIG ESS parser
+ * (#43 phase 1). The runtime BLE adapter is deferred to phase 2; these
+ * tests pin the parser surface every BLE sensor will land on.
+ *
+ * Reference values for the byte fixtures cross-check against the
+ * Bluetooth SIG **GATT Specification Supplement 8**, June 2024
+ * release — characteristic data formats for `0x2BD4` (PM2.5), `0x2B8C`
+ * (CO2), `0x2BE7` (VOC).
+ */
+class EnvironmentalSensingParserTest {
+
+    private val ts = 1_733_400_000_000L
+    private val sourceId = "ble-sensor-1"
+
+    // --- PM2.5 (uint16, resolution 0.1 µg/m³) ---
+
+    @Test
+    fun `PM25 0x0096 little-endian decodes to 15_0 ug per m3`() {
+        // 0x0096 = 150 raw → 15.0 µg/m³ after the 0.1 resolution scale.
+        // Spec: PM2.5 is uint16 with implicit 0.1 µg/m³ resolution.
+        val reading = EnvironmentalSensingParser.parsePm25(
+            byteArrayOf(0x96.toByte(), 0x00), ts, sourceId,
+        )
+        assertNotNull(reading)
+        assertEquals(MetricType.AIR_PM25.key, reading!!.metricType)
+        assertEquals(15.0, reading.value, 0.0)
+        assertEquals(ts, reading.timestamp)
+        assertEquals(sourceId, reading.sourceId)
+    }
+
+    @Test
+    fun `PM25 sentinel 0xFFFF is treated as not-known, returns null`() {
+        // Spec: 0xFFFF on a uint16 characteristic means "value not known."
+        // Surfacing 6553.5 µg/m³ as data would silently poison baselines.
+        assertNull(
+            EnvironmentalSensingParser.parsePm25(
+                byteArrayOf(0xFF.toByte(), 0xFF.toByte()), ts, sourceId,
+            ),
+        )
+    }
+
+    @Test
+    fun `PM25 truncated payload returns null rather than crashing`() {
+        // Defensive against malformed GATT notifications — adapters can
+        // pass through corruption from buggy peripherals.
+        assertNull(EnvironmentalSensingParser.parsePm25(byteArrayOf(0x96.toByte()), ts, sourceId))
+        assertNull(EnvironmentalSensingParser.parsePm25(byteArrayOf(), ts, sourceId))
+    }
+
+    @Test
+    fun `PM25 trailing bytes are ignored (some ESS chars carry trailing flags)`() {
+        // Some peripherals append a "timestamp" or "uncertainty" field per
+        // ESS profile. We only consume the first two bytes; extras don't
+        // break the parse.
+        val reading = EnvironmentalSensingParser.parsePm25(
+            byteArrayOf(0x96.toByte(), 0x00, 0xAA.toByte(), 0xBB.toByte()), ts, sourceId,
+        )
+        assertEquals(15.0, reading!!.value, 0.0)
+    }
+
+    // --- CO2 (uint16, ppm) ---
+
+    @Test
+    fun `CO2 0x03E8 little-endian decodes to 1000 ppm`() {
+        // 0x03E8 = 1000. CO2 is uint16 in ppm with no scale factor.
+        val reading = EnvironmentalSensingParser.parseCo2(
+            byteArrayOf(0xE8.toByte(), 0x03), ts, sourceId,
+        )
+        assertEquals(MetricType.AIR_CO2.key, reading!!.metricType)
+        assertEquals(1000.0, reading.value, 0.0)
+    }
+
+    @Test
+    fun `CO2 sentinel 0xFFFF returns null`() {
+        assertNull(
+            EnvironmentalSensingParser.parseCo2(
+                byteArrayOf(0xFF.toByte(), 0xFF.toByte()), ts, sourceId,
+            ),
+        )
+    }
+
+    // --- VOC (uint16, ppb) ---
+
+    @Test
+    fun `VOC 0x012C little-endian decodes to 300 ppb`() {
+        val reading = EnvironmentalSensingParser.parseVoc(
+            byteArrayOf(0x2C.toByte(), 0x01), ts, sourceId,
+        )
+        assertEquals(MetricType.AIR_VOC.key, reading!!.metricType)
+        assertEquals(300.0, reading.value, 0.0)
+    }
+
+    @Test
+    fun `VOC sentinel 0xFFFF returns null`() {
+        assertNull(
+            EnvironmentalSensingParser.parseVoc(
+                byteArrayOf(0xFF.toByte(), 0xFF.toByte()), ts, sourceId,
+            ),
+        )
+    }
+
+    // --- parse() dispatch ---
+
+    @Test
+    fun `parse dispatches by characteristic UUID short`() {
+        val pm25 = EnvironmentalSensingParser.parse(
+            EnvironmentalSensingParser.CHARACTERISTIC_PM25_SHORT,
+            byteArrayOf(0x96.toByte(), 0x00), ts, sourceId,
+        )
+        assertEquals(MetricType.AIR_PM25.key, pm25!!.metricType)
+
+        val co2 = EnvironmentalSensingParser.parse(
+            EnvironmentalSensingParser.CHARACTERISTIC_CO2_SHORT,
+            byteArrayOf(0xE8.toByte(), 0x03), ts, sourceId,
+        )
+        assertEquals(MetricType.AIR_CO2.key, co2!!.metricType)
+
+        val voc = EnvironmentalSensingParser.parse(
+            EnvironmentalSensingParser.CHARACTERISTIC_VOC_SHORT,
+            byteArrayOf(0x2C.toByte(), 0x01), ts, sourceId,
+        )
+        assertEquals(MetricType.AIR_VOC.key, voc!!.metricType)
+    }
+
+    @Test
+    fun `parse returns null for unsupported characteristic UUIDs`() {
+        // ESS has many characteristics Bios doesn't consume (humidity,
+        // temperature, wind speed, etc.). The runtime adapter should
+        // log-and-skip, not crash, when an unsupported notification
+        // arrives — so we return null here.
+        assertNull(
+            EnvironmentalSensingParser.parse(
+                0x2A6F, // Humidity, valid ESS UUID but not in Bios' scope
+                byteArrayOf(0x96.toByte(), 0x00), ts, sourceId,
+            ),
+        )
+    }
+
+    // --- Cross-file contract bindings ---
+
+    @Test
+    fun `all three air-quality MetricTypes live on the ENVIRONMENT domain`() {
+        for (metric in listOf(MetricType.AIR_PM25, MetricType.AIR_VOC, MetricType.AIR_CO2)) {
+            assertEquals(MetricDomain.ENVIRONMENT, metric.domain)
+        }
+    }
+
+    @Test
+    fun `air-quality MetricTypes carry the expected display units`() {
+        assertEquals(MetricUnit.UG_PER_M3, MetricType.AIR_PM25.unit)
+        assertEquals(MetricUnit.PPB, MetricType.AIR_VOC.unit)
+        assertEquals(MetricUnit.PPM, MetricType.AIR_CO2.unit)
+    }
+
+    @Test
+    fun `Sleep Disruption pattern consumes AIR_CO2 as an ABOVE corroborator`() {
+        // Bedroom CO2 > 1000 ppm degrades sleep efficiency (Strom-Tejsen
+        // 2016). Pinning the SignalRule so a future refactor of the
+        // pattern can't silently drop the air-quality corroborator.
+        val pattern = ConditionPatterns.sleepDisruption
+        val co2Rule = pattern.signalRules.singleOrNull { it.metricType == MetricType.AIR_CO2 }
+        assertNotNull("Sleep Disruption must include the AIR_CO2 SignalRule (#43)", co2Rule)
+        assertEquals(DeviationDirection.ABOVE, co2Rule!!.direction)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -347,6 +347,9 @@ class FhirExporterTest {
             MetricUnit.YEARS -> "a"
             MetricUnit.MS_SQUARED -> "ms2"
             MetricUnit.ML_PER_KG_MIN -> "mL/(kg.min)"
+            MetricUnit.UG_PER_M3 -> "ug/m3"
+            MetricUnit.PPM -> "[ppm]"
+            MetricUnit.PPB -> "[ppb]"
         }
     }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -83,6 +83,9 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
 
     // Environment (phone-sensor adapter)
     AMBIENT_LIGHT("ambient_light", MetricUnit.LUX, MetricDomain.ENVIRONMENT),
+    AIR_PM25("air_pm25", MetricUnit.UG_PER_M3, MetricDomain.ENVIRONMENT),
+    AIR_VOC("air_voc", MetricUnit.PPB, MetricDomain.ENVIRONMENT),
+    AIR_CO2("air_co2", MetricUnit.PPM, MetricDomain.ENVIRONMENT),
 
     // Biomarkers (lab-drawn or imported via FHIR; slow-moving, no streaming).
     // First wave matches the clinical concepts already described in
@@ -176,7 +179,10 @@ enum class MetricUnit(val symbol: String) {
     LUX("lx"),
     YEARS("yr"),
     MS_SQUARED("ms²"),
-    ML_PER_KG_MIN("mL/kg/min")
+    ML_PER_KG_MIN("mL/kg/min"),
+    UG_PER_M3("µg/m³"),
+    PPM("ppm"),
+    PPB("ppb")
 }
 
 enum class MetricDomain {

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -71,6 +71,9 @@ class MetricTypeKeysSnapshotTest {
         "cycle_day",
         // Environment
         "ambient_light",
+        "air_pm25",
+        "air_voc",
+        "air_co2",
         // Biomarkers
         "hba1c",
         "hscrp",


### PR DESCRIPTION
## Summary

Partial #43. Splits the ticket into two PRs: this one ships the contract + Bluetooth SIG **Environmental Sensing Service** byte parser + all the integration points (baseline / coverage / pattern wiring); the Android `BluetoothGatt` runtime + pairing UI is filed as #119 (phase 2). Same staging rationale as the #113 / #114 split: foundation now, on-device-only plumbing separately.

The audit doc (ECOSYSTEM_BOUNDARIES.md scope-decisions log, 2026-05) slotted air quality as Bios's 10th adapter: *"sensor-grade, passive, confounds nearly every existing pattern — sleep, HRV, infection, respiratory."*

## What landed

**Contract ([bios-contracts](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt))**

- Three new `MetricUnit`s: `UG_PER_M3` (`µg/m³`), `PPM` (`ppm`), `PPB` (`ppb`).
- Three new `MetricType`s on `ENVIRONMENT`: `AIR_PM25` (UG_PER_M3), `AIR_VOC` (PPB), `AIR_CO2` (PPM).
- UCUM mappings (`ug/m3`, `[ppm]`, `[ppb]`) — picked up by the existing "all units have UCUM mappings" sweep test.

**[EnvironmentalSensingParser.kt](android/app/src/main/java/com/bios/app/ingest/EnvironmentalSensingParser.kt)**

Pure-function parser for the Bluetooth SIG ESS service (`0x181A`). Phase 2's BLE runtime hands raw characteristic payloads to these functions; canonical `MetricReading`s come back. Supported characteristics:

- `0x2BD4` PM2.5 — `uint16`, resolution 0.1 µg/m³ (`raw / 10.0`)
- `0x2B8C` CO2 — `uint16`, ppm
- `0x2BE7` VOC — `uint16`, ppb

Defensive handling: `0xFFFF` ("value not known") → `null` (don't poison baselines with 65 535 readings); truncated payloads → `null` (buggy peripherals); trailing bytes ignored (some ESS chars carry flags / timestamps); unsupported characteristic UUIDs → `null` (log-and-skip rather than crash on humidity / wind / etc. notifications).

**Coverage / baseline / pattern wiring**

- New `CoverageRouteKind.BLE_PERIPHERAL` + `AdapterReadiness.bleAirQualityPaired` (default `false` until phase 2).
- [`MetricCoverageEngine`](android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt) renders the new route as "BLE air-quality sensor"; deep-link is `null` until the phase-2 pairing screen exists.
- [`MetricCoverageRegistry`](android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt): all three keys with **hourly** freshness — BLE sensors typically notify every 30-60s when active, so anything older than an hour is "drifted off."
- [`BaselineEngine`](android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt) baselines all three.
- [Sleep Disruption ConditionPattern](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt#L135) gains an `AIR_CO2 ABOVE` `SignalRule` (weight 0.5, 72h window). Strom-Tejsen et al. 2016 — bedroom CO2 above ~1000 ppm degrades sleep efficiency. Fires only when an ESS sensor is paired and CO2 trends above personal baseline; without a sensor the pattern works on the existing four signals.

**Tests ([EnvironmentalSensingParserTest.kt](android/app/src/test/java/com/bios/app/EnvironmentalSensingParserTest.kt))**

12 cases: each characteristic's happy-path decode, `0xFFFF` sentinel handling, truncated-payload defense, trailing-byte tolerance, `parse()` dispatch, unsupported-UUID null-return, plus three cross-file binding pins (domain / unit / Sleep Disruption pattern membership) so a future `MetricType` refactor can't silently sever the wiring.

## Phase 2 — filed as #119

The Android `BluetoothGatt` runtime (scan + connect + read + notify), pairing UI in Settings, manifest permissions (`BLUETOOTH_SCAN` / `BLUETOOTH_CONNECT`), and on-device testing against Atmotube Pro + Airthings Wave.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` + `:bios-contracts:test` green.
- [x] `./scripts/code-quality-check.sh` passes (file length, lint, build). `ConditionPatterns.kt` sits at 500 / 500 after the AIR_CO2 SignalRule addition.
- [ ] On-device sanity defers to #119 — phase 1 has no Android-runtime surface to exercise.

## Out of scope

- Android BLE plumbing (#119).
- Vendor-proprietary characteristics (Atmotube custom UUIDs, Airthings Wave's `b42e2a68-...` set). Standard ESS coverage is enough for v1.
- LOINC mapping for the air-quality keys — environmental readings aren't clinical biomarkers; the FHIR exporter's biomarker-focused LOINC table is the right scope to keep them out of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)