### PR TITLE
feat(adapter): ingest Oura workouts as EXERCISE_SESSION (#38)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -204,6 +204,13 @@ class IngestManager(
                     val sessions = healthConnect.fetchExerciseSessions(start, end, id)
                     persistSessions(sessions)
                 }
+                ouraSourceId?.let { id ->
+                    val adapter = ouraAdapter ?: return@let
+                    val sessions = runCatching {
+                        adapter.fetchExerciseSessions(start, end, id)
+                    }.getOrDefault(emptyList())
+                    persistSessions(sessions)
+                }
             }
 
             if (latencyTracker != null) {
@@ -258,6 +265,13 @@ class IngestManager(
 
                 healthConnectSourceId?.let { id ->
                     val sessions = healthConnect.fetchExerciseSessions(current, chunkEnd, id)
+                    persistSessions(sessions)
+                }
+                ouraSourceId?.let { id ->
+                    val adapter = ouraAdapter ?: return@let
+                    val sessions = runCatching {
+                        adapter.fetchExerciseSessions(current, chunkEnd, id)
+                    }.getOrDefault(emptyList())
                     persistSessions(sessions)
                 }
 

--- a/android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt
@@ -1,6 +1,10 @@
 package com.bios.app.ingest
 
 import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseModality
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ExerciseSessionFields
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import com.bios.app.model.SleepStage
@@ -13,6 +17,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -233,6 +238,86 @@ class OuraApiAdapter(
         }
     }
 
+    // MARK: - Exercise sessions
+
+    /**
+     * Reads Oura v2 `/workout` records in the window and returns each one as
+     * a composite [ExerciseSession] — a parent EXERCISE_SESSION MetricReading
+     * plus its EventPayloadField rows. Returned separately from
+     * [fetchReadings] for the same reason the Health Connect adapter does:
+     * the result type is structurally different (parent + payload) and the
+     * dedupe/quality pipeline doesn't yet know how to keep payload rows in
+     * sync with a deduped parent.
+     *
+     * Oura's `/workout` endpoint exposes an `activity` string (e.g.
+     * "running", "weight_training"), `start_datetime` / `end_datetime`, and
+     * an `average_heart_rate`. RPE isn't on the response, so the payload
+     * omits it. Missing fields fall through gracefully — sessions still
+     * land with whatever the source provided.
+     */
+    suspend fun fetchExerciseSessions(
+        startTime: Instant, endTime: Instant, sourceId: String
+    ): List<ExerciseSession> {
+        val token = getToken() ?: return emptyList()
+        val json = apiGet(token, "workout", formatDate(startTime), formatDate(endTime))
+            ?: return emptyList()
+        val data = json.optJSONArray("data") ?: return emptyList()
+
+        val sessions = mutableListOf<ExerciseSession>()
+        for (i in 0 until data.length()) {
+            val item = data.getJSONObject(i)
+            val startIso = item.optString("start_datetime").takeIf { it.isNotEmpty() } ?: continue
+            val endIso = item.optString("end_datetime").takeIf { it.isNotEmpty() } ?: continue
+            val startMs = parseTimestamp(startIso)
+            val endMs = parseTimestamp(endIso)
+            val durationSec = ((endMs - startMs) / 1000L).toInt()
+            if (durationSec <= 0) continue
+
+            val reading = MetricReading(
+                id = UUID.randomUUID().toString(),
+                metricType = MetricType.EXERCISE_SESSION.key,
+                value = 1.0,
+                timestamp = startMs,
+                durationSec = durationSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+
+            val payload = mutableListOf(
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.MODALITY,
+                    stringValue = mapOuraActivityToModality(item.optString("activity")),
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.START_UTC,
+                    longValue = startMs,
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.END_UTC,
+                    longValue = endMs,
+                ),
+            )
+
+            // Oura returns average_heart_rate as null for activities without
+            // wrist HR coverage (manual entries, very short walks). Treat the
+            // absence as "no avg HR" rather than writing a misleading zero.
+            val avgHr = item.optDouble("average_heart_rate", Double.NaN)
+            if (!avgHr.isNaN() && avgHr > 0.0) {
+                payload += EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.AVG_HR_BPM,
+                    doubleValue = avgHr,
+                )
+            }
+
+            sessions += ExerciseSession(reading = reading, payload = payload)
+        }
+        return sessions
+    }
+
     // MARK: - Sleep stage parsing
 
     /**
@@ -328,5 +413,35 @@ class OuraApiAdapter(
 
     companion object {
         internal const val BASE_URL = "https://api.ouraring.com/v2/usercollection"
+
+        /**
+         * Maps an Oura v2 `/workout.activity` string to Bios's coarse
+         * [ExerciseModality] bucket. Oura's catalog isn't an enum on the
+         * wire — it's free-form snake_case strings — so we normalize
+         * lowercased, underscore-stripped tokens. Unknown / empty strings
+         * fall to OTHER, matching the Health Connect adapter's policy.
+         */
+        internal fun mapOuraActivityToModality(activity: String?): String {
+            if (activity.isNullOrBlank()) return ExerciseModality.OTHER
+            return when (activity.lowercase().replace('-', '_')) {
+                "running", "treadmill_running", "walking", "hiking",
+                "cycling", "biking", "indoor_cycling", "stationary_bike",
+                "elliptical", "rowing", "indoor_rowing",
+                "swimming", "swimming_pool", "swimming_open_water",
+                "stair_climbing", "stairs", "stair_climbing_machine",
+                "cardio", "aerobics" -> ExerciseModality.CARDIO
+
+                "weight_training", "weightlifting", "strength_training",
+                "calisthenics", "resistance_training" -> ExerciseModality.STRENGTH
+
+                "hiit", "high_intensity_interval_training",
+                "crossfit", "interval_training", "tabata" -> ExerciseModality.INTERVAL
+
+                "yoga", "pilates", "stretching", "mobility",
+                "tai_chi", "qigong" -> ExerciseModality.MOBILITY
+
+                else -> ExerciseModality.OTHER
+            }
+        }
     }
 }

--- a/android/app/src/test/java/com/bios/app/OuraApiAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/OuraApiAdapterTest.kt
@@ -2,6 +2,7 @@ package com.bios.app
 
 import com.bios.app.ingest.OuraApiAdapter
 import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.ExerciseModality
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import com.bios.app.model.SleepStage
@@ -192,5 +193,63 @@ class OuraApiAdapterTest {
     fun `BASE_URL points to Oura v2 API`() {
         assertTrue(OuraApiAdapter.BASE_URL.contains("ouraring.com"))
         assertTrue(OuraApiAdapter.BASE_URL.contains("v2"))
+    }
+
+    // -- Workout / EXERCISE_SESSION modality mapping (#38) --
+
+    @Test
+    fun `mapOuraActivityToModality buckets cardio variants`() {
+        for (activity in listOf("running", "walking", "cycling", "rowing", "swimming",
+            "elliptical", "stair_climbing", "hiking", "treadmill_running")) {
+            assertEquals(
+                "activity '$activity' should map to CARDIO",
+                ExerciseModality.CARDIO,
+                OuraApiAdapter.mapOuraActivityToModality(activity)
+            )
+        }
+    }
+
+    @Test
+    fun `mapOuraActivityToModality buckets strength variants`() {
+        for (activity in listOf("weight_training", "weightlifting", "strength_training",
+            "calisthenics", "resistance_training")) {
+            assertEquals(
+                ExerciseModality.STRENGTH,
+                OuraApiAdapter.mapOuraActivityToModality(activity)
+            )
+        }
+    }
+
+    @Test
+    fun `mapOuraActivityToModality buckets HIIT and crossfit as INTERVAL`() {
+        assertEquals(ExerciseModality.INTERVAL, OuraApiAdapter.mapOuraActivityToModality("hiit"))
+        assertEquals(ExerciseModality.INTERVAL, OuraApiAdapter.mapOuraActivityToModality("crossfit"))
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            OuraApiAdapter.mapOuraActivityToModality("high_intensity_interval_training")
+        )
+    }
+
+    @Test
+    fun `mapOuraActivityToModality buckets yoga and pilates as MOBILITY`() {
+        for (activity in listOf("yoga", "pilates", "stretching", "tai_chi")) {
+            assertEquals(
+                ExerciseModality.MOBILITY,
+                OuraApiAdapter.mapOuraActivityToModality(activity)
+            )
+        }
+    }
+
+    @Test
+    fun `mapOuraActivityToModality falls back to OTHER for unknown or blank`() {
+        assertEquals(ExerciseModality.OTHER, OuraApiAdapter.mapOuraActivityToModality(""))
+        assertEquals(ExerciseModality.OTHER, OuraApiAdapter.mapOuraActivityToModality(null))
+        assertEquals(ExerciseModality.OTHER, OuraApiAdapter.mapOuraActivityToModality("alien_basketball"))
+    }
+
+    @Test
+    fun `mapOuraActivityToModality is case insensitive`() {
+        assertEquals(ExerciseModality.CARDIO, OuraApiAdapter.mapOuraActivityToModality("Running"))
+        assertEquals(ExerciseModality.STRENGTH, OuraApiAdapter.mapOuraActivityToModality("WEIGHT_TRAINING"))
     }
 }


### PR DESCRIPTION
## Summary
Second adapter for #38 — first was Health Connect's `ExerciseSessionRecord`, this picks up **Oura v2 `/workout`**. Each workout lands as a composite `EXERCISE_SESSION` (parent reading + `event_payloads` rows) with the same `ExerciseSessionFields` vocabulary the HC adapter emits, so consumers (pattern engine, exports, future overtraining/deconditioning rewrites) see one schema regardless of source.

- [OuraApiAdapter.fetchExerciseSessions](android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt) — hits `/workout` via the existing `apiGet` helper, parses ISO start/end, emits parent + payload (modality, start_utc, end_utc, optional avg_hr_bpm). RPE isn't on Oura's response so the payload omits it, mirroring HC's policy.
- [mapOuraActivityToModality](android/app/src/main/java/com/bios/app/ingest/OuraApiAdapter.kt) — normalizes Oura's free-form snake_case activity strings to `ExerciseModality` (CARDIO / STRENGTH / INTERVAL / MOBILITY / OTHER). Case-insensitive; unknown strings fall to OTHER.
- [IngestManager](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt) — `syncRecentData` and `syncHistoricalData` now call the new fetcher alongside the HC equivalent. Wrapped in `runCatching` so a transient `/workout` 5xx doesn't kill the rest of the sync (HC sessions aren't wrapped because HC failures throw inside the same adapter that handles fetchReadings, and the engine path treats a thrown error as "skip this source for now" already).

## Out of scope (matches #38)
Remaining adapters: **Garmin**, **WHOOP**, **Gadgetbridge**. Each is a separate PR — Oura is the highest-coverage one of the three remaining and keeps the diff small.

## Test plan
- [x] `./scripts/code-quality-check.sh` — lint, both flavor builds, unit tests.
- [x] 6 new unit tests in [OuraApiAdapterTest](android/app/src/test/java/com/bios/app/OuraApiAdapterTest.kt) — modality mapping across all five buckets, case insensitivity, null/blank/unknown fallbacks.
- [ ] Manual: with a real Oura token and recent workouts, verify `EXERCISE_SESSION` rows + `event_payloads` rows appear in the DB and survive the dedupe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)