### PR TITLE
feat(sleep): phone inference, regularity engine, and dashboard v1

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/DisconnectDetector.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/DisconnectDetector.kt
@@ -197,6 +197,7 @@ internal val SourceType.label: String
         SourceType.POLAR_API -> "Polar"
         SourceType.DIRECT_SENSOR -> "Direct sensor"
         SourceType.PHONE_SENSOR -> "Phone sensor"
+        SourceType.PHONE_SENSOR_DERIVED -> "Phone sleep fusion"
         SourceType.CAMERA_PPG -> "Camera PPG"
         SourceType.BLE_PERIPHERAL -> "Air-quality sensor"
         SourceType.SELF_REPORTED -> "Self-reported"

--- a/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiomarkerEntryRepo.kt
@@ -1,23 +1,23 @@
 package com.bios.app.data
 
 import com.bios.app.model.ConfidenceTier
-import com.bios.app.model.DataSource
 import com.bios.app.model.EventPayloadField
 import com.bios.app.model.MetricReading
-import com.bios.app.model.ReadingKind
-import com.bios.app.model.SensorType
-import com.bios.app.model.SourceType
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 
 /**
  * Persistence path for self-reported lab values entered through the
- * biomarker entry screen.
+ * biomarker entry screen. Sibling of [ManualReadingRepo] for clinical
+ * vital signs — both share the SELF_REPORTED write path via
+ * [resolveSelfReportedSource].
  *
- * Self-reported readings flow through a single SELF_REPORTED [DataSource]
- * tagged with [ReadingKind.SELF_REPORTED] so the baseline engine and anomaly
- * detector keep ignoring them (decision 3 in docs/SELF_REPORTED_DATA_HOME.md).
- * They still show up in trends, FHIR export, and condition-pattern displays.
+ * Self-reported readings flow through a single SELF_REPORTED
+ * [com.bios.app.model.DataSource] tagged with
+ * [com.bios.app.model.ReadingKind.SELF_REPORTED] so the baseline engine
+ * and anomaly detector keep ignoring them (decision 3 in
+ * docs/SELF_REPORTED_DATA_HOME.md). They still show up in trends, FHIR
+ * export, and condition-pattern displays.
  *
  * Optional [BiomarkerContext] carries lab provenance — engine-relevant
  * fields (lab, fasting, specimen, source URI) ride the existing
@@ -35,7 +35,7 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
         require(metricType.domain == MetricDomain.BIOMARKER) {
             "BiomarkerEntryRepo only accepts BIOMARKER metrics; got ${metricType.key}"
         }
-        val sourceId = getOrCreateSelfReportedSource()
+        val sourceId = resolveSelfReportedSource(db)
         val reading = MetricReading(
             metricType = metricType.key,
             value = value,
@@ -81,19 +81,6 @@ class BiomarkerEntryRepo(private val db: BiosDatabase) {
         if (fields.isNotEmpty()) {
             db.eventPayloadFieldDao().insertAll(fields)
         }
-    }
-
-    private suspend fun getOrCreateSelfReportedSource(): String {
-        val dao = db.dataSourceDao()
-        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
-        val source = DataSource(
-            sourceType = SourceType.SELF_REPORTED.key,
-            deviceName = "Self-reported",
-            sensorType = SensorType.DERIVED.name,
-            readingKind = ReadingKind.SELF_REPORTED.name
-        )
-        dao.insert(source)
-        return source.id
     }
 
     companion object {

--- a/android/app/src/main/java/com/bios/app/data/ConsciousnessScale.kt
+++ b/android/app/src/main/java/com/bios/app/data/ConsciousnessScale.kt
@@ -1,0 +1,22 @@
+package com.bios.app.data
+
+/**
+ * Input scales accepted for [com.bios.contracts.MetricType.CONSCIOUSNESS_LEVEL].
+ * GCS is canonical (3–15 total); AVPU is a lossless input shortcut that
+ * snaps onto representative GCS totals (A→15, V→13, P→8, U→3). When AVPU
+ * is used at entry, the original scale + value are preserved in the
+ * `event_payloads` sidecar via
+ * [ManualReadingPayloadKeys.ORIGINAL_SCALE] / [ManualReadingPayloadKeys.ORIGINAL_VALUE]
+ * so the provenance survives the lossy axis.
+ */
+enum class AvpuLevel(val gcsTotal: Int, val label: String) {
+    ALERT(15, "A — Alert"),
+    VOICE(13, "V — Responds to voice"),
+    PAIN(8, "P — Responds to pain"),
+    UNRESPONSIVE(3, "U — Unresponsive"),
+}
+
+object GcsBounds {
+    const val MIN = 3
+    const val MAX = 15
+}

--- a/android/app/src/main/java/com/bios/app/data/ManualReadingContext.kt
+++ b/android/app/src/main/java/com/bios/app/data/ManualReadingContext.kt
@@ -1,0 +1,60 @@
+package com.bios.app.data
+
+/**
+ * Provenance attached to a manually entered reading produced through the
+ * general manual-reading surface. Shape mirrors a clinical-visit triage
+ * row: one shared timestamp + clinic name + visit note + optional source
+ * artifact (chart PDF/photo) span N readings captured together (BP, SpO2,
+ * pulse, temp, RR, pain, GCS, O2 flow as one event).
+ *
+ * Single-reading entries (owner reading a cuff at home) use the same shape
+ * with [clinicName] / [visitNote] null and no bundle id.
+ *
+ * Some metrics carry a per-row provenance dimension that the bundle-level
+ * fields can't express. [CONSCIOUSNESS_LEVEL][com.bios.contracts.MetricType.CONSCIOUSNESS_LEVEL]
+ * is canonical GCS but accepts AVPU as a lossless input shortcut — when the
+ * owner enters "V" we store 13 as the value and ride the original scale +
+ * value alongside in [originalScale] / [originalValue]. Owner-recall text
+ * rides [note] (per-reading) and lives in `metric_readings.note`. Engines
+ * never read either.
+ *
+ * All fields are optional. A bare reading (metric + value + timestamp)
+ * leaves every field null and writes nothing to the sidecar.
+ */
+data class ManualReadingContext(
+    val clinicName: String? = null,
+    val visitNote: String? = null,
+    val sourceUri: String? = null,
+    val bundleId: String? = null,
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+    val note: String? = null,
+) {
+    val isEmpty: Boolean
+        get() = clinicName.isNullOrBlank() &&
+            visitNote.isNullOrBlank() &&
+            sourceUri.isNullOrBlank() &&
+            bundleId.isNullOrBlank() &&
+            originalScale.isNullOrBlank() &&
+            originalValue.isNullOrBlank() &&
+            note.isNullOrBlank()
+}
+
+/**
+ * Field keys for manual-reading provenance in the `event_payloads` sidecar.
+ * Stability contract: renames are breaking changes — see DATA_MODEL.md.
+ *
+ * Distinct namespace from [BiomarkerPayloadKeys]: a biomarker entry stores
+ * lab/fasting/specimen; a clinical-visit entry stores clinic/visit/bundle.
+ * The two surfaces share the SELF_REPORTED source but not the sidecar
+ * vocabulary, so consumers reading payloads can tell which surface a
+ * reading came from by which keys are present.
+ */
+object ManualReadingPayloadKeys {
+    const val CLINIC_NAME = "clinic_name"
+    const val VISIT_NOTE = "visit_note"
+    const val SOURCE_URI = "source_uri"
+    const val BUNDLE_ID = "bundle_id"
+    const val ORIGINAL_SCALE = "original_scale"
+    const val ORIGINAL_VALUE = "original_value"
+}

--- a/android/app/src/main/java/com/bios/app/data/ManualReadingRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/ManualReadingRepo.kt
@@ -1,0 +1,148 @@
+package com.bios.app.data
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.util.UUID
+
+/**
+ * General manual-reading persistence path for clinical vital signs and
+ * other owner-as-source metrics. Sibling of [BiomarkerEntryRepo] sharing
+ * the same SELF_REPORTED write path
+ * ([resolveSelfReportedSource]) — the split keeps the lab-specific
+ * provenance vocabulary ([BiomarkerContext]) separate from the
+ * clinical-visit vocabulary ([ManualReadingContext]) without forking the
+ * data source.
+ *
+ * Engine isolation still holds: rows insert through SELF_REPORTED so
+ * `BaselineEngine` and `AnomalyDetector` skip them
+ * (docs/SELF_REPORTED_DATA_HOME.md decision 3). The owner sees these in
+ * trends, FHIR export, and pull-side comparisons; nothing pushes a
+ * judgement on a self-reported value.
+ *
+ * Reproductive metrics (BBT, period onset) are NOT accepted here — their
+ * rows live in the isolated [ReproductiveDatabase] via
+ * [BbtEntryRepo] / [PeriodEntryRepo] for the encryption-isolation reason
+ * documented on those repos. The gate is [MetricType.allowsManualEntry];
+ * reproductive entries that pass it (e.g. MENSTRUATION_ONSET) still get
+ * routed to their domain repos by the UI layer.
+ */
+class ManualReadingRepo(private val db: BiosDatabase) {
+
+    suspend fun add(
+        metricType: MetricType,
+        value: Double,
+        timestamp: Long,
+        context: ManualReadingContext = ManualReadingContext(),
+    ): String {
+        require(metricType.allowsManualEntry) {
+            "ManualReadingRepo only accepts metrics with allowsManualEntry=true; " +
+                "got ${metricType.key}"
+        }
+        val sourceId = resolveSelfReportedSource(db)
+        val reading = MetricReading(
+            metricType = metricType.key,
+            value = value,
+            timestamp = timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            note = context.note?.takeIf { it.isNotBlank() },
+        )
+        db.metricReadingDao().insert(reading)
+        persistPayload(reading.id, context)
+        return reading.id
+    }
+
+    /**
+     * Clinical-visit bundle entry. One shared timestamp + clinic + visit
+     * note span N readings; each reading carries the same auto-generated
+     * [ManualReadingContext.bundleId] so the UI can later regroup them.
+     * Mirrors how a triage row gets recorded — BP + SpO2 + FC + Temp + FR +
+     * EVA + GCS + Flujo O2 captured as one event.
+     */
+    suspend fun addBundle(
+        timestamp: Long,
+        clinicName: String?,
+        visitNote: String?,
+        sourceUri: String?,
+        readings: List<BundleReading>,
+    ): String {
+        require(readings.isNotEmpty()) { "Clinical-visit bundle must contain at least one reading" }
+        val bundleId = UUID.randomUUID().toString()
+        val sharedContext = ManualReadingContext(
+            clinicName = clinicName?.takeIf { it.isNotBlank() },
+            visitNote = visitNote?.takeIf { it.isNotBlank() },
+            sourceUri = sourceUri?.takeIf { it.isNotBlank() },
+            bundleId = bundleId,
+        )
+        for (r in readings) {
+            val rowContext = sharedContext.copy(
+                originalScale = r.originalScale,
+                originalValue = r.originalValue,
+                note = r.note,
+            )
+            add(r.metricType, r.value, timestamp, rowContext)
+        }
+        return bundleId
+    }
+
+    suspend fun fetchContext(readingId: String): ManualReadingContext {
+        val rows = db.eventPayloadFieldDao().fetchForReading(readingId)
+        return rowsToContext(rows, note = null)
+    }
+
+    private suspend fun persistPayload(readingId: String, context: ManualReadingContext) {
+        val fields = buildList {
+            context.clinicName?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.CLINIC_NAME, stringValue = it))
+            }
+            context.visitNote?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.VISIT_NOTE, stringValue = it))
+            }
+            context.sourceUri?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.SOURCE_URI, stringValue = it))
+            }
+            context.bundleId?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.BUNDLE_ID, stringValue = it))
+            }
+            context.originalScale?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.ORIGINAL_SCALE, stringValue = it))
+            }
+            context.originalValue?.takeIf { it.isNotBlank() }?.let {
+                add(EventPayloadField(readingId, ManualReadingPayloadKeys.ORIGINAL_VALUE, stringValue = it))
+            }
+        }
+        if (fields.isNotEmpty()) {
+            db.eventPayloadFieldDao().insertAll(fields)
+        }
+    }
+
+    companion object {
+        internal fun rowsToContext(rows: List<EventPayloadField>, note: String?): ManualReadingContext {
+            val byKey = rows.associateBy { it.fieldKey }
+            return ManualReadingContext(
+                clinicName = byKey[ManualReadingPayloadKeys.CLINIC_NAME]?.stringValue,
+                visitNote = byKey[ManualReadingPayloadKeys.VISIT_NOTE]?.stringValue,
+                sourceUri = byKey[ManualReadingPayloadKeys.SOURCE_URI]?.stringValue,
+                bundleId = byKey[ManualReadingPayloadKeys.BUNDLE_ID]?.stringValue,
+                originalScale = byKey[ManualReadingPayloadKeys.ORIGINAL_SCALE]?.stringValue,
+                originalValue = byKey[ManualReadingPayloadKeys.ORIGINAL_VALUE]?.stringValue,
+                note = note,
+            )
+        }
+    }
+}
+
+/**
+ * One reading inside a clinical-visit bundle. [originalScale] /
+ * [originalValue] preserve scales like AVPU when the canonical metric is
+ * GCS — see [MetricType.CONSCIOUSNESS_LEVEL] for the lossless mapping.
+ */
+data class BundleReading(
+    val metricType: MetricType,
+    val value: Double,
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+    val note: String? = null,
+)

--- a/android/app/src/main/java/com/bios/app/data/SelfReportedMainSource.kt
+++ b/android/app/src/main/java/com/bios/app/data/SelfReportedMainSource.kt
@@ -1,0 +1,30 @@
+package com.bios.app.data
+
+import com.bios.app.model.DataSource
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+
+/**
+ * Resolves (creating if absent) the single SELF_REPORTED row in the main
+ * [BiosDatabase] that owns every manually entered reading. Shared by
+ * [BiomarkerEntryRepo], [ManualReadingRepo], and [SleepEntryRepo] so they
+ * all converge on one source id — without this, each repo would create its
+ * own SELF_REPORTED row and the data-coverage view would double-count.
+ *
+ * The reproductive flow ([BbtEntryRepo], [PeriodEntryRepo]) has its own
+ * helper because reproductive rows live in the isolated ReproductiveDatabase
+ * (separate encryption key, independent wipe).
+ */
+internal suspend fun resolveSelfReportedSource(db: BiosDatabase): String {
+    val dao = db.dataSourceDao()
+    dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
+    val source = DataSource(
+        sourceType = SourceType.SELF_REPORTED.key,
+        deviceName = "Self-reported",
+        sensorType = SensorType.DERIVED.name,
+        readingKind = ReadingKind.SELF_REPORTED.name
+    )
+    dao.insert(source)
+    return source.id
+}

--- a/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
@@ -1,11 +1,7 @@
 package com.bios.app.data
 
 import com.bios.app.model.ConfidenceTier
-import com.bios.app.model.DataSource
 import com.bios.app.model.MetricReading
-import com.bios.app.model.ReadingKind
-import com.bios.app.model.SensorType
-import com.bios.app.model.SourceType
 import com.bios.contracts.MetricType
 
 /**
@@ -14,8 +10,10 @@ import com.bios.contracts.MetricType
  * gap on a given night).
  *
  * Like [BiomarkerEntryRepo], rows are tagged with the shared SELF_REPORTED
- * [DataSource] + [ReadingKind.SELF_REPORTED] so the baseline engine ignores
- * them while they still surface in trends, coverage, and FHIR export.
+ * [com.bios.app.model.DataSource] +
+ * [com.bios.app.model.ReadingKind.SELF_REPORTED] so the baseline engine
+ * ignores them while they still surface in trends, coverage, and FHIR
+ * export.
  */
 class SleepEntryRepo(private val db: BiosDatabase) {
 
@@ -26,7 +24,7 @@ class SleepEntryRepo(private val db: BiosDatabase) {
         require(durationSeconds in 1..maxDurationSeconds) {
             "Sleep duration $durationSeconds s is outside the 1..$maxDurationSeconds range"
         }
-        val sourceId = getOrCreateSelfReportedSource()
+        val sourceId = resolveSelfReportedSource(db)
         db.metricReadingDao().insert(
             MetricReading(
                 metricType = MetricType.SLEEP_DURATION.key,
@@ -40,17 +38,4 @@ class SleepEntryRepo(private val db: BiosDatabase) {
 
     suspend fun fetchRecent(limit: Int = 20): List<MetricReading> =
         db.metricReadingDao().fetchLatest(MetricType.SLEEP_DURATION.key, limit)
-
-    private suspend fun getOrCreateSelfReportedSource(): String {
-        val dao = db.dataSourceDao()
-        dao.findByType(SourceType.SELF_REPORTED.key)?.let { return it.id }
-        val source = DataSource(
-            sourceType = SourceType.SELF_REPORTED.key,
-            deviceName = "Self-reported",
-            sensorType = SensorType.DERIVED.name,
-            readingKind = ReadingKind.SELF_REPORTED.name
-        )
-        dao.insert(source)
-        return source.id
-    }
 }

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -1,0 +1,208 @@
+package com.bios.app.engine
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Rule-based sleep inference from phone-only signals (issue #134).
+ *
+ * Inputs are five universally-available phone sensors fused over a nightly
+ * window: screen-off state, charging state, ambient-light lux, and
+ * accelerometer magnitude variance per sample bucket. The algorithm is
+ * intentionally simple — no ML, no per-owner training — because the goal
+ * is trend math, not stage-accurate clinical sleep scoring. Published
+ * accuracy of comparable phone-only apps is ~30 min RMSE vs actigraphy
+ * for total sleep time, which is good enough for Bios's baseline math.
+ *
+ * The pure logic lives here (a JVM-only object) so it can be exercised by
+ * unit tests without an Android device. The Android-bound collection
+ * lifecycle lives in [com.bios.app.ingest.PhoneSleepAdapter].
+ *
+ * Confidence: [ConfidenceTier.MEDIUM] when both charging and dark-environment
+ * boosters confirm, otherwise [ConfidenceTier.LOW] — the screen-off-only
+ * signal alone is no better than W2F's existing derivation.
+ */
+object PhoneSleepInference {
+
+    /** One phone-state observation, typically aggregated over ~1 minute. */
+    data class Sample(
+        val timestamp: Long,
+        val screenOff: Boolean,
+        val charging: Boolean,
+        val ambientLightLux: Float?,
+        val accelMagnitudeVar: Float?,
+    )
+
+    /**
+     * Run the inference. Returns at most one [MetricType.SLEEP_DURATION]
+     * reading plus optional [MetricType.SLEEP_STAGE] rows for LIGHT / AWAKE
+     * segments inside the sleep window. Empty when no viable window is found.
+     */
+    fun infer(samples: List<Sample>, sourceId: String): List<MetricReading> {
+        if (samples.size < 2) return emptyList()
+        val sorted = samples.sortedBy { it.timestamp }
+        val window = longestScreenOffStretch(sorted) ?: return emptyList()
+        val (startIdx, endIdx) = window
+        val windowMs = sorted[endIdx].timestamp - sorted[startIdx].timestamp
+        if (windowMs < MIN_SLEEP_WINDOW_MS) return emptyList()
+
+        val segments = segmentByActivity(sorted, startIdx, endIdx)
+        val awakeMs = segments.filter { it.stage == SleepStage.AWAKE }.sumOf { it.durationMs }
+        val sleepMs = max(0L, windowMs - awakeMs)
+        if (sleepMs < MIN_SLEEP_DURATION_MS) return emptyList()
+
+        val confidence = confidenceFor(sorted, startIdx, endIdx)
+        val midpoint = sorted[startIdx].timestamp + windowMs / 2L
+        val sleepSeconds = sleepMs / 1000L
+
+        val readings = mutableListOf<MetricReading>()
+        readings += MetricReading(
+            metricType = MetricType.SLEEP_DURATION.key,
+            value = sleepSeconds.toDouble(),
+            timestamp = midpoint,
+            durationSec = sleepSeconds.toInt(),
+            sourceId = sourceId,
+            confidence = confidence.level
+        )
+        // Emit per-segment stage rows so the dashboard can render the
+        // AWAKE interruption pattern. DEEP / REM are deliberately omitted
+        // — phone-only cannot discriminate them.
+        for (seg in segments) {
+            readings += MetricReading(
+                metricType = MetricType.SLEEP_STAGE.key,
+                value = seg.stage.value.toDouble(),
+                timestamp = seg.startMs,
+                durationSec = (seg.durationMs / 1000L).toInt(),
+                sourceId = sourceId,
+                confidence = confidence.level
+            )
+        }
+        return readings
+    }
+
+    private data class Segment(val stage: SleepStage, val startMs: Long, val durationMs: Long)
+
+    /**
+     * Walk the [start, end] index range and merge consecutive samples that
+     * share the same coarse activity label (AWAKE if accel variance is
+     * above [ACTIVITY_THRESHOLD], LIGHT otherwise) into contiguous segments.
+     */
+    private fun segmentByActivity(
+        samples: List<Sample>,
+        startIdx: Int,
+        endIdx: Int
+    ): List<Segment> {
+        val out = mutableListOf<Segment>()
+        var segStart = samples[startIdx].timestamp
+        var currentStage = stageAt(samples[startIdx])
+        for (i in (startIdx + 1)..endIdx) {
+            val stage = stageAt(samples[i])
+            if (stage != currentStage) {
+                out += Segment(currentStage, segStart, samples[i].timestamp - segStart)
+                segStart = samples[i].timestamp
+                currentStage = stage
+            }
+        }
+        out += Segment(currentStage, segStart, samples[endIdx].timestamp - segStart)
+        // Collapse very brief AWAKE flickers (< AWAKE_BOUT_MIN_MS) back into
+        // the surrounding sleep — single-minute movement bouts during sleep
+        // are normal posture shifts, not wake events.
+        return mergeBriefAwake(out)
+    }
+
+    private fun mergeBriefAwake(segments: List<Segment>): List<Segment> {
+        if (segments.size <= 1) return segments
+        val out = mutableListOf<Segment>()
+        for (seg in segments) {
+            val last = out.lastOrNull()
+            val tooBrief = seg.stage == SleepStage.AWAKE && seg.durationMs < AWAKE_BOUT_MIN_MS
+            if (tooBrief && last != null && last.stage == SleepStage.LIGHT) {
+                out[out.lastIndex] = last.copy(durationMs = last.durationMs + seg.durationMs)
+            } else if (last != null && last.stage == seg.stage) {
+                out[out.lastIndex] = last.copy(durationMs = last.durationMs + seg.durationMs)
+            } else {
+                out += seg
+            }
+        }
+        return out
+    }
+
+    private fun stageAt(sample: Sample): SleepStage {
+        val variance = sample.accelMagnitudeVar ?: 0f
+        return if (variance > ACTIVITY_THRESHOLD) SleepStage.AWAKE else SleepStage.LIGHT
+    }
+
+    /**
+     * Walk the samples and return the index range of the longest contiguous
+     * stretch where [Sample.screenOff] is true. Returns null when no
+     * screen-off stretch exists at all.
+     */
+    private fun longestScreenOffStretch(samples: List<Sample>): Pair<Int, Int>? {
+        var best: Pair<Int, Int>? = null
+        var bestLen = 0L
+        var runStart = -1
+        for (i in samples.indices) {
+            if (samples[i].screenOff) {
+                if (runStart == -1) runStart = i
+                if (i == samples.lastIndex) {
+                    val len = samples[i].timestamp - samples[runStart].timestamp
+                    if (len > bestLen) { best = runStart to i; bestLen = len }
+                }
+            } else if (runStart != -1) {
+                val runEnd = i - 1
+                val len = samples[runEnd].timestamp - samples[runStart].timestamp
+                if (len > bestLen) { best = runStart to runEnd; bestLen = len }
+                runStart = -1
+            }
+        }
+        return best
+    }
+
+    /**
+     * Two booster signals confirm "this was actual sleep, not a long
+     * powered-off phone in a drawer":
+     *
+     *  - charging plugged in for > [BOOSTER_FRACTION] of the window
+     *  - ambient light reading dark (lux < [DARK_LUX_THRESHOLD]) for >
+     *    [BOOSTER_FRACTION] of the window (ignoring null samples)
+     *
+     * Both confirm → MEDIUM. Otherwise the screen-off signal alone is no
+     * stronger than W2F's existing derivation → LOW.
+     */
+    private fun confidenceFor(samples: List<Sample>, startIdx: Int, endIdx: Int): ConfidenceTier {
+        val total = endIdx - startIdx + 1
+        if (total <= 0) return ConfidenceTier.LOW
+        val charging = (startIdx..endIdx).count { samples[it].charging }
+        val lit = (startIdx..endIdx).mapNotNull { samples[it].ambientLightLux }
+        val chargingFrac = charging.toDouble() / total
+        val darkFrac = if (lit.isEmpty()) 0.0
+            else lit.count { it < DARK_LUX_THRESHOLD }.toDouble() / lit.size
+        return if (chargingFrac > BOOSTER_FRACTION && darkFrac > BOOSTER_FRACTION) {
+            ConfidenceTier.MEDIUM
+        } else {
+            ConfidenceTier.LOW
+        }
+    }
+
+    // 4h minimum screen-off stretch — anything shorter is more likely a long
+    // meeting or movie than a sleep period.
+    internal const val MIN_SLEEP_WINDOW_MS: Long = 4L * 60L * 60L * 1000L
+    // After subtracting AWAKE bouts, demand at least 1h of actual sleep
+    // before publishing anything. Floors out clearly-bad windows.
+    internal const val MIN_SLEEP_DURATION_MS: Long = 1L * 60L * 60L * 1000L
+    // Brief movement bouts (< 5 min) are posture shifts, not wake events.
+    internal const val AWAKE_BOUT_MIN_MS: Long = 5L * 60L * 1000L
+    // Accel-magnitude variance above this counts a sample as AWAKE. Hand-
+    // tuned for ~5 Hz sampled accelerometer; the variance unit is (m/s^2)^2.
+    internal const val ACTIVITY_THRESHOLD: Float = 0.5f
+    // Ambient-light threshold below which a room reads as "dark." Dim
+    // bedroom nightlight = ~5 lux; phone screen at the lowest brightness
+    // pointing at the sensor easily clears 50.
+    internal const val DARK_LUX_THRESHOLD: Float = 5f
+    // Majority confirmation — both boosters need to hold over the window.
+    private const val BOOSTER_FRACTION: Double = 0.5
+}

--- a/android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt
@@ -1,0 +1,174 @@
+package com.bios.app.engine
+
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlin.math.cos
+import kotlin.math.ln
+import kotlin.math.roundToLong
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Computes [MetricType.SLEEP_REGULARITY] from a window of recent
+ * `SLEEP_DURATION` readings.
+ *
+ * Sleep researchers (Roenneberg, Walker, Phyllis Zee group) consistently
+ * rank regularity above absolute duration for long-term outcomes. Bios
+ * already tracks duration / latency / score; regularity is the gap this
+ * calculator fills. Implementation note: variability in *midpoint* is the
+ * strongest single regularity signal in the literature (Phillips et al.
+ * 2017), so the composite score keys off midpoint variance while bedtime
+ * and wake variance ride as sidecar fields.
+ *
+ * Time-of-day comparison has a wrap-around problem — 23:30 one night and
+ * 00:30 the next are 1h apart, not 23h. Standard fix is **circular
+ * statistics**: map each time-of-day to an angle on the unit circle, take
+ * the mean vector, and derive the circular std-deviation from its length
+ * (Mardia & Jupp). This gives a well-defined "spread" no matter where the
+ * cluster sits around the clock.
+ *
+ * Confidence on the composite is the **minimum** of the input readings'
+ * confidence tiers. A regularity computed over a window that includes
+ * LOW-confidence W2F-screen-off nights cannot honestly claim better than
+ * LOW itself. Engines that filter by confidence (BaselineEngine) keep the
+ * existing semantics unchanged.
+ */
+object SleepRegularityCalculator {
+
+    /**
+     * Sidecar field keys for the SLEEP_REGULARITY composite. Centralized so
+     * adapters, readers, and tests cannot drift on spelling. New keys belong
+     * in docs/DATA_MODEL.md alongside the metric they describe.
+     */
+    object Fields {
+        const val BEDTIME_VARIANCE_MIN = "bedtime_variance_min"
+        const val WAKE_VARIANCE_MIN = "wake_variance_min"
+        const val MIDPOINT_VARIANCE_MIN = "midpoint_variance_min"
+        const val WINDOW_DAYS = "window_days"
+    }
+
+    /** Parent reading + the four sidecar payload rows that ride beside it. */
+    data class Result(
+        val reading: MetricReading,
+        val payload: List<EventPayloadField>,
+    )
+
+    /**
+     * Compute regularity over the most recent [windowDays] of sleep readings.
+     * Returns null when fewer than [MIN_NIGHTS] usable nights exist — a
+     * std-deviation over two samples is meaningless and would mis-rank
+     * thin-data weeks against full ones.
+     */
+    fun derive(
+        sleepDurations: List<MetricReading>,
+        sourceId: String,
+        windowDays: Int = DEFAULT_WINDOW_DAYS,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Result? {
+        val cutoff = nowMs - windowDays.toLong() * MILLIS_PER_DAY
+        val nights = sleepDurations
+            .asSequence()
+            .filter { it.metricType == MetricType.SLEEP_DURATION.key }
+            .filter { it.timestamp >= cutoff && it.timestamp <= nowMs }
+            .filter { (it.durationSec ?: 0) > 0 }
+            .sortedBy { it.timestamp }
+            .toList()
+        if (nights.size < MIN_NIGHTS) return null
+
+        val midpointVarMin = circularStdMinutes(nights.map { midnightAngle(it.timestamp) })
+        val bedtimeVarMin = circularStdMinutes(nights.map {
+            midnightAngle(it.timestamp - (it.durationSec!! * 1000L) / 2L)
+        })
+        val wakeVarMin = circularStdMinutes(nights.map {
+            midnightAngle(it.timestamp + (it.durationSec!! * 1000L) / 2L)
+        })
+
+        val score = scoreFromMidpointVariance(midpointVarMin)
+        val confidence = nights.minOf { it.confidence }
+
+        val reading = MetricReading(
+            metricType = MetricType.SLEEP_REGULARITY.key,
+            value = score,
+            timestamp = nowMs,
+            durationSec = windowDays * SECONDS_PER_DAY,
+            sourceId = sourceId,
+            confidence = confidence
+        )
+        val payload = listOf(
+            EventPayloadField(
+                readingId = reading.id, fieldKey = Fields.BEDTIME_VARIANCE_MIN,
+                longValue = bedtimeVarMin
+            ),
+            EventPayloadField(
+                readingId = reading.id, fieldKey = Fields.WAKE_VARIANCE_MIN,
+                longValue = wakeVarMin
+            ),
+            EventPayloadField(
+                readingId = reading.id, fieldKey = Fields.MIDPOINT_VARIANCE_MIN,
+                longValue = midpointVarMin
+            ),
+            EventPayloadField(
+                readingId = reading.id, fieldKey = Fields.WINDOW_DAYS,
+                longValue = windowDays.toLong()
+            ),
+        )
+        return Result(reading, payload)
+    }
+
+    /** Epoch-ms timestamp → angle on the 24h unit circle, in radians. */
+    private fun midnightAngle(epochMs: Long): Double {
+        // Modulo into [0, 86_400_000) ms-since-midnight (UTC). The
+        // calculator works in UTC because that's where all timestamps in
+        // the Bios bus live; cross-timezone owners get the same
+        // dispersion shape, just rotated. (A future UI/dashboard layer
+        // can render in local time without changing the math here.)
+        var msOfDay = epochMs % MILLIS_PER_DAY
+        if (msOfDay < 0) msOfDay += MILLIS_PER_DAY
+        return 2.0 * Math.PI * (msOfDay.toDouble() / MILLIS_PER_DAY.toDouble())
+    }
+
+    /**
+     * Circular std-deviation of the given angles, returned in clock-minutes.
+     *
+     * Standard derivation: R = ||mean unit vector||, circular σ in radians
+     * is sqrt(-2 ln R). Convert back to minutes via 24h / 2π. When R ≈ 1
+     * (perfectly clustered) the formula goes to 0; when R ≈ 0 (uniform)
+     * it diverges, so we clamp at a half-day.
+     */
+    private fun circularStdMinutes(angles: List<Double>): Long {
+        if (angles.isEmpty()) return 0L
+        val meanCos = angles.sumOf { cos(it) } / angles.size
+        val meanSin = angles.sumOf { sin(it) } / angles.size
+        val r = sqrt(meanCos * meanCos + meanSin * meanSin).coerceIn(R_FLOOR, 1.0)
+        val sigmaRad = sqrt(-2.0 * ln(r))
+        val sigmaMin = sigmaRad * MINUTES_PER_DAY / (2.0 * Math.PI)
+        return sigmaMin.coerceAtMost(MINUTES_PER_DAY / 2.0).roundToLong()
+    }
+
+    /**
+     * Map midpoint variance (clock-minutes) to a 0–100 score. 100 at ≤ 15
+     * min spread (very-regular cluster), drops linearly to 0 at ≥ 90 min.
+     * Anchored to literature ranges: ≤ 15 min midpoint variability is the
+     * "very regular" band; > 90 min is the highly-irregular band associated
+     * with elevated cardiometabolic risk (Phillips 2017, Lunsford-Avery 2018).
+     */
+    private fun scoreFromMidpointVariance(varianceMin: Long): Double {
+        val v = varianceMin.toDouble()
+        return when {
+            v <= REGULAR_THRESHOLD_MIN -> 100.0
+            v >= IRREGULAR_THRESHOLD_MIN -> 0.0
+            else -> ((IRREGULAR_THRESHOLD_MIN - v) /
+                (IRREGULAR_THRESHOLD_MIN - REGULAR_THRESHOLD_MIN) * 100.0)
+        }
+    }
+
+    internal const val DEFAULT_WINDOW_DAYS = 7
+    internal const val MIN_NIGHTS = 3
+    internal const val REGULAR_THRESHOLD_MIN = 15.0
+    internal const val IRREGULAR_THRESHOLD_MIN = 90.0
+    private const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
+    private const val MINUTES_PER_DAY = 24.0 * 60.0
+    private const val SECONDS_PER_DAY = 24 * 60 * 60
+    private const val R_FLOOR = 1e-9
+}

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -403,6 +403,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.UG_PER_M3 -> "ug/m3"
     MetricUnit.PPM -> "[ppm]"
     MetricUnit.PPB -> "[ppb]"
+    MetricUnit.LITERS_PER_MIN -> "L/min"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -1,0 +1,127 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.BatteryManager
+import android.os.PowerManager
+import com.bios.app.engine.PhoneSleepInference
+import com.bios.app.model.MetricReading
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.math.sqrt
+
+/**
+ * Phone-only sleep derivation (issue #134). Fuses screen-off, charging,
+ * ambient-light and accelerometer-variance samples over a nightly window
+ * and hands the trace to [PhoneSleepInference], which produces the actual
+ * `SLEEP_DURATION` + `SLEEP_STAGE` readings.
+ *
+ * The adapter exists separately from [PhoneSensorAdapter] because the
+ * lifecycle is different: PhoneSensorAdapter does instantaneous reads on
+ * each sync, while sleep inference needs a continuous low-rate trace
+ * across the overnight window. Keeping the two apart also keeps the
+ * scalar phone-sensor sync path (steps, ambient light snapshot, active
+ * minutes) unchanged.
+ *
+ * The actual nightly scheduler (which calls [sample] periodically across
+ * the window and invokes [infer] at the close of the window) is a follow-up
+ * to issue #134: the orchestration belongs in the ingest layer alongside
+ * a registered `PHONE_SENSOR_DERIVED` data source row, but IngestManager
+ * is at its line-length cap so that wiring lands in a separate change.
+ */
+class PhoneSleepAdapter(private val context: Context) {
+
+    private val sensorManager =
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val powerManager =
+        context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val batteryManager =
+        context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
+
+    private val accelerometer: Sensor? =
+        sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+    private val lightSensor: Sensor? =
+        sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+
+    /**
+     * Returns true when the device has the minimum sensor surface needed
+     * to run the inference. Accelerometer is mandatory (movement bouts);
+     * the others are signal boosters.
+     */
+    val isAvailable: Boolean get() = accelerometer != null
+
+    /**
+     * Collects one [PhoneSleepInference.Sample] by sampling the
+     * accelerometer for [accelWindowMs] and reading current screen,
+     * charging, and ambient-light state. Suitable for calling on a
+     * periodic schedule (e.g. every minute) across the nightly window.
+     */
+    suspend fun sample(accelWindowMs: Long = DEFAULT_ACCEL_WINDOW_MS): PhoneSleepInference.Sample {
+        val now = System.currentTimeMillis()
+        return PhoneSleepInference.Sample(
+            timestamp = now,
+            screenOff = !powerManager.isInteractive,
+            charging = batteryManager.isCharging,
+            ambientLightLux = readOnce(lightSensor, AMBIENT_LIGHT_TIMEOUT_MS),
+            accelMagnitudeVar = sampleAccelVariance(accelWindowMs),
+        )
+    }
+
+    /**
+     * Hand the collected samples to the pure inference layer and emit
+     * `SLEEP_DURATION` (+ optional `SLEEP_STAGE`) readings.
+     */
+    fun infer(samples: List<PhoneSleepInference.Sample>, sourceId: String): List<MetricReading> =
+        PhoneSleepInference.infer(samples, sourceId)
+
+    private suspend fun sampleAccelVariance(durationMs: Long): Float? {
+        val sensor = accelerometer ?: return null
+        val magnitudes = mutableListOf<Float>()
+        suspendCancellableCoroutine<Unit> { cont ->
+            val listener = object : SensorEventListener {
+                val start = System.currentTimeMillis()
+                override fun onSensorChanged(event: SensorEvent) {
+                    val (x, y, z) = Triple(event.values[0], event.values[1], event.values[2])
+                    magnitudes += sqrt(x * x + y * y + z * z) - GRAVITY
+                    if (System.currentTimeMillis() - start >= durationMs) {
+                        sensorManager.unregisterListener(this)
+                        if (cont.isActive) cont.resumeWith(Result.success(Unit))
+                    }
+                }
+                override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+            }
+            sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+            cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
+        }
+        if (magnitudes.size < 2) return null
+        val mean = magnitudes.average().toFloat()
+        var sq = 0.0
+        for (m in magnitudes) { val d = m - mean; sq += d * d }
+        return (sq / magnitudes.size).toFloat()
+    }
+
+    private suspend fun readOnce(sensor: Sensor?, timeoutMs: Long): Float? {
+        if (sensor == null) return null
+        return kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+            suspendCancellableCoroutine<Float> { cont ->
+                val listener = object : SensorEventListener {
+                    override fun onSensorChanged(event: SensorEvent) {
+                        sensorManager.unregisterListener(this)
+                        if (cont.isActive) cont.resumeWith(Result.success(event.values[0]))
+                    }
+                    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+                }
+                sensorManager.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+                cont.invokeOnCancellation { sensorManager.unregisterListener(listener) }
+            }
+        }
+    }
+
+    companion object {
+        private const val GRAVITY = 9.81f
+        private const val DEFAULT_ACCEL_WINDOW_MS = 5_000L
+        private const val AMBIENT_LIGHT_TIMEOUT_MS = 1_000L
+    }
+}

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -17,6 +17,11 @@ enum class SourceType(val key: String) {
     DEXCOM_API("dexcom_api"),
     POLAR_API("polar_api"),
     PHONE_SENSOR("phone_sensor"),
+    // Phone-sensor fusion that produces derived signals (not raw samples) —
+    // currently the rule-based sleep inference (issue #134). Distinct from
+    // PHONE_SENSOR so DataSource provenance separates "raw accel reading"
+    // from "sleep duration inferred from accel + screen + charge".
+    PHONE_SENSOR_DERIVED("phone_sensor_derived"),
     CAMERA_PPG("camera_ppg"),
     BLE_PERIPHERAL("ble_peripheral"),
     SELF_REPORTED("self_reported")

--- a/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
@@ -82,6 +82,12 @@ internal object CompanionContract {
                 // producer-by-capture-surface rule.
                 "circadian_phase_shift",
                 "mood_drift_score",
+                // Producer-by-capture-surface: W2F's UsageStatsTracker derives
+                // sleep from screen-off patterns — a surface no other adapter
+                // has. Without this whitelist entry, LETHE owners with no
+                // wearable get an empty sleep bus while W2F sits on the data.
+                // Issue #133. Confidence stays LOW (proxy, not actigraphy).
+                "sleep_duration",
             ),
             defaultReadingKind = ReadingKind.DERIVED,
             // TODO populate with W2F's release-signing cert SHA-256 before the

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -27,6 +27,7 @@ import com.bios.app.ingest.WhoopApiAdapter
 import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
+import com.bios.app.data.ManualReadingRepo
 import com.bios.app.model.ActionItem
 import com.bios.app.model.Anomaly
 import com.bios.app.model.HealthEvent
@@ -490,4 +491,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     fun refreshRecentBiomarkers(limit: Int = 20) = biomarkers.refreshRecent(limit)
     fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long, context: BiomarkerContext = BiomarkerContext()) =
         biomarkers.addManual(metricType, value, timestamp, context)
+
+    // MARK: - General manual-reading entry (clinical vitals)
+
+    val manualReadingRepo: ManualReadingRepo = ManualReadingRepo(db)
 }

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -262,11 +262,17 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToPpgCapture = { navController.navigate("ppg_capture") },
                     onNavigateToCompanions = { navController.navigate("companions") },
                     onNavigateToMetric = { metric ->
-                        selectedTab = tabs.indexOfFirst { it.first == "trends" }
-                        navController.navigate("trends?metric=${metric.key}") {
-                            popUpTo("home") { saveState = true }
-                            launchSingleTop = true
-                            restoreState = true
+                        // SLEEP_DURATION has a dedicated dashboard richer
+                        // than the generic trends view.
+                        if (metric == MetricType.SLEEP_DURATION) {
+                            navController.navigate("sleep_dashboard")
+                        } else {
+                            selectedTab = tabs.indexOfFirst { it.first == "trends" }
+                            navController.navigate("trends?metric=${metric.key}") {
+                                popUpTo("home") { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
                         }
                     }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -333,6 +333,7 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToPrivacy = { navController.navigate("privacy") },
                     onNavigateToCompanions = { navController.navigate("companions") },
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
+                    onNavigateToClinicalEntry = { navController.navigate("clinical_entry") },
                     onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
                     onNavigateToPeriodEntry = { navController.navigate("period_entry") },
                     onNavigateToSleepEntry = { navController.navigate("sleep_entry") },
@@ -364,6 +365,12 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("biomarker_entry") {
                 com.bios.app.ui.biomarkers.BiomarkerEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable("clinical_entry") {
+                com.bios.app.ui.clinical.ClinicalReadingEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -390,6 +390,13 @@ fun BiosApp(viewModel: AppViewModel) {
             composable("sleep_entry") {
                 com.bios.app.ui.sleep.SleepEntryScreen(
                     viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
+                    onOpenDashboard = { navController.navigate("sleep_dashboard") }
+                )
+            }
+            composable("sleep_dashboard") {
+                com.bios.app.ui.sleep.SleepDashboardScreen(
+                    viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )
             }

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
@@ -1,0 +1,301 @@
+package com.bios.app.ui.clinical
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.ManualReadingRepo
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Bundle-style entry surface for clinical visits: one shared timestamp +
+ * clinic + visit note span N readings. Triage rows (BP / SpO2 / pulse /
+ * temp / RR / pain / GCS / O2 flow) get logged as one event the way a
+ * clinician records them on a chart. Single-reading entries (owner reading
+ * a cuff at home) work the same way with the bundle metadata left blank.
+ *
+ * Writes route through [ManualReadingRepo.addBundle] → SELF_REPORTED →
+ * engine-isolated (docs/SELF_REPORTED_DATA_HOME.md decision 3).
+ *
+ * Biomarker (lab) entries stay on the dedicated [com.bios.app.ui.biomarkers.BiomarkerEntryScreen]
+ * — they carry a different provenance vocabulary (lab/fasting/specimen)
+ * that doesn't apply at the bedside. Per-row UI (metric picker, value
+ * field, AVPU shortcut) lives in [ClinicalReadingRows].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClinicalReadingEntryScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val repo = viewModel.manualReadingRepo
+
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var clinicName by remember { mutableStateOf("") }
+    var visitNote by remember { mutableStateOf("") }
+    var sourceUri by remember { mutableStateOf<Uri?>(null) }
+    val rows = remember { mutableStateListOf<ReadingRowState>() }
+    var saveMessage by remember { mutableStateOf<String?>(null) }
+
+    if (rows.isEmpty()) {
+        defaultTriageRows().forEach { rows.add(it) }
+    }
+
+    val sourceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { picked ->
+        if (picked != null) {
+            try {
+                context.contentResolver.takePersistableUriPermission(
+                    picked, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            } catch (_: SecurityException) {
+                // Same fallback as biomarker entry — keep URI in-memory only
+                // when the provider won't grant persistable permission.
+            }
+            sourceUri = picked
+        }
+    }
+
+    val anyValid = rows.any { it.isFilled() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add clinical reading") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        "Self-reported",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        "Vital signs you enter — from a cuff, pulse-ox, thermometer, or a triage " +
+                            "chart a clinician handed you — stay on your device. They show up in " +
+                            "trends and FHIR export, but the baseline engine and anomaly detector " +
+                            "ignore them. Single-point clinical readings would otherwise poison " +
+                            "sensor baselines.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    OutlinedButton(
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Captured on: ${formatClinicalDate(timestamp)}")
+                    }
+
+                    OutlinedTextField(
+                        value = clinicName,
+                        onValueChange = { clinicName = it },
+                        label = { Text("Clinic / facility (optional)") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    OutlinedTextField(
+                        value = visitNote,
+                        onValueChange = { visitNote = it },
+                        label = { Text("Visit note (optional)") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    Text(
+                        "Triage chart (PDF or photo)",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(
+                            onClick = { sourceLauncher.launch(CLINICAL_SOURCE_MIME_TYPES) },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(if (sourceUri == null) "Attach…" else "Replace")
+                        }
+                        if (sourceUri != null) {
+                            TextButton(onClick = {
+                                sourceUri?.let { releasePersistableRead(context, it) }
+                                sourceUri = null
+                            }) { Text("Remove") }
+                        }
+                    }
+                    sourceUri?.let {
+                        Text(
+                            "Attached: ${it.lastPathSegment ?: it.toString()}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Text(
+                "Readings",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+
+            rows.forEachIndexed { index, row ->
+                ReadingRowCard(
+                    state = row,
+                    onChange = { rows[index] = it },
+                    onRemove = { rows.removeAt(index) },
+                    canRemove = rows.size > 1,
+                )
+            }
+
+            FilledTonalButton(
+                onClick = { rows.add(ReadingRowState()) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = null)
+                Text("  Add another reading")
+            }
+
+            OutlinedButton(
+                onClick = {
+                    val bundle = rows.mapNotNull { it.toBundleReading() }
+                    if (bundle.isEmpty()) {
+                        saveMessage = "Add at least one filled reading before saving."
+                        return@OutlinedButton
+                    }
+                    val capturedAt = timestamp
+                    val clinic = clinicName.ifBlank { null }
+                    val note = visitNote.ifBlank { null }
+                    val uri = sourceUri?.toString()
+                    scope.launch {
+                        repo.addBundle(
+                            timestamp = capturedAt,
+                            clinicName = clinic,
+                            visitNote = note,
+                            sourceUri = uri,
+                            readings = bundle,
+                        )
+                        saveMessage = "Saved ${bundle.size} reading${if (bundle.size == 1) "" else "s"}."
+                        rows.clear()
+                        defaultTriageRows().forEach { rows.add(it) }
+                        clinicName = ""
+                        visitNote = ""
+                        sourceUri = null
+                    }
+                },
+                enabled = anyValid,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Save")
+            }
+
+            saveMessage?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = timestamp)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { timestamp = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = state)
+        }
+    }
+}
+
+private val CLINICAL_SOURCE_MIME_TYPES: Array<String> = arrayOf(
+    "image/jpeg",
+    "image/png",
+    "application/pdf",
+)
+
+private fun releasePersistableRead(context: Context, uri: Uri) {
+    try {
+        context.contentResolver.releasePersistableUriPermission(
+            uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+    } catch (_: SecurityException) {
+        // Permission was never persisted or already revoked — nothing to release.
+    }
+}
+
+private fun formatClinicalDate(epochMs: Long): String =
+    SimpleDateFormat("d MMM yyyy", Locale.getDefault()).format(Date(epochMs))

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
@@ -1,0 +1,234 @@
+package com.bios.app.ui.clinical
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.AvpuLevel
+import com.bios.app.data.BundleReading
+import com.bios.app.data.GcsBounds
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ReadingRowCard(
+    state: ReadingRowState,
+    onChange: (ReadingRowState) -> Unit,
+    onRemove: () -> Unit,
+    canRemove: Boolean,
+) {
+    Card {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                MetricPicker(
+                    selected = state.metric,
+                    onSelect = { onChange(state.copy(metric = it, valueText = "", originalValue = null)) },
+                    modifier = Modifier.weight(1f),
+                )
+                if (canRemove) {
+                    IconButton(onClick = onRemove) {
+                        Icon(Icons.Default.Close, contentDescription = "Remove reading")
+                    }
+                }
+            }
+
+            when (state.metric) {
+                MetricType.CONSCIOUSNESS_LEVEL -> ConsciousnessInput(state, onChange)
+                else -> NumericInput(state, onChange)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MetricPicker(
+    selected: MetricType,
+    onSelect: (MetricType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = selected.readableName,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Metric") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            clinicalEntryMetrics.forEach { metric ->
+                DropdownMenuItem(
+                    text = { Text("${metric.readableName} (${metric.unit.symbol.ifEmpty { "—" }})") },
+                    onClick = {
+                        onSelect(metric)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumericInput(state: ReadingRowState, onChange: (ReadingRowState) -> Unit) {
+    OutlinedTextField(
+        value = state.valueText,
+        onValueChange = { onChange(state.copy(valueText = it.filter { c -> c.isDigit() || c == '.' })) },
+        label = { Text("Value") },
+        suffix = { Text(state.metric.unit.symbol.ifEmpty { "—" }) },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun ConsciousnessInput(state: ReadingRowState, onChange: (ReadingRowState) -> Unit) {
+    Text(
+        "AVPU shortcut maps to GCS losslessly — original scale + value " +
+            "are kept alongside for provenance.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        AvpuLevel.entries.forEach { level ->
+            AssistChip(
+                onClick = {
+                    onChange(
+                        state.copy(
+                            valueText = level.gcsTotal.toString(),
+                            originalScale = "AVPU",
+                            originalValue = level.name.first().toString(),
+                        )
+                    )
+                },
+                label = { Text(level.name.first().toString()) },
+            )
+        }
+    }
+    OutlinedTextField(
+        value = state.valueText,
+        onValueChange = {
+            val cleaned = it.filter { c -> c.isDigit() }
+            onChange(
+                state.copy(
+                    valueText = cleaned,
+                    originalScale = if (cleaned.isBlank()) null else "GCS",
+                    originalValue = null,
+                )
+            )
+        },
+        label = { Text("GCS total") },
+        suffix = { Text("${GcsBounds.MIN}–${GcsBounds.MAX}") },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    state.originalScale?.let { scale ->
+        val original = state.originalValue?.let { " ($it)" } ?: ""
+        FilterChip(
+            selected = true,
+            onClick = {},
+            label = { Text("Source: $scale$original") },
+        )
+    }
+}
+
+internal data class ReadingRowState(
+    val metric: MetricType = MetricType.BLOOD_PRESSURE_SYSTOLIC,
+    val valueText: String = "",
+    val originalScale: String? = null,
+    val originalValue: String? = null,
+) {
+    fun isFilled(): Boolean = valueText.toDoubleOrNull() != null
+
+    fun toBundleReading(): BundleReading? {
+        val parsed = valueText.toDoubleOrNull() ?: return null
+        val (scale, value) = if (metric == MetricType.CONSCIOUSNESS_LEVEL) {
+            (originalScale ?: "GCS") to (originalValue ?: parsed.toInt().toString())
+        } else {
+            null to null
+        }
+        return BundleReading(
+            metricType = metric,
+            value = parsed,
+            originalScale = scale,
+            originalValue = value,
+        )
+    }
+}
+
+/**
+ * Triage-default row order matches a Spanish ER chart's column layout
+ * (TAS / TAD / Sat O2 / FC / Temp / FR / EVA / GCS / Flujo O2) — that's
+ * the chart shape that motivated this surface.
+ */
+internal fun defaultTriageRows(): List<ReadingRowState> = listOf(
+    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
+    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+    ReadingRowState(metric = MetricType.BLOOD_OXYGEN),
+    ReadingRowState(metric = MetricType.HEART_RATE),
+    ReadingRowState(metric = MetricType.SKIN_TEMPERATURE),
+    ReadingRowState(metric = MetricType.RESPIRATORY_RATE),
+    ReadingRowState(metric = MetricType.PAIN_SCORE),
+    ReadingRowState(metric = MetricType.CONSCIOUSNESS_LEVEL),
+    ReadingRowState(metric = MetricType.OXYGEN_FLOW_RATE),
+)
+
+/**
+ * Metrics offered in the clinical-reading picker: everything that opts in
+ * to manual entry except the lab/biomarker surface (which has its own
+ * picker on BiomarkerEntryScreen) and reproductive metrics (which route
+ * through their isolated DB via BbtEntryRepo / PeriodEntryRepo).
+ */
+private val clinicalEntryMetrics: List<MetricType> by lazy {
+    MetricType.entries.filter {
+        it.allowsManualEntry &&
+            it.domain != MetricDomain.BIOMARKER &&
+            it.domain != MetricDomain.WOMENS_HEALTH &&
+            it.domain != MetricDomain.SLEEP
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ fun SettingsScreen(
     onNavigateToPrivacy: () -> Unit = {},
     onNavigateToCompanions: () -> Unit = {},
     onNavigateToBiomarkerEntry: () -> Unit = {},
+    onNavigateToClinicalEntry: () -> Unit = {},
     onNavigateToBbtEntry: () -> Unit = {},
     onNavigateToPeriodEntry: () -> Unit = {},
     onNavigateToSleepEntry: () -> Unit = {},
@@ -179,6 +180,8 @@ fun SettingsScreen(
 
                 Spacer(Modifier.height(8.dp))
                 SettingsActionButton("Add Lab Values", onNavigateToBiomarkerEntry)
+                Spacer(Modifier.height(4.dp))
+                SettingsActionButton("Add clinical reading", onNavigateToClinicalEntry)
                 Spacer(Modifier.height(4.dp))
                 SettingsActionButton("Log sleep", onNavigateToSleepEntry)
                 Spacer(Modifier.height(4.dp))

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -1,0 +1,297 @@
+package com.bios.app.ui.sleep
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.SleepRegularityCalculator
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.AppViewModel
+import com.bios.contracts.MetricType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Pull-side sleep dashboard (issue #135 — v1).
+ *
+ * Visualizes Bios's canonical sleep data without ever pushing a score,
+ * nudge, or coaching loop at the owner — the manifesto's "instrument,
+ * not coach" stance applied to the sleep surface. The owner picks a
+ * window, the dashboard renders the trend; evaluation belongs to the
+ * owner.
+ *
+ * v1 surfaces: window selector, regularity panel (composite + bedtime/
+ * wake/midpoint variance), per-night duration list with source +
+ * confidence provenance. Out of scope for v1 (separate follow-ups):
+ * bedtime/wake heatmap, per-night stage breakdown, correlation prompts.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SleepDashboardScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+) {
+    var windowDays by remember { mutableStateOf(7) }
+    var nights by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
+    var sourceLabels by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+
+    LaunchedEffect(windowDays) {
+        val end = System.currentTimeMillis()
+        val start = end - windowDays.toLong() * 24L * 3600L * 1000L
+        nights = viewModel.db.metricReadingDao()
+            .fetch(MetricType.SLEEP_DURATION.key, start, end)
+            .sortedByDescending { it.timestamp }
+        sourceLabels = viewModel.db.dataSourceDao().getAll()
+            .associate { it.id to (it.deviceName ?: it.sourceType) }
+    }
+
+    val regularity = remember(nights, windowDays) {
+        SleepRegularityCalculator.derive(
+            nights, sourceId = "dashboard-preview", windowDays = windowDays
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Sleep") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item { WindowSelector(windowDays) { windowDays = it } }
+            item { RegularityCard(regularity) }
+            item { SummaryCard(nights) }
+            item {
+                Text(
+                    "Recent nights",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            if (nights.isEmpty()) {
+                item {
+                    Text(
+                        "No sleep readings in the selected window. Connect a " +
+                            "wearable, sync Health Connect, or log a night manually.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                items(nights, key = { it.id }) { night ->
+                    NightRow(night, sourceLabels)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WindowSelector(selected: Int, onSelect: (Int) -> Unit) {
+    Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        listOf(7, 30, 90).forEach { days ->
+            FilterChip(
+                selected = selected == days,
+                onClick = { onSelect(days) },
+                label = { Text("${days}d") }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegularityCard(result: SleepRegularityCalculator.Result?) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                "Regularity",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+            if (result == null) {
+                Text(
+                    "Need at least ${SleepRegularityCalculator.MIN_NIGHTS} nights in the window " +
+                        "to compute a regularity score.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                return@Column
+            }
+            val bedtime = payloadLong(result, SleepRegularityCalculator.Fields.BEDTIME_VARIANCE_MIN)
+            val wake = payloadLong(result, SleepRegularityCalculator.Fields.WAKE_VARIANCE_MIN)
+            val midpoint = payloadLong(result, SleepRegularityCalculator.Fields.MIDPOINT_VARIANCE_MIN)
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                StatCell("Score", String.format(Locale.US, "%.0f", result.reading.value))
+                StatCell("Bedtime σ", "${bedtime}m")
+                StatCell("Midpoint σ", "${midpoint}m")
+                StatCell("Wake σ", "${wake}m")
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Score keys off midpoint variance. " +
+                    "Lower variance across the window means more regular timing — the " +
+                    "single sleep signal most consistently linked to long-term outcomes.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(nights: List<MetricReading>) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Duration", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            if (nights.isEmpty()) {
+                Text(
+                    "—",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                return@Column
+            }
+            val seconds = nights.map { it.value.toLong() }
+            val avg = seconds.average().toLong()
+            val min = seconds.min()
+            val max = seconds.max()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+            ) {
+                StatCell("Nights", "${nights.size}")
+                StatCell("Average", formatDuration(avg))
+                StatCell("Shortest", formatDuration(min))
+                StatCell("Longest", formatDuration(max))
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatCell(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun NightRow(reading: MetricReading, sourceLabels: Map<String, String>) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    formatDuration(reading.value.toLong()),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                ConfidenceBadge(reading.confidence)
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "${formatDate(reading.timestamp)} · ${sourceLabels[reading.sourceId] ?: "unknown source"}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfidenceBadge(level: Int) {
+    val tier = ConfidenceTier.fromLevel(level)
+    val color = when (tier) {
+        ConfidenceTier.CLINICAL, ConfidenceTier.HIGH -> MaterialTheme.colorScheme.primary
+        ConfidenceTier.MEDIUM -> MaterialTheme.colorScheme.tertiary
+        ConfidenceTier.LOW, ConfidenceTier.VENDOR_DERIVED -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(
+        tier.name.lowercase(),
+        style = MaterialTheme.typography.labelSmall,
+        color = color
+    )
+}
+
+private fun payloadLong(
+    result: SleepRegularityCalculator.Result,
+    fieldKey: String,
+): Long = result.payload.first { it.fieldKey == fieldKey }.longValue ?: 0L
+
+private fun formatDuration(seconds: Long): String {
+    val h = seconds / 3600
+    val m = (seconds % 3600) / 60
+    return "${h}h ${m}m"
+}
+
+private val dateFormat = SimpleDateFormat("EEE, MMM d", Locale.US)
+private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepEntryScreen.kt
@@ -51,7 +51,8 @@ import java.util.Locale
 @Composable
 fun SleepEntryScreen(
     viewModel: AppViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onOpenDashboard: (() -> Unit)? = null,
 ) {
     val repo = remember(viewModel) { SleepEntryRepo(viewModel.db) }
     val scope = rememberCoroutineScope()
@@ -93,6 +94,14 @@ fun SleepEntryScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            if (onOpenDashboard != null) {
+                OutlinedButton(
+                    onClick = onOpenDashboard,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("View sleep dashboard")
+                }
+            }
             Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text("Sleep duration", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)

--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -30,6 +30,23 @@ class BiosHealthProviderContractTest {
     }
 
     @Test
+    fun `W2F may write sleep_duration derived from screen-off (issue 133)`() {
+        // W2F's UsageStatsTracker is the unique screen-off producer surface.
+        // Without this entry, LETHE owners without a wearable see an empty
+        // sleep bus despite W2F holding the derivation locally.
+        assertTrue(
+            "W2F screen-off sleep must be writable to keep SLEEP_DURATION canonical",
+            "sleep_duration" in CompanionContract.WRITABLE_METRICS
+        )
+        assertTrue(CompanionContract.canWrite("com.w2f.app", "sleep_duration"))
+        // Cross-package isolation — only W2F may write the screen-off
+        // estimate; other companions have no legitimate sleep producer.
+        assertFalse(CompanionContract.canWrite("com.smokless.smokeless", "sleep_duration"))
+        assertFalse(CompanionContract.canWrite("com.virgil.app", "sleep_duration"))
+        assertFalse(CompanionContract.canWrite("com.unknown.app", "sleep_duration"))
+    }
+
+    @Test
     fun `companion whitelist contains Smokeless substance-use keys`() {
         assertTrue(
             "Smokeless tobacco_use must be writable via companion URI",
@@ -75,11 +92,12 @@ class BiosHealthProviderContractTest {
     }
 
     @Test
-    fun `W2F may only write its own mental-health keys`() {
+    fun `W2F may only write its own mental-health and sleep-derivation keys`() {
         val w2f = "com.w2f.app"
         assertTrue(CompanionContract.canWrite(w2f, "typing_cadence"))
         assertTrue(CompanionContract.canWrite(w2f, "mood_drift_score"))
         assertTrue(CompanionContract.canWrite(w2f, "circadian_phase_shift"))
+        assertTrue(CompanionContract.canWrite(w2f, "sleep_duration"))
         // Cross-package isolation — W2F must not write Smokeless keys
         assertFalse(CompanionContract.canWrite(w2f, "tobacco_use"))
         assertFalse(CompanionContract.canWrite(w2f, "tobacco_craving"))

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -353,6 +353,7 @@ class FhirExporterTest {
             MetricUnit.UG_PER_M3 -> "ug/m3"
             MetricUnit.PPM -> "[ppm]"
             MetricUnit.PPB -> "[ppb]"
+            MetricUnit.LITERS_PER_MIN -> "L/min"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
@@ -1,0 +1,114 @@
+package com.bios.app
+
+import com.bios.app.data.AvpuLevel
+import com.bios.app.data.GcsBounds
+import com.bios.app.data.ManualReadingContext
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the selectors the clinical-reading entry surface depends on:
+ *  - the canonical vital-sign set the picker offers;
+ *  - the AVPU → GCS lossless mapping the consciousness input applies;
+ *  - the [ManualReadingContext.isEmpty] contract that decides whether the
+ *    sidecar gets written at all.
+ *
+ * If these selectors silently drift, the bundle entry screen either drops
+ * relevant metrics or overwrites GCS values during AVPU shortcut entries.
+ */
+class ManualReadingSelectorsTest {
+
+    @Test
+    fun clinical_picker_includes_every_canonical_vital() {
+        // These are the columns of a Spanish ER triage chart (TAS, TAD,
+        // SatO2, FC, Temp, FR, EVA, GCS, Flujo O2). All must opt in to
+        // manual entry or the picker is missing the form the screen was
+        // built to capture.
+        val triage = setOf(
+            MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.BLOOD_OXYGEN,
+            MetricType.HEART_RATE,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.RESPIRATORY_RATE,
+            MetricType.PAIN_SCORE,
+            MetricType.CONSCIOUSNESS_LEVEL,
+            MetricType.OXYGEN_FLOW_RATE,
+        )
+        for (t in triage) {
+            assertTrue(
+                "${t.key} must allow manual entry — triage chart column",
+                t.allowsManualEntry
+            )
+        }
+    }
+
+    @Test
+    fun clinical_picker_excludes_biomarker_and_reproductive_metrics() {
+        // Biomarkers route through BiomarkerEntryScreen (lab provenance
+        // shape); reproductive metrics route through BbtEntryRepo /
+        // PeriodEntryRepo (isolated ReproductiveDatabase). The clinical
+        // bundle screen filters them out — verify the filter premise:
+        // each domain still has at least one allows-manual-entry entry,
+        // so excluding by domain is a meaningful split.
+        val biomarkerManual = MetricType.entries
+            .filter { it.domain == MetricDomain.BIOMARKER && it.allowsManualEntry }
+        assertTrue("Biomarker domain must have manual-entry metrics", biomarkerManual.isNotEmpty())
+        val reproductiveManual = MetricType.entries
+            .filter { it.domain == MetricDomain.WOMENS_HEALTH && it.allowsManualEntry }
+        assertTrue("Womens-health domain must have manual-entry metrics", reproductiveManual.isNotEmpty())
+    }
+
+    @Test
+    fun avpu_maps_lossless_to_canonical_gcs_totals() {
+        // AVPU → GCS mapping is the cited entry-time shortcut for
+        // CONSCIOUSNESS_LEVEL. Issue #131 fixed these values; renumbering
+        // here would silently rewrite the owner's chart history.
+        assertEquals(15, AvpuLevel.ALERT.gcsTotal)
+        assertEquals(13, AvpuLevel.VOICE.gcsTotal)
+        assertEquals(8, AvpuLevel.PAIN.gcsTotal)
+        assertEquals(3, AvpuLevel.UNRESPONSIVE.gcsTotal)
+    }
+
+    @Test
+    fun gcs_bounds_match_clinical_canonical_range() {
+        // 3..15 is the textbook GCS total range. The screen's input field
+        // hint depends on this; loosening it would let the owner enter
+        // out-of-band values that consumers (FHIR export, trends) won't
+        // know how to interpret.
+        assertEquals(3, GcsBounds.MIN)
+        assertEquals(15, GcsBounds.MAX)
+    }
+
+    @Test
+    fun manual_reading_context_is_empty_when_all_fields_blank() {
+        assertTrue(ManualReadingContext().isEmpty)
+        assertTrue(ManualReadingContext(clinicName = "", visitNote = "  ").isEmpty)
+    }
+
+    @Test
+    fun manual_reading_context_records_clinic_provenance() {
+        val context = ManualReadingContext(
+            clinicName = "Hospital de Triage",
+            originalScale = "AVPU",
+            originalValue = "V",
+        )
+        assertFalse(context.isEmpty)
+        assertEquals("AVPU", context.originalScale)
+        assertEquals("V", context.originalValue)
+    }
+
+    @Test
+    fun pain_and_consciousness_units_are_score() {
+        // The picker shows the unit suffix next to the entry field; SCORE
+        // resolves to an empty symbol intentionally (no display suffix
+        // for raw 0–10 / 3–15 numbers).
+        assertEquals(MetricUnit.SCORE, MetricType.PAIN_SCORE.unit)
+        assertEquals(MetricUnit.SCORE, MetricType.CONSCIOUSNESS_LEVEL.unit)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
@@ -1,0 +1,210 @@
+package com.bios.app
+
+import com.bios.app.engine.PhoneSleepInference
+import com.bios.app.engine.PhoneSleepInference.Sample
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the rule-based phone-only sleep inference (issue #134).
+ *
+ * The Android-bound collection path (PhoneSleepAdapter) is not exercised
+ * here — those tests would require a SensorManager and battery service.
+ * The inference itself is pure logic and fully testable.
+ */
+class PhoneSleepInferenceTest {
+
+    private val sourceId = "phone-sensor-derived"
+    private val minuteMs = 60_000L
+
+    @Test
+    fun `no samples produces no readings`() {
+        assertTrue(PhoneSleepInference.infer(emptyList(), sourceId).isEmpty())
+    }
+
+    @Test
+    fun `short screen-off stretch under threshold yields nothing`() {
+        // 1h of screen-off — well below the 4h minimum window.
+        val samples = trace(durationMs = 60 * minuteMs, screenOff = true, charging = true,
+            lux = 0f, accelVar = 0f)
+        assertTrue(PhoneSleepInference.infer(samples, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `8h quiet dark charging window emits a SLEEP_DURATION reading at MEDIUM confidence`() {
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = true, charging = true,
+            lux = 0f, accelVar = 0f)
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.firstOrNull { it.metricType == MetricType.SLEEP_DURATION.key }
+        assertNotNull("Expected a SLEEP_DURATION reading", duration)
+        // Sleep ~= window length when no AWAKE bouts. Allow a 1-minute
+        // tolerance for the segment closing boundary.
+        assertTrue(duration!!.value in (8 * 3600 - 60).toDouble()..(8 * 3600).toDouble())
+        assertEquals(ConfidenceTier.MEDIUM.level, duration.confidence)
+    }
+
+    @Test
+    fun `screen-on samples are not counted as sleep`() {
+        // Same 8h but screen is ON throughout — long meeting, not sleep.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = false, charging = true,
+            lux = 0f, accelVar = 0f)
+        assertTrue(PhoneSleepInference.infer(samples, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `quiet but unplugged window downgrades confidence to LOW`() {
+        // No charging confirmation, no ambient light reading — booster
+        // signals don't confirm, so confidence sags to LOW.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = true, charging = false,
+            lux = null, accelVar = 0f)
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.first { it.metricType == MetricType.SLEEP_DURATION.key }
+        assertEquals(ConfidenceTier.LOW.level, duration.confidence)
+    }
+
+    @Test
+    fun `lit room downgrades confidence to LOW even when charging`() {
+        // Plugged in but the room is bright (phone face-up on a lit desk) —
+        // not the dark-bedroom signature we want before claiming MEDIUM.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = true, charging = true,
+            lux = 200f, accelVar = 0f)
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.first { it.metricType == MetricType.SLEEP_DURATION.key }
+        assertEquals(ConfidenceTier.LOW.level, duration.confidence)
+    }
+
+    @Test
+    fun `prolonged movement bout in the middle subtracts from total sleep`() {
+        // 8h window, 1h of high accel variance in the middle = AWAKE.
+        val samples = buildList {
+            for (i in 0 until 8 * 60) {
+                val ts = i * minuteMs
+                val awake = i in 200..259 // ~1h awake stretch
+                add(Sample(
+                    timestamp = ts,
+                    screenOff = true,
+                    charging = true,
+                    ambientLightLux = 0f,
+                    accelMagnitudeVar = if (awake) 2.0f else 0f
+                ))
+            }
+        }
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.first { it.metricType == MetricType.SLEEP_DURATION.key }
+        // 8h - ~1h awake ≈ 7h sleep. Allow ±2 min tolerance.
+        val expected = (7 * 3600).toDouble()
+        assertTrue("expected ~7h, got ${duration.value}",
+            kotlin.math.abs(duration.value - expected) < 120.0)
+    }
+
+    @Test
+    fun `brief movement bouts under five minutes are not counted as wake`() {
+        // 8h, with a single 2-minute movement bout — posture shift, not wake.
+        val samples = buildList {
+            for (i in 0 until 8 * 60) {
+                val ts = i * minuteMs
+                val flicker = i in 240..241
+                add(Sample(
+                    timestamp = ts,
+                    screenOff = true,
+                    charging = true,
+                    ambientLightLux = 0f,
+                    accelMagnitudeVar = if (flicker) 2.0f else 0f
+                ))
+            }
+        }
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.first { it.metricType == MetricType.SLEEP_DURATION.key }
+        // Sleep should be ~full window, brief bout absorbed.
+        assertTrue(duration.value > (8 * 3600 - 120).toDouble())
+    }
+
+    @Test
+    fun `output stages are limited to LIGHT and AWAKE`() {
+        // Phone-only inference deliberately cannot discriminate DEEP / REM,
+        // so the stage rows it produces must stay inside {LIGHT, AWAKE}.
+        val samples = buildList {
+            for (i in 0 until 8 * 60) {
+                val ts = i * minuteMs
+                val awake = i in 200..259
+                add(Sample(
+                    timestamp = ts,
+                    screenOff = true,
+                    charging = true,
+                    ambientLightLux = 0f,
+                    accelMagnitudeVar = if (awake) 2.0f else 0f
+                ))
+            }
+        }
+        val stages = PhoneSleepInference.infer(samples, sourceId)
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .map { it.value.toInt() }
+            .toSet()
+        assertTrue(stages.isNotEmpty())
+        assertTrue(stages.all { it == SleepStage.LIGHT.value || it == SleepStage.AWAKE.value })
+        assertFalse(SleepStage.DEEP.value in stages)
+        assertFalse(SleepStage.REM.value in stages)
+    }
+
+    @Test
+    fun `picks the longest screen-off stretch when two exist`() {
+        // 2h quiet, 30m active, 8h quiet. The 8h stretch must be the one
+        // that lands — picking the 2h fragment would mis-attribute the trace.
+        val samples = mutableListOf<Sample>()
+        var t = 0L
+        repeat(2 * 60) { samples += sleepSample(t); t += minuteMs }
+        repeat(30) { samples += awakeSample(t); t += minuteMs }
+        repeat(8 * 60) { samples += sleepSample(t); t += minuteMs }
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.first { it.metricType == MetricType.SLEEP_DURATION.key }
+        // The 2h fragment is below the 4h minimum window, so the picked
+        // stretch must be the 8h one — sleep should be ~8h, not ~2h.
+        assertTrue(duration.value > (7 * 3600).toDouble())
+    }
+
+    @Test
+    fun `output sourceId is propagated`() {
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = true, charging = true,
+            lux = 0f, accelVar = 0f)
+        val readings = PhoneSleepInference.infer(samples, "test-source-id-xyz")
+        assertTrue(readings.isNotEmpty())
+        assertTrue(readings.all { it.sourceId == "test-source-id-xyz" })
+    }
+
+    // ---- helpers ----
+
+    private fun trace(
+        durationMs: Long,
+        screenOff: Boolean,
+        charging: Boolean,
+        lux: Float?,
+        accelVar: Float,
+    ): List<Sample> {
+        val n = (durationMs / minuteMs).toInt()
+        return List(n) { i ->
+            Sample(
+                timestamp = i * minuteMs,
+                screenOff = screenOff,
+                charging = charging,
+                ambientLightLux = lux,
+                accelMagnitudeVar = accelVar
+            )
+        }
+    }
+
+    private fun sleepSample(t: Long) = Sample(
+        timestamp = t, screenOff = true, charging = true,
+        ambientLightLux = 0f, accelMagnitudeVar = 0f
+    )
+
+    private fun awakeSample(t: Long) = Sample(
+        timestamp = t, screenOff = false, charging = false,
+        ambientLightLux = 300f, accelMagnitudeVar = 3f
+    )
+}

--- a/android/app/src/test/java/com/bios/app/SleepRegularityCalculatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepRegularityCalculatorTest.kt
@@ -1,0 +1,219 @@
+package com.bios.app
+
+import com.bios.app.engine.SleepRegularityCalculator
+import com.bios.app.engine.SleepRegularityCalculator.Fields
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the SLEEP_REGULARITY composite + sidecar contract.
+ *
+ * Algorithm under test is pure circular statistics over a window of
+ * SLEEP_DURATION readings — fully JVM-testable. Picks the implementation
+ * apart along three axes: well-clustered → high score, dispersed → low,
+ * wrap-around (around midnight) handled correctly.
+ */
+class SleepRegularityCalculatorTest {
+
+    private val sourceId = "test-source"
+    private val now = utcMidnight(2026, 5, 21) // Wed midnight UTC for reproducibility
+    private val hour = 3_600_000L
+
+    @Test
+    fun `fewer than three nights returns null`() {
+        val nights = listOf(
+            sleepNight(daysAgo = 1, bedHour = 23, durationH = 8),
+            sleepNight(daysAgo = 2, bedHour = 23, durationH = 8),
+        )
+        assertNull(SleepRegularityCalculator.derive(nights, sourceId, nowMs = now))
+    }
+
+    @Test
+    fun `perfectly-regular schedule scores 100`() {
+        // 7 nights, all bedtime 23:00, all 8h sleep. Midpoint = 03:00 every
+        // night. Variance ≈ 0 → score = 100.
+        val nights = (1..7).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)
+        assertNotNull(result)
+        assertEquals(100.0, result!!.reading.value, 0.5)
+        assertEquals(MetricType.SLEEP_REGULARITY.key, result.reading.metricType)
+    }
+
+    @Test
+    fun `highly-irregular schedule scores zero`() {
+        // 7 nights with bedtimes spread across the clock — high midpoint
+        // variance, score saturates at 0.
+        val bedtimes = listOf(20, 0, 4, 22, 12, 18, 2)
+        val nights = bedtimes.mapIndexed { i, hr ->
+            sleepNight(daysAgo = i + 1, bedHour = hr, durationH = 8)
+        }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)
+        assertNotNull(result)
+        assertEquals(0.0, result!!.reading.value, 0.5)
+    }
+
+    @Test
+    fun `bedtime wrap-around across midnight does not inflate variance`() {
+        // 7 nights bedtime alternating 23:30 / 00:30 — the actual spread is
+        // 1h, not 23h. Circular stats handle this; naive minute-arithmetic
+        // would not. Score should stay near 100 (≤ 15 min midpoint sigma).
+        val nights = (1..7).map { i ->
+            val isLate = i % 2 == 0
+            // 23:30 → bed at +23.5h; 00:30 → bed at +0.5h.
+            sleepNightHalfHour(daysAgo = i, bedHourHalfSteps = if (isLate) 47 else 1, durationH = 8)
+        }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)
+        assertNotNull(result)
+        val midpointVarMin = payloadLong(result!!, Fields.MIDPOINT_VARIANCE_MIN)
+        // 1h bedtime spread → ~30 min circular std. Must be well below 90
+        // (the irregular threshold) — the naive computation would yield
+        // ~11 hours of std and saturate at the half-day clamp.
+        assertTrue("midpoint variance $midpointVarMin min unexpectedly large for ±30min bedtime",
+            midpointVarMin < 90)
+    }
+
+    @Test
+    fun `sidecar payload contains all four field keys`() {
+        val nights = (1..7).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)!!
+        val keys = result.payload.map { it.fieldKey }.toSet()
+        assertEquals(
+            setOf(
+                Fields.BEDTIME_VARIANCE_MIN,
+                Fields.WAKE_VARIANCE_MIN,
+                Fields.MIDPOINT_VARIANCE_MIN,
+                Fields.WINDOW_DAYS,
+            ),
+            keys
+        )
+        // Every payload row joins back to the parent reading via FK.
+        assertTrue(result.payload.all { it.readingId == result.reading.id })
+        // Window days field carries the configured window.
+        assertEquals(7L, payloadLong(result, Fields.WINDOW_DAYS))
+    }
+
+    @Test
+    fun `non-default window is respected`() {
+        // Provide 14 nights but ask for a 14-day window; default is 7.
+        val nights = (1..14).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val sevenDayResult = SleepRegularityCalculator.derive(
+            nights, sourceId, windowDays = 7, nowMs = now
+        )!!
+        val fourteenDayResult = SleepRegularityCalculator.derive(
+            nights, sourceId, windowDays = 14, nowMs = now
+        )!!
+        assertEquals(7L, payloadLong(sevenDayResult, Fields.WINDOW_DAYS))
+        assertEquals(14L, payloadLong(fourteenDayResult, Fields.WINDOW_DAYS))
+    }
+
+    @Test
+    fun `readings outside the window are excluded`() {
+        // 6 well-clustered nights inside the 7-day window + 1 wildly-off
+        // night 30 days ago. The old night must not pull the score down —
+        // the windowing filter excludes it.
+        val recent = (1..6).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val ancient = listOf(sleepNight(daysAgo = 30, bedHour = 8, durationH = 4))
+        val result = SleepRegularityCalculator.derive(
+            recent + ancient, sourceId, nowMs = now
+        )!!
+        assertEquals(100.0, result.reading.value, 0.5)
+    }
+
+    @Test
+    fun `non-sleep-duration readings are ignored`() {
+        // Mix in HEART_RATE rows — they must not affect the regularity math.
+        val nights = (1..7).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val noise = (1..7).map {
+            MetricReading(
+                metricType = MetricType.HEART_RATE.key,
+                value = 60.0,
+                timestamp = now - it * 24 * hour,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        }
+        val result = SleepRegularityCalculator.derive(nights + noise, sourceId, nowMs = now)
+        assertEquals(100.0, result!!.reading.value, 0.5)
+    }
+
+    @Test
+    fun `confidence of result is the minimum of input confidences`() {
+        val mixed = (1..7).map { i ->
+            val tier = if (i == 3) ConfidenceTier.LOW else ConfidenceTier.HIGH
+            sleepNight(daysAgo = i, bedHour = 23, durationH = 8, confidence = tier)
+        }
+        val result = SleepRegularityCalculator.derive(mixed, sourceId, nowMs = now)!!
+        // The single LOW night drags the composite's confidence to LOW.
+        assertEquals(ConfidenceTier.LOW.level, result.reading.confidence)
+    }
+
+    @Test
+    fun `output is a SLEEP_REGULARITY reading carrying the window as duration`() {
+        val nights = (1..7).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)!!
+        assertEquals(MetricType.SLEEP_REGULARITY.key, result.reading.metricType)
+        assertEquals(7 * 24 * 3600, result.reading.durationSec)
+        assertEquals(sourceId, result.reading.sourceId)
+    }
+
+    // ---- helpers ----
+
+    private fun sleepNight(
+        daysAgo: Int,
+        bedHour: Int,
+        durationH: Int,
+        confidence: ConfidenceTier = ConfidenceTier.HIGH,
+    ): MetricReading {
+        // Bedtime = local midnight of (today - daysAgo) + bedHour hours.
+        val nightStart = now - daysAgo.toLong() * 24 * hour
+        val bed = nightStart + bedHour.toLong() * hour
+        val durMs = durationH.toLong() * hour
+        return MetricReading(
+            metricType = MetricType.SLEEP_DURATION.key,
+            value = (durationH * 3600).toDouble(),
+            timestamp = bed + durMs / 2L,
+            durationSec = durationH * 3600,
+            sourceId = sourceId,
+            confidence = confidence.level
+        )
+    }
+
+    /** Same as [sleepNight] but bedtime is expressed in 30-minute steps. */
+    private fun sleepNightHalfHour(
+        daysAgo: Int,
+        bedHourHalfSteps: Int,
+        durationH: Int,
+    ): MetricReading {
+        val nightStart = now - daysAgo.toLong() * 24 * hour
+        val bed = nightStart + bedHourHalfSteps.toLong() * (hour / 2L)
+        val durMs = durationH.toLong() * hour
+        return MetricReading(
+            metricType = MetricType.SLEEP_DURATION.key,
+            value = (durationH * 3600).toDouble(),
+            timestamp = bed + durMs / 2L,
+            durationSec = durationH * 3600,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level
+        )
+    }
+
+    private fun payloadLong(
+        result: SleepRegularityCalculator.Result,
+        fieldKey: String,
+    ): Long = result.payload.first { it.fieldKey == fieldKey }.longValue!!
+
+    private fun utcMidnight(year: Int, month: Int, dayOfMonth: Int): Long {
+        // Plain epoch math (no JDK time zone surprises): the calculator
+        // operates in UTC, so anchor the tests there too.
+        val cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+        cal.clear()
+        cal.set(year, month - 1, dayOfMonth, 0, 0, 0)
+        return cal.timeInMillis
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -78,6 +78,12 @@ enum class MetricType(
     SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),
     WAKE_AFTER_SLEEP_ONSET("wake_after_sleep_onset", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_SCORE("sleep_score", MetricUnit.SCORE, MetricDomain.SLEEP),
+    // Sleep researchers (Roenneberg, Walker, Phyllis Zee group) consistently
+    // rank regularity above absolute duration for long-term outcomes. Sidecar
+    // fields (bedtime/wake/midpoint variance + window_days) ride on
+    // event_payloads so a future specialty companion can read components
+    // rather than just the composite. See engine/SleepRegularityCalculator.
+    SLEEP_REGULARITY("sleep_regularity", MetricUnit.SCORE, MetricDomain.SLEEP),
     // Bios-produced from sleep-onset times via cosinor/DLMO math. Universal
     // chronobiology metric — not mood-specific despite W2F being the primary
     // consumer. See docs/ECOSYSTEM_BOUNDARIES.md producer-by-capture-surface

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -19,10 +19,23 @@ package com.bios.contracts
  *    existing entry — add a new entry.
  *  - Consumers must call `fromKey()` (not `valueOf`) and tolerate `null` for
  *    keys their contracts version doesn't know.
+ *
+ * [allowsManualEntry] gates the Bios-hosted manual-reading surface. The rule
+ * is *"can the owner be the source?"* — reading a device (cuff, pulse-ox,
+ * thermometer), being measured by a clinician, observing themselves. Derived
+ * keys (HRV power, glucose CV, sleep efficiency) and pure-sensor-only signals
+ * (raw accelerometer) stay false. Engine isolation still holds — manual
+ * entries flow through SELF_REPORTED and never feed BaselineEngine /
+ * AnomalyDetector. See docs/SELF_REPORTED_DATA_HOME.md decision 3.
  */
-enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricDomain) {
+enum class MetricType(
+    val key: String,
+    val unit: MetricUnit,
+    val domain: MetricDomain,
+    val allowsManualEntry: Boolean = false,
+) {
     // Cardiovascular
-    HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
+    HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
     HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
@@ -30,21 +43,36 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     HRV_LF_POWER("hrv_lf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     HRV_HF_POWER("hrv_hf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     VO2_MAX("vo2_max", MetricUnit.ML_PER_KG_MIN, MetricDomain.CARDIOVASCULAR),
-    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
-    BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
-    BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR),
-    BLOOD_OXYGEN("blood_oxygen", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR),
+    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    BLOOD_OXYGEN("blood_oxygen", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
 
     // Respiratory
-    RESPIRATORY_RATE("respiratory_rate", MetricUnit.BREATHS_PER_MIN, MetricDomain.RESPIRATORY),
+    RESPIRATORY_RATE("respiratory_rate", MetricUnit.BREATHS_PER_MIN, MetricDomain.RESPIRATORY, allowsManualEntry = true),
+    // Administered supplemental O2 (cannula/mask). Contextualises SpO2:
+    // 96 % on room air ≠ 96 % on 4 L/min. Single-point shape; ongoing-therapy
+    // log-shape (start/end + rate over time) is deferred — see issue #107.
+    OXYGEN_FLOW_RATE("oxygen_flow_rate", MetricUnit.LITERS_PER_MIN, MetricDomain.RESPIRATORY, allowsManualEntry = true),
 
     // Temperature
-    SKIN_TEMPERATURE("skin_temperature", MetricUnit.CELSIUS, MetricDomain.TEMPERATURE),
+    SKIN_TEMPERATURE("skin_temperature", MetricUnit.CELSIUS, MetricDomain.TEMPERATURE, allowsManualEntry = true),
     SKIN_TEMPERATURE_DEVIATION("skin_temperature_deviation", MetricUnit.DELTA_CELSIUS, MetricDomain.TEMPERATURE),
+
+    // Neurological (manual-capture clinical signs).
+    // PAIN_SCORE: 0–10 numeric (EVA / VAS / NRS interoperable). Universal
+    // triage vital.
+    // CONSCIOUSNESS_LEVEL: GCS canonical (3–15 total). GCS encodes AVPU but
+    // not vice versa, so GCS covers neuro/ICU/post-trauma/surgery contexts
+    // over a lifetime while AVPU-only is ER-triage-only. AVPU entry is a
+    // lossless input shortcut (A→15, V→13, P→8, U→3); the original scale +
+    // value are preserved in the event_payloads sidecar for provenance.
+    PAIN_SCORE("pain_score", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+    CONSCIOUSNESS_LEVEL("consciousness_level", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
     // Sleep
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),
-    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP),
+    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP, allowsManualEntry = true),
     SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_EFFICIENCY("sleep_efficiency", MetricUnit.PERCENT, MetricDomain.SLEEP),
     SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),
@@ -68,26 +96,26 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     EXERCISE_SESSION("exercise_session", MetricUnit.EVENT, MetricDomain.ACTIVITY),
 
     // Metabolic
-    BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
+    BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC, allowsManualEntry = true),
     // CGM-derived variability keys (#28). Computed over the last 24h of
     // BLOOD_GLUCOSE readings by GlucoseVariability; one value per 24h window.
     GLUCOSE_CV("glucose_cv", MetricUnit.PERCENT, MetricDomain.METABOLIC),
     GLUCOSE_MAGE("glucose_mage", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
     GLUCOSE_TIME_IN_RANGE("glucose_time_in_range", MetricUnit.PERCENT, MetricDomain.METABOLIC),
     GLUCOSE_PEAK_24H("glucose_peak_24h", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC),
-    BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
-    BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
-    LEAN_MASS("lean_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
-    BODY_WATER_PCT("body_water_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC),
-    BONE_MASS("bone_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC),
+    BODY_MASS("body_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BODY_FAT_PCT("body_fat_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC, allowsManualEntry = true),
+    LEAN_MASS("lean_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BODY_WATER_PCT("body_water_pct", MetricUnit.PERCENT, MetricDomain.METABOLIC, allowsManualEntry = true),
+    BONE_MASS("bone_mass", MetricUnit.KILOGRAMS, MetricDomain.METABOLIC, allowsManualEntry = true),
 
     // Recovery
     RECOVERY_SCORE("recovery_score", MetricUnit.SCORE, MetricDomain.RECOVERY),
 
     // Women's Health
-    BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH),
+    BASAL_BODY_TEMPERATURE("basal_body_temperature", MetricUnit.CELSIUS, MetricDomain.WOMENS_HEALTH, allowsManualEntry = true),
     CYCLE_PHASE("cycle_phase", MetricUnit.CATEGORY, MetricDomain.WOMENS_HEALTH),
-    MENSTRUATION_ONSET("menstruation_onset", MetricUnit.EVENT, MetricDomain.WOMENS_HEALTH),
+    MENSTRUATION_ONSET("menstruation_onset", MetricUnit.EVENT, MetricDomain.WOMENS_HEALTH, allowsManualEntry = true),
     CYCLE_DAY("cycle_day", MetricUnit.COUNT, MetricDomain.WOMENS_HEALTH),
 
     // Environment (phone-sensor adapter)
@@ -100,57 +128,57 @@ enum class MetricType(val key: String, val unit: MetricUnit, val domain: MetricD
     // First wave matches the clinical concepts already described in
     // alerts/BiomarkerReference.kt — direct readings displace the wearable
     // proxies when an owner imports labs.
-    HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
-    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER),
-    TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    VITAMIN_D_25OH("vitamin_d_25oh", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
-    TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER),
-    FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
-    FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    HEMOGLOBIN("hemoglobin", MetricUnit.G_PER_DL, MetricDomain.BIOMARKER),
-    HEMATOCRIT("hematocrit", MetricUnit.PERCENT, MetricDomain.BIOMARKER),
-    WBC("wbc", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
-    RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER),
-    PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER),
+    HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TRIGLYCERIDES("triglycerides", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    APO_B("apo_b", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    VITAMIN_D_25OH("vitamin_d_25oh", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    TSH("tsh", MetricUnit.MIU_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FREE_T4("free_t4", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FREE_T3("free_t3", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HEMOGLOBIN("hemoglobin", MetricUnit.G_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HEMATOCRIT("hematocrit", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    WBC("wbc", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    RBC("rbc", MetricUnit.TERA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    PLATELETS("platelets", MetricUnit.GIGA_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Glycemic-extended (#24). Fasting glucose + insulin enable HOMA-IR, the
     // canonical insulin-resistance index — clinically meaningful before HbA1c
     // shifts. HOMA-IR is stored as the calculated value (Matthews 1985:
     // (fasting insulin µIU/mL × fasting glucose mg/dL) / 405).
-    FASTING_GLUCOSE("fasting_glucose", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
-    FASTING_INSULIN("fasting_insulin", MetricUnit.MICRO_IU_PER_ML, MetricDomain.BIOMARKER),
-    HOMA_IR("homa_ir", MetricUnit.SCORE, MetricDomain.BIOMARKER),
+    FASTING_GLUCOSE("fasting_glucose", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FASTING_INSULIN("fasting_insulin", MetricUnit.MICRO_IU_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HOMA_IR("homa_ir", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Iron status (#24). Ferritin is the most-cited single marker for body
     // iron stores; relevant to fatigue / inflammation patterns.
-    FERRITIN("ferritin", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
+    FERRITIN("ferritin", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Endocrine panel (#24). Sex hormones + adrenal (cortisol) + IGF-1.
     // Reference ranges vary by sex/age — Bios stores raw values, the owner's
     // own provider-supplied range travels with the FHIR import.
-    TESTOSTERONE_TOTAL("testosterone_total", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER),
-    ESTRADIOL("estradiol", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    CORTISOL("cortisol", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER),
-    IGF_1("igf_1", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
+    TESTOSTERONE_TOTAL("testosterone_total", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ESTRADIOL("estradiol", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    CORTISOL("cortisol", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    IGF_1("igf_1", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Micronutrients (#24). Common deficiency panel — methylation cofactors
     // (B12/folate) and the electrolyte the standard CMP often omits.
-    VITAMIN_B12("vitamin_b12", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER),
-    FOLATE("folate", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER),
-    MAGNESIUM("magnesium", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER),
+    VITAMIN_B12("vitamin_b12", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    FOLATE("folate", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    MAGNESIUM("magnesium", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
     // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
     // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age
     // score" from these (manifesto: never evaluate the person).
-    EPIGENETIC_AGE_DUNEDIN_PACE("epigenetic_age_dunedin_pace", MetricUnit.SCORE, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_GRIM("epigenetic_age_grim", MetricUnit.YEARS, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_PHENO("epigenetic_age_pheno", MetricUnit.YEARS, MetricDomain.BIOMARKER),
-    EPIGENETIC_AGE_HORVATH("epigenetic_age_horvath", MetricUnit.YEARS, MetricDomain.BIOMARKER),
+    EPIGENETIC_AGE_DUNEDIN_PACE("epigenetic_age_dunedin_pace", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_GRIM("epigenetic_age_grim", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_PHENO("epigenetic_age_pheno", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    EPIGENETIC_AGE_HORVATH("epigenetic_age_horvath", MetricUnit.YEARS, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
     // Companion signals (injected by W2F via ContentProvider).
     // typing_cadence requires the AccessibilityService capture surface;
@@ -219,11 +247,12 @@ enum class MetricUnit(val symbol: String) {
     ML_PER_KG_MIN("mL/kg/min"),
     UG_PER_M3("µg/m³"),
     PPM("ppm"),
-    PPB("ppb")
+    PPB("ppb"),
+    LITERS_PER_MIN("L/min")
 }
 
 enum class MetricDomain {
     CARDIOVASCULAR, RESPIRATORY, TEMPERATURE, SLEEP,
     ACTIVITY, METABOLIC, RECOVERY, WOMENS_HEALTH,
-    MENTAL_HEALTH, INTAKE, SAFETY, ENVIRONMENT, BIOMARKER
+    MENTAL_HEALTH, NEUROLOGICAL, INTAKE, SAFETY, ENVIRONMENT, BIOMARKER
 }

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -41,6 +41,10 @@ class MetricTypeKeysSnapshotTest {
         "blood_oxygen",
         // Respiratory
         "respiratory_rate",
+        "oxygen_flow_rate",
+        // Neurological (manual-capture clinical signs)
+        "pain_score",
+        "consciousness_level",
         // Temperature
         "skin_temperature",
         "skin_temperature_deviation",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -56,6 +56,7 @@ class MetricTypeKeysSnapshotTest {
         "sleep_fragmentation_index",
         "wake_after_sleep_onset",
         "sleep_score",
+        "sleep_regularity",
         "circadian_phase_shift",
         // Activity
         "steps",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -3,6 +3,7 @@ package com.bios.contracts
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
@@ -211,6 +212,95 @@ class MetricTypeTest {
         // EVENT unit matches the marker semantics (value = 1.0).
         assertEquals(MetricDomain.ACTIVITY, MetricType.EXERCISE_SESSION.domain)
         assertEquals(MetricUnit.EVENT, MetricType.EXERCISE_SESSION.unit)
+    }
+
+    @Test
+    fun pain_score_is_neurological_score() {
+        assertEquals(MetricDomain.NEUROLOGICAL, MetricType.PAIN_SCORE.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.PAIN_SCORE.unit)
+        assertTrue(
+            MetricType.PAIN_SCORE.allowsManualEntry,
+            "PAIN_SCORE must allow manual entry — it's the canonical triage vital",
+        )
+    }
+
+    @Test
+    fun consciousness_level_is_neurological_score() {
+        // GCS canonical scale, 3–15 total. AVPU input is an entry-time shortcut
+        // mapped lossless into GCS — see MetricType.kt header doc.
+        assertEquals(MetricDomain.NEUROLOGICAL, MetricType.CONSCIOUSNESS_LEVEL.domain)
+        assertEquals(MetricUnit.SCORE, MetricType.CONSCIOUSNESS_LEVEL.unit)
+        assertTrue(
+            MetricType.CONSCIOUSNESS_LEVEL.allowsManualEntry,
+            "CONSCIOUSNESS_LEVEL must allow manual entry — clinicians and " +
+                "owners both produce it from the bedside",
+        )
+    }
+
+    @Test
+    fun oxygen_flow_rate_is_respiratory_liters_per_min() {
+        assertEquals(MetricDomain.RESPIRATORY, MetricType.OXYGEN_FLOW_RATE.domain)
+        assertEquals(MetricUnit.LITERS_PER_MIN, MetricType.OXYGEN_FLOW_RATE.unit)
+        assertEquals("L/min", MetricUnit.LITERS_PER_MIN.symbol)
+        assertTrue(
+            MetricType.OXYGEN_FLOW_RATE.allowsManualEntry,
+            "OXYGEN_FLOW_RATE must allow manual entry — it's recorded at " +
+                "the bedside, not by a wearable",
+        )
+    }
+
+    @Test
+    fun allows_manual_entry_defaults_false_for_pure_sensor_keys() {
+        // Spot-check: streaming sensor / derived signals must never opt in
+        // to the manual-reading surface, or the picker fills with noise.
+        val notManual = listOf(
+            MetricType.HEART_RATE_VARIABILITY,
+            MetricType.HRV_LF_POWER, MetricType.HRV_HF_POWER,
+            MetricType.PARASYMPATHETIC_TONE, MetricType.STRESS_SCORE,
+            MetricType.LF_HF_RATIO, MetricType.VO2_MAX,
+            MetricType.SKIN_TEMPERATURE_DEVIATION,
+            MetricType.SLEEP_STAGE, MetricType.SLEEP_EFFICIENCY,
+            MetricType.STEPS, MetricType.ACTIVE_CALORIES,
+            MetricType.AMBIENT_LIGHT, MetricType.AIR_PM25,
+            MetricType.TYPING_CADENCE, MetricType.MOOD_DRIFT_SCORE,
+            MetricType.TOBACCO_USE, MetricType.FALL_EVENT,
+        )
+        for (t in notManual) {
+            assertEquals(
+                false, t.allowsManualEntry,
+                "${t.key} must not opt in to manual entry",
+            )
+        }
+    }
+
+    @Test
+    fun allows_manual_entry_true_for_clinical_vitals() {
+        val manual = listOf(
+            MetricType.HEART_RATE, MetricType.RESTING_HEART_RATE,
+            MetricType.BLOOD_PRESSURE_SYSTOLIC, MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.BLOOD_OXYGEN, MetricType.RESPIRATORY_RATE,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.PAIN_SCORE, MetricType.CONSCIOUSNESS_LEVEL,
+            MetricType.OXYGEN_FLOW_RATE,
+        )
+        for (t in manual) {
+            assertTrue(
+                t.allowsManualEntry,
+                "${t.key} must opt in to manual entry — owner can be the source",
+            )
+        }
+    }
+
+    @Test
+    fun every_biomarker_allows_manual_entry() {
+        // Biomarkers have no streaming source; manual entry is the only path
+        // for owners without a FHIR feed.
+        for (t in MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }) {
+            assertTrue(
+                t.allowsManualEntry,
+                "${t.key} (biomarker) must allow manual entry",
+            )
+        }
     }
 
     @Test

--- a/docs/ECOSYSTEM_BOUNDARIES.md
+++ b/docs/ECOSYSTEM_BOUNDARIES.md
@@ -40,6 +40,8 @@ Applied:
 | `tobacco_use`, `fall_event`, etc. | discrete user actions | **companion** | requires tap-to-log / fall-detection surface |
 | `reaction_time_ms` | active test result | **Fil / W2F** | requires active-test surface |
 | `circadian_phase_shift` | sleep-onset times | **Bios** | inputs are canonical (sleep timing from 9 adapters); no companion-specific surface |
+| `sleep_duration` from screen-off | long quiet screen-off windows | **W2F** (LOW confidence) | UsageStatsTracker / screen-off is W2F's unique surface; Bios accepts the write via companion URI |
+| `sleep_duration` from phone sensors | accel + screen-off + charging + ambient-light fusion | **Bios** (MEDIUM confidence) | universal-infrastructure: every phone has these sensors; not domain-specific |
 | `cognitive_speed` (planned) | TBD | **decide at landing** | if active test output → Fil; if composite over canonical inputs → Bios |
 
 The corollary: if a companion has built logic that turns canonical Bios
@@ -88,7 +90,7 @@ logic.
 | App | Domain | Owns | Reads from Bios | Writes to Bios |
 |---|---|---|---|---|
 | **Fil** | Neurological / MS | **Built:** gait analysis (phone accel), drift z-score engine, fall detection. **Planned:** keystroke analysis, active cognitive micro-tests (SDMT, tapping, contrast), MS-specific composite, fall auto-answer | HRV, sleep, steps, activity | `gait_asymmetry`, `cognitive_speed`, `motor_score`, `relapse_risk` (future keys) |
-| **W2F** | Mood / bipolar | ADA-1, HDA-1, Friction Vault, SOS Mechanical Restart, typing cadence capture | sleep, HRV, activity, `circadian_phase_shift` | `typing_cadence`, `mood_drift_score` |
+| **W2F** | Mood / bipolar | ADA-1, HDA-1, Friction Vault, SOS Mechanical Restart, typing cadence capture | sleep, HRV, activity, `circadian_phase_shift` | `typing_cadence`, `mood_drift_score`, `sleep_duration` (LOW conf., screen-off derivation) |
 | **Virgil** | Solitary-living safety | Fall detection, check-in timer, SMS + GPS alerts, emergency call | *nothing — standalone* | `fall_event`, `near_miss_fall`, `check_in_miss` (opt-in, future) |
 | **SoulRadio** | Ambient sound / nervous-system rest | 24-hour Solfeggio + Schumann auto-loop, dial, listener library, frequency-band catalogue | *nothing — standalone* | *nothing* |
 | **Smokeless** | Substance-use tracking / cessation | Use + craving event capture, per-substance history, widget, cessation UI | *nothing — standalone* (Phase 3 plan: RHR/HRV/sleep/SpO2 reads for recovery trajectory) | `tobacco_use`, `tobacco_craving`, `cannabis_use`, `cannabis_craving` (shipped Phase 2.1); `caffeine_use`, `caffeine_craving`, `alcohol_use`, `alcohol_craving` (reserved — Phase 2.4, paired with W2F FuelLog hoist) |

--- a/docs/SELF_REPORTED_DATA_HOME.md
+++ b/docs/SELF_REPORTED_DATA_HOME.md
@@ -142,10 +142,11 @@ effect alongside this PR.
 Originally framed as *"Bios is a consumer, never the entry point —
 period."* That absolute is now wrong-as-written: since then, BBT manual
 entry (`BbtEntryRepo`), biomarker entry (`BiomarkerEntryRepo`), manual
-sleep duration, and lab-report attachment (PR #106) have all shipped as
-legitimate Bios-hosted entry surfaces.
+sleep duration, lab-report attachment (PR #106), and the general
+clinical-reading bundle surface (`ManualReadingRepo`, issue #131) have
+all shipped as legitimate Bios-hosted entry surfaces.
 
-The corrected rule — which all four shipped surfaces already satisfy —
+The corrected rule — which all five shipped surfaces already satisfy —
 is the same producer-by-capture-surface line codified in
 [ECOSYSTEM_BOUNDARIES.md](ECOSYSTEM_BOUNDARIES.md) ("No domain-specific
 active tests in Bios"). **Bios hosts an entry point if and only if the
@@ -153,9 +154,17 @@ data being entered is a canonical Bios-owned key with no other producer
 available.** Biomarkers are typed because no sensor draws blood; BBT is
 typed because no wearable on the owner's wrist measures basal body
 temperature; manual sleep is typed when Health Connect / Oura / Gadgetbridge
-are all silent. Bios is *not* the entry point for data a companion
-uniquely owns — typing cadence belongs in W2F, SDMT in Fil, fall-event
-in Virgil.
+are all silent; clinical vitals (BP cuff, pulse-ox, thermometer, triage
+chart) are typed because the LETHE-correct case is a degoogled phone
+with no Health Connect at all — the owner *is* the producer, not just
+the reader. Bios is *not* the entry point for data a companion uniquely
+owns — typing cadence belongs in W2F, SDMT in Fil, fall-event in
+Virgil.
+
+The gate is now per-metric: [MetricType.allowsManualEntry] declares
+which keys accept owner-as-source entry. Engine isolation still holds —
+manual entries flow through SELF_REPORTED and skip the baseline /
+anomaly engines per decision 3 above.
 
 The "future asks of 'let me log sleep directly in Bios'" line from the
 old wording was directionally right but the verdict's been wrong: the


### PR DESCRIPTION
Builds on PR #132 (manual-reading surface). Branch name is from the prior PR — this PR's scope is the sleep stack.

Addresses issues #133, #134, #135.

## Summary

Five commits closing the sleep gap for LETHE owners without a wearable, and giving everyone a dedicated dashboard.

- **fix(provider) #133** — whitelist `sleep_duration` for W2F derivation so screen-off-derived nights from W2F land on the Bios sleep bus. Without this, LETHE owners with neither a wearable nor Health Connect see an empty sleep view despite W2F holding the data locally.
- **feat(adapter) #134** — `PhoneSleepInference` + `PhoneSleepAdapter`: rule-based fusion of accel variance, screen-off, charging state, and ambient light over a nightly window. New `PHONE_SENSOR_DERIVED` `SourceType` so derived phone-sleep readings carry distinct provenance from raw `PHONE_SENSOR` samples.
- **feat(engine) #135** — `SleepRegularityCalculator`: composite `SLEEP_REGULARITY` score + sidecar bedtime / wake / midpoint variance (minutes). Circular statistics handle midnight wrap-around. Confidence is the min of inputs, so a LOW W2F-screen-off night can't claim better than LOW.
- **feat(ui) #135** — `SleepDashboardScreen`: 7/30/90-day window selector, regularity panel, duration summary, per-night list with source + confidence. Reached from a "View sleep dashboard" button on `SleepEntryScreen`.
- **feat(ui)** — Home `SLEEP_DURATION` tile routes to the new dashboard instead of the generic trends view.

Manifesto-clean throughout: pull-side surfaces, no nudges, no judgment. The owner picks the window; Bios renders what it has.

Deferred (tracked under #135): bedtime/wake heatmap, per-night stage breakdown, correlation prompts.

## Test plan

- [x] `:bios-contracts:test` — `MetricTypeKeysSnapshotTest` extended with `SLEEP_REGULARITY`; `MetricTypeTest` confidence/composite invariants.
- [x] `:app:testStandaloneDebugUnitTest` — new `PhoneSleepInferenceTest` (11 cases: window selection, AWAKE bout subtraction, brief-bout merging, booster downgrade, stage limitation) and `SleepRegularityCalculatorTest` (10 cases: midnight wrap, min-confidence rule, score-curve anchors); `BiosHealthProviderContractTest` pins the `sleep_duration` whitelist for W2F.
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [ ] Manual UI smoke — open Home, tap sleep tile, confirm dashboard loads with regularity + per-night list; cycle 7/30/90d window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)