### PR TITLE
fix(data): ReproductiveDatabase MIGRATION_1_2 for note column

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/ReproductiveDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/ReproductiveDatabase.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import androidx.sqlite.db.SupportSQLiteDatabase
 import android.util.Log
 import com.bios.app.data.dao.DataSourceDao
 import com.bios.app.data.dao.MetricReadingDao
@@ -29,7 +31,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
  */
 @Database(
     entities = [MetricReading::class, DataSource::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class ReproductiveDatabase : RoomDatabase() {
@@ -147,7 +149,23 @@ abstract class ReproductiveDatabase : RoomDatabase() {
                 DB_NAME
             )
                 .openHelperFactory(factory)
+                .addMigrations(MIGRATION_1_2)
                 .build()
+        }
+
+        // Mirrors BiosDatabase.MIGRATION_9_10: MetricReading gained an
+        // owner-recall `note` column when biomarker context capture landed
+        // (#103, commit 323aa6a). The main DB got its migration; this one
+        // didn't, so on-device reproductive DBs persisted at v1 fail to open
+        // against the v2 entity schema with an identity-hash mismatch
+        // ("Expected …, found …"), silently breaking baseline + anomaly
+        // detection for reproductive metrics (BBT, CYCLE_PHASE, CYCLE_DAY).
+        // The column is owner-recall free-text only; no engine reads it, so
+        // the migration is a pure ALTER TABLE with no backfill.
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE metric_readings ADD COLUMN note TEXT")
+            }
         }
 
         private fun getPassphrase(context: Context): String? {


### PR DESCRIPTION
## Summary
Found by tailing device logs. Every sync on a device with a pre-#103 `ReproductiveDatabase` fires:

\`\`\`
java.lang.IllegalStateException: Room cannot verify the data integrity.
Looks like you've changed schema but forgot to update the version number.
Expected identity hash: 32f1c2dd557324ca4a7bb8f4b020cc17,
found:    9a921a7baa0b0424a22441ba8899d0ab
\`\`\`

With `BiosSyncWorker: Baseline computation failed, continuing to detection` and `BiosSyncWorker: Anomaly detection failed`. **Silent functional break** — no visible crash, but baseline + anomaly evaluation for reproductive metrics (BBT, CYCLE_PHASE, CYCLE_DAY) never runs for any owner who has BBT tracking enabled.

## Root cause
[`MetricReading`](android/app/src/main/java/com/bios/app/model/MetricReading.kt) gained an owner-recall `note` column in #103 (commit 323aa6a). The main [BiosDatabase](android/app/src/main/java/com/bios/app/data/BiosDatabase.kt) got `MIGRATION_9_10` to `ALTER TABLE` in step. [ReproductiveDatabase](android/app/src/main/java/com/bios/app/data/ReproductiveDatabase.kt) — which also uses `MetricReading::class` as an entity — was overlooked: stayed at `version = 1` with no migration list. On-device repro DBs persisted at v1 fail to open against the v2 entity schema.

## Fix
Bump `version` to 2 and add `MIGRATION_1_2` mirroring the main DB's note-column ALTER. The column is owner-recall free text only; no engine reads it, so the migration is a pure `ALTER TABLE` with no backfill required.

## Verification on device
1. Installed the patched APK on the test device
2. Restarted the app
3. `adb logcat` shows clean SyncWorker run — no `IllegalStateException`, no `BiosSyncWorker: Baseline computation failed` lines

Pre-fix logs (excerpt):
\`\`\`
W BiosSyncWorker: Baseline computation failed, continuing to detection
W BiosSyncWorker: java.lang.IllegalStateException: Room cannot verify the data integrity...
W BiosSyncWorker: Anomaly detection failed
W BiosSyncWorker: java.lang.IllegalStateException: Room cannot verify the data integrity...
\`\`\`

Post-fix: zero hits on either pattern.

## Test plan
- [x] `./scripts/code-quality-check.sh` — lint, both flavor builds, unit tests.
- [x] On-device sanity check (described above).
- [ ] Future-proofing: a regression test would need to spin up a v1 repro DB fixture and verify the migration runs — out of scope for the fix PR but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)