### PR TITLE
feat(entry): general manual-reading surface for clinical vitals (#131)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
@@ -1,23 +1,23 @@
 package com.bios.app.data
 
 import com.bios.app.model.ConfidenceTier
-import com.bios.app.model.DataSource
 import com.bios.app.model.EventPayloadField
 import com.bios.app.model.MetricReading
-import com.bios.app.model.ReadingKind
-import com.bios.app.model.SensorType
-import com.bios.app.model.SourceType
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 
 /**
  * Persistence path for self-reported lab values entered through the
- * biomarker entry screen.
+ * biomarker entry screen. Sibling of [ManualReadingRepo] for clinical
+ * vital signs — both share the SELF_REPORTED write path via
+ * [resolveSelfReportedSource].
  *
- * Self-reported readings flow through a single SELF_REPORTED [DataSource]
- * tagged with [ReadingKind.SELF_REPORTED] so the baseline engine and anomaly
- * detector keep ignoring them (decision 3 in docs/SELF_REPORTED_DATA_HOME.md).
- * They still show up in trends, FHIR export, and condition-pattern displays.
+ * Self-reported readings flow through a single SELF_REPORTED
+ * [com.bios.app.model.DataSource] tagged with
+ * [com.bios.app.model.ReadingKind.SELF_REPORTED] so the baseline engine
+ * and anomaly detector keep ignoring them (decision 3 in
+ * docs/SELF_REPORTED_DATA_HOME.md). They still show up in trends, FHIR
+ * export, and condition-pattern displays.
  *
  * Optional [BiomarkerContext] carries lab provenance — engine-relevant
  * fields (lab, fasting, specimen, source URI) ride the existing
@@ -35,7 +35,7 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
         require(metricType.domain == MetricDomain.BIOMARKER) {
             "BiomarkerEntryRepo only accepts BIOMARKER metrics; got ${metricType.key}"
         }
-        val sourceId = getOrCreateSelfReportedSource()
+        val sourceId = resolveSelfReportedSource(db)
         val reading = MetricReading(
             metricType = metricType.key,
             value = value,
@@ -81,19 +81,6 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
         if (fields.isNotEmpty()) {
             db.eventPayloadFieldDao().insertAll(fields)
         }
-    }
-
-    private suspend fun getOrCreateSelfReportedSource(): String {
-        val dao = db.dataSourceDao()
-        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
-        val source = DataSource(
-            sourceType = SourceType.SELF_REPORTED.key,
-            deviceName = "Self-reported",
-            sensorType = SensorType.DERIVED.name,
-            readingKind = ReadingKind.SELF_REPORTED.name
-        )
-        dao.insert(source)
-        return source.id
     }
 
     companion object {

--- a/android/app/src/main/java/com/bios/app/data/ConsciousnessScale.kt
+++ b/android/app/src/main/java/com/bios/app/data/ConsciousnessScale.kt
@@ -1,0 +1,22 @@
+package com.bios.app.data
+
+/**
+ * Input scales accepted for [com.bios.contracts.MetricType.CONSCIOUSNESS_LEVEL].
+ * GCS is canonical (3–15 total); AVPU is a lossless input shortcut that
+ * snaps onto representative GCS totals (A→15, V→13, P→8, U→3). When AVPU
+ * is used at entry, the original scale + value are preserved in the
+ * `event_payloads` sidecar via
+ * [ManualReadingPayloadKeys.ORIGINAL_SCALE] / [ManualReadingPayloadKeys.ORIGINAL_VALUE]
+ * so the provenance survives the lossy axis.
+ */
+enum class AvpuLevel(val gcsTotal: Int, val label: String) {
+    ALERT(15, "A — Alert"),
+    VOICE(13, "V — Responds to voice"),
+    PAIN(8, "P — Responds to pain"),
+    UNRESPONSIVE(3, "U — Unresponsive"),
+}
+
+object GcsBounds {
+    const val MIN = 3
+    const val MAX = 15
+}

--- a/android/app/src/main/java/com/bios/app/data/ManualReadingContext.kt
+++ b/android/app/src/main/java/com/bios/app/data/ManualReadingContext.kt
@@ -1,0 +1,60 @@
+package com.bios.app.data
+
+/**
+ * Provenance attached to a manually entered reading produced through the
+ * general manual-reading surface. Shape mirrors a clinical-visit triage
+ * row: one shared timestamp + clinic name + visit note + optional source
+ * artifact (chart PDF/photo) span N readings captured together (BP, SpO2,
+ * pulse, temp, RR, pain, GCS, O2 flow as one event).
+ *
+ * Single-reading entries (owner reading a cuff at home) use the same shape
+ * with [clinicName] / [visitNote] null and no bundle id.
+ *
+ * Some metrics carry a per-row provenance dimension that the bundle-level
+ * fields can't express. [CONSCIOUSNESS_LEVEL][com.bios.contracts.MetricType.CONSCIOUSNESS_LEVEL]
+ * is canonical GCS but accepts AVPU as a lossless input shortcut — when the
+ * owner enters "V" we store 13 as the value and ride the original scale +
+ * value alongside in [originalScale] / [originalValue]. Owner-recall text
+ * rides [note] (per-reading) and lives in `metric_readings.note`. Engines
+ * never read either.
+ *
+ * All fields are optional. A bare reading (metric + value + timestamp)
+ * leaves every field null and writes nothing to the sidecar.
+ */
+data class ManualReadingContext(
+    val clinicName: String? = null,
+    val visitNote: String? = null,
+    val sourceUri: String? = null,
+    val bundleId: String? = null,
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+    val note: String? = null,
+) {
+    val isEmpty: Boolean
+        get() = clinicName.isNullOrBlank() &&
+            visitNote.isNullOrBlank() &&
+            sourceUri.isNullOrBlank() &&
+            bundleId.isNullOrBlank() &&
+            originalScale.isNullOrBlank() &&
+            originalValue.isNullOrBlank() &&
+            note.isNullOrBlank()
+}
+
+/**
+ * Field keys for manual-reading provenance in the `event_payloads` sidecar.
+ * Stability contract: renames are breaking changes — see DATA_MODEL.md.
+ *
+ * Distinct namespace from [BiomarkerPayloadKeys]: a biomarker entry stores
+ * lab/fasting/specimen; a clinical-visit entry stores clinic/visit/bundle.
+ * The two surfaces share the SELF_REPORTED source but not the sidecar
+ * vocabulary, so consumers reading payloads can tell which surface a
+ * reading came from by which keys are present.
+ */
+object ManualReadingPayloadKeys {
+    const val CLINIC_NAME = "clinic_name"
+    const val VISIT_NOTE = "visit_note"
+    const val SOURCE_URI = "source_uri"
+    const val BUNDLE_ID = "bundle_id"
+    const val ORIGINAL_SCALE = "original_scale"
+    const val ORIGINAL_VALUE = "original_value"
+}

--- a/android/app/src/main/java/com/bios/app/data/ManualReadingRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/ManualReadingRepo.kt
@@ -1,0 +1,148 @@
+package com.bios.app.data
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.util.UUID
+
+/**
+ * General manual-reading persistence path for clinical vital signs and
+ * other owner-as-source metrics. Sibling of [BiomarkerEntryRepo] sharing
+ * the same SELF_REPORTED write path
+ * ([resolveSelfReportedSource]) — the split keeps the lab-specific
+ * provenance vocabulary ([BiomarkerContext]) separate from the
+ * clinical-visit vocabulary ([ManualReadingContext]) without forking the
+ * data source.
+ *
+ * Engine isolation still holds: rows insert through SELF_REPORTED so
+ * `BaselineEngine` and `AnomalyDetector` skip them
+ * (docs/SELF_REPORTED_DATA_HOME.md decision 3). The owner sees these in
+ * trends, FHIR export, and pull-side comparisons; nothing pushes a
+ * judgement on a self-reported value.
+ *
+ * Reproductive metrics (BBT, period onset) are NOT accepted here — their
+ * rows live in the isolated [ReproductiveDatabase] via
+ * [BbtEntryRepo] / [PeriodEntryRepo] for the encryption-isolation reason
+ * documented on those repos. The gate is [MetricType.allowsManualEntry];
+ * reproductive entries that pass it (e.g. MENSTRUATION_ONSET) still get
+ * routed to their domain repos by the UI layer.
+ */
+class ManualReadingRepo(private val db: BiosDatabase) {
+
+    suspend fun add(
+        metricType: MetricType,
+        value: Double,
+        timestamp: Long,
+        context: ManualReadingContext = ManualReadingContext(),
+    ): String {
+        require(metricType.allowsManualEntry) {
+            "ManualReadingRepo only accepts metrics with allowsManualEntry=true; " +
+                "got ${metricType.key}"
+        }
+        val sourceId = resolveSelfReportedSource(db)
+        val reading = MetricReading(
+            metricType = metricType.key,
+            value = value,
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            note = context.note?.takeIf { it.isNotBlank() },
+        )
+        db.metricReadingDao().insert(reading)
+        persistPayload(reading.id, context)
+        return reading.id
+    }
+
+    /**
+     * Clinical-visit bundle entry. One shared timestamp + clinic + visit
+     * note span N readings; each reading carries the same auto-generated
+     * [ManualReadingContext.bundleId] so the UI can later regroup them.
+     * Mirrors how a triage row gets recorded — BP + SpO2 + FC + Temp + FR +
+     * EVA + GCS + Flujo O2 captured as one event.
+     */
+    suspend fun addBundle(
+        timestamp: Long,
+        clinicName: String?,
+        visitNote: String?,
+        sourceUri: String?,
+        readings: List<BundleReading>,
+    ): String {
+        require(readings.isNotEmpty()) { "Clinical-visit bundle must contain at least one reading" }
+        val bundleId = UUID.randomUUID().toString()
+        val sharedContext = ManualReadingContext(
+            clinicName = clinicName?.takeIf { it.isNotBlank() },
+            visitNote = visitNote?.takeIf { it.isNotBlank() },
+            sourceUri = sourceUri?.takeIf { it.isNotBlank() },
+            bundleId = bundleId,
+        )
+        for (r in readings) {
+            val rowContext = sharedContext.copy(
+                originalScale = r.originalScale,
+                originalValue = r.originalValue,
+                note = r.note,
+            )
+            add(r.metricType, r.value, timestamp, rowContext)
+        }
+        return bundleId
+    }
+
+    suspend fun fetchContext(readingId: String): ManualReadingContext {
+        val rows = db.eventPayloadFieldDao().fetchForReading(readingId)
+        return rowsToContext(rows, note = null)
+    }
+
+    private suspend fun persistPayload(readingId: String, context: ManualReadingContext) {
+        val fields = buildList {
+            context.clinicName?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.CLINIC_NAME, stringValue = it))
+            }
+            context.visitNote?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.VISIT_NOTE, stringValue = it))
+            }
+            context.sourceUri?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.SOURCE_URI, stringValue = it))
+            }
+            context.bundleId?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.BUNDLE_ID, stringValue = it))
+            }
+            context.originalScale?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.ORIGINAL_SCALE, stringValue = it))
+            }
+            context.originalValue?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.ORIGINAL_VALUE, stringValue = it))
+            }
+        }
+        if (fields.isNotEmpty()) {
+            db.eventPayloadFieldDao().insertAll(fields)
+        }
+    }
+
+    companion object {
+        internal fun rowsToContext(rows: List<EventPayloadField>, note: String?): ManualReadingContext {
+            val byKey = rows.associateBy { it.fieldKey }
+            return ManualReadingContext(
+                clinicName = byKey[ManualReadingPayloadKeys.CLINIC_NAME]?.stringValue,
+                visitNote = byKey[ManualReadingPayloadKeys.VISIT_NOTE]?.stringValue,
+                sourceUri = byKey[ManualReadingPayloadKeys.SOURCE_URI]?.stringValue,
+                bundleId = byKey[ManualReadingPayloadKeys.BUNDLE_ID]?.stringValue,
+                originalScale = byKey[ManualReadingPayloadKeys.ORIGINAL_SCALE]?.stringValue,
+                originalValue = byKey[ManualReadingPayloadKeys.ORIGINAL_VALUE]?.stringValue,
+                note = note,
+            )
+        }
+    }
+}
+
+/**
+ * One reading inside a clinical-visit bundle. [originalScale] /
+ * [originalValue] preserve scales like AVPU when the canonical metric is
+ * GCS — see [MetricType.CONSCIOUSNESS_LEVEL] for the lossless mapping.
+ */
+data class BundleReading(
+    val metricType: MetricType,
+    val value: Double,
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+    val note: String? = null,
+)

--- a/android/app/src/main/java/com/bios/app/data/SelfReportedMainSource.kt
+++ b/android/app/src/main/java/com/bios/app/data/SelfReportedMainSource.kt
@@ -1,0 +1,30 @@
+package com.bios.app.data
+
+import com.bios.app.model.DataSource
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+
+/**
+ * Resolves (creating if absent) the single SELF_REPORTED row in the main
+ * [BiosDatabase] that owns every manually entered reading. Shared by
+ * [BiomarkerEntryRepo], [ManualReadingRepo], and [SleepEntryRepo] so they
+ * all converge on one source id — without this, each repo would create its
+ * own SELF_REPORTED row and the data-coverage view would double-count.
+ *
+ * The reproductive flow ([BbtEntryRepo], [PeriodEntryRepo]) has its own
+ * helper because reproductive rows live in the isolated ReproductiveDatabase
+ * (separate encryption key, independent wipe).
+ */
+internal suspend fun resolveSelfReportedSource(db: BiosDatabase): String {
+    val dao = db.dataSourceDao()
+    dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
+    val source = DataSource(
+        sourceType = SourceType.SELF_REPORTED.key,
+        deviceName = "Self-reported",
+        sensorType = SensorType.DERIVED.name,
+        readingKind = ReadingKind.SELF_REPORTED.name
+    )
+    dao.insert(source)
+    return source.id
+}

--- a/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
@@ -1,11 +1,7 @@
 package com.bios.app.data
 
 import com.bios.app.model.ConfidenceTier
-import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
-import com.bios.app.model.ReadingKind
-import com.bios.app.model.SensorType
-import com.bios.app.model.SourceType
 import com.bios.contracts.MetricType
 
 /**
@@ -14,8 +10,10 @@ import com.bios.contracts.MetricType
  * gap on a given night).
  *
  * Like [BiomarkerEntryRepo], rows are tagged with the shared SELF_REPORTED
- * [DataSource] + [ReadingKind.SELF_REPORTED] so the baseline engine ignores
- * them while they still surface in trends, coverage, and FHIR export.
+ * [com.bios.app.model.DataSource] +
+ * [com.bios.app.model.ReadingKind.SELF_REPORTED] so the baseline engine
+ * ignores them while they still surface in trends, coverage, and FHIR
+ * export.
  */
 class SleepEntryRepo(private val db: BiosDatabase) {
 
@@ -26,7 +24,7 @@ class SleepEntryRepo(private val db: BiosDatabase) {
         require(durationSeconds in 1..maxDurationSeconds) {
             "Sleep duration $durationSeconds s is outside the 1..$maxDurationSeconds range"
         }
-        val sourceId = getOrCreateSelfReportedSource()
+        val sourceId = resolveSelfReportedSource(db)
         db.metricReadingDao().insert(
             MetricReading(
                 metricType = MetricType.SLEEP_DURATION.key,
@@ -40,17 +38,4 @@ class SleepEntryRepo(private val db: BiosDatabase) {
 
     suspend fun fetchRecent(limit: Int = 20): List<MetricReading> =
         db.metricReadingDao().fetchLatest(MetricType.SLEEP_DURATION.key, limit)
-
-    private suspend fun getOrCreateSelfReportedSource(): String {
-        val dao = db.dataSourceDao()
-        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
-        val source = DataSource(
-            sourceType = SourceType.SELF_REPORTED.key,
-            deviceName = "Self-reported",
-            sensorType = SensorType.DERIVED.name,
-            readingKind = ReadingKind.SELF_REPORTED.name
-        )
-        dao.insert(source)
-        return source.id
-    }
 }

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -403,6 +403,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.UG_PER_M3 -> "ug/m3"
     MetricUnit.PPM -> "[ppm]"
     MetricUnit.PPB -> "[ppb]"
+    MetricUnit.LITERS_PER_MIN -> "L/min"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -27,6 +27,7 @@ import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.app.data.ManualReadingRepo
 import com.bios.app.model.ActionItem
 import com.bios.app.model.Anomaly
 import com.bios.app.model.HealthEvent
@@ -490,4 +491,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     fun refreshRecentBiomarkers(limit: Int = 20) = biomarkers.refreshRecent(limit)
     fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long, context: BiomarkerContext = BiomarkerContext()) =
         biomarkers.addManual(metricType, value, timestamp, context)
+
+    // MARK: - General manual-reading entry (clinical vitals)
+
+    val manualReadingRepo: ManualReadingRepo = ManualReadingRepo(db)
 }

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -333,6 +333,7 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToPrivacy = { navController.navigate("privacy") },
                     onNavigateToCompanions = { navController.navigate("companions") },
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
+                    onNavigateToClinicalEntry = { navController.navigate("clinical_entry") },
                     onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
                     onNavigateToPeriodEntry = { navController.navigate("period_entry") },
                     onNavigateToSleepEntry = { navController.navigate("sleep_entry") },
@@ -364,6 +365,12 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("biomarker_entry") {
                 com.bios.app.ui.biomarkers.BiomarkerEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable("clinical_entry") {
+                com.bios.app.ui.clinical.ClinicalReadingEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
@@ -1,0 +1,301 @@
+package com.bios.app.ui.clinical
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.ManualReadingRepo
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Bundle-style entry surface for clinical visits: one shared timestamp +
+ * clinic + visit note span N readings. Triage rows (BP / SpO2 / pulse /
+ * temp / RR / pain / GCS / O2 flow) get logged as one event the way a
+ * clinician records them on a chart. Single-reading entries (owner reading
+ * a cuff at home) work the same way with the bundle metadata left blank.
+ *
+ * Writes route through [ManualReadingRepo.addBundle] → SELF_REPORTED →
+ * engine-isolated (docs/SELF_REPORTED_DATA_HOME.md decision 3).
+ *
+ * Biomarker (lab) entries stay on the dedicated [com.bios.app.ui.biomarkers.BiomarkerEntryScreen]
+ * — they carry a different provenance vocabulary (lab/fasting/specimen)
+ * that doesn't apply at the bedside. Per-row UI (metric picker, value
+ * field, AVPU shortcut) lives in [ClinicalReadingRows].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClinicalReadingEntryScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val repo = viewModel.manualReadingRepo
+
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var clinicName by remember { mutableStateOf("") }
+    var visitNote by remember { mutableStateOf("") }
+    var sourceUri by remember { mutableStateOf<Uri?>(null) }
+    val rows = remember { mutableStateListOf<ReadingRowState>() }
+    var saveMessage by remember { mutableStateOf<String?>(null) }
+
+    if (rows.isEmpty()) {
+        defaultTriageRows().forEach { rows.add(it) }
+    }
+
+    val sourceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { picked ->
+        if (picked != null) {
+            try {
+                context.contentResolver.takePersistableUriPermission(
+                    picked, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            } catch (_: SecurityException) {
+                // Same fallback as biomarker entry — keep URI in-memory only
+                // when the provider won't grant persistable permission.
+            }
+            sourceUri = picked
+        }
+    }
+
+    val anyValid = rows.any { it.isFilled() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add clinical reading") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        "Self-reported",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Vital signs you enter — from a cuff, pulse-ox, thermometer, or a triage " +
+                            "chart a clinician handed you — stay on your device. They show up in " +
+                            "trends and FHIR export, but the baseline engine and anomaly detector " +
+                            "ignore them. Single-point clinical readings would otherwise poison " +
+                            "sensor baselines.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    OutlinedButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Captured on: ${formatClinicalDate(timestamp)}")
+                    }
+
+                    OutlinedTextField(
+                        value = clinicName,
+                        onValueChange = { clinicName = it },
+                        label = { Text("Clinic / facility (optional)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    OutlinedTextField(
+                        value = visitNote,
+                        onValueChange = { visitNote = it },
+                        label = { Text("Visit note (optional)") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Text(
+                        "Triage chart (PDF or photo)",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(
+                            onClick = { sourceLauncher.launch(CLINICAL_SOURCE_MIME_TYPES) },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(if (sourceUri == null) "Attach…" else "Replace")
+                        }
+                        if (sourceUri != null) {
+                            TextButton(onClick = {
+                                sourceUri?.let { releasePersistableRead(context, it) }
+                                sourceUri = null
+                            }) { Text("Remove") }
+                        }
+                    }
+                    sourceUri?.let {
+                        Text(
+                            "Attached: ${it.lastPathSegment ?: it.toString()}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Text(
+                "Readings",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+
+            rows.forEachIndexed { index, row ->
+                ReadingRowCard(
+                    state = row,
+                    onChange = { rows[index] = it },
+                    onRemove = { rows.removeAt(index) },
+                    canRemove = rows.size > 1,
+                )
+            }
+
+            FilledTonalButton(
+                onClick = { rows.add(ReadingRowState()) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Text("  Add another reading")
+            }
+
+            OutlinedButton(
+                onClick = {
+                    val bundle = rows.mapNotNull { it.toBundleReading() }
+                    if (bundle.isEmpty()) {
+                        saveMessage = "Add at least one filled reading before saving."
+                        return@OutlinedButton
+                    }
+                    val capturedAt = timestamp
+                    val clinic = clinicName.ifBlank { null }
+                    val note = visitNote.ifBlank { null }
+                    val uri = sourceUri?.toString()
+                    scope.launch {
+                        repo.addBundle(
+                            timestamp = capturedAt,
+                            clinicName = clinic,
+                            visitNote = note,
+                            sourceUri = uri,
+                            readings = bundle,
+                        )
+                        saveMessage = "Saved ${bundle.size} reading${if (bundle.size == 1) "" else "s"}."
+                        rows.clear()
+                        defaultTriageRows().forEach { rows.add(it) }
+                        clinicName = ""
+                        visitNote = ""
+                        sourceUri = null
+                    }
+                },
+                enabled = anyValid,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Save")
+            }
+
+            saveMessage?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = timestamp)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { timestamp = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+
+private val CLINICAL_SOURCE_MIME_TYPES: Array<String> = arrayOf(
+    "image/jpeg",
+    "image/png",
+    "application/pdf",
+)
+
+private fun releasePersistableRead(context: Context, uri: Uri) {
+    try {
+        context.contentResolver.releasePersistableUriPermission(
+            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+    } catch (_: SecurityException) {
+        // Permission was never persisted or already revoked — nothing to release.
+    }
+}
+
+private fun formatClinicalDate(epochMs: Long): String =
+    SimpleDateFormat("d MMM yyyy", Locale.getDefault()).format(Date(epochMs))

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
@@ -1,0 +1,234 @@
+package com.bios.app.ui.clinical
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.AvpuLevel
+import com.bios.app.data.BundleReading
+import com.bios.app.data.GcsBounds
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ReadingRowCard(
+    state: ReadingRowState,
+    onChange: (ReadingRowState) -> Unit,
+    onRemove: () -> Unit,
+    canRemove: Boolean,
+) {
+    Card {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                MetricPicker(
+                    selected = state.metric,
+                    onSelect = { onChange(state.copy(metric = it, valueText = "", originalValue = null)) },
+                    modifier = Modifier.weight(1f),
+                )
+                if (canRemove) {
+                    IconButton(onClick = onRemove) {
+                        Icon(Icons.Default.Close, contentDescription = "Remove reading")
+                    }
+                }
+            }
+
+            when (state.metric) {
+                MetricType.CONSCIOUSNESS_LEVEL -> ConsciousnessInput(state, onChange)
+                else -> NumericInput(state, onChange)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MetricPicker(
+    selected: MetricType,
+    onSelect: (MetricType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = selected.readableName,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Metric") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            clinicalEntryMetrics.forEach { metric ->
+                DropdownMenuItem(
+                    text = { Text("${metric.readableName} (${metric.unit.symbol.ifEmpty { "—" }})") },
+                    onClick = {
+                        onSelect(metric)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumericInput(state: ReadingRowState, onChange: (ReadingRowState) -> Unit) {
+    OutlinedTextField(
+        value = state.valueText,
+        onValueChange = { onChange(state.copy(valueText = it.filter { c -> c.isDigit() || c == '.' })) },
+        label = { Text("Value") },
+        suffix = { Text(state.metric.unit.symbol.ifEmpty { "—" }) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun ConsciousnessInput(state: ReadingRowState, onChange: (ReadingRowState) -> Unit) {
+    Text(
+        "AVPU shortcut maps to GCS losslessly — original scale + value " +
+            "are kept alongside for provenance.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        AvpuLevel.entries.forEach { level ->
+            AssistChip(
+                onClick = {
+                    onChange(
+                        state.copy(
+                            valueText = level.gcsTotal.toString(),
+                            originalScale = "AVPU",
+                            originalValue = level.name.first().toString(),
+                        )
+                    )
+                },
+                label = { Text(level.name.first().toString()) },
+            )
+        }
+    }
+    OutlinedTextField(
+        value = state.valueText,
+        onValueChange = {
+            val cleaned = it.filter { c -> c.isDigit() }
+            onChange(
+                state.copy(
+                    valueText = cleaned,
+                    originalScale = if (cleaned.isBlank()) null else "GCS",
+                    originalValue = null,
+                )
+            )
+        },
+        label = { Text("GCS total") },
+        suffix = { Text("${GcsBounds.MIN}–${GcsBounds.MAX}") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    state.originalScale?.let { scale ->
+        val original = state.originalValue?.let { " ($it)" } ?: ""
+        FilterChip(
+            selected = true,
+            onClick = {},
+            label = { Text("Source: $scale$original") },
+        )
+    }
+}
+
+internal data class ReadingRowState(
+    val metric: MetricType = MetricType.BLOOD_PRESSURE_SYSTOLIC,
+    val valueText: String = "",
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+) {
+    fun isFilled(): Boolean = valueText.toDoubleOrNull() != null
+
+    fun toBundleReading(): BundleReading? {
+        val parsed = valueText.toDoubleOrNull() ?: return null
+        val (scale, value) = if (metric == MetricType.CONSCIOUSNESS_LEVEL) {
+            (originalScale ?: "GCS") to (originalValue ?: parsed.toInt().toString())
+        } else {
+            null to null
+        }
+        return BundleReading(
+            metricType = metric,
+            value = parsed,
+            originalScale = scale,
+            originalValue = value,
+        )
+    }
+}
+
+/**
+ * Triage-default row order matches a Spanish ER chart's column layout
+ * (TAS / TAD / Sat O2 / FC / Temp / FR / EVA / GCS / Flujo O2) — that's
+ * the chart shape that motivated this surface.
+ */
+internal fun defaultTriageRows(): List<ReadingRowState> = listOf(
+    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
+    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+    ReadingRowState(metric = MetricType.BLOOD_OXYGEN),
+    ReadingRowState(metric = MetricType.HEART_RATE),
+    ReadingRowState(metric = MetricType.SKIN_TEMPERATURE),
+    ReadingRowState(metric = MetricType.RESPIRATORY_RATE),
+    ReadingRowState(metric = MetricType.PAIN_SCORE),
+    ReadingRowState(metric = MetricType.CONSCIOUSNESS_LEVEL),
+    ReadingRowState(metric = MetricType.OXYGEN_FLOW_RATE),
+)
+
+/**
+ * Metrics offered in the clinical-reading picker: everything that opts in
+ * to manual entry except the lab/biomarker surface (which has its own
+ * picker on BiomarkerEntryScreen) and reproductive metrics (which route
+ * through their isolated DB via BbtEntryRepo / PeriodEntryRepo).
+ */
+private val clinicalEntryMetrics: List<MetricType> by lazy {
+    MetricType.entries.filter {
+        it.allowsManualEntry &&
+            it.domain != MetricDomain.BIOMARKER &&
+            it.domain != MetricDomain.WOMENS_HEALTH &&
+            it.domain != MetricDomain.SLEEP
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ fun SettingsScreen(
     onNavigateToPrivacy: () -> Unit = {},
     onNavigateToCompanions: () -> Unit = {},
     onNavigateToBiomarkerEntry: () -> Unit = {},
+    onNavigateToClinicalEntry: () -> Unit = {},
     onNavigateToBbtEntry: () -> Unit = {},
     onNavigateToPeriodEntry: () -> Unit = {},
     onNavigateToSleepEntry: () -> Unit = {},
@@ -179,6 +180,8 @@ fun SettingsScreen(
 
                 Spacer(Modifier.height(8.dp))
                 SettingsActionButton("Add Lab Values", onNavigateToBiomarkerEntry)
+                Spacer(Modifier.height(4.dp))
+                SettingsActionButton("Add clinical reading", onNavigateToClinicalEntry)
                 Spacer(Modifier.height(4.dp))
                 SettingsActionButton("Log sleep", onNavigateToSleepEntry)
                 Spacer(Modifier.height(4.dp))

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -353,6 +353,7 @@ class FhirExporterTest {
             MetricUnit.UG_PER_M3 -> "ug/m3"
             MetricUnit.PPM -> "[ppm]"
             MetricUnit.PPB -> "[ppb]"
+            MetricUnit.LITERS_PER_MIN -> "L/min"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
@@ -1,0 +1,114 @@
+package com.bios.app
+
+import com.bios.app.data.AvpuLevel
+import com.bios.app.data.GcsBounds
+import com.bios.app.data.ManualReadingContext
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the selectors the clinical-reading entry surface depends on:
+ *  - the canonical vital-sign set the picker offers;
+ *  - the AVPU → GCS lossless mapping the consciousness input applies;
+ *  - the [ManualReadingContext.isEmpty] contract that decides whether the
+ *    sidecar gets written at all.
+ *
+ * If these selectors silently drift, the bundle entry screen either drops
+ * relevant metrics or overwrites GCS values during AVPU shortcut entries.
+ */
+class ManualReadingSelectorsTest {
+
+    @Test
+    fun clinical_picker_includes_every_canonical_vital() {
+        // These are the columns of a Spanish ER triage chart (TAS, TAD,
+        // SatO2, FC, Temp, FR, EVA, GCS, Flujo O2). All must opt in to
+        // manual entry or the picker is missing the form the screen was
+        // built to capture.
+        val triage = setOf(
+            MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.BLOOD_OXYGEN,
+            MetricType.HEART_RATE,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.RESPIRATORY_RATE,
+            MetricType.PAIN_SCORE,
+            MetricType.CONSCIOUSNESS_LEVEL,
+            MetricType.OXYGEN_FLOW_RATE,
+        )
+        for (t in triage) {
+            assertTrue(
+                "${t.key} must allow manual entry — triage chart column",
+                t.allowsManualEntry
+            )
+        }
+    }
+
+    @Test
+    fun clinical_picker_excludes_biomarker_and_reproductive_metrics() {
+        // Biomarkers route through BiomarkerEntryScreen (lab provenance
+        // shape); reproductive metrics route through BbtEntryRepo /
+        // PeriodEntryRepo (isolated ReproductiveDatabase). The clinical
+        // bundle screen filters them out — verify the filter premise:
+        // each domain still has at least one allows-manual-entry entry,
+        // so excluding by domain is a meaningful split.
+        val biomarkerManual = MetricType.entries
+            .filter { it.domain == MetricDomain.BIOMARKER && it.allowsManualEntry }
+        assertTrue("Biomarker domain must have manual-entry metrics", biomarkerManual.isNotEmpty())
+        val reproductiveManual = MetricType.entries
+            .filter { it.domain == MetricDomain.WOMENS_HEALTH && it.allowsManualEntry }
+        assertTrue("Womens-health domain must have manual-entry metrics", reproductiveManual.isNotEmpty())
+    }
+
+    @Test
+    fun avpu_maps_lossless_to_canonical_gcs_totals() {
+        // AVPU → GCS mapping is the cited entry-time shortcut for
+        // CONSCIOUSNESS_LEVEL. Issue #131 fixed these values; renumbering
+        // here would silently rewrite the owner's chart history.
+        assertEquals(15, AvpuLevel.ALERT.gcsTotal)
+        assertEquals(13, AvpuLevel.VOICE.gcsTotal)
+        assertEquals(8, AvpuLevel.PAIN.gcsTotal)
+        assertEquals(3, AvpuLevel.UNRESPONSIVE.gcsTotal)
+    }
+
+    @Test
+    fun gcs_bounds_match_clinical_canonical_range() {
+        // 3..15 is the textbook GCS total range. The screen's input field
+        // hint depends on this; loosening it would let the owner enter
+        // out-of-band values that consumers (FHIR export, trends) won't
+        // know how to interpret.
+        assertEquals(3, GcsBounds.MIN)
+        assertEquals(15, GcsBounds.MAX)
+    }
+
+    @Test
+    fun manual_reading_context_is_empty_when_all_fields_blank() {
+        assertTrue(ManualReadingContext().isEmpty)
+        assertTrue(ManualReadingContext(clinicName = "", visitNote = "  ").isEmpty)
+    }
+
+    @Test
+    fun manual_reading_context_records_clinic_provenance() {
+        val context = ManualReadingContext(
+            clinicName = "Hospital de Triage",
+            originalScale = "AVPU",
+            originalValue = "V",
+        )
+        assertFalse(context.isEmpty)
+        assertEquals("AVPU", context.originalScale)
+        assertEquals("V", context.originalValue)
+    }
+
+    @Test
+    fun pain_and_consciousness_units_are_score() {
+        // The picker shows the unit suffix next to the entry field; SCORE
+        // resolves to an empty symbol intentionally (no display suffix
+        // for raw 0–10 / 3–15 numbers).
+        assertEquals(MetricUnit.SCORE, MetricType.PAIN_SCORE.unit)
+        assertEquals(MetricUnit.SCORE, MetricType.CONSCIOUSNESS_LEVEL.unit)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -19,10 +19,23 @@ package com.bios.contracts
  *    existing entry — add a new entry.
  *  - Consumers must call `fromKey()` (not `valueOf`) and tolerate `null` for
  *    keys their contracts version doesn't know.
+ *
+ * [allowsManualEntry] gates the Bios-hosted manual-reading surface. The rule
+ * is *"can the owner be the source?"* — reading a device (cuff, pulse-ox,
+ * thermometer), being measured by a clinician, observing themselves. Derived
+ * keys (HRV power, glucose CV, sleep efficiency) and pure-sensor-only signals
+ * (raw accelerometer) stay false. Engine isolation still holds — manual
+ * entries flow through SELF_REPORTED and never feed BaselineEngine /
+ * AnomalyDetector. See docs/SELF_REPORTED_DATA_HOME.md decision 3.
  */
-enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricDomain) {
+enum class MetricType(
+    val key: String,
+    val unit: MetricUnit,
+    val domain: MetricDomain,
+    val allowsManualEntry: Boolean = false,
+) {
     // Cardiovascular
-    HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
+    HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
     HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
@@ -30,21 +43,36 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     HRV_LF_POWER("hrv_lf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     HRV_HF_POWER("hrv_hf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     VO2_MAX("vo2_max", MetricUnit.ML_PER_KG_MIN, MetricDomain.CARDIOVASCULAR),
-    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
-    BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
-    BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
-    BLOOD_OXYGEN("blood_oxygen", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR),
+    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_OXYGEN("blood_oxygen", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
 
     // Respiratory
-    RESPIRATORY_RATE("respiratory_rate", MetricUnit.BREATHS_PER_MIN, MetricDomain.RESPIRATORY),
+    RESPIRATORY_RATE("respiratory_rate", MetricUnit.BREATHS_PER_MIN, MetricDomain.RESPIRATORY, allowsManualEntry = true),
+    // Administered supplemental O2 (cannula/mask). Contextualises SpO2:
+    // 96 % on room air ≠ 96 % on 4 L/min. Single-point shape; ongoing-therapy
+    // log-shape (start/end + rate over time) is deferred — see issue #107.
+    OXYGEN_FLOW_RATE("oxygen_flow_rate", MetricUnit.LITERS_PER_MIN, MetricDomain.RESPIRATORY, allowsManualEntry = true),
 
     // Temperature
-    SKIN_TEMPERATURE("skin_temperature", MetricUnit.CELSIUS, MetricDomain.TEMPERATURE),
+    SKIN_TEMPERATURE("skin_temperature", MetricUnit.CELSIUS, MetricDomain.TEMPERATURE, allowsManualEntry = true),
     SKIN_TEMPERATURE_DEVIATION("skin_temperature_deviation", MetricUnit.DELTA_CELSIUS, MetricDomain.TEMPERATURE),
+
+    // Neurological (manual-capture clinical signs).
+    // PAIN_SCORE: 0–10 numeric (EVA / VAS / NRS interoperable). Universal
+    // triage vital.
+    // CONSCIOUSNESS_LEVEL: GCS canonical (3–15 total). GCS encodes AVPU but
+    // not vice versa, so GCS covers neuro/ICU/post-trauma/surgery contexts
+    // over a lifetime while AVPU-only is ER-triage-only. AVPU entry is a
+    // lossless input shortcut (A→15, V→13, P→8, U→3); the original scale +
+    // value are preserved in the event_payloads sidecar for provenance.
+    PAIN_SCORE("pain_score", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+    CONSCIOUSNESS_LEVEL("consciousness_level", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
     // Sleep
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),
-    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP),
+    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP, allowsManualEntry = true),
     SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_EFFICIENCY("sleep_efficiency", MetricUnit.PERCENT, MetricDomain.SLEEP),
     SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),
@@ -68,26 +96,26 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     EXERCISE_SESSION("exercise_session", MetricUnit.EVENT, MetricDomain.ACTIVITY),
 
     // Metabolic
-    BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
+    BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC, allowsManualEntry = true),
     // CGM-derived variability keys (#28). Computed over the last 24h of
     // BLOOD_GLUCOSE readings by GlucoseVariability; one value per 24h window.
     GLUCOSE_CV("glucose_cv", MetricUnit.PERCENT, MetricDomain.METABOLIC),
     GLUCOSE_MAGE("glucose_mage", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
     GLUCOSE_TIME_IN_RANGE("glucose_time_in_range", MetricUnit.PERCENT, MetricDomain.METABOLIC),
     GLUCOSE_PEAK_24H("glucose_peak_24h", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
-    BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
-    BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
-    LEAN_MASS("lean_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
-    BODY_WATER_PCT("body_water_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
-    BONE_MASS("bone_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
+    BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC, allowsManualEntry = true),
+    LEAN_MASS("lean_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BODY_WATER_PCT("body_water_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BONE_MASS("bone_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
 
     // Recovery
     RECOVERY_SCORE("recovery_score", MetricUnit.SCORE, MetricDomain.RECOVERY),
 
     // Women's Health
-    BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH),
+    BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH, allowsManualEntry = true),
     CYCLE_PHASE("cycle_phase", MetricUnit.CATEGORY, MetricDomain.WOMENS_HEALTH),
-    MENSTRUATION_ONSET("menstruation_onset", MetricUnit.EVENT, MetricDomain.WOMENS_HEALTH),
+    MENSTRUATION_ONSET("menstruation_onset", MetricUnit.EVENT, MetricDomain.WOMENS_HEALTH, allowsManualEntry = true),
     CYCLE_DAY("cycle_day", MetricUnit.COUNT, MetricDomain.WOMENS_HEALTH),
 
     // Environment (phone-sensor adapter)
@@ -100,57 +128,57 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // First wave matches the clinical concepts already described in
     // alerts/BiomarkerReference.kt — direct readings displace the wearable
     // proxies when an owner imports labs.
-    HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
-    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER),
-    TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    VITAMIN_D_25OH("vitamin_d_25oh", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
-    TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER),
-    FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
-    FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    HEMOGLOBIN("hemoglobin", MetricUnit.G_PER_DL, MetricDomain.BIOMARKER),
-    HEMATOCRIT("hematocrit", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
-    WBC("wbc", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
-    RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER),
-    PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
+    HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    VITAMIN_D_25OH("vitamin_d_25oh", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HEMOGLOBIN("hemoglobin", MetricUnit.G_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HEMATOCRIT("hematocrit", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    WBC("wbc", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Glycemic-extended (#24). Fasting glucose + insulin enable HOMA-IR, the
     // canonical insulin-resistance index — clinically meaningful before HbA1c
     // shifts. HOMA-IR is stored as the calculated value (Matthews 1985:
     // (fasting insulin µIU/mL × fasting glucose mg/dL) / 405).
-    FASTING_GLUCOSE("fasting_glucose", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    FASTING_INSULIN("fasting_insulin", MetricUnit.MICRO_IU_PER_ML, MetricDomain.BIOMARKER),
-    HOMA_IR("homa_ir", MetricUnit.SCORE, MetricDomain.BIOMARKER),
+    FASTING_GLUCOSE("fasting_glucose", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FASTING_INSULIN("fasting_insulin", MetricUnit.MICRO_IU_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HOMA_IR("homa_ir", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Iron status (#24). Ferritin is the most-cited single marker for body
     // iron stores; relevant to fatigue / inflammation patterns.
-    FERRITIN("ferritin", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
+    FERRITIN("ferritin", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Endocrine panel (#24). Sex hormones + adrenal (cortisol) + IGF-1.
     // Reference ranges vary by sex/age — Bios stores raw values, the owner's
     // own provider-supplied range travels with the FHIR import.
-    TESTOSTERONE_TOTAL("testosterone_total", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
-    ESTRADIOL("estradiol", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    CORTISOL("cortisol", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER),
-    IGF_1("igf_1", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
+    TESTOSTERONE_TOTAL("testosterone_total", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ESTRADIOL("estradiol", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    CORTISOL("cortisol", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    IGF_1("igf_1", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Micronutrients (#24). Common deficiency panel — methylation cofactors
     // (B12/folate) and the electrolyte the standard CMP often omits.
-    VITAMIN_B12("vitamin_b12", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    FOLATE("folate", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
-    MAGNESIUM("magnesium", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    VITAMIN_B12("vitamin_b12", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FOLATE("folate", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    MAGNESIUM("magnesium", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
     // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
     // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age
     // score" from these (manifesto: never evaluate the person).
-    EPIGENETIC_AGE_DUNEDIN_PACE("epigenetic_age_dunedin_pace", MetricUnit.SCORE, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_GRIM("epigenetic_age_grim", MetricUnit.YEARS, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_PHENO("epigenetic_age_pheno", MetricUnit.YEARS, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_HORVATH("epigenetic_age_horvath", MetricUnit.YEARS, MetricDomain.BIOMARKER),
+    EPIGENETIC_AGE_DUNEDIN_PACE("epigenetic_age_dunedin_pace", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_GRIM("epigenetic_age_grim", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_PHENO("epigenetic_age_pheno", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_HORVATH("epigenetic_age_horvath", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Companion signals (injected by W2F via ContentProvider).
     // typing_cadence requires the AccessibilityService capture surface;
@@ -219,11 +247,12 @@ enum class MetricUnit(val symbol: String) {
     ML_PER_KG_MIN("mL/kg/min"),
     UG_PER_M3("µg/m³"),
     PPM("ppm"),
-    PPB("ppb")
+    PPB("ppb"),
+    LITERS_PER_MIN("L/min")
 }
 
 enum class MetricDomain {
     CARDIOVASCULAR, RESPIRATORY, TEMPERATURE, SLEEP,
     ACTIVITY, METABOLIC, RECOVERY, WOMENS_HEALTH,
-    MENTAL_HEALTH, INTAKE, SAFETY, ENVIRONMENT, BIOMARKER
+    MENTAL_HEALTH, NEUROLOGICAL, INTAKE, SAFETY, ENVIRONMENT, BIOMARKER
 }

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -41,6 +41,10 @@ class MetricTypeKeysSnapshotTest {
         "blood_oxygen",
         // Respiratory
         "respiratory_rate",
+        "oxygen_flow_rate",
+        // Neurological (manual-capture clinical signs)
+        "pain_score",
+        "consciousness_level",
         // Temperature
         "skin_temperature",
         "skin_temperature_deviation",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -3,6 +3,7 @@ package com.bios.contracts
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -211,6 +212,95 @@ class MetricTypeTest {
         // EVENT unit matches the marker semantics (value = 1.0).
         assertEquals(MetricDomain.ACTIVITY, MetricType.EXERCISE_SESSION.domain)
         assertEquals(MetricUnit.EVENT, MetricType.EXERCISE_SESSION.unit)
+    }
+
+    @Test
+    fun pain_score_is_neurological_score() {
+        assertEquals(MetricDomain.NEUROLOGICAL, MetricType.PAIN_SCORE.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.PAIN_SCORE.unit)
+        assertTrue(
+            MetricType.PAIN_SCORE.allowsManualEntry,
+            "PAIN_SCORE must allow manual entry — it's the canonical triage vital",
+        )
+    }
+
+    @Test
+    fun consciousness_level_is_neurological_score() {
+        // GCS canonical scale, 3–15 total. AVPU input is an entry-time shortcut
+        // mapped lossless into GCS — see MetricType.kt header doc.
+        assertEquals(MetricDomain.NEUROLOGICAL, MetricType.CONSCIOUSNESS_LEVEL.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.CONSCIOUSNESS_LEVEL.unit)
+        assertTrue(
+            MetricType.CONSCIOUSNESS_LEVEL.allowsManualEntry,
+            "CONSCIOUSNESS_LEVEL must allow manual entry — clinicians and " +
+                "owners both produce it from the bedside",
+        )
+    }
+
+    @Test
+    fun oxygen_flow_rate_is_respiratory_liters_per_min() {
+        assertEquals(MetricDomain.RESPIRATORY, MetricType.OXYGEN_FLOW_RATE.domain)
+        assertEquals(MetricUnit.LITERS_PER_MIN, MetricType.OXYGEN_FLOW_RATE.unit)
+        assertEquals("L/min", MetricUnit.LITERS_PER_MIN.symbol)
+        assertTrue(
+            MetricType.OXYGEN_FLOW_RATE.allowsManualEntry,
+            "OXYGEN_FLOW_RATE must allow manual entry — it's recorded at " +
+                "the bedside, not by a wearable",
+        )
+    }
+
+    @Test
+    fun allows_manual_entry_defaults_false_for_pure_sensor_keys() {
+        // Spot-check: streaming sensor / derived signals must never opt in
+        // to the manual-reading surface, or the picker fills with noise.
+        val notManual = listOf(
+            MetricType.HEART_RATE_VARIABILITY,
+            MetricType.HRV_LF_POWER, MetricType.HRV_HF_POWER,
+            MetricType.PARASYMPATHETIC_TONE, MetricType.STRESS_SCORE,
+            MetricType.LF_HF_RATIO, MetricType.VO2_MAX,
+            MetricType.SKIN_TEMPERATURE_DEVIATION,
+            MetricType.SLEEP_STAGE, MetricType.SLEEP_EFFICIENCY,
+            MetricType.STEPS, MetricType.ACTIVE_CALORIES,
+            MetricType.AMBIENT_LIGHT, MetricType.AIR_PM25,
+            MetricType.TYPING_CADENCE, MetricType.MOOD_DRIFT_SCORE,
+            MetricType.TOBACCO_USE, MetricType.FALL_EVENT,
+        )
+        for (t in notManual) {
+            assertEquals(
+                false, t.allowsManualEntry,
+                "${t.key} must not opt in to manual entry",
+            )
+        }
+    }
+
+    @Test
+    fun allows_manual_entry_true_for_clinical_vitals() {
+        val manual = listOf(
+            MetricType.HEART_RATE, MetricType.RESTING_HEART_RATE,
+            MetricType.BLOOD_PRESSURE_SYSTOLIC, MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.BLOOD_OXYGEN, MetricType.RESPIRATORY_RATE,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.PAIN_SCORE, MetricType.CONSCIOUSNESS_LEVEL,
+            MetricType.OXYGEN_FLOW_RATE,
+        )
+        for (t in manual) {
+            assertTrue(
+                t.allowsManualEntry,
+                "${t.key} must opt in to manual entry — owner can be the source",
+            )
+        }
+    }
+
+    @Test
+    fun every_biomarker_allows_manual_entry() {
+        // Biomarkers have no streaming source; manual entry is the only path
+        // for owners without a FHIR feed.
+        for (t in MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }) {
+            assertTrue(
+                t.allowsManualEntry,
+                "${t.key} (biomarker) must allow manual entry",
+            )
+        }
     }
 
     @Test

--- a/docs/SELF_REPORTED_DATA_HOME.md
+++ b/docs/SELF_REPORTED_DATA_HOME.md
@@ -142,10 +142,11 @@ effect alongside this PR.
 Originally framed as *"Bios is a consumer, never the entry point —
 period."* That absolute is now wrong-as-written: since then, BBT manual
 entry (`BbtEntryRepo`), biomarker entry (`BiomarkerEntryRepo`), manual
-sleep duration, and lab-report attachment (PR #106) have all shipped as
-legitimate Bios-hosted entry surfaces.
+sleep duration, lab-report attachment (PR #106), and the general
+clinical-reading bundle surface (`ManualReadingRepo`, issue #131) have
+all shipped as legitimate Bios-hosted entry surfaces.
 
-The corrected rule — which all four shipped surfaces already satisfy —
+The corrected rule — which all five shipped surfaces already satisfy —
 is the same producer-by-capture-surface line codified in
 [ECOSYSTEM_BOUNDARIES.md](ECOSYSTEM_BOUNDARIES.md) ("No domain-specific
 active tests in Bios"). **Bios hosts an entry point if and only if the
@@ -153,9 +154,17 @@ data being entered is a canonical Bios-owned key with no other producer
 available.** Biomarkers are typed because no sensor draws blood; BBT is
 typed because no wearable on the owner's wrist measures basal body
 temperature; manual sleep is typed when Health Connect / Oura / Gadgetbridge
-are all silent. Bios is *not* the entry point for data a companion
-uniquely owns — typing cadence belongs in W2F, SDMT in Fil, fall-event
-in Virgil.
+are all silent; clinical vitals (BP cuff, pulse-ox, thermometer, triage
+chart) are typed because the LETHE-correct case is a degoogled phone
+with no Health Connect at all — the owner *is* the producer, not just
+the reader. Bios is *not* the entry point for data a companion uniquely
+owns — typing cadence belongs in W2F, SDMT in Fil, fall-event in
+Virgil.
+
+The gate is now per-metric: [MetricType.allowsManualEntry] declares
+which keys accept owner-as-source entry. Engine isolation still holds —
+manual entries flow through SELF_REPORTED and skip the baseline /
+anomaly engines per decision 3 above.
 
 The "future asks of 'let me log sleep directly in Bios'" line from the
 old wording was directionally right but the verdict's been wrong: the


### PR DESCRIPTION
Closes #131.

## Summary

Bios's only manual-entry path required `MetricDomain.BIOMARKER`, which blocked clinical vital signs (BP / SpO2 / pulse / temp / RR / pain / GCS / O2 flow) — exactly the LETHE case where the owner has no Health Connect and *is* the producer at the bedside.

- **MetricType**: add `allowsManualEntry` per-key flag (default `false`). Adds three new keys:
  - `PAIN_SCORE` — 0–10 score, new `NEUROLOGICAL` domain.
  - `CONSCIOUSNESS_LEVEL` — GCS canonical (3–15) with AVPU lossless input shortcut (A→15, V→13, P→8, U→3); original-scale + value preserved in `event_payloads`.
  - `OXYGEN_FLOW_RATE` — L/min, respiratory; new `LITERS_PER_MIN` unit.
- **ManualReadingRepo**: sibling of `BiomarkerEntryRepo` sharing the SELF_REPORTED write path via the extracted `resolveSelfReportedSource()`. Supports a clinical-visit bundle write (one shared timestamp + clinic + visit note + N readings).
- **ClinicalReadingEntryScreen**: bundle-style UI modeled on a Spanish ER triage chart (TAS / TAD / SatO2 / FC / Temp / FR / EVA / GCS / Flujo O2). AVPU shortcut chips + GCS input on the consciousness row.
- **Engine isolation hold**: `BaselineEngine` / `AnomalyDetector` / `SignalQualityFilter` still filter by `ReadingKind.SENSOR`. Manual entries flow as SELF_REPORTED so single-point clinical readings can't poison sensor baselines (`SELF_REPORTED_DATA_HOME.md` decision 3).
- **Docs**: updated decision 6 in `SELF_REPORTED_DATA_HOME.md` to record the new surface and the per-metric gate.

## Test plan

- [x] `:bios-contracts:test` — new `MetricTypeTest` cases for `PAIN_SCORE` / `CONSCIOUSNESS_LEVEL` / `OXYGEN_FLOW_RATE`, `allowsManualEntry` invariants for vitals + biomarkers + pure-sensor keys; snapshot test extended with the 3 new keys.
- [x] `:app:testStandaloneDebugUnitTest` — new `ManualReadingSelectorsTest` guards triage picker contents, AVPU mapping, and `ManualReadingContext.isEmpty`. Existing `BiomarkerEntrySelectorsTest`, `AnomalyDetectorReadingKindFilterTest`, `FhirExporterTest` still green (FHIR UCUM mapping extended for `L/min`).
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, assemble, unit tests).
- [ ] Manual smoke (UI): navigate Settings → Add clinical reading, save a triage bundle, confirm rows show up in Trends with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)