### PR TITLE
feat(adapter): activate WHOOP end-to-end + workout sessions (#38)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
@@ -68,6 +68,7 @@ data class AdapterReadiness(
     val healthConnectGranted: Boolean,
     val ouraConfigured: Boolean,
     val withingsConfigured: Boolean,
+    val whoopConfigured: Boolean,
     val polarConfigured: Boolean,
     val dexcomConfigured: Boolean,
     val directSensorAvailable: Boolean,

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
@@ -125,10 +125,14 @@ object MetricCoverageEngine {
                 listOf("Dexcom" to readiness.dexcomConfigured)
 
             MetricType.RECOVERY_SCORE ->
-                listOf("Oura" to readiness.ouraConfigured)
+                listOf(
+                    "Oura" to readiness.ouraConfigured,
+                    "WHOOP" to readiness.whoopConfigured,
+                )
 
             else -> listOf(
                 "Oura" to readiness.ouraConfigured,
+                "WHOOP" to readiness.whoopConfigured,
                 "Polar" to readiness.polarConfigured,
             )
         }

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -42,6 +42,7 @@ class IngestManager(
     private val gadgetbridgeAdapter: GadgetbridgeAdapter? = null,
     private val directSensorAdapter: DirectSensorAdapter? = null,
     private val withingsAdapter: WithingsApiAdapter? = null,
+    private val whoopAdapter: WhoopApiAdapter? = null,
     private val bleAirQualityAdapter: BleAirQualityAdapter? = null,
     private val latencyTracker: DetectionLatencyTracker? = null
 ) {
@@ -74,6 +75,7 @@ class IngestManager(
     private var gadgetbridgeSourceId: String? = null
     private var directSensorSourceId: String? = null
     private var withingsSourceId: String? = null
+    private var whoopSourceId: String? = null
     private var bleAirQualitySourceId: String? = null
 
     // MARK: - Setup
@@ -111,6 +113,13 @@ class IngestManager(
         if (withingsAdapter?.isConnected == true) {
             withingsSourceId = getOrCreateSource(
                 SourceType.WITHINGS_API, "Withings", SensorType.DERIVED
+            )
+        }
+
+        // WHOOP API (strap — recovery, sleep, workouts)
+        if (whoopAdapter?.isConnected == true) {
+            whoopSourceId = getOrCreateSource(
+                SourceType.WHOOP_API, "WHOOP", SensorType.OPTICAL_HR
             )
         }
 
@@ -155,7 +164,8 @@ class IngestManager(
         val hasWearableHistorySource = healthConnectSourceId != null ||
             gadgetbridgeSourceId != null ||
             ouraSourceId != null ||
-            withingsSourceId != null
+            withingsSourceId != null ||
+            whoopSourceId != null
         if (!hasWearableHistorySource) return false
         for (metric in PRIMARY_METRICS_FOR_BACKFILL) {
             if (readingDao.count(metric.key) == 0) return true
@@ -184,6 +194,7 @@ class IngestManager(
                         async { fetchDirectSensorReadings() },
                         async { fetchOuraReadings(start, end) },
                         async { fetchWithingsReadings(start, end) },
+                        async { fetchWhoopReadings(start, end) },
                         async { fetchPhoneSensorReadings() }
                     )
                     jobs.awaitAll().flatten()
@@ -201,16 +212,10 @@ class IngestManager(
                 // land directly. Multi-adapter dedupe lands when a second
                 // session-emitting adapter exists.
                 healthConnectSourceId?.let { id ->
-                    val sessions = healthConnect.fetchExerciseSessions(start, end, id)
-                    persistSessions(sessions)
+                    persistSessions(healthConnect.fetchExerciseSessions(start, end, id))
                 }
-                ouraSourceId?.let { id ->
-                    val adapter = ouraAdapter ?: return@let
-                    val sessions = runCatching {
-                        adapter.fetchExerciseSessions(start, end, id)
-                    }.getOrDefault(emptyList())
-                    persistSessions(sessions)
-                }
+                persistApiSessions(ouraSourceId, ouraAdapter, start, end) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
+                persistApiSessions(whoopSourceId, whoopAdapter, start, end) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
             }
 
             if (latencyTracker != null) {
@@ -252,7 +257,8 @@ class IngestManager(
                         },
                         async { fetchGadgetbridgeReadings(current, chunkEnd) },
                         async { fetchOuraReadings(current, chunkEnd) },
-                        async { fetchWithingsReadings(current, chunkEnd) }
+                        async { fetchWithingsReadings(current, chunkEnd) },
+                        async { fetchWhoopReadings(current, chunkEnd) }
                     )
                     jobs.awaitAll().flatten()
                 }
@@ -264,16 +270,10 @@ class IngestManager(
                 updateLastReadings(quality)
 
                 healthConnectSourceId?.let { id ->
-                    val sessions = healthConnect.fetchExerciseSessions(current, chunkEnd, id)
-                    persistSessions(sessions)
+                    persistSessions(healthConnect.fetchExerciseSessions(current, chunkEnd, id))
                 }
-                ouraSourceId?.let { id ->
-                    val adapter = ouraAdapter ?: return@let
-                    val sessions = runCatching {
-                        adapter.fetchExerciseSessions(current, chunkEnd, id)
-                    }.getOrDefault(emptyList())
-                    persistSessions(sessions)
-                }
+                persistApiSessions(ouraSourceId, ouraAdapter, current, chunkEnd) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
+                persistApiSessions(whoopSourceId, whoopAdapter, current, chunkEnd) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
 
                 current = chunkEnd
                 completedDays++
@@ -335,6 +335,20 @@ class IngestManager(
      * source list is empty (the common case when no HC sessions exist
      * in the window).
      */
+    /** Common path for API adapters that expose `fetchExerciseSessions`.
+     *  Skips when the source row hasn't been created or the adapter is null,
+     *  and swallows fetch failures so a transient 5xx doesn't kill the sync. */
+    private suspend fun <T> persistApiSessions(
+        sourceId: String?,
+        adapter: T?,
+        start: Instant,
+        end: Instant,
+        fetch: suspend (T, Instant, Instant, String) -> List<ExerciseSession>,
+    ) {
+        if (sourceId == null || adapter == null) return
+        persistSessions(runCatching { fetch(adapter, start, end, sourceId) }.getOrDefault(emptyList()))
+    }
+
     private suspend fun persistSessions(sessions: List<ExerciseSession>) {
         if (sessions.isEmpty()) return
         readingDao.insertAll(sessions.map { it.reading })
@@ -401,6 +415,16 @@ class IngestManager(
     private suspend fun fetchWithingsReadings(start: Instant, end: Instant): List<MetricReading> {
         val sourceId = withingsSourceId ?: return emptyList()
         val adapter = withingsAdapter ?: return emptyList()
+        return try {
+            adapter.fetchReadings(start, end, sourceId)
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    private suspend fun fetchWhoopReadings(start: Instant, end: Instant): List<MetricReading> {
+        val sourceId = whoopSourceId ?: return emptyList()
+        val adapter = whoopAdapter ?: return emptyList()
         return try {
             adapter.fetchReadings(start, end, sourceId)
         } catch (_: Exception) {

--- a/android/app/src/main/java/com/bios/app/ingest/WhoopApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/WhoopApiAdapter.kt
@@ -1,6 +1,10 @@
 package com.bios.app.ingest
 
 import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseModality
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ExerciseSessionFields
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import com.bios.app.model.SleepStage
@@ -12,6 +16,7 @@ import org.json.JSONObject
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -194,6 +199,88 @@ class WhoopApiAdapter(
         return readings
     }
 
+    /**
+     * Reads WHOOP `/activity/workout` records in the window and returns each
+     * as a composite [ExerciseSession] — parent EXERCISE_SESSION reading +
+     * `event_payloads` rows. Mirrors the HC / Oura emission shape so the
+     * pattern engine sees one schema regardless of source.
+     *
+     * WHOOP's workout record carries:
+     *  - `start` / `end` ISO timestamps
+     *  - `sport_id` (numeric) and, on newer responses, `sport_name` (string)
+     *  - `score.average_heart_rate`
+     *
+     * Modality buckets fall back through three layers: prefer the
+     * `sport_name` string (matched the same way as Oura activity strings),
+     * else a small numeric `sport_id` map for the well-documented IDs, else
+     * `OTHER`. RPE isn't in the workout payload, so the field is omitted.
+     */
+    suspend fun fetchExerciseSessions(
+        startTime: Instant, endTime: Instant, sourceId: String
+    ): List<ExerciseSession> {
+        val token = getToken() ?: return emptyList()
+        val json = apiGet(token, "activity/workout", startTime, endTime) ?: return emptyList()
+        val records = json.optJSONArray("records") ?: return emptyList()
+
+        val sessions = mutableListOf<ExerciseSession>()
+        for (i in 0 until records.length()) {
+            val record = records.getJSONObject(i)
+            val startIso = record.optString("start").takeIf { it.isNotEmpty() } ?: continue
+            val endIso = record.optString("end").takeIf { it.isNotEmpty() } ?: continue
+            val startMs = parseTimestamp(startIso)
+            val endMs = parseTimestamp(endIso)
+            val durationSec = ((endMs - startMs) / 1000L).toInt()
+            if (durationSec <= 0) continue
+
+            val reading = MetricReading(
+                id = UUID.randomUUID().toString(),
+                metricType = MetricType.EXERCISE_SESSION.key,
+                value = 1.0,
+                timestamp = startMs,
+                durationSec = durationSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+
+            val modality = mapWhoopSportToModality(
+                sportName = record.optString("sport_name").takeIf { it.isNotEmpty() },
+                sportId = if (record.has("sport_id") && !record.isNull("sport_id"))
+                    record.optInt("sport_id") else null,
+            )
+
+            val payload = mutableListOf(
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.MODALITY,
+                    stringValue = modality,
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.START_UTC,
+                    longValue = startMs,
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.END_UTC,
+                    longValue = endMs,
+                ),
+            )
+
+            val avgHr = record.optJSONObject("score")
+                ?.optDouble("average_heart_rate", Double.NaN) ?: Double.NaN
+            if (!avgHr.isNaN() && avgHr > 0.0) {
+                payload += EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.AVG_HR_BPM,
+                    doubleValue = avgHr,
+                )
+            }
+
+            sessions += ExerciseSession(reading = reading, payload = payload)
+        }
+        return sessions
+    }
+
     private fun sleepStageReading(
         stage: SleepStage, durationSec: Int, timestamp: Long, sourceId: String
     ) = MetricReading(
@@ -228,5 +315,50 @@ class WhoopApiAdapter(
     companion object {
         internal const val BASE_URL = "https://api.prod.whoop.com/developer/v1"
         const val PROVIDER_KEY = "whoop"
+
+        /**
+         * Maps a WHOOP workout to a Bios [ExerciseModality] bucket. Prefers
+         * the `sport_name` string (matched case-insensitively against the
+         * same normalized vocabulary the Oura adapter uses), falling back
+         * to a minimal `sport_id` map for the well-documented IDs in
+         * WHOOP's public catalog. Anything unknown — including null both
+         * sides — lands on [ExerciseModality.OTHER].
+         */
+        internal fun mapWhoopSportToModality(sportName: String?, sportId: Int?): String {
+            if (!sportName.isNullOrBlank()) {
+                val normalized = sportName.lowercase().replace('-', '_').replace(' ', '_')
+                val mapped = when (normalized) {
+                    "running", "trail_running", "walking", "hiking",
+                    "cycling", "indoor_cycling", "biking", "stationary_bike",
+                    "elliptical", "rowing", "indoor_rowing",
+                    "swimming", "open_water_swimming",
+                    "stair_climber", "stair_climbing", "stairs" -> ExerciseModality.CARDIO
+
+                    "weightlifting", "weight_lifting", "powerlifting",
+                    "strength_training", "calisthenics" -> ExerciseModality.STRENGTH
+
+                    "hiit", "crossfit", "interval_training", "tabata" -> ExerciseModality.INTERVAL
+
+                    "yoga", "pilates", "stretching", "mobility" -> ExerciseModality.MOBILITY
+
+                    else -> null
+                }
+                if (mapped != null) return mapped
+            }
+            // Numeric fallback for known WHOOP sport_ids. Conservative set —
+            // only the IDs whose modality is clearly documented in WHOOP's
+            // public catalog. Anything else falls to OTHER.
+            return when (sportId) {
+                0 -> ExerciseModality.CARDIO        // Running
+                1 -> ExerciseModality.CARDIO        // Cycling
+                18 -> ExerciseModality.CARDIO       // Rowing
+                30 -> ExerciseModality.CARDIO       // Swimming
+                35 -> ExerciseModality.STRENGTH     // Weightlifting
+                36 -> ExerciseModality.MOBILITY     // Yoga
+                39 -> ExerciseModality.INTERVAL     // HIIT
+                63 -> ExerciseModality.STRENGTH     // CrossFit-style mixed
+                else -> ExerciseModality.OTHER
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -21,6 +21,7 @@ import com.bios.app.ingest.IngestManager
 import com.bios.app.ingest.OuraApiAdapter
 import com.bios.app.ingest.OuraTokenStore
 import com.bios.app.ingest.PhoneSensorAdapter
+import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
@@ -51,6 +52,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val ouraAdapter = OuraApiAdapter(ouraTokenStore)
     val apiTokenStore = ApiTokenStore(application)
     val withingsAdapter = WithingsApiAdapter(apiTokenStore)
+    val whoopAdapter = WhoopApiAdapter(apiTokenStore)
     val phoneSensorAdapter = PhoneSensorAdapter(application)
     val gadgetbridgeAdapter = GadgetbridgeAdapter(application)
     val directSensorAdapter = DirectSensorAdapter(application)
@@ -58,7 +60,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val latencyTracker = DetectionLatencyTracker()
     val ingestManager = IngestManager(
         healthConnect, db, ouraAdapter, phoneSensorAdapter,
-        gadgetbridgeAdapter, directSensorAdapter, withingsAdapter, bleAirQualityAdapter, latencyTracker
+        gadgetbridgeAdapter, directSensorAdapter, withingsAdapter, whoopAdapter,
+        bleAirQualityAdapter, latencyTracker
     )
     private val reproductiveReadingDao = ReproductiveDatabase.readingDaoOrNull(application)
     val baselineEngine = BaselineEngine(db, latencyTracker, reproductiveReadingDao)

--- a/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
@@ -7,6 +7,7 @@ import com.bios.app.engine.MetricCoverage
 import com.bios.app.engine.MetricCoverageEngine
 import com.bios.app.ingest.DexcomApiAdapter
 import com.bios.app.ingest.PolarApiAdapter
+import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.ui.AppViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -41,6 +42,7 @@ class DataCoverageViewModel(
                 healthConnectGranted = app.hasPermissions.value,
                 ouraConfigured = app.ouraTokenStore.hasToken(),
                 withingsConfigured = app.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY),
+                whoopConfigured = app.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY),
                 polarConfigured = app.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY),
                 dexcomConfigured = app.apiTokenStore.hasToken(DexcomApiAdapter.PROVIDER_KEY),
                 directSensorAvailable = app.directSensorAdapter.hasAnySensor,

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsNotificationsCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsNotificationsCard.kt
@@ -1,0 +1,100 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.bios.app.alerts.DailyDigestWorker
+import com.bios.app.push.PushRegistrationManager
+
+/**
+ * Settings → Notifications card. Three toggles: daily digest, disconnect
+ * alerts, and UnifiedPush registration. Extracted from [SettingsScreen]
+ * so the host file stays under the 500-line cap as more data-source rows
+ * (WHOOP, future Garmin) land in the data-sources block above.
+ */
+@Composable
+internal fun SettingsNotificationsCard() {
+    val context = LocalContext.current
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Notifications", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            var digestEnabled by remember { mutableStateOf(DailyDigestWorker.isEnabled(context)) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Daily Digest", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Morning summary of your vitals at 8 AM",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = digestEnabled,
+                    onCheckedChange = {
+                        digestEnabled = it
+                        DailyDigestWorker.setEnabled(context, it)
+                    }
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            DisconnectAlertToggle()
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            var pushEnabled by remember { mutableStateOf(PushRegistrationManager.isEnabled(context)) }
+            var pushDistributor by remember { mutableStateOf(PushRegistrationManager.getDistributorName(context)) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Push Notifications", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        if (pushEnabled && pushDistributor != null)
+                            "Via $pushDistributor — no Google required"
+                        else
+                            "Receive population health signals without polling. Requires a UnifiedPush distributor (e.g. ntfy).",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked = pushEnabled,
+                    onCheckedChange = { enabled ->
+                        pushEnabled = enabled
+                        if (enabled) {
+                            PushRegistrationManager.setEnabled(context, true)
+                            PushRegistrationManager.register(context)
+                        } else {
+                            PushRegistrationManager.unregister(context)
+                        }
+                        pushDistributor = PushRegistrationManager.getDistributorName(context)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.core.content.FileProvider
 import com.bios.app.engine.BaselineEngine
 import com.bios.app.export.DataExporter
 import com.bios.app.export.FhirExporter
+import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.model.CompanionGrant
 import com.bios.app.model.PrivacyTier
@@ -51,6 +52,10 @@ fun SettingsScreen(
     var showWithingsDialog by remember { mutableStateOf(false) }
     var isWithingsConnected by remember {
         mutableStateOf(viewModel.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY))
+    }
+    var showWhoopDialog by remember { mutableStateOf(false) }
+    var isWhoopConnected by remember {
+        mutableStateOf(viewModel.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY))
     }
     val companionGrants by viewModel.db.companionGrantDao()
         .observeAll()
@@ -110,6 +115,17 @@ fun SettingsScreen(
                             WithingsApiAdapter.PROVIDER_KEY
                         )
                         isWithingsConnected = false
+                    },
+                )
+
+                Spacer(Modifier.height(4.dp))
+                ConnectableSourceRow(
+                    name = "WHOOP",
+                    isConnected = isWhoopConnected,
+                    onConnect = { showWhoopDialog = true },
+                    onDisconnect = {
+                        viewModel.apiTokenStore.clearToken(WhoopApiAdapter.PROVIDER_KEY)
+                        isWhoopConnected = false
                     },
                 )
 
@@ -260,77 +276,7 @@ fun SettingsScreen(
             }
         }
 
-        // Notifications
-        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text("Notifications", style = MaterialTheme.typography.titleSmall)
-                Spacer(Modifier.height(8.dp))
-
-                var digestEnabled by remember {
-                    mutableStateOf(DailyDigestWorker.isEnabled(context))
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text("Daily Digest", style = MaterialTheme.typography.bodyMedium)
-                        Text(
-                            "Morning summary of your vitals at 8 AM",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Switch(
-                        checked = digestEnabled,
-                        onCheckedChange = {
-                            digestEnabled = it
-                            DailyDigestWorker.setEnabled(context, it)
-                        }
-                    )
-                }
-
-                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                DisconnectAlertToggle()
-                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-
-                var pushEnabled by remember {
-                    mutableStateOf(PushRegistrationManager.isEnabled(context))
-                }
-                var pushDistributor by remember {
-                    mutableStateOf(PushRegistrationManager.getDistributorName(context))
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text("Push Notifications", style = MaterialTheme.typography.bodyMedium)
-                        Text(
-                            if (pushEnabled && pushDistributor != null)
-                                "Via $pushDistributor — no Google required"
-                            else
-                                "Receive population health signals without polling. Requires a UnifiedPush distributor (e.g. ntfy).",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                    Switch(
-                        checked = pushEnabled,
-                        onCheckedChange = { enabled ->
-                            pushEnabled = enabled
-                            if (enabled) {
-                                PushRegistrationManager.setEnabled(context, true)
-                                PushRegistrationManager.register(context)
-                            } else {
-                                PushRegistrationManager.unregister(context)
-                            }
-                            pushDistributor = PushRegistrationManager.getDistributorName(context)
-                        }
-                    )
-                }
-            }
-        }
+        SettingsNotificationsCard()
 
         // Privacy Tier
         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
@@ -461,6 +407,17 @@ fun SettingsScreen(
                 showWithingsDialog = false
             },
             onDismiss = { showWithingsDialog = false }
+        )
+    }
+
+    if (showWhoopDialog) {
+        WhoopConnectDialog(
+            onConnect = { token ->
+                viewModel.apiTokenStore.saveToken(WhoopApiAdapter.PROVIDER_KEY, token)
+                isWhoopConnected = true
+                showWhoopDialog = false
+            },
+            onDismiss = { showWhoopDialog = false }
         )
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/settings/WhoopConnectDialog.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/WhoopConnectDialog.kt
@@ -1,0 +1,69 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * WHOOP connection dialog — paste an OAuth-issued access token.
+ *
+ * WHOOP's developer API requires OAuth 2.0; this dialog accepts a bearer
+ * token the owner has obtained out-of-band against developer.whoop.com,
+ * mirroring the Oura / Withings paste-the-token pattern. Refresh handling
+ * is out of scope for the first cut — owners replace the value when it
+ * expires; a registered Bios WHOOP app with refresh-aware token storage
+ * is a future PR.
+ */
+@Composable
+fun WhoopConnectDialog(
+    onConnect: (token: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var tokenInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Connect WHOOP") },
+        text = {
+            Column {
+                Text(
+                    "Paste a WHOOP API access token. Obtain one through a WHOOP " +
+                        "developer-account OAuth exchange against developer.whoop.com — " +
+                        "Bios does not perform the OAuth dance itself yet.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("Access Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val trimmed = tokenInput.trim()
+                    if (trimmed.isNotBlank()) onConnect(trimmed)
+                }
+            ) { Text("Connect") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
@@ -19,6 +19,7 @@ class MetricCoverageEngineTest {
         healthConnectGranted = false,
         ouraConfigured = false,
         withingsConfigured = false,
+        whoopConfigured = false,
         polarConfigured = false,
         dexcomConfigured = false,
         directSensorAvailable = false,

--- a/android/app/src/test/java/com/bios/app/WhoopApiAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/WhoopApiAdapterTest.kt
@@ -1,0 +1,128 @@
+package com.bios.app
+
+import com.bios.app.ingest.WhoopApiAdapter
+import com.bios.app.model.ExerciseModality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-Kotlin tests for the WHOOP adapter's static surface — sport name +
+ * sport_id mapping to [ExerciseModality]. Network calls aren't tested here;
+ * the JSON parsing path is covered by the IngestManager integration once a
+ * real WHOOP token is in play.
+ */
+class WhoopApiAdapterTest {
+
+    @Test
+    fun `mapWhoopSportToModality prefers sport_name over sport_id`() {
+        // Even with a numeric id that would map to STRENGTH, a "running"
+        // sport_name string should still resolve to CARDIO.
+        assertEquals(
+            ExerciseModality.CARDIO,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = "running", sportId = 35)
+        )
+    }
+
+    @Test
+    fun `mapWhoopSportToModality buckets common cardio sport_names`() {
+        for (name in listOf("running", "walking", "cycling", "swimming",
+            "rowing", "elliptical", "hiking", "stair_climber")) {
+            assertEquals(
+                "sport_name '$name' should map to CARDIO",
+                ExerciseModality.CARDIO,
+                WhoopApiAdapter.mapWhoopSportToModality(sportName = name, sportId = null)
+            )
+        }
+    }
+
+    @Test
+    fun `mapWhoopSportToModality buckets strength sport_names`() {
+        for (name in listOf("weightlifting", "weight_lifting", "powerlifting",
+            "strength_training", "calisthenics")) {
+            assertEquals(
+                ExerciseModality.STRENGTH,
+                WhoopApiAdapter.mapWhoopSportToModality(sportName = name, sportId = null)
+            )
+        }
+    }
+
+    @Test
+    fun `mapWhoopSportToModality buckets HIIT and CrossFit as INTERVAL`() {
+        for (name in listOf("hiit", "crossfit", "tabata", "interval_training")) {
+            assertEquals(
+                ExerciseModality.INTERVAL,
+                WhoopApiAdapter.mapWhoopSportToModality(sportName = name, sportId = null)
+            )
+        }
+    }
+
+    @Test
+    fun `mapWhoopSportToModality buckets yoga and pilates as MOBILITY`() {
+        for (name in listOf("yoga", "pilates", "stretching", "mobility")) {
+            assertEquals(
+                ExerciseModality.MOBILITY,
+                WhoopApiAdapter.mapWhoopSportToModality(sportName = name, sportId = null)
+            )
+        }
+    }
+
+    @Test
+    fun `mapWhoopSportToModality normalizes case and separators`() {
+        assertEquals(
+            ExerciseModality.CARDIO,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = "TRAIL-RUNNING", sportId = null)
+        )
+        assertEquals(
+            ExerciseModality.STRENGTH,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = "Weight Lifting", sportId = null)
+        )
+    }
+
+    @Test
+    fun `mapWhoopSportToModality falls back to sport_id when name is null`() {
+        assertEquals(
+            ExerciseModality.CARDIO,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = null, sportId = 0)
+        )
+        assertEquals(
+            ExerciseModality.STRENGTH,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = null, sportId = 35)
+        )
+        assertEquals(
+            ExerciseModality.MOBILITY,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = null, sportId = 36)
+        )
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = null, sportId = 39)
+        )
+    }
+
+    @Test
+    fun `mapWhoopSportToModality falls back to OTHER for blank name and unknown id`() {
+        assertEquals(
+            ExerciseModality.OTHER,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = "", sportId = null)
+        )
+        assertEquals(
+            ExerciseModality.OTHER,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = null, sportId = null)
+        )
+        assertEquals(
+            ExerciseModality.OTHER,
+            WhoopApiAdapter.mapWhoopSportToModality(sportName = "alien_basketball", sportId = 999)
+        )
+    }
+
+    @Test
+    fun `BASE_URL points to the WHOOP developer v1 API`() {
+        assertEquals("https://api.prod.whoop.com/developer/v1", WhoopApiAdapter.BASE_URL)
+    }
+
+    @Test
+    fun `PROVIDER_KEY is whoop`() {
+        // ApiTokenStore keys this string into EncryptedSharedPreferences;
+        // renaming would orphan existing tokens after upgrade.
+        assertEquals("whoop", WhoopApiAdapter.PROVIDER_KEY)
+    }
+}


### PR DESCRIPTION
## Summary
`WhoopApiAdapter` existed in tree but was dormant — no `IngestManager` hookup, no Settings UI, no Data Coverage CTA. This activates it fully (mirroring the Withings/Oura pattern from earlier PRs) and closes the WHOOP slice of #38 by emitting `EXERCISE_SESSION` composites from `/activity/workout`.

## End-to-end activation
- **Token + DataSource**: WHOOP token via `ApiTokenStore` (`PROVIDER_KEY = "whoop"`); `SourceType.WHOOP_API` row created on `IngestManager.setup()` when `isConnected`.
- **Sync**: [IngestManager](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt) — `fetchWhoopReadings` joins the parallel `awaitAll` block in both `syncRecentData` and `syncHistoricalData`; backfill gate includes `whoopSourceId`.
- **Coverage + UI**: [DataCoverageViewModel](android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt) snapshots `whoopConfigured`; [MetricCoverageEngine](android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt) surfaces WHOOP as a candidate API_ADAPTER for `RECOVERY_SCORE` and the generic-wearable fallback; [WhoopConnectDialog](android/app/src/main/java/com/bios/app/ui/settings/WhoopConnectDialog.kt) lets the owner paste a developer-issued OAuth token (same UX as Oura/Withings — full OAuth dance is a future PR).

## Exercise sessions
- [WhoopApiAdapter.fetchExerciseSessions](android/app/src/main/java/com/bios/app/ingest/WhoopApiAdapter.kt) — parses `/activity/workout` into composite `EXERCISE_SESSION` readings + `event_payloads` (modality, start_utc, end_utc, optional avg_hr_bpm). RPE omitted; not on WHOOP's payload.
- [mapWhoopSportToModality](android/app/src/main/java/com/bios/app/ingest/WhoopApiAdapter.kt) — prefers `sport_name` string (case-insensitive, separator-normalized), falls back to a small numeric `sport_id` map for the well-documented IDs (0/1/18/30 CARDIO, 35 STRENGTH, 36 MOBILITY, 39 INTERVAL, etc.), else `OTHER`. Conservative — any unknown sport lands on OTHER rather than guessing.
- [IngestManager.persistApiSessions](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt) — generic helper that deduplicates the Oura/WHOOP session-fetch glue at both call sites (`syncRecentData` + `syncHistoricalData`).

## Housekeeping
- [SettingsNotificationsCard](android/app/src/main/java/com/bios/app/ui/settings/SettingsNotificationsCard.kt) extracted from `SettingsScreen` so the host stays under the 500-line cap with the new WHOOP row + dialog. Behavior unchanged.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file lengths, lint, both flavor builds, unit tests.
- [x] [WhoopApiAdapterTest](android/app/src/test/java/com/bios/app/WhoopApiAdapterTest.kt) — 8 cases: name-over-id precedence, all five modality buckets, case + separator normalization, sport_id fallbacks, blank/null/unknown → OTHER, `BASE_URL` + `PROVIDER_KEY` stability.
- [x] [MetricCoverageEngineTest](android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt) — `whoopConfigured` added to the test fixture.
- [ ] Manual: paste a real WHOOP developer token, verify recovery/sleep/workout readings + `EXERCISE_SESSION` rows land, Settings shows "Connected", Data Coverage marks the WHOOP-routed metrics LIVE.

## Closes part of #38
HC, Oura, and now WHOOP wired. Garmin and Gadgetbridge remain — Garmin needs the same end-to-end activation pattern as WHOOP got here; Gadgetbridge's ContentProvider doesn't expose a reliable session surface across its 40+ devices, so its session slice is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)