### PR TITLE
fix(sleep): derive durationSec on companion writes + better empty state

### DIFF
--- a/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
+++ b/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
@@ -186,6 +186,7 @@ class BiosHealthProvider : ContentProvider() {
             metricType = metricType,
             value = value,
             timestamp = timestamp,
+            durationSec = companionDurationSecFor(metricType, value),
             sourceId = companion.sourceId,
             confidence = ConfidenceTier.MEDIUM.level,
             isPrimary = true
@@ -299,3 +300,18 @@ class BiosHealthProvider : ContentProvider() {
     override fun delete(uri: Uri, sel: String?, args: Array<out String>?): Int =
         throw UnsupportedOperationException("Companion apps cannot delete Bios data")
 }
+
+/**
+ * Derives the `durationSec` column for a companion-written reading from
+ * its `value`. The companion-insert contract only carries `value` and
+ * `timestamp`, but consumers like `SleepRegularityCalculator` filter rows
+ * by `(durationSec ?: 0) > 0`. Without this derivation, every W2F-pushed
+ * `sleep_duration` row would land with `durationSec = null` and never
+ * feed regularity. Confined to keys whose unit is seconds and whose
+ * value-as-duration semantics are well-defined — currently sleep_duration.
+ *
+ * Top-level so unit tests exercise it without touching the provider's
+ * Android dependencies (UriMatcher / Uri / ContentResolver).
+ */
+internal fun companionDurationSecFor(metricType: String, value: Double): Int? =
+    if (metricType == MetricType.SLEEP_DURATION.key && value > 0.0) value.toInt() else null

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -405,7 +405,8 @@ fun BiosApp(viewModel: AppViewModel) {
             composable("sleep_dashboard") {
                 com.bios.app.ui.sleep.SleepDashboardScreen(
                     viewModel = viewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStack() },
+                    onLogSleepManually = { navController.navigate("sleep_entry") }
                 )
             }
             composable("active_substances") {

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -62,6 +63,7 @@ import java.util.Locale
 fun SleepDashboardScreen(
     viewModel: AppViewModel,
     onBack: () -> Unit,
+    onLogSleepManually: () -> Unit = {},
 ) {
     var windowDays by remember { mutableStateOf(7) }
     var nights by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
@@ -113,18 +115,63 @@ fun SleepDashboardScreen(
                 )
             }
             if (nights.isEmpty()) {
-                item {
-                    Text(
-                        "No sleep readings in the selected window. Connect a " +
-                            "wearable, sync Health Connect, or log a night manually.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                item { EmptySleepCard(onLogSleepManually) }
             } else {
                 items(nights, key = { it.id }) { night ->
                     NightRow(night, sourceLabels)
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Empty-state guidance for the sleep dashboard. Explicit about every
+ * way the bus can populate so phone-only owners aren't left guessing:
+ * a wearable / Health Connect feed, the W2F companion (screen-off
+ * inference), or a manual entry through the existing
+ * `sleep_entry` route. The CTA opens the manual-entry flow directly
+ * since that's the only path the owner can act on without leaving
+ * Bios. Phone-side auto-derivation (`PhoneSleepAdapter` from #134)
+ * lands separately — the orchestration worker is the next layer.
+ */
+@Composable
+private fun EmptySleepCard(onLogSleepManually: () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "No sleep readings yet",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                "Bios renders sleep that lands on its bus. Any of these " +
+                    "fills the dashboard:",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                "• Connect a wearable (Oura, WHOOP, Garmin, Withings, Polar)" +
+                    "\n• Enable Health Connect with a sleep-tracking app" +
+                    "\n• Install W2F with the Bios integration toggled on " +
+                    "(screen-off inference)" +
+                    "\n• Log a night manually below",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            FilledTonalButton(
+                onClick = onLogSleepManually,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Log a sleep night")
             }
         }
     }

--- a/android/app/src/test/java/com/bios/app/CompanionDurationSecTest.kt
+++ b/android/app/src/test/java/com/bios/app/CompanionDurationSecTest.kt
@@ -1,0 +1,69 @@
+package com.bios.app
+
+import com.bios.app.provider.companionDurationSecFor
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the companion-insert duration derivation behind the
+ * BiosHealthProvider. SleepRegularityCalculator filters rows by
+ * `(durationSec ?: 0) > 0`, so a W2F-pushed sleep_duration that lands
+ * with durationSec = null gets silently dropped from the regularity
+ * window. The provider derives durationSec from value at insert time;
+ * these tests pin that contract so the derivation can't quietly
+ * regress and break the regularity score for phone-only owners.
+ */
+class CompanionDurationSecTest {
+
+    @Test
+    fun `sleep_duration positive value seeds durationSec`() {
+        // 7h * 3600 = 25200 seconds. The value comes from W2F's screen-off
+        // estimate or a wearable's seconds field; either way the
+        // derivation must round-trip cleanly.
+        val out = companionDurationSecFor(MetricType.SLEEP_DURATION.key, 25_200.0)
+        assertEquals(25_200, out)
+    }
+
+    @Test
+    fun `sleep_duration zero or negative value yields null durationSec`() {
+        // Defensive against bad pushes — a zero/negative value can't
+        // describe a real night and shouldn't feed regularity as if it
+        // were one second of sleep.
+        assertNull(companionDurationSecFor(MetricType.SLEEP_DURATION.key, 0.0))
+        assertNull(companionDurationSecFor(MetricType.SLEEP_DURATION.key, -1.0))
+    }
+
+    @Test
+    fun `fractional seconds truncate to whole seconds`() {
+        // The Int column can't hold sub-second precision. Truncation
+        // (not rounding) is the conservative choice — undercount over
+        // overstate.
+        val out = companionDurationSecFor(MetricType.SLEEP_DURATION.key, 25_200.9)
+        assertEquals(25_200, out)
+    }
+
+    @Test
+    fun `non sleep_duration keys never get a durationSec`() {
+        // Other companion-written keys are event markers (tobacco_use,
+        // fall_event) or scalar samples (typing_cadence) — duration has
+        // no defined meaning there. Only sleep_duration carries seconds
+        // as its value semantics.
+        val intakeOrEvent = listOf(
+            MetricType.TOBACCO_USE.key,
+            MetricType.CANNABIS_USE.key,
+            MetricType.FALL_EVENT.key,
+            MetricType.TYPING_CADENCE.key,
+            MetricType.MOOD_DRIFT_SCORE.key,
+            MetricType.CIRCADIAN_PHASE_SHIFT.key,
+            MetricType.CAFFEINE_INTAKE.key,
+        )
+        for (k in intakeOrEvent) {
+            assertNull(
+                "durationSec must be null for $k",
+                companionDurationSecFor(k, 100.0)
+            )
+        }
+    }
+}


### PR DESCRIPTION
Two paired fixes around the sleep dashboard surface, addressing real-world reports from a phone-only smoke test.

## Summary

**1. Companion writes for `sleep_duration` were losing `durationSec`.** `BiosHealthProvider.insert()` was inserting rows with `durationSec = null` because `BiosHealthContract.CompanionInsert` only carries `value` and `timestamp`. `SleepRegularityCalculator` filters rows via `(durationSec ?: 0) > 0`, so every W2F-pushed night silently dropped out of the regularity window — the duration values rendered on the dashboard fine (they read `value`), but the regularity score stayed empty no matter how many nights W2F forwarded.

The provider now derives `durationSec` from `value` when the key is `sleep_duration` and the value is positive. Logic extracted to a top-level `companionDurationSecFor()` helper so the rule is unit-tested without spinning up the ContentProvider's Android dependencies.

**2. Dashboard empty state was action-less.** Previous copy: *"Connect a wearable, sync Health Connect, or log a night manually."* — accurate but on a phone-only setup the owner had no in-app path to do anything. The new `EmptySleepCard` lists every producer route explicitly (wearable / Health Connect / W2F companion / manual) and ships a **"Log a sleep night"** CTA wired to the existing `sleep_entry` route.

Phone-side auto-derivation for users without W2F (the `PhoneSleepAdapter` orchestration deferred in #134) still needs its nightly worker — that's the next follow-up.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` — new `CompanionDurationSecTest` (4 cases) pins positive `sleep_duration` seeds the column, zero/negative yields null, fractional values truncate, and non-sleep keys never get a `durationSec` regardless of value magnitude.
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [ ] Live UI smoke (recommended): with the [W2F PR #19](https://github.com/thdelmas/W2F/pull/19) also merged, let W2F's `MetricSyncWorker` push a few nights, then open the Bios sleep dashboard — duration tiles should populate AND the regularity card should compute a score. On a fresh setup with no producer, the dashboard empty state shows the producer list + the "Log a sleep night" CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)