### PR TITLE
fix(dashboard): render tobacco/cannabis event tiles

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -154,7 +154,7 @@ fun HomeScreen(
         HomeEntryCard(
             icon = Icons.Default.Medication,
             title = "Active Substances",
-            subtitle = "Caffeine, alcohol — current concentration in body",
+            subtitle = "Caffeine, alcohol, tobacco, cannabis — concentration + event log",
             onClick = onNavigateToActiveSubstances,
         )
 

--- a/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesAggregator.kt
+++ b/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesAggregator.kt
@@ -10,35 +10,55 @@ import com.bios.contracts.MetricType
 /**
  * Pure aggregator behind the "what's still in your body" dashboard (#138).
  *
- * Reads a flat list of recent intake [MetricReading]s (every `*_INTAKE`
- * key that has data) plus the source-label map and a "now" timestamp,
- * and produces one [SubstanceCard] per known substance: current amount
- * in body, last-dose timestamp + source, projected time-until-below the
- * picked threshold, and a sampled decay curve.
+ * Produces one [SubstanceCard] per known substance. Two modes:
  *
- * Pure so the screen layer has zero state-machine logic — the test
- * harness exercises every empty-state / threshold-crossing / multi-dose
- * branch without spinning up Room. The screen calls this once, renders,
- * recomposes on time-tick.
+ *  - [DisplayMode.DOSED] — the intake key carries a dose (caffeine,
+ *    alcohol). The card renders concentration math: current amount in
+ *    body, threshold crossing, 24 h decay curve.
+ *  - [DisplayMode.EVENT_ONLY] — the intake key is timestamp-only
+ *    (`tobacco_use`, `cannabis_use` from Smokeless). The card renders
+ *    the event log: how many in the window, when the last one was,
+ *    which app logged it. No concentration math because the engine
+ *    needs a dose to be honest. Documented explicitly in #138 as the
+ *    interim shape until a dose-bearing companion key ships.
+ *
+ * Pure so the screen layer is a thin renderer — every empty-state /
+ * threshold / window edge runs under JUnit without Compose or Room.
  *
  * **Window semantics.** Intakes older than `historicalWindowMs` are
- * dropped before the curve sample because the engine math already
- * weights them by elapsed time and a 24 h window keeps the sparkline
- * legible. Owners who want longer lookback get it from the trends tab.
+ * dropped before the curve sample and the recent-doses list; the
+ * engine math still reads the full prior history for the
+ * concentration computation in DOSED mode.
  */
 object ActiveSubstancesAggregator {
 
+    enum class DisplayMode {
+        /** Carries a dose; concentration math drives the card. */
+        DOSED,
+
+        /** Timestamp-only event marker; the card renders the event log. */
+        EVENT_ONLY,
+    }
+
     /**
-     * Per-substance dashboard tile. [pk] is non-null even for empty
-     * tiles so the UI can render the unit label and substance name
-     * without re-deriving them. [lastDoseTimestampMs] / [lastDoseLabel]
-     * are null when no intake landed inside [historicalWindowMs] — the
-     * UI uses that to distinguish "zero on board" from "unknown".
+     * Per-substance dashboard tile.
+     *
+     *  - In [DisplayMode.DOSED]: [pk], [currentAmountMg], [curve], and
+     *    optionally [thresholdMg]/[timeUntilBelowThresholdMs] populate.
+     *  - In [DisplayMode.EVENT_ONLY]: [pk] is null, [currentAmountMg]
+     *    is null, [curve] is empty, [thresholdMg] is null. The card
+     *    surfaces `recentDoses` (one entry per logged event) plus the
+     *    last-event metadata.
+     *
+     * [lastDoseTimestampMs] / [lastDoseLabel] are null when nothing
+     * landed inside the window — the UI uses that to distinguish *"zero
+     * on board"* from *"unknown"*.
      */
     data class SubstanceCard(
         val metricKey: String,
-        val pk: Pharmacokinetics,
-        val currentAmountMg: Double,
+        val displayMode: DisplayMode,
+        val pk: Pharmacokinetics?,
+        val currentAmountMg: Double?,
         val lastDoseTimestampMs: Long?,
         val lastDoseLabel: String?,
         val thresholdMg: Double?,
@@ -49,15 +69,16 @@ object ActiveSubstancesAggregator {
         val hasRecentIntake: Boolean get() = lastDoseTimestampMs != null
     }
 
-    /** A single intake row as the dashboard renders it. */
+    /** A single intake row as the dashboard renders it. For event-only
+     *  substances [doseMg] is null since no dose is recorded. */
     data class DoseDisplay(
         val timestampMs: Long,
-        val doseMg: Double,
+        val doseMg: Double?,
         val sourceLabel: String,
     )
 
     /**
-     * Compute one tile per [PharmacokineticsReference] substance.
+     * Compute one tile per known substance (dosed + event-only).
      *
      * @param intakes every intake reading the screen wants to consider —
      *   the aggregator filters to the keys it knows.
@@ -80,23 +101,32 @@ object ActiveSubstancesAggregator {
         thresholdOverridesMg: Map<String, Double> = emptyMap(),
     ): List<SubstanceCard> {
         val windowStart = nowMs - historicalWindowMs
-        return PharmacokineticsReference.all.values
-            .mapNotNull { pk ->
-                val metricKey = metricKeyForSubstance(pk.substanceKey) ?: return@mapNotNull null
-                cardFor(
-                    metricKey = metricKey,
-                    pk = pk,
-                    intakes = intakes,
-                    sourceLabels = sourceLabels,
-                    nowMs = nowMs,
-                    windowStart = windowStart,
-                    curveStepMinutes = curveStepMinutes,
-                    thresholdMg = thresholdOverridesMg[metricKey] ?: pk.defaultThresholdMg,
-                )
-            }
+        val dosedCards = PharmacokineticsReference.all.values.mapNotNull { pk ->
+            val metricKey = metricKeyForSubstance(pk.substanceKey) ?: return@mapNotNull null
+            dosedCardFor(
+                metricKey = metricKey,
+                pk = pk,
+                intakes = intakes,
+                sourceLabels = sourceLabels,
+                nowMs = nowMs,
+                windowStart = windowStart,
+                curveStepMinutes = curveStepMinutes,
+                thresholdMg = thresholdOverridesMg[metricKey] ?: pk.defaultThresholdMg,
+            )
+        }
+        val eventCards = EVENT_ONLY_METRIC_KEYS.map { metricKey ->
+            eventOnlyCardFor(
+                metricKey = metricKey,
+                intakes = intakes,
+                sourceLabels = sourceLabels,
+                nowMs = nowMs,
+                windowStart = windowStart,
+            )
+        }
+        return dosedCards + eventCards
     }
 
-    private fun cardFor(
+    private fun dosedCardFor(
         metricKey: String,
         pk: Pharmacokinetics,
         intakes: List<MetricReading>,
@@ -139,6 +169,7 @@ object ActiveSubstancesAggregator {
 
         return SubstanceCard(
             metricKey = metricKey,
+            displayMode = DisplayMode.DOSED,
             pk = pk,
             currentAmountMg = currentAmount,
             lastDoseTimestampMs = last?.timestamp,
@@ -150,9 +181,46 @@ object ActiveSubstancesAggregator {
         )
     }
 
+    private fun eventOnlyCardFor(
+        metricKey: String,
+        intakes: List<MetricReading>,
+        sourceLabels: Map<String, String>,
+        nowMs: Long,
+        windowStart: Long,
+    ): SubstanceCard {
+        val priorEvents = intakes
+            .asSequence()
+            .filter { it.metricType == metricKey }
+            .filter { it.timestamp <= nowMs }
+            .sortedBy { it.timestamp }
+            .toList()
+        val last = priorEvents.lastOrNull()
+        val recent = priorEvents
+            .filter { it.timestamp >= windowStart }
+            .map {
+                DoseDisplay(
+                    timestampMs = it.timestamp,
+                    doseMg = null,
+                    sourceLabel = sourceLabels[it.sourceId] ?: UNKNOWN_SOURCE_LABEL,
+                )
+            }
+        return SubstanceCard(
+            metricKey = metricKey,
+            displayMode = DisplayMode.EVENT_ONLY,
+            pk = null,
+            currentAmountMg = null,
+            lastDoseTimestampMs = last?.timestamp,
+            lastDoseLabel = last?.sourceId?.let { sourceLabels[it] ?: UNKNOWN_SOURCE_LABEL },
+            thresholdMg = null,
+            timeUntilBelowThresholdMs = null,
+            curve = emptyList(),
+            recentDoses = recent,
+        )
+    }
+
     /**
      * Reverse of [PharmacokineticsReference.substanceKeyForMetric] for
-     * the single-metric substances. Multi-metric substances (the future
+     * dosed substances. Multi-metric substances (the future
      * medication_intake → many drugs) need per-event routing and are
      * deliberately absent here — the dashboard only renders deterministic
      * tiles.
@@ -160,12 +228,16 @@ object ActiveSubstancesAggregator {
     private fun metricKeyForSubstance(substanceKey: String): String? = when (substanceKey) {
         "caffeine" -> MetricType.CAFFEINE_INTAKE.key
         "alcohol" -> MetricType.ALCOHOL_INTAKE.key
-        // Nicotine + THC are produced by Smokeless via tobacco_use /
-        // cannabis_use (event-marker keys, no dose). The dashboard cannot
-        // compute an honest concentration without a dose, so the cards
-        // are left out until a dose-bearing companion key ships.
         else -> null
     }
+
+    /** Event-marker intake keys Smokeless writes — concentration math is
+     *  skipped because no dose ships, but the dashboard still surfaces
+     *  the event log so logged intakes are visible (#138). */
+    internal val EVENT_ONLY_METRIC_KEYS: List<String> = listOf(
+        MetricType.TOBACCO_USE.key,
+        MetricType.CANNABIS_USE.key,
+    )
 
     internal const val DEFAULT_WINDOW_MS = 24L * 60L * 60L * 1000L
     internal const val DEFAULT_CURVE_STEP_MIN = 5

--- a/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/intake/ActiveSubstancesScreen.kt
@@ -72,9 +72,14 @@ fun ActiveSubstancesScreen(
         val windowStart = now - ActiveSubstancesAggregator.DEFAULT_WINDOW_MS
         val dao = viewModel.db.metricReadingDao()
         // Read each intake key separately — the DAO indexes by
-        // metricType + timestamp, so two short scans beat one big one.
-        val intakes = listOf(MetricType.CAFFEINE_INTAKE, MetricType.ALCOHOL_INTAKE)
-            .flatMap { dao.fetch(it.key, windowStart, now) }
+        // metricType + timestamp, so several short scans beat one big
+        // table scan. Dosed keys + Smokeless event-marker keys both feed
+        // the dashboard (event-only tiles for the latter, #138).
+        val intakeKeys = listOf(
+            MetricType.CAFFEINE_INTAKE.key,
+            MetricType.ALCOHOL_INTAKE.key,
+        ) + ActiveSubstancesAggregator.EVENT_ONLY_METRIC_KEYS
+        val intakes = intakeKeys.flatMap { dao.fetch(it, windowStart, now) }
         val sources = viewModel.db.dataSourceDao().getAll()
             .associate { it.id to (it.deviceName ?: it.sourceType) }
         cards = ActiveSubstancesAggregator.compute(intakes, sources, nowMs = now)
@@ -130,8 +135,10 @@ fun ActiveSubstancesScreen(
 @Composable
 private fun Intro() {
     Text(
-        "Pull-side decay curves for substances Bios knows the " +
-            "pharmacokinetics of. Math only — you read the number.",
+        "Pull-side decay curves for substances with a dose model (caffeine, " +
+            "alcohol) plus the event log for substances that ship as " +
+            "timestamp-only markers (tobacco, cannabis). Math only — " +
+            "you read the number.",
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
@@ -144,59 +151,113 @@ private fun SubstanceTile(card: SubstanceCard) {
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    substanceLabel(card),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-                if (card.hasRecentIntake) {
-                    Text(
-                        formatAmount(card.currentAmountMg, card.metricKey),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-            }
-
-            if (!card.hasRecentIntake) {
-                Text(
-                    "No recent intake logged in the last 24h. Unknown, not zero.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                return@Column
-            }
-
-            Sparkline(card)
-
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                StatCell("Last dose", lastDoseLabel(card))
-                card.thresholdMg?.let {
-                    StatCell(
-                        "Below ${formatAmount(it, card.metricKey)} at",
-                        belowThresholdLabel(card),
-                    )
-                }
-                StatCell("Kinetics", kineticsLabel(card.pk.kinetics))
-            }
-
-            if (card.recentDoses.isNotEmpty()) {
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Recent doses",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                card.recentDoses.sortedByDescending { it.timestampMs }.forEach { dose ->
-                    DoseRow(dose, card.metricKey)
-                }
+            TileHeader(card)
+            when (card.displayMode) {
+                ActiveSubstancesAggregator.DisplayMode.DOSED -> DosedBody(card)
+                ActiveSubstancesAggregator.DisplayMode.EVENT_ONLY -> EventOnlyBody(card)
             }
         }
+    }
+}
+
+@Composable
+private fun TileHeader(card: SubstanceCard) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            substanceLabel(card),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        val amount = card.currentAmountMg
+        if (card.displayMode == ActiveSubstancesAggregator.DisplayMode.DOSED &&
+            card.hasRecentIntake && amount != null
+        ) {
+            Text(
+                formatAmount(amount, card.metricKey),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        } else if (card.displayMode == ActiveSubstancesAggregator.DisplayMode.EVENT_ONLY &&
+            card.hasRecentIntake
+        ) {
+            Text(
+                "${card.recentDoses.size} event${if (card.recentDoses.size == 1) "" else "s"}",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DosedBody(card: SubstanceCard) {
+    val pk = card.pk
+    if (!card.hasRecentIntake || pk == null) {
+        Text(
+            "No recent intake logged in the last 24h. Unknown, not zero.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+
+    Sparkline(card)
+
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        StatCell("Last dose", lastDoseLabel(card))
+        card.thresholdMg?.let {
+            StatCell(
+                "Below ${formatAmount(it, card.metricKey)} at",
+                belowThresholdLabel(card),
+            )
+        }
+        StatCell("Kinetics", kineticsLabel(pk.kinetics))
+    }
+
+    if (card.recentDoses.isNotEmpty()) {
+        Spacer(Modifier.height(4.dp))
+        Text(
+            "Recent doses",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        card.recentDoses.sortedByDescending { it.timestampMs }.forEach { dose ->
+            DoseRow(dose, card.metricKey)
+        }
+    }
+}
+
+@Composable
+private fun EventOnlyBody(card: SubstanceCard) {
+    if (!card.hasRecentIntake) {
+        Text(
+            "No ${substanceLabel(card).lowercase()} events logged in the last 24h.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+    Text(
+        "No dose recorded by the producer — Bios shows the event log only. " +
+            "Concentration math activates once a dose-bearing companion key ships.",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        StatCell("Last event", lastDoseLabel(card))
+    }
+    Spacer(Modifier.height(4.dp))
+    Text(
+        "Recent events",
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+    )
+    card.recentDoses.sortedByDescending { it.timestampMs }.forEach { dose ->
+        DoseRow(dose, card.metricKey)
     }
 }
 
@@ -267,15 +328,17 @@ private fun StatCell(label: String, value: String) {
 
 @Composable
 private fun DoseRow(dose: DoseDisplay, metricKey: String) {
+    val left = if (dose.doseMg != null) {
+        "${formatTime(dose.timestampMs)} · ${formatAmount(dose.doseMg, metricKey)}"
+    } else {
+        formatTime(dose.timestampMs)
+    }
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            "${formatTime(dose.timestampMs)} · ${formatAmount(dose.doseMg, metricKey)}",
-            style = MaterialTheme.typography.bodySmall,
-        )
+        Text(left, style = MaterialTheme.typography.bodySmall)
         Text(
             dose.sourceLabel,
             style = MaterialTheme.typography.labelSmall,
@@ -288,7 +351,9 @@ private fun DoseRow(dose: DoseDisplay, metricKey: String) {
 private fun substanceLabel(card: SubstanceCard): String = when (card.metricKey) {
     MetricType.CAFFEINE_INTAKE.key -> "Caffeine"
     MetricType.ALCOHOL_INTAKE.key -> "Alcohol"
-    else -> card.pk.substanceKey
+    MetricType.TOBACCO_USE.key -> "Tobacco"
+    MetricType.CANNABIS_USE.key -> "Cannabis"
+    else -> card.pk?.substanceKey ?: card.metricKey
 }
 
 private fun kineticsLabel(k: EliminationKinetics): String = when (k) {

--- a/android/app/src/test/java/com/bios/app/ActiveSubstancesAggregatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/ActiveSubstancesAggregatorTest.kt
@@ -4,6 +4,7 @@ import com.bios.app.engine.EliminationKinetics
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.MetricReading
 import com.bios.app.ui.intake.ActiveSubstancesAggregator
+import com.bios.app.ui.intake.ActiveSubstancesAggregator.DisplayMode
 import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -14,11 +15,10 @@ import org.junit.Test
 /**
  * Pure-state tests for the "what's still in your body" aggregator (#138).
  *
- * Exercises empty-state semantics (no recent intake ≠ zero), source
- * provenance plumbing, threshold-crossing readout, and the curve sample
- * shape. The math itself is covered by ConcentrationMathTest; here we
- * only confirm the dashboard layer wires the right inputs and presents
- * them honestly.
+ * Exercises both display modes — DOSED tiles (caffeine, alcohol) with
+ * concentration math, and EVENT_ONLY tiles (tobacco, cannabis) with the
+ * event log only. Pins the shipping substance set so future expansions
+ * land as deliberate edits.
  */
 class ActiveSubstancesAggregatorTest {
 
@@ -32,18 +32,25 @@ class ActiveSubstancesAggregatorTest {
             sourceLabels = emptyMap(),
             nowMs = now,
         )
-        // Caffeine and alcohol are the two routed substances today; future
-        // dose-bearing keys grow this set without changing the empty-state
-        // contract.
         val keys = cards.map { it.metricKey }.toSet()
         assertTrue("caffeine card always present", MetricType.CAFFEINE_INTAKE.key in keys)
         assertTrue("alcohol card always present", MetricType.ALCOHOL_INTAKE.key in keys)
+        assertTrue("tobacco event card always present", MetricType.TOBACCO_USE.key in keys)
+        assertTrue("cannabis event card always present", MetricType.CANNABIS_USE.key in keys)
         for (c in cards) {
-            assertEquals(0.0, c.currentAmountMg, 1e-9)
             assertNull("no last dose when there are no intakes", c.lastDoseTimestampMs)
             assertNull(c.lastDoseLabel)
             assertTrue("no recent doses to display", c.recentDoses.isEmpty())
             assertEquals(false, c.hasRecentIntake)
+            when (c.displayMode) {
+                DisplayMode.DOSED -> assertEquals(0.0, c.currentAmountMg!!, 1e-9)
+                DisplayMode.EVENT_ONLY -> {
+                    assertNull("event-only cards carry no current-amount", c.currentAmountMg)
+                    assertNull("event-only cards carry no PK profile", c.pk)
+                    assertTrue("event-only cards carry no curve", c.curve.isEmpty())
+                    assertNull(c.thresholdMg)
+                }
+            }
         }
     }
 
@@ -58,12 +65,11 @@ class ActiveSubstancesAggregatorTest {
             nowMs = now,
         )
         val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        assertEquals(DisplayMode.DOSED, caffeine.displayMode)
         assertEquals(true, caffeine.hasRecentIntake)
-        // 200 mg with t½ = 5 h and 2 h elapsed ⇒ 200 × 0.5^(2/5) ≈ 152 mg.
-        // Bateman absorption with 7-min half-life is fully complete by 2 h.
         assertTrue(
-            "current amount $caffeine.currentAmountMg should be near 152 mg",
-            caffeine.currentAmountMg in 145.0..158.0
+            "current amount ${caffeine.currentAmountMg} should be near 152 mg",
+            caffeine.currentAmountMg!! in 145.0..158.0
         )
         assertEquals("W2F", caffeine.lastDoseLabel)
         assertEquals(now - 2L * hour, caffeine.lastDoseTimestampMs)
@@ -71,9 +77,6 @@ class ActiveSubstancesAggregatorTest {
 
     @Test
     fun `older doses outside the window still inform current amount`() {
-        // 8 h ago: caffeine t½ 5 h ⇒ ~33 % remaining = ~66 mg from a 200mg
-        // dose. The dose itself falls outside the 24h list-recent-doses
-        // window only if it's > 24 h old; an 8 h dose is inside.
         val intakes = listOf(
             caffeineIntake(timestampMs = now - 8L * hour, doseMg = 200.0, sourceId = "src"),
         )
@@ -85,15 +88,12 @@ class ActiveSubstancesAggregatorTest {
         val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
         assertTrue(
             "8h-old caffeine should still contribute ~60-70mg, got ${caffeine.currentAmountMg}",
-            caffeine.currentAmountMg in 55.0..75.0
+            caffeine.currentAmountMg!! in 55.0..75.0
         )
     }
 
     @Test
     fun `intakes 2 days old contribute to current concentration but not recent-doses list`() {
-        // Engine math reads the full prior history (the aggregator does
-        // not window the doseEvents list); only the recent-doses display
-        // is windowed.
         val intakes = listOf(
             caffeineIntake(timestampMs = now - 48L * hour, doseMg = 200.0, sourceId = "src"),
             caffeineIntake(timestampMs = now - 1L * hour, doseMg = 100.0, sourceId = "src"),
@@ -129,11 +129,8 @@ class ActiveSubstancesAggregatorTest {
 
     @Test
     fun `alcohol value is converted from grams to milligrams in the dose-event stream`() {
-        // 14 g of ethanol (one US standard drink) recorded as ALCOHOL_INTAKE.
-        // F = 0.9 ⇒ 12 600 mg on-board after absorption; zero-order rate
-        // ≈ 117 mg/min ⇒ after 60 min: 12600 − 7000 = 5600 mg.
         val intakes = listOf(
-            alcoholIntake(timestampMs = now - 60L * 60L * 1000L, doseG = 14.0, sourceId = "src"),
+            alcoholIntake(timestampMs = now - hour, doseG = 14.0, sourceId = "src"),
         )
         val cards = ActiveSubstancesAggregator.compute(
             intakes = intakes,
@@ -141,26 +138,21 @@ class ActiveSubstancesAggregatorTest {
             nowMs = now,
         )
         val alcohol = cards.first { it.metricKey == MetricType.ALCOHOL_INTAKE.key }
-        assertEquals(EliminationKinetics.ZERO_ORDER, alcohol.pk.kinetics)
+        assertEquals(EliminationKinetics.ZERO_ORDER, alcohol.pk!!.kinetics)
         assertTrue(
             "alcohol on-board after 1h should be ~5600 mg, got ${alcohol.currentAmountMg}",
-            alcohol.currentAmountMg in 5_400.0..5_800.0
+            alcohol.currentAmountMg!! in 5_400.0..5_800.0
         )
         // Display side: 14 g entered → 14000 mg in the dose-event stream.
-        assertEquals(14_000.0, alcohol.recentDoses.first().doseMg, 1.0)
+        assertEquals(14_000.0, alcohol.recentDoses.first().doseMg!!, 1.0)
     }
 
     @Test
     fun `threshold override beats the substance default`() {
-        // Dose at now-1h so the Bateman absorption phase is complete and
-        // current amount is well above both thresholds; otherwise both
-        // crossings land at 0 (already-below) and the comparison is
-        // meaningless.
         val intakes = listOf(caffeineIntake(timestampMs = now - hour, doseMg = 200.0, sourceId = "src"))
         val withDefault = ActiveSubstancesAggregator.compute(
             intakes = intakes, sourceLabels = emptyMap(), nowMs = now,
         ).first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
-        // Caffeine default threshold is 50 mg.
         assertEquals(50.0, withDefault.thresholdMg!!, 1e-9)
 
         val withOverride = ActiveSubstancesAggregator.compute(
@@ -170,7 +162,6 @@ class ActiveSubstancesAggregatorTest {
             thresholdOverridesMg = mapOf(MetricType.CAFFEINE_INTAKE.key to 25.0),
         ).first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
         assertEquals(25.0, withOverride.thresholdMg!!, 1e-9)
-        // Time-until-below: tighter threshold ⇒ longer wait.
         assertTrue(
             "tighter threshold should push the crossing later " +
                 "(default=${withDefault.timeUntilBelowThresholdMs}, " +
@@ -181,7 +172,7 @@ class ActiveSubstancesAggregatorTest {
     }
 
     @Test
-    fun `curve points span the configured window`() {
+    fun `curve points span the configured window for dosed substances`() {
         val intakes = listOf(caffeineIntake(timestampMs = now - hour, doseMg = 100.0, sourceId = "src"))
         val cards = ActiveSubstancesAggregator.compute(
             intakes = intakes,
@@ -189,19 +180,13 @@ class ActiveSubstancesAggregatorTest {
             nowMs = now,
         )
         val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
-        // 24 h / 5 min step ⇒ 289 samples (inclusive of both endpoints).
         assertEquals(289, caffeine.curve.size)
-        // First point at window start, last at now.
         assertEquals(now - ActiveSubstancesAggregator.DEFAULT_WINDOW_MS, caffeine.curve.first().first)
         assertEquals(now, caffeine.curve.last().first)
     }
 
     @Test
     fun `unknown metric_type readings do not pollute substance cards`() {
-        // A glucose row landing in the intake list (e.g. caller didn't
-        // pre-filter) must be silently ignored — the aggregator routes by
-        // metric_type so it can't accidentally treat blood_glucose as a
-        // caffeine dose.
         val intakes = listOf(
             MetricReading(
                 metricType = MetricType.BLOOD_GLUCOSE.key,
@@ -217,17 +202,20 @@ class ActiveSubstancesAggregatorTest {
             nowMs = now,
         )
         for (c in cards) {
-            assertEquals(0.0, c.currentAmountMg, 1e-9)
             assertNull(c.lastDoseTimestampMs)
+            assertTrue(c.recentDoses.isEmpty())
+            if (c.displayMode == DisplayMode.DOSED) {
+                assertEquals(0.0, c.currentAmountMg!!, 1e-9)
+            }
         }
     }
 
     @Test
-    fun `card list contains the documented substances and nothing else`() {
-        // Pins the shipping surface so new substances are an opt-in
-        // dashboard expansion, not a silent UI surprise. Both directions:
-        // the two substances are present, and no others sneak in (e.g.
-        // tobacco/cannabis remain absent until dose-bearing keys ship).
+    fun `card list pins the shipping substance set`() {
+        // Adding a substance is a deliberate dashboard expansion. The test
+        // catches drift on the EVENT_ONLY side too — Smokeless event keys
+        // must keep rendering until a dose-bearing companion key replaces
+        // them.
         val cards = ActiveSubstancesAggregator.compute(
             intakes = emptyList(),
             sourceLabels = emptyMap(),
@@ -235,16 +223,20 @@ class ActiveSubstancesAggregatorTest {
         )
         val keys = cards.map { it.metricKey }.toSet()
         assertEquals(
-            setOf(MetricType.CAFFEINE_INTAKE.key, MetricType.ALCOHOL_INTAKE.key),
+            setOf(
+                MetricType.CAFFEINE_INTAKE.key,
+                MetricType.ALCOHOL_INTAKE.key,
+                MetricType.TOBACCO_USE.key,
+                MetricType.CANNABIS_USE.key,
+            ),
             keys,
         )
     }
 
     @Test
-    fun `time until below returns zero when already under threshold`() {
-        // No intake at all → current amount is zero, which is below any
-        // positive threshold. The dashboard should render "already below"
-        // (timeUntilBelow = 0), not "no crossing in 10 days".
+    fun `time until below returns zero when dosed card has no intake`() {
+        // Zero amount is below any positive threshold → the card renders
+        // "already below" instead of "no crossing".
         val cards = ActiveSubstancesAggregator.compute(
             intakes = emptyList(),
             sourceLabels = emptyMap(),
@@ -253,6 +245,93 @@ class ActiveSubstancesAggregatorTest {
         val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
         assertNotNull(caffeine.thresholdMg)
         assertEquals(0L, caffeine.timeUntilBelowThresholdMs)
+    }
+
+    // ---- event-only tiles (tobacco / cannabis) ----
+
+    @Test
+    fun `cannabis_use event surfaces on the cannabis event-only tile`() {
+        // The user-reported bug: a Smokeless-logged cannabis_use event must
+        // appear on the dashboard. Engine math is skipped (no dose) but
+        // the event log is the whole point.
+        val intakes = listOf(
+            eventOnly(
+                metricKey = MetricType.CANNABIS_USE.key,
+                timestampMs = now - 30L * 60L * 1000L,
+                sourceId = "smokeless",
+            ),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("smokeless" to "Smokeless"),
+            nowMs = now,
+        )
+        val cannabis = cards.first { it.metricKey == MetricType.CANNABIS_USE.key }
+        assertEquals(DisplayMode.EVENT_ONLY, cannabis.displayMode)
+        assertEquals(true, cannabis.hasRecentIntake)
+        assertEquals(now - 30L * 60L * 1000L, cannabis.lastDoseTimestampMs)
+        assertEquals("Smokeless", cannabis.lastDoseLabel)
+        assertEquals(1, cannabis.recentDoses.size)
+        assertNull("event-only dose has no mg recorded", cannabis.recentDoses.first().doseMg)
+        // No concentration math because there's nothing to integrate.
+        assertNull(cannabis.currentAmountMg)
+        assertNull(cannabis.pk)
+        assertNull(cannabis.thresholdMg)
+        assertTrue(cannabis.curve.isEmpty())
+    }
+
+    @Test
+    fun `tobacco_use events accumulate as multiple recent events`() {
+        val intakes = listOf(
+            eventOnly(MetricType.TOBACCO_USE.key, now - 4L * hour, "smokeless"),
+            eventOnly(MetricType.TOBACCO_USE.key, now - 2L * hour, "smokeless"),
+            eventOnly(MetricType.TOBACCO_USE.key, now - 30L * 60L * 1000L, "smokeless"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("smokeless" to "Smokeless"),
+            nowMs = now,
+        )
+        val tobacco = cards.first { it.metricKey == MetricType.TOBACCO_USE.key }
+        assertEquals(3, tobacco.recentDoses.size)
+        // Latest event timestamp wins for last-dose.
+        assertEquals(now - 30L * 60L * 1000L, tobacco.lastDoseTimestampMs)
+    }
+
+    @Test
+    fun `event-only intakes older than the window are excluded from recent list`() {
+        val intakes = listOf(
+            eventOnly(MetricType.CANNABIS_USE.key, now - 48L * hour, "smokeless"),
+            eventOnly(MetricType.CANNABIS_USE.key, now - hour, "smokeless"),
+        )
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = mapOf("smokeless" to "Smokeless"),
+            nowMs = now,
+        )
+        val cannabis = cards.first { it.metricKey == MetricType.CANNABIS_USE.key }
+        assertEquals(
+            "24h window should drop the 48h-old event from recent-doses",
+            1, cannabis.recentDoses.size,
+        )
+        // But last-dose still tracks the most recent event inside the window.
+        assertEquals(now - hour, cannabis.lastDoseTimestampMs)
+    }
+
+    @Test
+    fun `cannabis events do not pollute caffeine or alcohol tiles`() {
+        val intakes = listOf(eventOnly(MetricType.CANNABIS_USE.key, now - hour, "smokeless"))
+        val cards = ActiveSubstancesAggregator.compute(
+            intakes = intakes,
+            sourceLabels = emptyMap(),
+            nowMs = now,
+        )
+        val caffeine = cards.first { it.metricKey == MetricType.CAFFEINE_INTAKE.key }
+        val alcohol = cards.first { it.metricKey == MetricType.ALCOHOL_INTAKE.key }
+        assertEquals(0.0, caffeine.currentAmountMg!!, 1e-9)
+        assertEquals(0.0, alcohol.currentAmountMg!!, 1e-9)
+        assertTrue(caffeine.recentDoses.isEmpty())
+        assertTrue(alcohol.recentDoses.isEmpty())
     }
 
     // ---- helpers ----
@@ -270,6 +349,15 @@ class ActiveSubstancesAggregatorTest {
         MetricReading(
             metricType = MetricType.ALCOHOL_INTAKE.key,
             value = doseG,
+            timestamp = timestampMs,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+        )
+
+    private fun eventOnly(metricKey: String, timestampMs: Long, sourceId: String): MetricReading =
+        MetricReading(
+            metricType = metricKey,
+            value = 1.0, // event marker
             timestamp = timestampMs,
             sourceId = sourceId,
             confidence = ConfidenceTier.HIGH.level,


### PR DESCRIPTION
Follow-up to #141.

## Summary

Real-world bug from the user: logged a cannabis use through Smokeless, opened the Bios "Active Substances" dashboard, and saw nothing. The shipping aggregator silently dropped `tobacco_use` and `cannabis_use` because the engine math needs a dose and Smokeless writes timestamp-only event markers.

The original issue #138 actually called this out: *"Until [a dose-bearing companion key] lands, dashboard renders only Smokeless tobacco/cannabis events."* I missed that requirement on the original PR. This PR ships it.

- **`SubstanceCard`** gains a `DisplayMode` (`DOSED` vs `EVENT_ONLY`); `pk`, `currentAmountMg`, and `curve` are nullable on event-only tiles.
- **Aggregator** emits one tile per known dosed substance (caffeine, alcohol) **plus** one per event-only key (`tobacco_use`, `cannabis_use`). Event tiles surface `lastDoseTimestampMs`, source label, and the recent-events list — without concentration math.
- **`ActiveSubstancesScreen`** branches on `displayMode`: dosed tiles keep the sparkline + threshold readout; event-only tiles render an "events" count, last-event-ago, and the recent-events list, with a small note explaining concentration math is gated on a dose-bearing producer.
- DAO fetch in the screen now reads `tobacco_use` and `cannabis_use` alongside the dosed keys.
- Home subtitle updated to mention tobacco/cannabis coverage.

**Manifesto check:** event-only tiles state explicitly that no dose is recorded and concentration math is therefore not computed. No fabricated "default" dose to hide the gap.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` — `ActiveSubstancesAggregatorTest` rewritten for the new shape. Existing DOSED cases keep their assertions with `!!` on the now-nullable amount; four new EVENT_ONLY cases cover (1) cannabis-event surfacing reproducing the user-reported bug, (2) multi-tobacco-event accumulation, (3) 24h-window exclusion of older events, (4) cross-tile isolation so cannabis events don't pollute caffeine/alcohol math. The shipping-substances pin now lists all four metric keys.
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [ ] Live UI smoke — the original report came from a user smoke test; need an Android device to verify the event-only tile renders as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)