### PR TITLE
feat(adapter): activate Garmin end-to-end + workout sessions (#38)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt
@@ -69,6 +69,7 @@ data class AdapterReadiness(
     val ouraConfigured: Boolean,
     val withingsConfigured: Boolean,
     val whoopConfigured: Boolean,
+    val garminConfigured: Boolean,
     val polarConfigured: Boolean,
     val dexcomConfigured: Boolean,
     val directSensorAvailable: Boolean,

--- a/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt
@@ -133,6 +133,7 @@ object MetricCoverageEngine {
             else -> listOf(
                 "Oura" to readiness.ouraConfigured,
                 "WHOOP" to readiness.whoopConfigured,
+                "Garmin" to readiness.garminConfigured,
                 "Polar" to readiness.polarConfigured,
             )
         }

--- a/android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt
@@ -1,6 +1,10 @@
 package com.bios.app.ingest
 
 import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseModality
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ExerciseSessionFields
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 import com.bios.app.model.SleepStage
@@ -11,6 +15,7 @@ import okhttp3.Request
 import org.json.JSONArray
 import org.json.JSONObject
 import java.time.Instant
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -186,6 +191,95 @@ class GarminApiAdapter(
         }
     }
 
+    /**
+     * Reads Garmin `/activities` records in the window and returns each as a
+     * composite [ExerciseSession] — parent EXERCISE_SESSION reading +
+     * `event_payloads` rows (modality, start_utc, end_utc, optional
+     * avg_hr_bpm). Mirrors the HC / Oura / WHOOP emission shape.
+     *
+     * Garmin Wellness API activity records carry `activityType` as a string
+     * (FIT SDK enum names like "RUNNING", "TREADMILL_RUNNING",
+     * "STRENGTH_TRAINING"), `startTimeInSeconds`, `durationInSeconds`, and
+     * `averageHeartRateInBeatsPerMinute`. RPE isn't in the payload, so the
+     * field is omitted.
+     */
+    suspend fun fetchExerciseSessions(
+        startTime: Instant, endTime: Instant, sourceId: String
+    ): List<ExerciseSession> {
+        val token = getToken() ?: return emptyList()
+        val records = apiGetArray(token, "activities", startTime, endTime) ?: return emptyList()
+
+        val sessions = mutableListOf<ExerciseSession>()
+        for (i in 0 until records.length()) {
+            val item = records.optJSONObject(i) ?: continue
+            val startSec = item.optLong("startTimeInSeconds", -1L)
+            val durationSec = item.optInt("durationInSeconds", 0)
+            if (startSec <= 0 || durationSec <= 0) continue
+            val startMs = startSec * 1000L
+            val endMs = startMs + durationSec * 1000L
+
+            val reading = MetricReading(
+                id = UUID.randomUUID().toString(),
+                metricType = MetricType.EXERCISE_SESSION.key,
+                value = 1.0,
+                timestamp = startMs,
+                durationSec = durationSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+
+            val payload = mutableListOf(
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.MODALITY,
+                    stringValue = mapGarminActivityToModality(item.optString("activityType")),
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.START_UTC,
+                    longValue = startMs,
+                ),
+                EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.END_UTC,
+                    longValue = endMs,
+                ),
+            )
+
+            val avgHr = item.optDouble("averageHeartRateInBeatsPerMinute", Double.NaN)
+            if (!avgHr.isNaN() && avgHr > 0.0) {
+                payload += EventPayloadField(
+                    readingId = reading.id,
+                    fieldKey = ExerciseSessionFields.AVG_HR_BPM,
+                    doubleValue = avgHr,
+                )
+            }
+
+            sessions += ExerciseSession(reading = reading, payload = payload)
+        }
+        return sessions
+    }
+
+    /**
+     * Variant of [apiGet] that decodes the response body as a `JSONArray`
+     * rather than an object — Garmin's `/activities` endpoint returns a
+     * top-level array of activity records (no wrapping envelope).
+     */
+    private suspend fun apiGetArray(
+        token: String, endpoint: String, start: Instant, end: Instant
+    ): JSONArray? = withContext(Dispatchers.IO) {
+        val url = "$BASE_URL/$endpoint?uploadStartTimeInSeconds=${start.epochSecond}&uploadEndTimeInSeconds=${end.epochSecond}"
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $token")
+            .build()
+
+        val response = client.newCall(request).execute()
+        if (!response.isSuccessful) return@withContext null
+        val body = response.body?.string() ?: return@withContext null
+        runCatching { JSONArray(body) }.getOrNull()
+    }
+
     private fun sleepStage(stage: SleepStage, durationSec: Int, timestamp: Long, sourceId: String) =
         MetricReading(
             metricType = MetricType.SLEEP_STAGE.key,
@@ -214,5 +308,34 @@ class GarminApiAdapter(
     companion object {
         internal const val BASE_URL = "https://apis.garmin.com/wellness-api/rest"
         const val PROVIDER_KEY = "garmin"
+
+        /**
+         * Maps a Garmin `activityType` string (FIT SDK enum, uppercase
+         * snake_case like "RUNNING", "STRENGTH_TRAINING") to a Bios
+         * [ExerciseModality] bucket. Unknown / blank → OTHER, matching
+         * the policy in the HC and Oura adapters.
+         */
+        internal fun mapGarminActivityToModality(activityType: String?): String {
+            if (activityType.isNullOrBlank()) return ExerciseModality.OTHER
+            return when (activityType.uppercase()) {
+                "RUNNING", "TREADMILL_RUNNING", "TRAIL_RUNNING", "INDOOR_RUNNING",
+                "WALKING", "INDOOR_WALKING", "HIKING",
+                "CYCLING", "INDOOR_CYCLING", "ROAD_BIKING", "MOUNTAIN_BIKING",
+                "ELLIPTICAL", "STAIR_CLIMBING", "INDOOR_CARDIO",
+                "ROWING", "INDOOR_ROWING",
+                "LAP_SWIMMING", "OPEN_WATER_SWIMMING", "SWIMMING",
+                "CARDIO" -> ExerciseModality.CARDIO
+
+                "STRENGTH_TRAINING", "WEIGHTLIFTING",
+                "BODY_WEIGHT", "CALISTHENICS" -> ExerciseModality.STRENGTH
+
+                "HIIT", "INTERVAL_TRAINING", "CROSS_TRAINING" -> ExerciseModality.INTERVAL
+
+                "YOGA", "PILATES", "STRETCHING", "MEDITATION",
+                "MOBILITY" -> ExerciseModality.MOBILITY
+
+                else -> ExerciseModality.OTHER
+            }
+        }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -43,6 +43,7 @@ class IngestManager(
     private val directSensorAdapter: DirectSensorAdapter? = null,
     private val withingsAdapter: WithingsApiAdapter? = null,
     private val whoopAdapter: WhoopApiAdapter? = null,
+    private val garminAdapter: GarminApiAdapter? = null,
     private val bleAirQualityAdapter: BleAirQualityAdapter? = null,
     private val latencyTracker: DetectionLatencyTracker? = null
 ) {
@@ -76,6 +77,7 @@ class IngestManager(
     private var directSensorSourceId: String? = null
     private var withingsSourceId: String? = null
     private var whoopSourceId: String? = null
+    private var garminSourceId: String? = null
     private var bleAirQualitySourceId: String? = null
 
     // MARK: - Setup
@@ -123,6 +125,13 @@ class IngestManager(
             )
         }
 
+        // Garmin API (watch — HR, sleep, steps, SpO2, respiration, activities)
+        if (garminAdapter?.isConnected == true) {
+            garminSourceId = getOrCreateSource(
+                SourceType.GARMIN_API, "Garmin", SensorType.OPTICAL_HR
+            )
+        }
+
         // Phone sensors (always available as last resort)
         if (phoneSensorAdapter?.hasAccelerometer == true ||
             phoneSensorAdapter?.hasStepCounter == true ||
@@ -165,7 +174,8 @@ class IngestManager(
             gadgetbridgeSourceId != null ||
             ouraSourceId != null ||
             withingsSourceId != null ||
-            whoopSourceId != null
+            whoopSourceId != null ||
+            garminSourceId != null
         if (!hasWearableHistorySource) return false
         for (metric in PRIMARY_METRICS_FOR_BACKFILL) {
             if (readingDao.count(metric.key) == 0) return true
@@ -195,6 +205,7 @@ class IngestManager(
                         async { fetchOuraReadings(start, end) },
                         async { fetchWithingsReadings(start, end) },
                         async { fetchWhoopReadings(start, end) },
+                        async { fetchGarminReadings(start, end) },
                         async { fetchPhoneSensorReadings() }
                     )
                     jobs.awaitAll().flatten()
@@ -216,6 +227,7 @@ class IngestManager(
                 }
                 persistApiSessions(ouraSourceId, ouraAdapter, start, end) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
                 persistApiSessions(whoopSourceId, whoopAdapter, start, end) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
+                persistApiSessions(garminSourceId, garminAdapter, start, end) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
             }
 
             if (latencyTracker != null) {
@@ -258,7 +270,8 @@ class IngestManager(
                         async { fetchGadgetbridgeReadings(current, chunkEnd) },
                         async { fetchOuraReadings(current, chunkEnd) },
                         async { fetchWithingsReadings(current, chunkEnd) },
-                        async { fetchWhoopReadings(current, chunkEnd) }
+                        async { fetchWhoopReadings(current, chunkEnd) },
+                        async { fetchGarminReadings(current, chunkEnd) }
                     )
                     jobs.awaitAll().flatten()
                 }
@@ -274,6 +287,7 @@ class IngestManager(
                 }
                 persistApiSessions(ouraSourceId, ouraAdapter, current, chunkEnd) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
                 persistApiSessions(whoopSourceId, whoopAdapter, current, chunkEnd) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
+                persistApiSessions(garminSourceId, garminAdapter, current, chunkEnd) { a, s, e, id -> a.fetchExerciseSessions(s, e, id) }
 
                 current = chunkEnd
                 completedDays++
@@ -374,18 +388,20 @@ class IngestManager(
         return source.id
     }
 
-    private suspend fun fetchGadgetbridgeReadings(
-        start: Instant,
-        end: Instant
+    /** Generic adapter-fetch helper. Returns empty when the source row
+     *  hasn't been registered or the adapter is null; swallows fetch
+     *  failures so a transient 5xx from one adapter doesn't kill the sync. */
+    private suspend inline fun <T> fetchApiReadings(
+        sourceId: String?,
+        adapter: T?,
+        crossinline fetch: suspend (T, String) -> List<MetricReading>,
     ): List<MetricReading> {
-        val sourceId = gadgetbridgeSourceId ?: return emptyList()
-        val adapter = gadgetbridgeAdapter ?: return emptyList()
-        return try {
-            adapter.fetchReadings(start, end, sourceId)
-        } catch (_: Exception) {
-            emptyList()
-        }
+        if (sourceId == null || adapter == null) return emptyList()
+        return runCatching { fetch(adapter, sourceId) }.getOrDefault(emptyList())
     }
+
+    private suspend fun fetchGadgetbridgeReadings(start: Instant, end: Instant) =
+        fetchApiReadings(gadgetbridgeSourceId, gadgetbridgeAdapter) { a, id -> a.fetchReadings(start, end, id) }
 
     private suspend fun fetchDirectSensorReadings(): List<MetricReading> {
         val sourceId = directSensorSourceId ?: return emptyList()
@@ -402,35 +418,17 @@ class IngestManager(
         }
     }
 
-    private suspend fun fetchOuraReadings(start: Instant, end: Instant): List<MetricReading> {
-        val sourceId = ouraSourceId ?: return emptyList()
-        val adapter = ouraAdapter ?: return emptyList()
-        return try {
-            adapter.fetchReadings(start, end, sourceId)
-        } catch (_: Exception) {
-            emptyList()
-        }
-    }
+    private suspend fun fetchOuraReadings(start: Instant, end: Instant) =
+        fetchApiReadings(ouraSourceId, ouraAdapter) { a, id -> a.fetchReadings(start, end, id) }
 
-    private suspend fun fetchWithingsReadings(start: Instant, end: Instant): List<MetricReading> {
-        val sourceId = withingsSourceId ?: return emptyList()
-        val adapter = withingsAdapter ?: return emptyList()
-        return try {
-            adapter.fetchReadings(start, end, sourceId)
-        } catch (_: Exception) {
-            emptyList()
-        }
-    }
+    private suspend fun fetchWithingsReadings(start: Instant, end: Instant) =
+        fetchApiReadings(withingsSourceId, withingsAdapter) { a, id -> a.fetchReadings(start, end, id) }
 
-    private suspend fun fetchWhoopReadings(start: Instant, end: Instant): List<MetricReading> {
-        val sourceId = whoopSourceId ?: return emptyList()
-        val adapter = whoopAdapter ?: return emptyList()
-        return try {
-            adapter.fetchReadings(start, end, sourceId)
-        } catch (_: Exception) {
-            emptyList()
-        }
-    }
+    private suspend fun fetchWhoopReadings(start: Instant, end: Instant) =
+        fetchApiReadings(whoopSourceId, whoopAdapter) { a, id -> a.fetchReadings(start, end, id) }
+
+    private suspend fun fetchGarminReadings(start: Instant, end: Instant) =
+        fetchApiReadings(garminSourceId, garminAdapter) { a, id -> a.fetchReadings(start, end, id) }
 
     private suspend fun fetchPhoneSensorReadings(): List<MetricReading> {
         val sourceId = phoneSensorSourceId ?: return emptyList()

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -16,6 +16,7 @@ import com.bios.app.ingest.ApiTokenStore
 import com.bios.app.ingest.BleAirQualityAdapter
 import com.bios.app.ingest.DirectSensorAdapter
 import com.bios.app.ingest.GadgetbridgeAdapter
+import com.bios.app.ingest.GarminApiAdapter
 import com.bios.app.ingest.HealthConnectAdapter
 import com.bios.app.ingest.IngestManager
 import com.bios.app.ingest.OuraApiAdapter
@@ -53,6 +54,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val apiTokenStore = ApiTokenStore(application)
     val withingsAdapter = WithingsApiAdapter(apiTokenStore)
     val whoopAdapter = WhoopApiAdapter(apiTokenStore)
+    val garminAdapter = GarminApiAdapter(apiTokenStore)
     val phoneSensorAdapter = PhoneSensorAdapter(application)
     val gadgetbridgeAdapter = GadgetbridgeAdapter(application)
     val directSensorAdapter = DirectSensorAdapter(application)
@@ -61,7 +63,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     val ingestManager = IngestManager(
         healthConnect, db, ouraAdapter, phoneSensorAdapter,
         gadgetbridgeAdapter, directSensorAdapter, withingsAdapter, whoopAdapter,
-        bleAirQualityAdapter, latencyTracker
+        garminAdapter, bleAirQualityAdapter, latencyTracker
     )
     private val reproductiveReadingDao = ReproductiveDatabase.readingDaoOrNull(application)
     val baselineEngine = BaselineEngine(db, latencyTracker, reproductiveReadingDao)

--- a/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt
@@ -6,6 +6,7 @@ import com.bios.app.engine.AdapterReadiness
 import com.bios.app.engine.MetricCoverage
 import com.bios.app.engine.MetricCoverageEngine
 import com.bios.app.ingest.DexcomApiAdapter
+import com.bios.app.ingest.GarminApiAdapter
 import com.bios.app.ingest.PolarApiAdapter
 import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
@@ -43,6 +44,7 @@ class DataCoverageViewModel(
                 ouraConfigured = app.ouraTokenStore.hasToken(),
                 withingsConfigured = app.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY),
                 whoopConfigured = app.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY),
+                garminConfigured = app.apiTokenStore.hasToken(GarminApiAdapter.PROVIDER_KEY),
                 polarConfigured = app.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY),
                 dexcomConfigured = app.apiTokenStore.hasToken(DexcomApiAdapter.PROVIDER_KEY),
                 directSensorAvailable = app.directSensorAdapter.hasAnySensor,

--- a/android/app/src/main/java/com/bios/app/ui/settings/GarminConnectDialog.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/GarminConnectDialog.kt
@@ -1,0 +1,73 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Garmin connection dialog — paste an OAuth-issued access token for the
+ * Garmin Wellness API. Same paste-the-token UX as Oura / Withings / WHOOP.
+ *
+ * Caveat: Garmin's Wellness API officially uses OAuth 1.0a signed
+ * requests, not OAuth 2.0 bearer tokens. The current
+ * [com.bios.app.ingest.GarminApiAdapter] sends `Authorization: Bearer <token>`
+ * which works when the upstream accepts a session token but won't pass
+ * Garmin's signed-request enforcement out of the box — a registered Bios
+ * Garmin developer app and per-request HMAC-SHA1 signing is a follow-up.
+ * Until that lands, this surface is useful for owners proxying through a
+ * pre-signed gateway, and for getting the wiring tests green.
+ */
+@Composable
+fun GarminConnectDialog(
+    onConnect: (token: String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var tokenInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Connect Garmin") },
+        text = {
+            Column {
+                Text(
+                    "Paste a Garmin Wellness API access token (or a pre-signed " +
+                        "session token from a Garmin proxy). Bios does not perform " +
+                        "the OAuth 1.0a dance itself yet — see the connection notes " +
+                        "for what works today.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = tokenInput,
+                    onValueChange = { tokenInput = it },
+                    label = { Text("Access Token") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val trimmed = tokenInput.trim()
+                    if (trimmed.isNotBlank()) onConnect(trimmed)
+                }
+            ) { Text("Connect") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.core.content.FileProvider
 import com.bios.app.engine.BaselineEngine
 import com.bios.app.export.DataExporter
 import com.bios.app.export.FhirExporter
+import com.bios.app.ingest.GarminApiAdapter
 import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.model.CompanionGrant
@@ -56,6 +57,10 @@ fun SettingsScreen(
     var showWhoopDialog by remember { mutableStateOf(false) }
     var isWhoopConnected by remember {
         mutableStateOf(viewModel.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY))
+    }
+    var showGarminDialog by remember { mutableStateOf(false) }
+    var isGarminConnected by remember {
+        mutableStateOf(viewModel.apiTokenStore.hasToken(GarminApiAdapter.PROVIDER_KEY))
     }
     val companionGrants by viewModel.db.companionGrantDao()
         .observeAll()
@@ -126,6 +131,17 @@ fun SettingsScreen(
                     onDisconnect = {
                         viewModel.apiTokenStore.clearToken(WhoopApiAdapter.PROVIDER_KEY)
                         isWhoopConnected = false
+                    },
+                )
+
+                Spacer(Modifier.height(4.dp))
+                ConnectableSourceRow(
+                    name = "Garmin",
+                    isConnected = isGarminConnected,
+                    onConnect = { showGarminDialog = true },
+                    onDisconnect = {
+                        viewModel.apiTokenStore.clearToken(GarminApiAdapter.PROVIDER_KEY)
+                        isGarminConnected = false
                     },
                 )
 
@@ -418,6 +434,17 @@ fun SettingsScreen(
                 showWhoopDialog = false
             },
             onDismiss = { showWhoopDialog = false }
+        )
+    }
+
+    if (showGarminDialog) {
+        GarminConnectDialog(
+            onConnect = { token ->
+                viewModel.apiTokenStore.saveToken(GarminApiAdapter.PROVIDER_KEY, token)
+                isGarminConnected = true
+                showGarminDialog = false
+            },
+            onDismiss = { showGarminDialog = false }
         )
     }
 }

--- a/android/app/src/test/java/com/bios/app/GarminApiAdapterTest.kt
+++ b/android/app/src/test/java/com/bios/app/GarminApiAdapterTest.kt
@@ -1,0 +1,105 @@
+package com.bios.app
+
+import com.bios.app.ingest.GarminApiAdapter
+import com.bios.app.model.ExerciseModality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-Kotlin tests for [GarminApiAdapter]'s static surface — activity-type
+ * → modality mapping plus a couple of contract stability checks. Network
+ * calls aren't tested here; live JSON parsing is covered by the
+ * IngestManager integration once a real Garmin token is in play.
+ */
+class GarminApiAdapterTest {
+
+    @Test
+    fun `mapGarminActivityToModality buckets cardio types`() {
+        for (type in listOf("RUNNING", "TREADMILL_RUNNING", "WALKING", "HIKING",
+            "CYCLING", "INDOOR_CYCLING", "ELLIPTICAL", "ROWING", "LAP_SWIMMING",
+            "STAIR_CLIMBING")) {
+            assertEquals(
+                "activityType '$type' should map to CARDIO",
+                ExerciseModality.CARDIO,
+                GarminApiAdapter.mapGarminActivityToModality(type)
+            )
+        }
+    }
+
+    @Test
+    fun `mapGarminActivityToModality buckets strength types`() {
+        for (type in listOf("STRENGTH_TRAINING", "WEIGHTLIFTING",
+            "BODY_WEIGHT", "CALISTHENICS")) {
+            assertEquals(
+                ExerciseModality.STRENGTH,
+                GarminApiAdapter.mapGarminActivityToModality(type)
+            )
+        }
+    }
+
+    @Test
+    fun `mapGarminActivityToModality buckets HIIT and cross-training as INTERVAL`() {
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            GarminApiAdapter.mapGarminActivityToModality("HIIT")
+        )
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            GarminApiAdapter.mapGarminActivityToModality("INTERVAL_TRAINING")
+        )
+        assertEquals(
+            ExerciseModality.INTERVAL,
+            GarminApiAdapter.mapGarminActivityToModality("CROSS_TRAINING")
+        )
+    }
+
+    @Test
+    fun `mapGarminActivityToModality buckets yoga and pilates as MOBILITY`() {
+        for (type in listOf("YOGA", "PILATES", "STRETCHING", "MEDITATION")) {
+            assertEquals(
+                ExerciseModality.MOBILITY,
+                GarminApiAdapter.mapGarminActivityToModality(type)
+            )
+        }
+    }
+
+    @Test
+    fun `mapGarminActivityToModality is case insensitive`() {
+        assertEquals(
+            ExerciseModality.CARDIO,
+            GarminApiAdapter.mapGarminActivityToModality("running")
+        )
+        assertEquals(
+            ExerciseModality.STRENGTH,
+            GarminApiAdapter.mapGarminActivityToModality("Strength_Training")
+        )
+    }
+
+    @Test
+    fun `mapGarminActivityToModality falls back to OTHER for blank or unknown`() {
+        assertEquals(
+            ExerciseModality.OTHER,
+            GarminApiAdapter.mapGarminActivityToModality(null)
+        )
+        assertEquals(
+            ExerciseModality.OTHER,
+            GarminApiAdapter.mapGarminActivityToModality("")
+        )
+        assertEquals(
+            ExerciseModality.OTHER,
+            GarminApiAdapter.mapGarminActivityToModality("ALIEN_BASKETBALL")
+        )
+    }
+
+    @Test
+    fun `BASE_URL points to the Garmin Wellness API`() {
+        assertEquals("https://apis.garmin.com/wellness-api/rest", GarminApiAdapter.BASE_URL)
+    }
+
+    @Test
+    fun `PROVIDER_KEY is garmin`() {
+        // ApiTokenStore keys this string into EncryptedSharedPreferences;
+        // renaming would orphan existing tokens after upgrade.
+        assertEquals("garmin", GarminApiAdapter.PROVIDER_KEY)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt
@@ -20,6 +20,7 @@ class MetricCoverageEngineTest {
         ouraConfigured = false,
         withingsConfigured = false,
         whoopConfigured = false,
+        garminConfigured = false,
         polarConfigured = false,
         dexcomConfigured = false,
         directSensorAvailable = false,


### PR DESCRIPTION
## Summary
`GarminApiAdapter` existed in tree but was dormant — no `IngestManager` hookup, no Settings UI, no Data Coverage CTA. This activates it fully (mirrors the Withings/Oura/WHOOP pattern) and closes the Garmin slice of #38 by emitting `EXERCISE_SESSION` composites from `/activities`.

## End-to-end activation
- **Token + DataSource**: Garmin token via `ApiTokenStore` (`PROVIDER_KEY = "garmin"`); `SourceType.GARMIN_API` row created on `IngestManager.setup()` when `isConnected`.
- **Sync**: [IngestManager](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt) — `fetchGarminReadings` joins the parallel `awaitAll` block in both sync paths; backfill gate includes `garminSourceId`.
- **Coverage + UI**: `garminConfigured` flag wired through [AdapterReadiness](android/app/src/main/java/com/bios/app/engine/MetricCoverage.kt), [DataCoverageViewModel](android/app/src/main/java/com/bios/app/ui/coverage/DataCoverageViewModel.kt), and [MetricCoverageEngine](android/app/src/main/java/com/bios/app/engine/MetricCoverageEngine.kt) (Garmin joins Oura/WHOOP/Polar as a candidate `API_ADAPTER`). [GarminConnectDialog](android/app/src/main/java/com/bios/app/ui/settings/GarminConnectDialog.kt) lets the owner paste a developer-issued token (same UX as Oura/Withings/WHOOP).

## Exercise sessions
- [GarminApiAdapter.fetchExerciseSessions](android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt) — parses Garmin Wellness API `/activities` records into composite `EXERCISE_SESSION` readings + `event_payloads` (modality, start_utc, end_utc, optional avg_hr_bpm). Uses a new `apiGetArray` helper since `/activities` returns a top-level JSON array (no envelope, unlike the other Garmin endpoints).
- [mapGarminActivityToModality](android/app/src/main/java/com/bios/app/ingest/GarminApiAdapter.kt) — maps Garmin's FIT-SDK `activityType` strings (uppercase snake_case like `"RUNNING"`, `"STRENGTH_TRAINING"`, `"HIIT"`) to `ExerciseModality` buckets. Case-insensitive; unknown / blank → `OTHER`.

## Housekeeping
- Collapsed the five near-identical `fetchXxxReadings` helpers (Oura, Withings, WHOOP, Garmin, Gadgetbridge) in IngestManager into a single generic `fetchApiReadings` inline helper. Saves ~30 lines and keeps the file under the 500-line cap with the new Garmin wiring.

## Caveat — Garmin auth
[GarminConnectDialog](android/app/src/main/java/com/bios/app/ui/settings/GarminConnectDialog.kt) notes the issue explicitly: Garmin's Wellness API uses OAuth 1.0a signed requests, not OAuth 2.0 bearer. The current adapter sends `Authorization: Bearer`, which won't pass Garmin's signature enforcement on its own — useful today for owners proxying through a pre-signed gateway and for getting the wiring tests green. Full HMAC-SHA1 signing against a registered Bios Garmin developer app is a separate follow-up.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file lengths, lint, both flavor builds, unit tests.
- [x] [GarminApiAdapterTest](android/app/src/test/java/com/bios/app/GarminApiAdapterTest.kt) — 8 cases: all five modality buckets, case insensitivity, blank/null/unknown → OTHER, `BASE_URL` + `PROVIDER_KEY` stability.
- [x] [MetricCoverageEngineTest](android/app/src/test/java/com/bios/app/MetricCoverageEngineTest.kt) — `garminConfigured` added to the test fixture.
- [ ] Manual: with a pre-signed Garmin token, verify dailies/sleep/HR readings + `EXERCISE_SESSION` rows land, Settings shows "Connected", Data Coverage marks the Garmin-routed metrics LIVE.

## #38 status after this PR
HC ✓ Oura ✓ WHOOP ✓ Garmin ✓. Only Gadgetbridge remains — its ContentProvider doesn't expose a reliable session surface across its 40+ devices, so its session slice stays deferred. Could close #38 entirely with a note, or hold it open for Gadgetbridge as a future-when-upstream-supports item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)