### PR TITLE
ci: signed APK release pipeline (standalone)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release APK
+
+# Trigger: push a tag like v1.2.3
+# Builds a signed release APK and attaches it (plus SHA-256) to a GitHub Release.
+#
+# Per-repo customisation: set WORKING_DIR below.
+#   - `.`        for repos with gradle at root  (Smokeless, SoulRadio, W2F)
+#   - `android`  for repos with gradle nested   (Bios, Fil, Virgil)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.2.3)'
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  WORKING_DIR: android
+  BUILD_TASK: assembleStandaloneRelease
+  APK_GLOB: "app/build/outputs/apk/**/release/*.apk"
+
+jobs:
+  build:
+    name: Build signed APK
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 secret is not set. See templates/android-release/README.md."
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+          echo "RELEASE_KEYSTORE_PATH=$RUNNER_TEMP/release.keystore" >> "$GITHUB_ENV"
+
+      - name: Assemble release APK
+        working-directory: ${{ env.WORKING_DIR }}
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: ./gradlew ${{ env.BUILD_TASK }} --no-daemon
+
+      - name: Locate APK
+        id: find_apk
+        run: |
+          shopt -s globstar nullglob
+          mapfile -t APKS < <(ls ${{ env.WORKING_DIR }}/${{ env.APK_GLOB }} 2>/dev/null | grep -v unsigned)
+          if [ ${#APKS[@]} -eq 0 ]; then
+            echo "::error::No release APK found under ${{ env.WORKING_DIR }}/${{ env.APK_GLOB }}"
+            exit 1
+          fi
+          TAG="${GITHUB_REF#refs/tags/}"
+          [ "$TAG" = "$GITHUB_REF" ] && TAG="${{ github.event.inputs.tag }}"
+          REPO="${GITHUB_REPOSITORY##*/}"
+          : > release-files.txt
+          for APK in "${APKS[@]}"; do
+            FLAVOR="$(basename "$(dirname "$(dirname "$APK")")")"
+            # If flavor dir is the same as variant ("release"), there is no flavor — drop suffix.
+            if [ "$FLAVOR" = "release" ] || [ "$FLAVOR" = "apk" ]; then
+              OUT="${REPO}-${TAG}.apk"
+            else
+              OUT="${REPO}-${FLAVOR}-${TAG}.apk"
+            fi
+            cp "$APK" "$OUT"
+            sha256sum "$OUT" > "${OUT}.sha256"
+            echo "$OUT" >> release-files.txt
+            echo "${OUT}.sha256" >> release-files.txt
+            echo "  built: $OUT"
+          done
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: |
+            *.apk
+            *.apk.sha256
+          retention-days: 30
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.find_apk.outputs.tag }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            *.apk
+            *.apk.sha256

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,6 +19,18 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath: String? = System.getenv("RELEASE_KEYSTORE_PATH")
+            if (!keystorePath.isNullOrBlank()) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
@@ -26,6 +38,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = if (!System.getenv("RELEASE_KEYSTORE_PATH").isNullOrBlank()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Tag-triggered release pipeline: `v*` push builds standalone-flavor APK, signed with shared Bios-ecosystem key, attached to GitHub Release with SHA-256
- Env-driven signing config (debug fallback when keystore env unset → local \`./gradlew assembleStandaloneRelease\` still works)
- Lethe flavor not built in this workflow (system-app, not a public sideload target)

## Test plan
- [x] \`./gradlew tasks\` parses build.gradle.kts clean (local)
- [ ] After merge: tag \`v0.1.0\` triggers release workflow
- [ ] Workflow produces signed APK, SHA-256, GitHub Release
- [ ] \`apksigner verify\` shows the same SHA-256 fingerprint as Smokeless v3.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)