### PR TITLE
fix(perms): declare HC body-comp + VO2_MAX perms in manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,15 @@
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.READ_VO2_MAX" />
+    <!-- Body composition (Weight + BodyFat + LeanBodyMass) — read paths in
+         HealthConnectBodyComposition.kt. Missing-from-manifest causes the
+         HC permission contract to filter these out of the requestable set,
+         which silently turns onboarding's "Grant Permissions" button into
+         a no-op once the other perms are granted. -->
+    <uses-permission android:name="android.permission.health.READ_WEIGHT" />
+    <uses-permission android:name="android.permission.health.READ_BODY_FAT" />
+    <uses-permission android:name="android.permission.health.READ_LEAN_BODY_MASS" />
     <!--
       Required so SyncWorker (WorkManager, runs in background) can read data
       written by other apps (Google Fit, Fitbit, etc.). Without this, Health

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -23,5 +23,9 @@
         <item>android.permission.health.READ_STEPS</item>
         <item>android.permission.health.READ_ACTIVE_CALORIES_BURNED</item>
         <item>android.permission.health.READ_EXERCISE</item>
+        <item>android.permission.health.READ_VO2_MAX</item>
+        <item>android.permission.health.READ_WEIGHT</item>
+        <item>android.permission.health.READ_BODY_FAT</item>
+        <item>android.permission.health.READ_LEAN_BODY_MASS</item>
     </array>
 </resources>


### PR DESCRIPTION
## Summary
Onboarding's **"Grant Permissions" button silently no-ops** on devices where the legacy 10 Health Connect permissions were already granted before VO2_MAX and body-composition shipped.

Found by user report ("button does nothing") cross-referenced with the OS verbose log line:

\`\`\`
05-20 08:08:53.383 705 705 V Activity: No requestable permission in the request.
\`\`\`

(PID 705 = Bios this session.)

## Root cause
[HealthConnectAdapter](android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt) and [HealthConnectBodyComposition](android/app/src/main/java/com/bios/app/ingest/HealthConnectBodyComposition.kt) together request **14 permissions**, but only **10** are declared in [AndroidManifest.xml](android/app/src/main/AndroidManifest.xml) + [strings.xml health_permissions array](android/app/src/main/res/values/strings.xml). Missing:

- `android.permission.health.READ_VO2_MAX`
- `android.permission.health.READ_WEIGHT`
- `android.permission.health.READ_BODY_FAT`
- `android.permission.health.READ_LEAN_BODY_MASS`

When `PermissionController.createRequestPermissionResultContract()` launches with permissions that aren't declared in the manifest, it filters them out before calling the OS layer. If the remaining (declared) perms are already granted, the filtered array is empty and the OS short-circuits with `"No requestable permission in the request"` — the contract returns immediately with no UI shown.

Meanwhile, `hasAllPermissions()` keeps returning `false` because the 4 undeclared perms never get into the granted set → `hasPermissions` stays `false` → onboarding never closes → tapping the button keeps doing nothing. **Stuck state.**

## Fix
Declare the 4 missing permissions in both:
- [AndroidManifest.xml](android/app/src/main/AndroidManifest.xml) — controls installability
- [strings.xml @ array/health_permissions](android/app/src/main/res/values/strings.xml) — drives the HC permission-rationale metadata

The two surfaces have to stay in sync.

## Verification on device
Post-install `dumpsys`:

\`\`\`
android.permission.health.READ_BODY_FAT        # declared, not granted (NEW)
android.permission.health.READ_LEAN_BODY_MASS  # declared, not granted (NEW)
android.permission.health.READ_VO2_MAX         # declared, not granted (NEW)
android.permission.health.READ_WEIGHT          # declared, not granted (NEW)
android.permission.health.READ_HEART_RATE: granted=true  # legacy, already granted
... 9 more legacy perms granted=true
\`\`\`

Exactly the state needed for the contract to route the 4 new perms to the HC permission UI when the user next taps Grant.

## Test plan
- [x] `./scripts/code-quality-check.sh` — file lengths, lint, both flavor builds.
- [x] On-device: `dumpsys package com.bios.app` confirms the 4 new perms are declared.
- [ ] Manual user test: open the app → tap Grant Permissions → expect the HC permission UI to appear listing the 4 new permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)