### PR TITLE
feat(engine): glucose variability — CV, MAGE, TIR, peak (#28)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/CircadianConditionPattern.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/CircadianConditionPattern.kt
@@ -1,0 +1,62 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Circadian-disruption pattern. Lifted out of [ConditionPatterns] so the
+ * host file stays under the 500-line cap once more longevity-science
+ * patterns (#28 glucose variability and friends) wire their corroborating
+ * signal rules into the existing patterns. The pattern itself is unchanged
+ * from its in-place definition; it's surfaced through the same
+ * `ConditionPatterns.all` aggregate so detection sees no behavior change.
+ */
+object CircadianConditionPattern {
+
+    val all: List<ConditionPattern> by lazy { listOf(circadianDisruption) }
+
+    /**
+     * Circadian disruption: erratic light-exposure pattern over a 7-day window
+     * paired with sleep degradation. The phone's ambient-light sensor (sampled
+     * on a screen-on duty cycle by SyncWorker) is the only Bios-side proxy for
+     * the owner's daily light environment. When the AMBIENT_LIGHT z-score
+     * pattern drifts well past baseline — e.g. a shift to night-shift work,
+     * heavy evening screen exposure replacing daytime sunlight, or jet-lag
+     * misalignment — and sleep architecture concurrently degrades, the
+     * convergence is the strongest non-invasive circadian-disruption signal
+     * available.
+     *
+     * This is the §8.1 cross-correlation consumer of `AMBIENT_LIGHT`: required
+     * = true on the lux rule so wearable sleep drift alone never fires the
+     * pattern (per §8.6 / §8.8 gating discipline).
+     */
+    val circadianDisruption = ConditionPattern(
+        id = "circadian_disruption",
+        title = "Erratic light-exposure pattern with sleep degradation",
+        category = ConditionCategory.SLEEP,
+        signalRules = listOf(
+            SignalRule(MetricType.AMBIENT_LIGHT, DeviationDirection.IRREGULAR, 1.5, 168, 1.2,
+                ThresholdSource.LITERATURE,
+                "Wright KP et al. (2013) — entrainment to the natural light-dark cycle is the dominant circadian zeitgeber; sustained departures from the owner's habitual light pattern are the canonical marker of misalignment",
+                required = true),
+            SignalRule(MetricType.SLEEP_STAGE, DeviationDirection.BELOW, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Chang AM et al. (2015) — evening light exposure suppresses melatonin, delays sleep onset, and reduces deep-sleep proportion"),
+            SignalRule(MetricType.SLEEP_DURATION, DeviationDirection.IRREGULAR, 1.5, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Roenneberg T et al. (2007) — social-jetlag-style variability in sleep timing accompanies circadian misalignment and tracks light-exposure irregularity"),
+        ),
+        minActiveSignals = 2,
+        explanation = "Your ambient-light exposure pattern over the past week has deviated substantially from your established baseline, and at least one sleep signal (depth or timing) has degraded in parallel. The combination is consistent with circadian misalignment — caused by night work, heavy evening screen use, jet-lag, or a sudden change in daily light environment. This is a data observation about your environment, not a judgment about your habits.",
+        suggestedAction = "If the disruption is intentional (travel, shift work), no action is needed beyond awareness. Otherwise, increasing morning-daylight exposure and reducing bright-screen exposure within 2 hours of bedtime are the highest-evidence interventions for re-entrainment.",
+        references = listOf(
+            "Wright KP Jr et al. (2013) — Entrainment of the human circadian clock to the natural light-dark cycle",
+            "Chang AM et al. (2015) — Evening use of light-emitting eReaders negatively affects sleep, circadian timing, and next-morning alertness",
+            "Roenneberg T et al. (2007) — Epidemiology of the human circadian clock"
+        ),
+        earlyDetection = "Circadian disruption is silent in the short term — the owner often doesn't notice until sleep quality, mood, or daytime alertness has already degraded. The phone's ambient-light sensor captures the upstream cause (changed light environment) days before downstream symptoms accumulate. Pairing the light-exposure shift with sleep degradation is what distinguishes a meaningful misalignment from a one-off late night.",
+        prevention = "Anchor the day with bright outdoor light within the first hour after waking — the strongest circadian zeitgeber. Keep evening environments dim (especially the 2-3 hours before bed); warm-color bulbs and reduced screen brightness help. For shift workers, maintain a consistent sleep schedule even on off-days; intermittent re-entrainment is worse than a stable shifted phase.",
+        healing = "Most circadian misalignment self-corrects within 7-10 days of restored light-dark cues. Accelerate re-entrainment with timed bright light (morning if phase-delayed, evening if phase-advanced) and strict avoidance of bright light during the new biological night. Consider melatonin (0.3-0.5 mg) 4-6 hours before target sleep onset for travel adjustment, only short-term. If sleep quality and daytime alertness don't recover within 2 weeks, consult a sleep specialist — chronic circadian misalignment can indicate delayed sleep-wake phase disorder or shift-work disorder.",
+        risks = "Chronic circadian disruption is independently associated with metabolic syndrome, cardiovascular disease, mood disorders, and certain cancers (IARC classifies shift work as probably carcinogenic). The mechanism is misaligned hormonal and metabolic rhythms — insulin sensitivity, cortisol, and inflammatory regulation all follow circadian patterns. Short-term mismatches recover; sustained ones compound. Early detection via wearable proxy signals provides the window where lifestyle realignment is highly effective."
+    )
+}

--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -80,8 +80,8 @@ object ConditionPatterns {
             infectionOnset, sleepDisruption, cardiovascularStress, overtraining,
             metabolicDrift, cardiorespiratoryDeconditioning, chronicInflammation, recoveryDeficit,
             respiratoryInfection, atrialFibrillationScreen, mentalHealthCorrelate, menstrualCycleAnomaly,
-            circadianDisruption,
-        ) + CompanionConditionPatterns.all + BiomarkerConditionPatterns.all
+        ) + CircadianConditionPattern.all +
+            CompanionConditionPatterns.all + BiomarkerConditionPatterns.all
     }
 
     /** Infection / illness onset: the Phase 1 primary detection target. */
@@ -207,6 +207,11 @@ object ConditionPatterns {
         signalRules = listOf(
             SignalRule(MetricType.BLOOD_GLUCOSE, DeviationDirection.IRREGULAR, 1.5, 168, 1.2,
                 ThresholdSource.LITERATURE, "Hall et al. (2018) - glucose variability increase identifies pre-diabetic glucotypes"),
+            // CV rising + TIR falling are earlier markers than mean glucose (#28).
+            SignalRule(MetricType.GLUCOSE_CV, DeviationDirection.ABOVE, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE, "Battelino et al. (2019) - CV > baseline is an earlier marker than mean glucose"),
+            SignalRule(MetricType.GLUCOSE_TIME_IN_RANGE, DeviationDirection.BELOW, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE, "Battelino et al. (2019) - TIR decline tracks pre-diabetic transition before HbA1c shifts"),
             SignalRule(MetricType.SLEEP_STAGE, DeviationDirection.BELOW, 1.0, 168, 0.8,
                 ThresholdSource.LITERATURE, "Reutrakul & Van Cauter (2018) - sleep disruption impairs glucose regulation"),
             SignalRule(MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 0.6,
@@ -453,48 +458,4 @@ object ConditionPatterns {
         risks = "Menstrual cycle irregularities can indicate underlying hormonal or metabolic conditions. Anovulatory cycles (no ovulation) affect fertility and may indicate PCOS or thyroid dysfunction. Shortened luteal phases can impair implantation. Irregular cycles are also associated with higher cardiovascular risk and lower bone density long-term. Early detection of pattern changes — when they're subtle shifts rather than dramatic disruptions — allows earlier investigation and treatment."
     )
 
-    /**
-     * Circadian disruption: erratic light-exposure pattern over a 7-day window
-     * paired with sleep degradation. The phone's ambient-light sensor (sampled
-     * on a screen-on duty cycle by SyncWorker) is the only Bios-side proxy for
-     * the owner's daily light environment. When the AMBIENT_LIGHT z-score
-     * pattern drifts well past baseline — e.g. a shift to night-shift work,
-     * heavy evening screen exposure replacing daytime sunlight, or jet-lag
-     * misalignment — and sleep architecture concurrently degrades, the
-     * convergence is the strongest non-invasive circadian-disruption signal
-     * available.
-     *
-     * This is the §8.1 cross-correlation consumer of `AMBIENT_LIGHT`: required
-     * = true on the lux rule so wearable sleep drift alone never fires the
-     * pattern (per §8.6 / §8.8 gating discipline).
-     */
-    val circadianDisruption = ConditionPattern(
-        id = "circadian_disruption",
-        title = "Erratic light-exposure pattern with sleep degradation",
-        category = ConditionCategory.SLEEP,
-        signalRules = listOf(
-            SignalRule(MetricType.AMBIENT_LIGHT, DeviationDirection.IRREGULAR, 1.5, 168, 1.2,
-                ThresholdSource.LITERATURE,
-                "Wright KP et al. (2013) — entrainment to the natural light-dark cycle is the dominant circadian zeitgeber; sustained departures from the owner's habitual light pattern are the canonical marker of misalignment",
-                required = true),
-            SignalRule(MetricType.SLEEP_STAGE, DeviationDirection.BELOW, 1.0, 168, 1.0,
-                ThresholdSource.LITERATURE,
-                "Chang AM et al. (2015) — evening light exposure suppresses melatonin, delays sleep onset, and reduces deep-sleep proportion"),
-            SignalRule(MetricType.SLEEP_DURATION, DeviationDirection.IRREGULAR, 1.5, 168, 0.8,
-                ThresholdSource.LITERATURE,
-                "Roenneberg T et al. (2007) — social-jetlag-style variability in sleep timing accompanies circadian misalignment and tracks light-exposure irregularity"),
-        ),
-        minActiveSignals = 2,
-        explanation = "Your ambient-light exposure pattern over the past week has deviated substantially from your established baseline, and at least one sleep signal (depth or timing) has degraded in parallel. The combination is consistent with circadian misalignment — caused by night work, heavy evening screen use, jet-lag, or a sudden change in daily light environment. This is a data observation about your environment, not a judgment about your habits.",
-        suggestedAction = "If the disruption is intentional (travel, shift work), no action is needed beyond awareness. Otherwise, increasing morning-daylight exposure and reducing bright-screen exposure within 2 hours of bedtime are the highest-evidence interventions for re-entrainment.",
-        references = listOf(
-            "Wright KP Jr et al. (2013) — Entrainment of the human circadian clock to the natural light-dark cycle",
-            "Chang AM et al. (2015) — Evening use of light-emitting eReaders negatively affects sleep, circadian timing, and next-morning alertness",
-            "Roenneberg T et al. (2007) — Epidemiology of the human circadian clock"
-        ),
-        earlyDetection = "Circadian disruption is silent in the short term — the owner often doesn't notice until sleep quality, mood, or daytime alertness has already degraded. The phone's ambient-light sensor captures the upstream cause (changed light environment) days before downstream symptoms accumulate. Pairing the light-exposure shift with sleep degradation is what distinguishes a meaningful misalignment from a one-off late night.",
-        prevention = "Anchor the day with bright outdoor light within the first hour after waking — the strongest circadian zeitgeber. Keep evening environments dim (especially the 2-3 hours before bed); warm-color bulbs and reduced screen brightness help. For shift workers, maintain a consistent sleep schedule even on off-days; intermittent re-entrainment is worse than a stable shifted phase.",
-        healing = "Most circadian misalignment self-corrects within 7-10 days of restored light-dark cues. Accelerate re-entrainment with timed bright light (morning if phase-delayed, evening if phase-advanced) and strict avoidance of bright light during the new biological night. Consider melatonin (0.3-0.5 mg) 4-6 hours before target sleep onset for travel adjustment, only short-term. If sleep quality and daytime alertness don't recover within 2 weeks, consult a sleep specialist — chronic circadian misalignment can indicate delayed sleep-wake phase disorder or shift-work disorder.",
-        risks = "Chronic circadian disruption is independently associated with metabolic syndrome, cardiovascular disease, mood disorders, and certain cancers (IARC classifies shift work as probably carcinogenic). The mechanism is misaligned hormonal and metabolic rhythms — insulin sensitivity, cortisol, and inflammatory regulation all follow circadian patterns. Short-term mismatches recover; sustained ones compound. Early detection via wearable proxy signals provides the window where lifestyle realignment is highly effective."
-    )
 }

--- a/android/app/src/main/java/com/bios/app/engine/GlucoseVariability.kt
+++ b/android/app/src/main/java/com/bios/app/engine/GlucoseVariability.kt
@@ -1,0 +1,159 @@
+package com.bios.app.engine
+
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlin.math.absoluteValue
+import kotlin.math.sqrt
+
+/**
+ * Pure-function derivations over a window of BLOOD_GLUCOSE readings (#28).
+ *
+ * Bios ingests raw CGM samples through [com.bios.app.ingest.DexcomApiAdapter]
+ * (or Health Connect's blood-glucose feed) at the device's native cadence —
+ * typically every 5 minutes for Dexcom, less frequent for finger-stick
+ * imports. The four derivations here describe how variable that stream is
+ * over the window the caller passes in, which is what the metabolic
+ * literature flags as an earlier marker than absolute glucose level:
+ *
+ *  - **GLUCOSE_CV** — coefficient of variation (SD / mean × 100), in
+ *    percent. The ADA's "stable" cut-off is < 36 % (Battelino et al. 2019);
+ *    Blueprint's OCOR range pushes tighter at < 18 %.
+ *  - **GLUCOSE_MAGE** — Mean Amplitude of Glycemic Excursions, in mg/dL,
+ *    using Service et al.'s 1970 algorithm: among the peak↔nadir transitions
+ *    in the series, keep those whose amplitude exceeds 1 SD and average
+ *    them. The Baghurst (2011) variant is more rigorous but its automated
+ *    deterministic form is a follow-up; Service is the canonical reference
+ *    and matches what most published thresholds (< 60 mg/dL "good control")
+ *    were derived against.
+ *  - **GLUCOSE_TIME_IN_RANGE** — percent of readings in the 70-140 mg/dL
+ *    target window. Tighter than the ADA's 70-180 for diabetics; matches
+ *    the Blueprint protocol's post-prandial target and the issue's spec.
+ *  - **GLUCOSE_PEAK_24H** — max value in the window, in mg/dL.
+ *
+ * **Window semantics.** Each function takes the readings already pulled into
+ * the sync batch (typically the last 24 h in `IngestManager.syncRecentData`)
+ * and emits one reading per call, anchored at the first sample's timestamp
+ * and tagged with `durationSec` spanning to the last sample. The caller is
+ * responsible for the window — these functions don't query the DAO. That
+ * keeps the derivations pure and testable without Room.
+ *
+ * **Minimum-data threshold.** All four return `null` below
+ * [MIN_SAMPLES_FOR_VARIABILITY] readings — under ~8 hours of 5-min CGM
+ * coverage, the statistics are too sparse to be informative and would
+ * mostly add baseline noise. TIR is the most forgiving but still needs
+ * enough samples to make the percentage meaningful.
+ *
+ * Confidence and sourceId are inherited from the input rows, mirroring
+ * the [SleepDerivations] convention.
+ */
+object GlucoseVariability {
+
+    /** Coefficient of variation = SD / mean × 100. Returns null when the
+     *  window is too sparse or mean ≤ 0 (defensive against bad data). */
+    fun deriveCv(readings: List<MetricReading>, sourceId: String): MetricReading? {
+        val series = glucoseSeries(readings) ?: return null
+        val mean = series.sumOf { it.value } / series.size
+        if (mean <= 0.0) return null
+        val variance = series.sumOf { (it.value - mean) * (it.value - mean) } / series.size
+        val cv = sqrt(variance) / mean * 100.0
+        return derivedReading(MetricType.GLUCOSE_CV, cv, series, sourceId)
+    }
+
+    /** Time in 70–140 mg/dL, expressed as percent of the input rows. */
+    fun deriveTimeInRange(readings: List<MetricReading>, sourceId: String): MetricReading? {
+        val series = glucoseSeries(readings) ?: return null
+        val inRange = series.count { it.value in TIR_LOW_MG_DL..TIR_HIGH_MG_DL }
+        val pct = inRange.toDouble() / series.size * 100.0
+        return derivedReading(MetricType.GLUCOSE_TIME_IN_RANGE, pct, series, sourceId)
+    }
+
+    /** Highest mg/dL value in the window. */
+    fun derivePeak(readings: List<MetricReading>, sourceId: String): MetricReading? {
+        val series = glucoseSeries(readings) ?: return null
+        val peak = series.maxOf { it.value }
+        return derivedReading(MetricType.GLUCOSE_PEAK_24H, peak, series, sourceId)
+    }
+
+    /**
+     * Service-1970 MAGE: average amplitude of peak↔nadir transitions that
+     * exceed 1 SD of the glucose series. Walks the series once, marking
+     * turning points (a sample is a turn when its slope sign flips relative
+     * to the previous run), then takes |Δ| between adjacent turns and
+     * averages the ones above the SD threshold.
+     *
+     * Returns null when the window has fewer than two turning points whose
+     * excursion clears the SD threshold — a flat-line trace has no MAGE
+     * to report and emitting a zero would mis-rank truly stable days
+     * against days where the algorithm just didn't fire.
+     */
+    fun deriveMage(readings: List<MetricReading>, sourceId: String): MetricReading? {
+        val series = glucoseSeries(readings) ?: return null
+        val values = series.map { it.value }
+        val mean = values.average()
+        val sd = sqrt(values.sumOf { (it - mean) * (it - mean) } / values.size)
+        if (sd <= 0.0) return null
+
+        // Mark turning points. A sample is a turn when the running direction
+        // (rising vs. falling) reverses; the first and last samples bookend
+        // the series and are always included so a monotonic window still
+        // yields one excursion.
+        val turns = mutableListOf<Double>()
+        turns += values.first()
+        var direction = 0  // -1 falling, 0 unknown, +1 rising
+        for (i in 1 until values.size) {
+            val delta = values[i] - values[i - 1]
+            val sign = when {
+                delta > 0 -> 1
+                delta < 0 -> -1
+                else -> direction
+            }
+            if (direction != 0 && sign != 0 && sign != direction) {
+                turns += values[i - 1]
+            }
+            if (sign != 0) direction = sign
+        }
+        turns += values.last()
+        if (turns.size < 2) return null
+
+        val excursions = (1 until turns.size)
+            .map { (turns[it] - turns[it - 1]).absoluteValue }
+            .filter { it > sd }
+        if (excursions.isEmpty()) return null
+
+        val mage = excursions.average()
+        return derivedReading(MetricType.GLUCOSE_MAGE, mage, series, sourceId)
+    }
+
+    /** Filter to BLOOD_GLUCOSE, sort, and return only when the window has
+     *  enough samples to compute meaningful variability statistics. */
+    private fun glucoseSeries(readings: List<MetricReading>): List<MetricReading>? {
+        val series = readings
+            .filter { it.metricType == MetricType.BLOOD_GLUCOSE.key }
+            .sortedBy { it.timestamp }
+        if (series.size < MIN_SAMPLES_FOR_VARIABILITY) return null
+        return series
+    }
+
+    private fun derivedReading(
+        type: MetricType,
+        value: Double,
+        series: List<MetricReading>,
+        sourceId: String,
+    ): MetricReading = MetricReading(
+        metricType = type.key,
+        value = value,
+        timestamp = series.first().timestamp,
+        durationSec = ((series.last().timestamp - series.first().timestamp) / 1000L).toInt(),
+        sourceId = sourceId,
+        confidence = series.first().confidence,
+    )
+
+    /** ~8 hours of 5-min CGM coverage. Below this the stats are too sparse
+     *  to be informative — see "Minimum-data threshold" in the class kdoc. */
+    internal const val MIN_SAMPLES_FOR_VARIABILITY = 96
+
+    /** TIR target window. Tighter than the ADA 70-180 standard; matches
+     *  the Blueprint protocol cited in the issue. */
+    internal const val TIR_LOW_MG_DL = 70.0
+    internal const val TIR_HIGH_MG_DL = 140.0
+}

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt
@@ -137,6 +137,27 @@ object MetricCoverageRegistry {
             MetricType.BLOOD_GLUCOSE, 4 * H,
             listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
         ),
+        // CGM-derived variability metrics (#28). Same staleness budget as
+        // the underlying BLOOD_GLUCOSE stream — they're recomputed on every
+        // sync, so freshness tracks the source. Routes mirror the source:
+        // no separate "configure CV" surface, the CTA still leads to the
+        // CGM connection itself.
+        MetricCoverageSpec(
+            MetricType.GLUCOSE_CV, 4 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.GLUCOSE_MAGE, 4 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.GLUCOSE_TIME_IN_RANGE, 4 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
+        MetricCoverageSpec(
+            MetricType.GLUCOSE_PEAK_24H, 4 * H,
+            listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)
+        ),
         MetricCoverageSpec(
             MetricType.BODY_MASS, MONTH,
             listOf(CoverageRouteKind.HEALTH_CONNECT, CoverageRouteKind.API_ADAPTER)

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -3,6 +3,7 @@ package com.bios.app.ingest
 import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.CircadianEngine
 import com.bios.app.engine.DetectionLatencyTracker
+import com.bios.app.engine.GlucoseVariability
 import com.bios.app.engine.PipelineStage
 import com.bios.app.engine.SignalQualityFilter
 import com.bios.app.engine.SleepDerivations
@@ -300,6 +301,10 @@ class IngestManager(
             SleepDerivations.deriveSleepFragmentation(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveWakeAfterSleepOnset(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepScore(rows, sourceId)?.let { derived += it }
+            GlucoseVariability.deriveCv(rows, sourceId)?.let { derived += it }
+            GlucoseVariability.deriveTimeInRange(rows, sourceId)?.let { derived += it }
+            GlucoseVariability.derivePeak(rows, sourceId)?.let { derived += it }
+            GlucoseVariability.deriveMage(rows, sourceId)?.let { derived += it }
         }
         return derived
     }

--- a/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt
@@ -144,12 +144,12 @@ class ConditionPatternsTest {
 
     @Test
     fun `circadian disruption pattern is registered in the global all list`() {
-        assertTrue(ConditionPatterns.circadianDisruption in ConditionPatterns.all)
+        assertTrue(com.bios.app.alerts.CircadianConditionPattern.circadianDisruption in ConditionPatterns.all)
     }
 
     @Test
     fun `circadian disruption gates on AMBIENT_LIGHT irregularity as the required rule`() {
-        val pattern = ConditionPatterns.circadianDisruption
+        val pattern = com.bios.app.alerts.CircadianConditionPattern.circadianDisruption
         val lightRule = pattern.signalRules.first {
             it.metricType == com.bios.contracts.MetricType.AMBIENT_LIGHT
         }
@@ -163,7 +163,7 @@ class ConditionPatternsTest {
 
     @Test
     fun `circadian disruption corroborators cover sleep depth and timing`() {
-        val pattern = ConditionPatterns.circadianDisruption
+        val pattern = com.bios.app.alerts.CircadianConditionPattern.circadianDisruption
         val corroborators = pattern.signalRules
             .filter { !it.required }
             .map { it.metricType }
@@ -177,7 +177,7 @@ class ConditionPatternsTest {
 
     @Test
     fun `circadian disruption requires at least one corroborator alongside the light gate`() {
-        assertEquals(2, ConditionPatterns.circadianDisruption.minActiveSignals)
+        assertEquals(2, com.bios.app.alerts.CircadianConditionPattern.circadianDisruption.minActiveSignals)
     }
 
     @Test

--- a/android/app/src/test/java/com/bios/app/GlucoseVariabilityTest.kt
+++ b/android/app/src/test/java/com/bios/app/GlucoseVariabilityTest.kt
@@ -1,0 +1,174 @@
+package com.bios.app
+
+import com.bios.app.engine.GlucoseVariability
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the four CGM-variability derivations (#28). Each derivation
+ * is exercised through happy-path, edge-case (sparse window, flat trace,
+ * mixed metrics), and a clinical sanity-check against a known-stable and
+ * known-spiky pattern.
+ */
+class GlucoseVariabilityTest {
+
+    private val sourceId = "dexcom"
+    private val baseTimestamp = 1_700_000_000_000L
+
+    /** Build a 96-sample 8h window at the 5-min CGM cadence. */
+    private fun glucoseSeries(values: List<Double>): List<MetricReading> =
+        values.mapIndexed { i, v ->
+            MetricReading(
+                metricType = MetricType.BLOOD_GLUCOSE.key,
+                value = v,
+                timestamp = baseTimestamp + i * 5L * 60_000L,
+                durationSec = 300,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level,
+            )
+        }
+
+    /** Replicate a single value n times. */
+    private fun flat(value: Double, n: Int = 96): List<Double> = List(n) { value }
+
+    @Test
+    fun `derivations all return null below the minimum-samples threshold`() {
+        // Fewer than 96 samples — every derivation should refuse to emit.
+        val sparse = glucoseSeries(flat(110.0, n = 60))
+        assertNull(GlucoseVariability.deriveCv(sparse, sourceId))
+        assertNull(GlucoseVariability.deriveTimeInRange(sparse, sourceId))
+        assertNull(GlucoseVariability.derivePeak(sparse, sourceId))
+        assertNull(GlucoseVariability.deriveMage(sparse, sourceId))
+    }
+
+    @Test
+    fun `derivations ignore non-glucose readings in the input`() {
+        // Mix in 200 HR samples on top of a 96-sample glucose window —
+        // the HR rows must not perturb the glucose derivations.
+        val mixed: List<MetricReading> = glucoseSeries(flat(100.0)) +
+            List(200) {
+                MetricReading(
+                    metricType = MetricType.HEART_RATE.key,
+                    value = 70.0,
+                    timestamp = baseTimestamp + it * 1_000L,
+                    sourceId = sourceId,
+                    confidence = ConfidenceTier.HIGH.level,
+                )
+            }
+        val cv = GlucoseVariability.deriveCv(mixed, sourceId)
+        assertNotNull(cv)
+        // Flat 100.0 series → CV = 0.
+        assertEquals(0.0, cv!!.value, 1e-9)
+    }
+
+    @Test
+    fun `CV is zero on a perfectly flat trace`() {
+        val flat = glucoseSeries(flat(120.0))
+        val cv = GlucoseVariability.deriveCv(flat, sourceId)!!
+        assertEquals(MetricType.GLUCOSE_CV.key, cv.metricType)
+        assertEquals(0.0, cv.value, 1e-9)
+    }
+
+    @Test
+    fun `CV reflects SD over mean as percent`() {
+        // Two-value oscillation: 80, 120, 80, 120... mean=100, SD=20, CV=20%.
+        val osc = glucoseSeries(List(96) { if (it % 2 == 0) 80.0 else 120.0 })
+        val cv = GlucoseVariability.deriveCv(osc, sourceId)!!
+        assertEquals(20.0, cv.value, 1e-9)
+    }
+
+    @Test
+    fun `TIR is 100 percent when every reading is in the 70 to 140 window`() {
+        val inRange = glucoseSeries(flat(100.0))
+        val tir = GlucoseVariability.deriveTimeInRange(inRange, sourceId)!!
+        assertEquals(MetricType.GLUCOSE_TIME_IN_RANGE.key, tir.metricType)
+        assertEquals(100.0, tir.value, 1e-9)
+    }
+
+    @Test
+    fun `TIR is zero when every reading is out of range`() {
+        val highSpike = glucoseSeries(flat(200.0))
+        val tir = GlucoseVariability.deriveTimeInRange(highSpike, sourceId)!!
+        assertEquals(0.0, tir.value, 1e-9)
+    }
+
+    @Test
+    fun `TIR window endpoints 70 and 140 are inclusive`() {
+        val onEdges = glucoseSeries(List(96) { if (it % 2 == 0) 70.0 else 140.0 })
+        val tir = GlucoseVariability.deriveTimeInRange(onEdges, sourceId)!!
+        assertEquals(100.0, tir.value, 1e-9)
+    }
+
+    @Test
+    fun `TIR is approximately the fraction in 70 to 140`() {
+        // 72 readings at 100 mg/dL, 24 readings at 200 mg/dL → 75% in range.
+        val mixed = glucoseSeries(List(72) { 100.0 } + List(24) { 200.0 })
+        val tir = GlucoseVariability.deriveTimeInRange(mixed, sourceId)!!
+        assertEquals(75.0, tir.value, 1e-9)
+    }
+
+    @Test
+    fun `peak reports the maximum value in the window`() {
+        val withSpike = glucoseSeries(flat(100.0).toMutableList().also { it[50] = 220.0 })
+        val peak = GlucoseVariability.derivePeak(withSpike, sourceId)!!
+        assertEquals(MetricType.GLUCOSE_PEAK_24H.key, peak.metricType)
+        assertEquals(220.0, peak.value, 1e-9)
+    }
+
+    @Test
+    fun `MAGE is null on a flat trace where no excursion exceeds the SD`() {
+        // SD is zero, so the > SD filter rejects every excursion — null is
+        // the right answer (a confident zero would falsely rank flat days
+        // against truly variable ones).
+        val flat = glucoseSeries(flat(120.0))
+        assertNull(GlucoseVariability.deriveMage(flat, sourceId))
+    }
+
+    @Test
+    fun `MAGE averages excursions exceeding 1 SD`() {
+        // Construct a saw-tooth: alternating 80 ↔ 160. SD ≈ 40, every
+        // peak↔nadir transition is |Δ|=80 > SD, so MAGE = 80.
+        val sawtooth = glucoseSeries(List(96) { if (it % 2 == 0) 80.0 else 160.0 })
+        val mage = GlucoseVariability.deriveMage(sawtooth, sourceId)!!
+        assertEquals(MetricType.GLUCOSE_MAGE.key, mage.metricType)
+        assertEquals(80.0, mage.value, 1e-9)
+    }
+
+    @Test
+    fun `derived readings inherit confidence from the source rows`() {
+        val series = glucoseSeries(flat(100.0))
+        val cv = GlucoseVariability.deriveCv(series, sourceId)!!
+        assertEquals(ConfidenceTier.HIGH.level, cv.confidence)
+        assertEquals(sourceId, cv.sourceId)
+    }
+
+    @Test
+    fun `derived reading timestamp anchors at the first sample`() {
+        val series = glucoseSeries(flat(100.0))
+        val peak = GlucoseVariability.derivePeak(series, sourceId)!!
+        assertEquals(series.first().timestamp, peak.timestamp)
+        // durationSec spans the window — first to last sample, in seconds.
+        val expectedDuration = (series.last().timestamp - series.first().timestamp) / 1000L
+        assertEquals(expectedDuration.toInt(), peak.durationSec)
+    }
+
+    @Test
+    fun `unsorted input still produces correct derivations`() {
+        // Same data shuffled — derivations sort internally, so the output
+        // matches the sorted case.
+        val sorted = glucoseSeries(List(96) { 80.0 + it })
+        val shuffled = sorted.shuffled()
+        val sortedCv = GlucoseVariability.deriveCv(sorted, sourceId)!!.value
+        val shuffledCv = GlucoseVariability.deriveCv(shuffled, sourceId)!!.value
+        assertTrue(
+            "shuffled CV ($shuffledCv) should equal sorted CV ($sortedCv)",
+            kotlin.math.abs(sortedCv - shuffledCv) < 1e-9
+        )
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -69,6 +69,12 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
 
     // Metabolic
     BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
+    // CGM-derived variability keys (#28). Computed over the last 24h of
+    // BLOOD_GLUCOSE readings by GlucoseVariability; one value per 24h window.
+    GLUCOSE_CV("glucose_cv", MetricUnit.PERCENT, MetricDomain.METABOLIC),
+    GLUCOSE_MAGE("glucose_mage", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
+    GLUCOSE_TIME_IN_RANGE("glucose_time_in_range", MetricUnit.PERCENT, MetricDomain.METABOLIC),
+    GLUCOSE_PEAK_24H("glucose_peak_24h", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
     BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
     BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
     LEAN_MASS("lean_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -60,6 +60,10 @@ class MetricTypeKeysSnapshotTest {
         "exercise_session",
         // Metabolic
         "blood_glucose",
+        "glucose_cv",
+        "glucose_mage",
+        "glucose_time_in_range",
+        "glucose_peak_24h",
         "body_mass",
         "body_fat_pct",
         "lean_mass",


### PR DESCRIPTION
## Summary
Closes #28. Bios ingests raw 5-min CGM samples via [DexcomApiAdapter](android/app/src/main/java/com/bios/app/ingest/DexcomApiAdapter.kt) but until now surfaced no variability statistics — and the literature (Hall 2018, Battelino 2019) flags CV / TIR as earlier markers of glucose dysregulation than the mean.

- [GlucoseVariability](android/app/src/main/java/com/bios/app/engine/GlucoseVariability.kt) — pure-function derivations over the sync batch:
  - **GLUCOSE_CV** — SD / mean × 100 (%).
  - **GLUCOSE_MAGE** — Service 1970 algorithm: peak↔nadir excursions exceeding 1 SD, averaged. The Baghurst (2011) deterministic variant is a deliberate follow-up — Service is the canonical reference and matches the published thresholds.
  - **GLUCOSE_TIME_IN_RANGE** — % of readings in **70–140 mg/dL** (Blueprint OCOR window per the issue, tighter than the ADA 70–180 standard for diabetics).
  - **GLUCOSE_PEAK_24H** — max in the window.
  - All four return null below 96 samples (~8h of 5-min CGM coverage) — sparser windows are too noisy to be informative.
- [IngestManager.deriveAll](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt#L296) now invokes the four derivations once per `sourceId` per sync, alongside the existing sleep derivations.
- [MetricCoverageRegistry](android/app/src/main/java/com/bios/app/engine/MetricCoverageRegistry.kt#L141) — four new specs at the 4h staleness budget matching BLOOD_GLUCOSE.
- [ConditionPatterns.metabolicDrift](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt) — adds GLUCOSE_CV ABOVE / GLUCOSE_TIME_IN_RANGE BELOW rules (Battelino 2019), strengthening the pattern's early-marker signal stack alongside the existing BLOOD_GLUCOSE IRREGULAR rule.
- [CircadianConditionPattern](android/app/src/main/java/com/bios/app/alerts/CircadianConditionPattern.kt) — extracted from ConditionPatterns.kt so the host stays under the 500-line cap with the new glucose rules wired in. Behavior unchanged.
- [MetricTypeKeysSnapshotTest](android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt) — four new keys appended (additive, no companion break).

## Algorithm choices
- **MAGE**: locked to Service-1970. Baghurst is more rigorous but its deterministic automated form is a follow-up.
- **TIR window 70–140 mg/dL**: per the issue spec (Blueprint OCOR), not the ADA 70–180 (which is for diabetics).
- **Minimum samples = 96**: ~8h of 5-min CGM coverage. Below this the stats are too sparse to be useful and would add noise to baselines.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file lengths, secret scan, both flavor builds, lint, unit tests.
- [x] [GlucoseVariabilityTest](android/app/src/test/java/com/bios/app/GlucoseVariabilityTest.kt) — sparse window null, flat-trace CV=0 / MAGE=null, oscillating CV=20, TIR endpoints inclusive (70 and 140 count), peak picks the max, MAGE saw-tooth=80, unsorted input matches sorted, confidence/sourceId inheritance.
- [x] [ConditionPatternsTest](android/app/src/test/java/com/bios/app/ConditionPatternsTest.kt) — updated to reach `CircadianConditionPattern.circadianDisruption` after the extraction.
- [ ] Manual: with a real Dexcom token and 24h of readings, verify the four derived rows appear in MetricReading and the Data Coverage screen marks them LIVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)