### PR TITLE
feat(dashboard): active substances surface (#138)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/ConcentrationCalculator.kt
+++ b/android/app/src/main/java/com/bios/app/engine/ConcentrationCalculator.kt
@@ -94,17 +94,8 @@ class ConcentrationCalculator(
         return readings.map { intakeToDoseEvent(metricKey, it) }
     }
 
-    private fun intakeToDoseEvent(metricKey: String, reading: MetricReading): ConcentrationMath.DoseEvent {
-        // ALCOHOL_INTAKE stores grams of ethanol per its MetricType unit;
-        // the math layer works in milligrams to share one mass unit across
-        // substances. Caffeine and medication keys are already in mg.
-        val doseMg = if (metricKey == MetricType.ALCOHOL_INTAKE.key) {
-            reading.value * GRAMS_TO_MG
-        } else {
-            reading.value
-        }
-        return ConcentrationMath.DoseEvent(timestampMs = reading.timestamp, doseMg = doseMg)
-    }
+    private fun intakeToDoseEvent(metricKey: String, reading: MetricReading): ConcentrationMath.DoseEvent =
+        intakeReadingToDoseEvent(metricKey, reading)
 
     companion object {
         /** How far back to read intake events. 14 days covers ≥ 5 half-lives
@@ -115,6 +106,25 @@ class ConcentrationCalculator(
         internal const val GRAMS_TO_MG = 1000.0
         internal const val DEFAULT_CURVE_STEP_MIN = 5
     }
+}
+
+/**
+ * Convert an intake [reading] to a milligram-denominated dose event for
+ * [ConcentrationMath]. Lives at top level so the dashboard aggregator
+ * (#138) can reuse the per-key unit normalisation without duplicating
+ * the alcohol grams→mg conversion. Keep this in lockstep with
+ * `MetricType.*_INTAKE` units.
+ */
+fun intakeReadingToDoseEvent(
+    metricKey: String,
+    reading: MetricReading,
+): ConcentrationMath.DoseEvent {
+    val doseMg = if (metricKey == MetricType.ALCOHOL_INTAKE.key) {
+        reading.value * ConcentrationCalculator.GRAMS_TO_MG
+    } else {
+        reading.value
+    }
+    return ConcentrationMath.DoseEvent(timestampMs = reading.timestamp, doseMg = doseMg)
 }
 
 /**

--- a/android/app/src/main/java/com/bios/app/engine/PharmacokineticsReference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PharmacokineticsReference.kt
@@ -51,6 +51,14 @@ data class Pharmacokinetics(
      * plasma concentration would be misleading for the substance.
      */
     val volumeOfDistributionLPerKg: Double? = null,
+    /**
+     * Default "below threshold" the dashboard surfaces use for the
+     * *"drops below X at HH:MM"* readout (#138). Owner-adjustable in the
+     * UI; this just seeds the picker so the screen renders something
+     * meaningful on first open. Null → no default published, the
+     * dashboard hides the readout instead of guessing.
+     */
+    val defaultThresholdMg: Double? = null,
     /** Short citation pinning the values to a literature source. */
     val source: String,
 )
@@ -89,6 +97,9 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 7.0,
         bioavailability = 1.0,
         volumeOfDistributionLPerKg = 0.6,
+        // 50 mg ≈ half an espresso. Common reference point for the
+        // "sleep-safe" cutoff popularly cited from Drake 2013.
+        defaultThresholdMg = 50.0,
         source = "Mandel HG 2002, Statland & Demas 1980 (5h population t½, ~99 % oral bioavailability)",
     )
 
@@ -102,6 +113,9 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 0.0,
         bioavailability = 1.0,
         volumeOfDistributionLPerKg = 2.6,
+        // ~5 % of a typical cigarette dose. Below this point the
+        // pharmacological effect is generally subjective-noise level.
+        defaultThresholdMg = 0.1,
         source = "Benowitz NL 2009 (t½ ~ 2 h, V_d 2.6 L/kg, inhaled bioavailability ≈ 100 % of inhaled dose)",
     )
 
@@ -115,6 +129,7 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 30.0,
         bioavailability = 0.5,
         volumeOfDistributionLPerKg = 2.6,
+        defaultThresholdMg = 0.1,
         source = "Benowitz NL 2009, Choi 1988 (buccal F ~ 50 %, t½ ~ 2 h)",
     )
 
@@ -131,6 +146,9 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 0.0,
         bioavailability = 0.3,
         volumeOfDistributionLPerKg = 10.0,
+        // 1 mg ≈ where acute intoxication tapers; chronic redistribution
+        // body burden persists much longer (terminal t½ ~ 30 h).
+        defaultThresholdMg = 1.0,
         source = "Huestis MA 2007 (inhaled F 10–35 %, terminal t½ ~ 30 h, V_d 10 L/kg)",
     )
 
@@ -144,6 +162,7 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 90.0,
         bioavailability = 0.1,
         volumeOfDistributionLPerKg = 10.0,
+        defaultThresholdMg = 1.0,
         source = "Huestis MA 2007, Vandrey 2017 (oral F 4–12 %, peak 1–3 h post-ingestion)",
     )
 
@@ -159,6 +178,12 @@ object PharmacokineticsReference {
         absorptionHalfLifeMinutes = 15.0,
         bioavailability = 0.9,
         volumeOfDistributionLPerKg = 0.6,
+        // ~ 0.02 % BAC equivalent for a 70 kg adult (V_d 0.6 L/kg ×
+        // 70 kg × 0.0002 g/mL ≈ 8.4 g ≈ 8400 mg). Below this the
+        // pharmacological effect approaches noise; the "no measurable
+        // impairment" band varies by individual and jurisdiction so the
+        // owner picks their own number in the UI.
+        defaultThresholdMg = 8_400.0,
         source = "Widmark EMP 1932, Holford NHG 1987 (zero-order ~ 0.015 % BAC/h ≈ 7 g/h for 70 kg adult)",
     )
 

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -261,6 +261,7 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToDiagnostics = { navController.navigate("diagnostics") },
                     onNavigateToPpgCapture = { navController.navigate("ppg_capture") },
                     onNavigateToCompanions = { navController.navigate("companions") },
+                    onNavigateToActiveSubstances = { navController.navigate("active_substances") },
                     onNavigateToMetric = { metric ->
                         // SLEEP_DURATION has a dedicated dashboard richer
                         // than the generic trends view.
@@ -402,6 +403,12 @@ fun BiosApp(viewModel: AppViewModel) {
             }
             composable("sleep_dashboard") {
                 com.bios.app.ui.sleep.SleepDashboardScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+            composable("active_substances") {
+                com.bios.app.ui.intake.ActiveSubstancesScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeEntryCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeEntryCard.kt
@@ -1,0 +1,70 @@
+package com.bios.app.ui.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+/**
+ * Standard "tap to open a sub-screen" entry card used by [HomeScreen].
+ *
+ * One shape, three callers (HRV Snapshot, Diagnostics, Active
+ * Substances) — extracted to keep HomeScreen under the 500-line cap
+ * and so future entries land here with no boilerplate.
+ */
+@Composable
+fun HomeEntryCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = onClick,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleSmall)
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -39,6 +39,7 @@ fun HomeScreen(
     onNavigateToDiagnostics: () -> Unit = {},
     onNavigateToPpgCapture: () -> Unit = {},
     onNavigateToCompanions: () -> Unit = {},
+    onNavigateToActiveSubstances: () -> Unit = {},
     onNavigateToMetric: (MetricType) -> Unit = {}
 ) {
     val unacknowledged by viewModel.unacknowledgedAlerts.collectAsState()
@@ -135,81 +136,26 @@ fun HomeScreen(
             }
         }
 
-        // HRV snapshot entry (camera-PPG)
-        Card(
-            modifier = Modifier.fillMaxWidth(),
+        HomeEntryCard(
+            icon = Icons.Default.CameraAlt,
+            title = "Take HRV Snapshot",
+            subtitle = "Fingertip reading via camera — 60 seconds",
             onClick = onNavigateToPpgCapture,
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            )
-        ) {
-            Row(
-                modifier = Modifier.padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    Icons.Default.CameraAlt,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Take HRV Snapshot",
-                        style = MaterialTheme.typography.titleSmall
-                    )
-                    Text(
-                        "Fingertip reading via camera — 60 seconds",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Icon(
-                    Icons.Default.ChevronRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+        )
 
-        // Diagnostics entry
-        Card(
-            modifier = Modifier.fillMaxWidth(),
+        HomeEntryCard(
+            icon = Icons.Default.MonitorHeart,
+            title = "Health Diagnostics",
+            subtitle = "View condition pattern analysis",
             onClick = onNavigateToDiagnostics,
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            )
-        ) {
-            Row(
-                modifier = Modifier.padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    Icons.Default.MonitorHeart,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        "Health Diagnostics",
-                        style = MaterialTheme.typography.titleSmall
-                    )
-                    Text(
-                        "View condition pattern analysis",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                Icon(
-                    Icons.Default.ChevronRight,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+        )
+
+        HomeEntryCard(
+            icon = Icons.Default.Medication,
+            title = "Active Substances",
+            subtitle = "Caffeine, alcohol — current concentration in body",
+            onClick = onNavigateToActiveSubstances,
+        )
 
         // Today's vitals
         Text("Today's Vitals", style = MaterialTheme.typography.titleMedium)

--- a/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesAggregator.kt
+++ b/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesAggregator.kt
@@ -1,0 +1,173 @@
+package com.bios.app.ui.intake
+
+import com.bios.app.engine.ConcentrationMath
+import com.bios.app.engine.Pharmacokinetics
+import com.bios.app.engine.PharmacokineticsReference
+import com.bios.app.engine.intakeReadingToDoseEvent
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Pure aggregator behind the "what's still in your body" dashboard (#138).
+ *
+ * Reads a flat list of recent intake [MetricReading]s (every `*_INTAKE`
+ * key that has data) plus the source-label map and a "now" timestamp,
+ * and produces one [SubstanceCard] per known substance: current amount
+ * in body, last-dose timestamp + source, projected time-until-below the
+ * picked threshold, and a sampled decay curve.
+ *
+ * Pure so the screen layer has zero state-machine logic — the test
+ * harness exercises every empty-state / threshold-crossing / multi-dose
+ * branch without spinning up Room. The screen calls this once, renders,
+ * recomposes on time-tick.
+ *
+ * **Window semantics.** Intakes older than `historicalWindowMs` are
+ * dropped before the curve sample because the engine math already
+ * weights them by elapsed time and a 24 h window keeps the sparkline
+ * legible. Owners who want longer lookback get it from the trends tab.
+ */
+object ActiveSubstancesAggregator {
+
+    /**
+     * Per-substance dashboard tile. [pk] is non-null even for empty
+     * tiles so the UI can render the unit label and substance name
+     * without re-deriving them. [lastDoseTimestampMs] / [lastDoseLabel]
+     * are null when no intake landed inside [historicalWindowMs] — the
+     * UI uses that to distinguish "zero on board" from "unknown".
+     */
+    data class SubstanceCard(
+        val metricKey: String,
+        val pk: Pharmacokinetics,
+        val currentAmountMg: Double,
+        val lastDoseTimestampMs: Long?,
+        val lastDoseLabel: String?,
+        val thresholdMg: Double?,
+        val timeUntilBelowThresholdMs: Long?,
+        val curve: List<Pair<Long, Double>>,
+        val recentDoses: List<DoseDisplay>,
+    ) {
+        val hasRecentIntake: Boolean get() = lastDoseTimestampMs != null
+    }
+
+    /** A single intake row as the dashboard renders it. */
+    data class DoseDisplay(
+        val timestampMs: Long,
+        val doseMg: Double,
+        val sourceLabel: String,
+    )
+
+    /**
+     * Compute one tile per [PharmacokineticsReference] substance.
+     *
+     * @param intakes every intake reading the screen wants to consider —
+     *   the aggregator filters to the keys it knows.
+     * @param sourceLabels sourceId → human-readable label.
+     * @param nowMs current epoch ms.
+     * @param historicalWindowMs how far back to sample the curve + list
+     *   recent doses. Defaults to 24 h per the issue's "Last 24h timeline"
+     *   ship target.
+     * @param curveStepMinutes sparkline resolution. 5 min × 288 samples =
+     *   one 24 h curve.
+     * @param thresholdOverridesMg owner-picked per-metric-key threshold
+     *   overrides; falls back to [Pharmacokinetics.defaultThresholdMg].
+     */
+    fun compute(
+        intakes: List<MetricReading>,
+        sourceLabels: Map<String, String>,
+        nowMs: Long = System.currentTimeMillis(),
+        historicalWindowMs: Long = DEFAULT_WINDOW_MS,
+        curveStepMinutes: Int = DEFAULT_CURVE_STEP_MIN,
+        thresholdOverridesMg: Map<String, Double> = emptyMap(),
+    ): List<SubstanceCard> {
+        val windowStart = nowMs - historicalWindowMs
+        return PharmacokineticsReference.all.values
+            .mapNotNull { pk ->
+                val metricKey = metricKeyForSubstance(pk.substanceKey) ?: return@mapNotNull null
+                cardFor(
+                    metricKey = metricKey,
+                    pk = pk,
+                    intakes = intakes,
+                    sourceLabels = sourceLabels,
+                    nowMs = nowMs,
+                    windowStart = windowStart,
+                    curveStepMinutes = curveStepMinutes,
+                    thresholdMg = thresholdOverridesMg[metricKey] ?: pk.defaultThresholdMg,
+                )
+            }
+    }
+
+    private fun cardFor(
+        metricKey: String,
+        pk: Pharmacokinetics,
+        intakes: List<MetricReading>,
+        sourceLabels: Map<String, String>,
+        nowMs: Long,
+        windowStart: Long,
+        curveStepMinutes: Int,
+        thresholdMg: Double?,
+    ): SubstanceCard {
+        // Engine math reads the full prior history (a dose from 8 h ago
+        // still contributes to current concentration); the window only
+        // bounds the curve we draw and the recent-doses list.
+        val priorIntakes = intakes
+            .asSequence()
+            .filter { it.metricType == metricKey }
+            .filter { it.timestamp <= nowMs }
+            .sortedBy { it.timestamp }
+            .toList()
+        val doseEvents = priorIntakes.map { intakeReadingToDoseEvent(metricKey, it) }
+        val currentAmount = ConcentrationMath.amountInBodyAt(pk, doseEvents, nowMs)
+        val curve = ConcentrationMath.curve(
+            pk, doseEvents, fromMillis = windowStart, toMillis = nowMs,
+            stepMinutes = curveStepMinutes,
+        )
+
+        val timeUntilBelow = thresholdMg?.let { thr ->
+            ConcentrationMath.timeUntilBelow(pk, doseEvents, thr, fromMillis = nowMs)
+        }
+
+        val last = priorIntakes.lastOrNull()
+        val recent = priorIntakes
+            .filter { it.timestamp >= windowStart }
+            .map {
+                DoseDisplay(
+                    timestampMs = it.timestamp,
+                    doseMg = intakeReadingToDoseEvent(metricKey, it).doseMg,
+                    sourceLabel = sourceLabels[it.sourceId] ?: UNKNOWN_SOURCE_LABEL,
+                )
+            }
+
+        return SubstanceCard(
+            metricKey = metricKey,
+            pk = pk,
+            currentAmountMg = currentAmount,
+            lastDoseTimestampMs = last?.timestamp,
+            lastDoseLabel = last?.sourceId?.let { sourceLabels[it] ?: UNKNOWN_SOURCE_LABEL },
+            thresholdMg = thresholdMg,
+            timeUntilBelowThresholdMs = timeUntilBelow,
+            curve = curve,
+            recentDoses = recent,
+        )
+    }
+
+    /**
+     * Reverse of [PharmacokineticsReference.substanceKeyForMetric] for
+     * the single-metric substances. Multi-metric substances (the future
+     * medication_intake → many drugs) need per-event routing and are
+     * deliberately absent here — the dashboard only renders deterministic
+     * tiles.
+     */
+    private fun metricKeyForSubstance(substanceKey: String): String? = when (substanceKey) {
+        "caffeine" -> MetricType.CAFFEINE_INTAKE.key
+        "alcohol" -> MetricType.ALCOHOL_INTAKE.key
+        // Nicotine + THC are produced by Smokeless via tobacco_use /
+        // cannabis_use (event-marker keys, no dose). The dashboard cannot
+        // compute an honest concentration without a dose, so the cards
+        // are left out until a dose-bearing companion key ships.
+        else -> null
+    }
+
+    internal const val DEFAULT_WINDOW_MS = 24L * 60L * 60L * 1000L
+    internal const val DEFAULT_CURVE_STEP_MIN = 5
+    internal const val UNKNOWN_SOURCE_LABEL = "unknown source"
+}

--- a/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesScreen.kt
@@ -1,0 +1,329 @@
+package com.bios.app.ui.intake
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.EliminationKinetics
+import com.bios.app.ui.AppViewModel
+import com.bios.app.ui.intake.ActiveSubstancesAggregator.DoseDisplay
+import com.bios.app.ui.intake.ActiveSubstancesAggregator.SubstanceCard
+import com.bios.contracts.MetricType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * "What's still in your body" dashboard (issue #138). One tile per
+ * substance Bios can compute a dose-based concentration for (currently
+ * caffeine + alcohol). Tobacco / cannabis intakes ship as opaque event
+ * markers via Smokeless and have no dose attached, so they're absent
+ * from this surface until a dose-bearing companion key lands.
+ *
+ * The screen is a thin renderer over [ActiveSubstancesAggregator]; the
+ * data shape and empty-state semantics live there so the math layer can
+ * be exercised end-to-end without Compose. Manifesto-clean: the surface
+ * is descriptive output of the #136 pharmacokinetic engine, no nudges,
+ * no "should you have another" coaching.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActiveSubstancesScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+) {
+    var cards by remember { mutableStateOf<List<SubstanceCard>>(emptyList()) }
+    var loaded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        val now = System.currentTimeMillis()
+        val windowStart = now - ActiveSubstancesAggregator.DEFAULT_WINDOW_MS
+        val dao = viewModel.db.metricReadingDao()
+        // Read each intake key separately — the DAO indexes by
+        // metricType + timestamp, so two short scans beat one big one.
+        val intakes = listOf(MetricType.CAFFEINE_INTAKE, MetricType.ALCOHOL_INTAKE)
+            .flatMap { dao.fetch(it.key, windowStart, now) }
+        val sources = viewModel.db.dataSourceDao().getAll()
+            .associate { it.id to (it.deviceName ?: it.sourceType) }
+        cards = ActiveSubstancesAggregator.compute(intakes, sources, nowMs = now)
+        loaded = true
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Active Substances") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Intro() }
+            if (!loaded) {
+                item {
+                    Text(
+                        "Loading recent intake…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else if (cards.isEmpty()) {
+                item {
+                    Text(
+                        "No substances configured. Log a caffeine or " +
+                            "alcohol intake to populate this dashboard.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                items(cards, key = { it.metricKey }) { card ->
+                    SubstanceTile(card)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Intro() {
+    Text(
+        "Pull-side decay curves for substances Bios knows the " +
+            "pharmacokinetics of. Math only — you read the number.",
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun SubstanceTile(card: SubstanceCard) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    substanceLabel(card),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (card.hasRecentIntake) {
+                    Text(
+                        formatAmount(card.currentAmountMg, card.metricKey),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+
+            if (!card.hasRecentIntake) {
+                Text(
+                    "No recent intake logged in the last 24h. Unknown, not zero.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                return@Column
+            }
+
+            Sparkline(card)
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                StatCell("Last dose", lastDoseLabel(card))
+                card.thresholdMg?.let {
+                    StatCell(
+                        "Below ${formatAmount(it, card.metricKey)} at",
+                        belowThresholdLabel(card),
+                    )
+                }
+                StatCell("Kinetics", kineticsLabel(card.pk.kinetics))
+            }
+
+            if (card.recentDoses.isNotEmpty()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Recent doses",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                card.recentDoses.sortedByDescending { it.timestampMs }.forEach { dose ->
+                    DoseRow(dose, card.metricKey)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Sparkline(card: SubstanceCard) {
+    val curve = card.curve
+    val lineColor = MaterialTheme.colorScheme.primary
+    val markerColor = MaterialTheme.colorScheme.tertiary
+    val thresholdColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val maxY = (curve.maxOfOrNull { it.second } ?: 0.0)
+        .coerceAtLeast(card.thresholdMg ?: 0.0)
+        .coerceAtLeast(1e-6)
+    val firstTs = curve.firstOrNull()?.first ?: return
+    val lastTs = curve.lastOrNull()?.first ?: return
+    val spanMs = (lastTs - firstTs).coerceAtLeast(1L).toDouble()
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(80.dp),
+    ) {
+        val w = size.width
+        val h = size.height
+        if (curve.size >= 2) {
+            for (i in 1 until curve.size) {
+                val (t0, c0) = curve[i - 1]
+                val (t1, c1) = curve[i]
+                val x0 = ((t0 - firstTs) / spanMs).toFloat() * w
+                val x1 = ((t1 - firstTs) / spanMs).toFloat() * w
+                val y0 = h - (c0 / maxY).toFloat() * h
+                val y1 = h - (c1 / maxY).toFloat() * h
+                drawLine(
+                    color = lineColor,
+                    start = Offset(x0, y0),
+                    end = Offset(x1, y1),
+                    strokeWidth = 4f,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+        card.thresholdMg?.let { thr ->
+            val y = h - (thr / maxY).toFloat() * h
+            drawLine(
+                color = thresholdColor.copy(alpha = 0.5f),
+                start = Offset(0f, y),
+                end = Offset(w, y),
+                strokeWidth = 2f,
+            )
+        }
+        for (dose in card.recentDoses) {
+            val x = ((dose.timestampMs - firstTs).coerceAtLeast(0L) / spanMs).toFloat() * w
+            drawCircle(
+                color = markerColor,
+                radius = 5f,
+                center = Offset(x.coerceIn(0f, w), h - 3f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatCell(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.Start) {
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun DoseRow(dose: DoseDisplay, metricKey: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "${formatTime(dose.timestampMs)} · ${formatAmount(dose.doseMg, metricKey)}",
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            dose.sourceLabel,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    Box(modifier = Modifier.height(2.dp))
+}
+
+private fun substanceLabel(card: SubstanceCard): String = when (card.metricKey) {
+    MetricType.CAFFEINE_INTAKE.key -> "Caffeine"
+    MetricType.ALCOHOL_INTAKE.key -> "Alcohol"
+    else -> card.pk.substanceKey
+}
+
+private fun kineticsLabel(k: EliminationKinetics): String = when (k) {
+    EliminationKinetics.FIRST_ORDER -> "1st-order"
+    EliminationKinetics.ZERO_ORDER -> "Zero-order"
+}
+
+private fun lastDoseLabel(card: SubstanceCard): String {
+    val ts = card.lastDoseTimestampMs ?: return "—"
+    val deltaMin = ((System.currentTimeMillis() - ts) / 60_000L).coerceAtLeast(0L)
+    val src = card.lastDoseLabel?.let { " · $it" } ?: ""
+    return when {
+        deltaMin < 1L -> "just now$src"
+        deltaMin < 60L -> "${deltaMin}m ago$src"
+        else -> "${deltaMin / 60L}h ${deltaMin % 60L}m ago$src"
+    }
+}
+
+private fun belowThresholdLabel(card: SubstanceCard): String {
+    val ms = card.timeUntilBelowThresholdMs ?: return "no crossing in 10 days"
+    if (ms <= 0L) return "already below"
+    val target = System.currentTimeMillis() + ms
+    return clockFormat.format(Date(target))
+}
+
+private fun formatAmount(mg: Double, metricKey: String): String {
+    // Display amounts in the metric's native unit so the owner sees the
+    // same number they entered: caffeine in mg, alcohol back in g.
+    return if (metricKey == MetricType.ALCOHOL_INTAKE.key) {
+        String.format(Locale.US, "%.1f g", mg / 1000.0)
+    } else {
+        String.format(Locale.US, "%.0f mg", mg)
+    }
+}
+
+private val clockFormat = SimpleDateFormat("HH:mm", Locale.US)
+private val dateTimeFormat = SimpleDateFormat("EEE HH:mm", Locale.US)
+private fun formatTime(millis: Long): String = dateTimeFormat.format(Date(millis))

--- a/android/app/src/test/java/com/bios/app/ActiveSubstancesAggregatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/ActiveSubstancesAggregatorTest.kt
@@ -1,0 +1,277 @@
+package com.bios.app
+
+import com.bios.app.engine.EliminationKinetics
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.intake.ActiveSubstancesAggregator
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-state tests for the "what's still in your body" aggregator (#138).
+ *
+ * Exercises empty-state semantics (no recent intake ≠ zero), source
+ * provenance plumbing, threshold-crossing readout, and the curve sample
+ * shape. The math itself is covered by ConcentrationMathTest; here we
+ * only confirm the dashboard layer wires the right inputs and presents
+ * them honestly.
+ */
+class ActiveSubstancesAggregatorTest {
+
+    private val now = 1_700_000_000_000L
+    private val hour = 60L * 60L * 1000L
+
+    @Test
+    fun `empty intake list yields all known substances as empty cards`() {
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = emptyList(),
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        // Caffeine and alcohol are the two routed substances today; future
+        // dose-bearing keys grow this set without changing the empty-state
+        // contract.
+        val keys = cards.map { it.metricKey }.toSet()
+        assertTrue("caffeine card always present", MetricType.CAFFEINE_INTAKE.key in keys)
+        assertTrue("alcohol card always present", MetricType.ALCOHOL_INTAKE.key in keys)
+        for (c in cards) {
+            assertEquals(0.0, c.currentAmountMg, 1e-9)
+            assertNull("no last dose when there are no intakes", c.lastDoseTimestampMs)
+            assertNull(c.lastDoseLabel)
+            assertTrue("no recent doses to display", c.recentDoses.isEmpty())
+            assertEquals(false, c.hasRecentIntake)
+        }
+    }
+
+    @Test
+    fun `caffeine card surfaces current amount and last dose source`() {
+        val intakes = listOf(
+            caffeineIntake(timestampMs = now - 2L * hour, doseMg = 200.0, sourceId = "src-w2f"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("src-w2f" to "W2F"),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertEquals(true, caffeine.hasRecentIntake)
+        // 200 mg with t½ = 5 h and 2 h elapsed ⇒ 200 × 0.5^(2/5) ≈ 152 mg.
+        // Bateman absorption with 7-min half-life is fully complete by 2 h.
+        assertTrue(
+            "current amount $caffeine.currentAmountMg should be near 152 mg",
+            caffeine.currentAmountMg in 145.0..158.0
+        )
+        assertEquals("W2F", caffeine.lastDoseLabel)
+        assertEquals(now - 2L * hour, caffeine.lastDoseTimestampMs)
+    }
+
+    @Test
+    fun `older doses outside the window still inform current amount`() {
+        // 8 h ago: caffeine t½ 5 h ⇒ ~33 % remaining = ~66 mg from a 200mg
+        // dose. The dose itself falls outside the 24h list-recent-doses
+        // window only if it's > 24 h old; an 8 h dose is inside.
+        val intakes = listOf(
+            caffeineIntake(timestampMs = now - 8L * hour, doseMg = 200.0, sourceId = "src"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("src" to "W2F"),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertTrue(
+            "8h-old caffeine should still contribute ~60-70mg, got ${caffeine.currentAmountMg}",
+            caffeine.currentAmountMg in 55.0..75.0
+        )
+    }
+
+    @Test
+    fun `intakes 2 days old contribute to current concentration but not recent-doses list`() {
+        // Engine math reads the full prior history (the aggregator does
+        // not window the doseEvents list); only the recent-doses display
+        // is windowed.
+        val intakes = listOf(
+            caffeineIntake(timestampMs = now - 48L * hour, doseMg = 200.0, sourceId = "src"),
+            caffeineIntake(timestampMs = now - 1L * hour, doseMg = 100.0, sourceId = "src"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("src" to "W2F"),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertEquals(
+            "recent-doses list should only show the 1h dose (24h window)",
+            1, caffeine.recentDoses.size,
+        )
+        assertEquals(now - 1L * hour, caffeine.recentDoses.first().timestampMs)
+    }
+
+    @Test
+    fun `unknown source falls back to a labelled placeholder`() {
+        val intakes = listOf(caffeineIntake(timestampMs = now - hour, doseMg = 100.0, sourceId = "ghost"))
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertEquals(ActiveSubstancesAggregator.UNKNOWN_SOURCE_LABEL, caffeine.lastDoseLabel)
+        assertEquals(
+            ActiveSubstancesAggregator.UNKNOWN_SOURCE_LABEL,
+            caffeine.recentDoses.first().sourceLabel,
+        )
+    }
+
+    @Test
+    fun `alcohol value is converted from grams to milligrams in the dose-event stream`() {
+        // 14 g of ethanol (one US standard drink) recorded as ALCOHOL_INTAKE.
+        // F = 0.9 ⇒ 12 600 mg on-board after absorption; zero-order rate
+        // ≈ 117 mg/min ⇒ after 60 min: 12600 − 7000 = 5600 mg.
+        val intakes = listOf(
+            alcoholIntake(timestampMs = now - 60L * 60L * 1000L, doseG = 14.0, sourceId = "src"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val alcohol = cards.first { it.metricKey == MetricType.ALCOHOL_INTAKE.key }
+        assertEquals(EliminationKinetics.ZERO_ORDER, alcohol.pk.kinetics)
+        assertTrue(
+            "alcohol on-board after 1h should be ~5600 mg, got ${alcohol.currentAmountMg}",
+            alcohol.currentAmountMg in 5_400.0..5_800.0
+        )
+        // Display side: 14 g entered → 14000 mg in the dose-event stream.
+        assertEquals(14_000.0, alcohol.recentDoses.first().doseMg, 1.0)
+    }
+
+    @Test
+    fun `threshold override beats the substance default`() {
+        // Dose at now-1h so the Bateman absorption phase is complete and
+        // current amount is well above both thresholds; otherwise both
+        // crossings land at 0 (already-below) and the comparison is
+        // meaningless.
+        val intakes = listOf(caffeineIntake(timestampMs = now - hour, doseMg = 200.0, sourceId = "src"))
+        val withDefault = ActiveSubstancesAggregator.compute(
+            intakes = intakes, sourceLabels = emptyMap(), nowMs = now,
+        ).first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        // Caffeine default threshold is 50 mg.
+        assertEquals(50.0, withDefault.thresholdMg!!, 1e-9)
+
+        val withOverride = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+            thresholdOverridesMg = mapOf(MetricType.CAFFEINE_INTAKE.key to 25.0),
+        ).first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertEquals(25.0, withOverride.thresholdMg!!, 1e-9)
+        // Time-until-below: tighter threshold ⇒ longer wait.
+        assertTrue(
+            "tighter threshold should push the crossing later " +
+                "(default=${withDefault.timeUntilBelowThresholdMs}, " +
+                "override=${withOverride.timeUntilBelowThresholdMs})",
+            (withOverride.timeUntilBelowThresholdMs ?: 0L) >
+                (withDefault.timeUntilBelowThresholdMs ?: 0L)
+        )
+    }
+
+    @Test
+    fun `curve points span the configured window`() {
+        val intakes = listOf(caffeineIntake(timestampMs = now - hour, doseMg = 100.0, sourceId = "src"))
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        // 24 h / 5 min step ⇒ 289 samples (inclusive of both endpoints).
+        assertEquals(289, caffeine.curve.size)
+        // First point at window start, last at now.
+        assertEquals(now - ActiveSubstancesAggregator.DEFAULT_WINDOW_MS, caffeine.curve.first().first)
+        assertEquals(now, caffeine.curve.last().first)
+    }
+
+    @Test
+    fun `unknown metric_type readings do not pollute substance cards`() {
+        // A glucose row landing in the intake list (e.g. caller didn't
+        // pre-filter) must be silently ignored — the aggregator routes by
+        // metric_type so it can't accidentally treat blood_glucose as a
+        // caffeine dose.
+        val intakes = listOf(
+            MetricReading(
+                metricType = MetricType.BLOOD_GLUCOSE.key,
+                value = 90.0,
+                timestamp = now - hour,
+                sourceId = "cgm",
+                confidence = ConfidenceTier.HIGH.level,
+            ),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        for (c in cards) {
+            assertEquals(0.0, c.currentAmountMg, 1e-9)
+            assertNull(c.lastDoseTimestampMs)
+        }
+    }
+
+    @Test
+    fun `card list contains the documented substances and nothing else`() {
+        // Pins the shipping surface so new substances are an opt-in
+        // dashboard expansion, not a silent UI surprise. Both directions:
+        // the two substances are present, and no others sneak in (e.g.
+        // tobacco/cannabis remain absent until dose-bearing keys ship).
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = emptyList(),
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val keys = cards.map { it.metricKey }.toSet()
+        assertEquals(
+            setOf(MetricType.CAFFEINE_INTAKE.key, MetricType.ALCOHOL_INTAKE.key),
+            keys,
+        )
+    }
+
+    @Test
+    fun `time until below returns zero when already under threshold`() {
+        // No intake at all → current amount is zero, which is below any
+        // positive threshold. The dashboard should render "already below"
+        // (timeUntilBelow = 0), not "no crossing in 10 days".
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = emptyList(),
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertNotNull(caffeine.thresholdMg)
+        assertEquals(0L, caffeine.timeUntilBelowThresholdMs)
+    }
+
+    // ---- helpers ----
+
+    private fun caffeineIntake(timestampMs: Long, doseMg: Double, sourceId: String): MetricReading =
+        MetricReading(
+            metricType = MetricType.CAFFEINE_INTAKE.key,
+            value = doseMg,
+            timestamp = timestampMs,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+        )
+
+    private fun alcoholIntake(timestampMs: Long, doseG: Double, sourceId: String): MetricReading =
+        MetricReading(
+            metricType = MetricType.ALCOHOL_INTAKE.key,
+            value = doseG,
+            timestamp = timestampMs,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+        )
+}


### PR DESCRIPTION
Closes #138.

## Summary

Pull-side dashboard rendering current concentration, time-until-below threshold, and a 24h decay-curve sparkline for every substance Bios has a dose-bearing intake key for (caffeine, alcohol today). First consumer of the #136 pharmacokinetic engine — validates its API surface on a real screen so further callers grow against a tested shape.

- **ActiveSubstancesAggregator** (pure): routes intake readings to PK profiles, converts grams→mg per metric key, samples the curve, surfaces per-dose source labels, applies owner threshold overrides.
- **ActiveSubstancesScreen** (Compose): per-substance tile with sparkline (Canvas-rendered line + dose markers + threshold guide), current amount, time-since-last-dose, time-until-below readout, recent-doses list. Empty state distinguishes *"no recent intake logged"* from *"zero on board"* per the manifesto.
- **Pharmacokinetics** gains `defaultThresholdMg`; seeded for caffeine (50 mg), nicotine (0.1 mg), THC (1 mg), alcohol (~0.02 % BAC ≈ 8.4 g for a 70 kg adult).
- `intakeReadingToDoseEvent` helper lifted to file scope so the aggregator and `ConcentrationCalculator` share unit normalisation.
- `HomeEntryCard` composable extracted from `HomeScreen` (three near-identical nav cards collapsed; `HomeScreen` back under the 500-line cap).
- Navigation: new `active_substances` route in `MainActivity`, Home entry card linking to it.

Tobacco / cannabis sit out for now: Smokeless writes event-marker keys with no dose attached, so the engine can't compute an honest concentration. The aggregator's substance-routing table grows when a dose-bearing companion key ships.

Manifesto-clean: descriptive math output of the #136 engine, no *"should you have another"* coaching, no nudges, no push alerts.

**Out of scope per the issue** (and deliberate non-goals here): pharmacogenomic individualisation, drug-drug interaction warnings, sleep-correlation surfaces (those live on the sleep dashboard #135), HRV-correlation surfaces.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` — new `ActiveSubstancesAggregatorTest` (10 cases) pins empty-state shape, current-amount math against the engine, recent-doses windowing, source-label fallback, grams→mg conversion (zero-order alcohol path), threshold-override behaviour (tighter threshold ⇒ later crossing), curve sample count (24h / 5min ⇒ 289 points), substance-set shipping invariants, unknown-metric isolation, and the `current=0 ⇒ already-below` empty-current-amount case.
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [ ] Live UI smoke — none in this PR; need an Android device to exercise the navigation flow + sparkline render. Aggregator is the algorithmic surface and is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)