### PR TITLE
feat(sleep): phone-only auto-derivation worker (#134)

### DIFF
--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -64,6 +64,12 @@ class BiosApplication : Application() {
         // Schedule periodic health data sync (HTTP/IPFS)
         SyncWorker.enqueuePeriodicSync(this)
 
+        // Schedule periodic phone-sleep sampling + morning inference.
+        // Idempotent via WorkManager's unique-work policy; only does
+        // anything on devices with an accelerometer (the worker
+        // self-skips otherwise).
+        com.bios.app.ingest.PhoneSleepWorker.enqueuePeriodicWork(this)
+
         // Schedule daily digest notification (8 AM, user can disable in settings)
         if (DailyDigestWorker.isEnabled(this)) {
             DailyDigestWorker.schedule(this)

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -25,9 +25,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         ProfessionalReview::class,
         CompanionGrant::class,
         LoggedEvent::class,
-        EventPayloadField::class
+        EventPayloadField::class,
+        PhoneSleepSample::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -44,6 +45,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun companionGrantDao(): CompanionGrantDao
     abstract fun loggedEventDao(): LoggedEventDao
     abstract fun eventPayloadFieldDao(): EventPayloadFieldDao
+    abstract fun phoneSleepSampleDao(): PhoneSleepSampleDao
 
     companion object {
         @Volatile
@@ -66,7 +68,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
                 .build()
         }
 
@@ -262,6 +264,29 @@ abstract class BiosDatabase : RoomDatabase() {
         private val MIGRATION_9_10 = object : Migration(9, 10) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE metric_readings ADD COLUMN note TEXT")
+            }
+        }
+
+        // Sample buffer behind PhoneSleepWorker (#134). Holds ~96 rows per
+        // night so PhoneSleepInference can run morning-trigger inference
+        // from the overnight trace. Pruned by the worker after each
+        // successful inference.
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS phone_sleep_samples (
+                        id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                        timestamp INTEGER NOT NULL,
+                        screenOff INTEGER NOT NULL,
+                        charging INTEGER NOT NULL,
+                        ambientLightLux REAL,
+                        accelMagnitudeVar REAL
+                    )
+                """.trimIndent())
+                db.execSQL("""
+                    CREATE INDEX IF NOT EXISTS index_phone_sleep_samples_timestamp
+                    ON phone_sleep_samples (timestamp)
+                """.trimIndent())
             }
         }
 

--- a/android/app/src/main/java/com/bios/app/data/dao/PhoneSleepSampleDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/PhoneSleepSampleDao.kt
@@ -1,0 +1,35 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.bios.app.model.PhoneSleepSample
+
+/**
+ * Sample buffer behind [com.bios.app.ingest.PhoneSleepWorker] (#134).
+ *
+ * The worker writes one row per periodic firing, reads back the
+ * overnight window at the morning trigger, and prunes anything older
+ * than 48 h so the buffer can't grow unboundedly. Keep operations
+ * minimal — this is a transient buffer, not a long-lived archive.
+ */
+@Dao
+interface PhoneSleepSampleDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(sample: PhoneSleepSample)
+
+    @Query("""
+        SELECT * FROM phone_sleep_samples
+        WHERE timestamp >= :startMillis AND timestamp <= :endMillis
+        ORDER BY timestamp ASC
+    """)
+    suspend fun fetchInRange(startMillis: Long, endMillis: Long): List<PhoneSleepSample>
+
+    @Query("DELETE FROM phone_sleep_samples WHERE timestamp < :beforeMillis")
+    suspend fun deleteOlderThan(beforeMillis: Long): Int
+
+    @Query("SELECT COUNT(*) FROM phone_sleep_samples")
+    suspend fun count(): Int
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepScheduler.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepScheduler.kt
@@ -1,0 +1,112 @@
+package com.bios.app.ingest
+
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Pure decision layer for [PhoneSleepWorker] (#134).
+ *
+ * The worker fires every 15 minutes via WorkManager. Each firing does
+ * two things: append one new phone-state sample, and ask this scheduler
+ * whether the current moment crosses the "morning trigger" for last
+ * night's sleep window. Doing both inside one worker keeps the
+ * sample-and-infer lifecycle in a single place and avoids a second
+ * WorkManager registration just for the morning sweep.
+ *
+ * The trigger fires when:
+ *  1. We are past [wakeHour] today in local time.
+ *  2. We have not already inferred sleep whose midpoint sits in
+ *     yesterday's overnight window (cutoff = noon-to-noon to handle
+ *     odd-hour sleepers).
+ *
+ * The "have we already inferred" check is the caller's responsibility —
+ * the scheduler just returns a [TriggerDecision.Fire] with the window
+ * to feed [com.bios.app.engine.PhoneSleepInference]. The caller then
+ * dedupes against existing rows in `metric_readings`.
+ *
+ * Pure so unit tests exercise every clock + state combination without
+ * touching WorkManager or Room.
+ */
+object PhoneSleepScheduler {
+
+    sealed interface TriggerDecision {
+        /** Not yet past the wake hour, or already inferred. Caller appends
+         *  a sample and exits. */
+        object Skip : TriggerDecision
+
+        /** Time to run inference. [windowStartMs] / [windowEndMs] bound
+         *  the overnight sample window. Caller fetches the buffer,
+         *  invokes the inference, writes outputs, and prunes the buffer. */
+        data class Fire(val windowStartMs: Long, val windowEndMs: Long) : TriggerDecision
+    }
+
+    /**
+     * @param nowMs current epoch ms.
+     * @param zoneId local time zone for the wake-hour comparison.
+     * @param wakeHour hour-of-day at or after which we consider the
+     *   previous night "complete".
+     * @param lastInferredMidpointMs midpoint timestamp of the most
+     *   recently produced PHONE_SENSOR_DERIVED sleep reading, or null
+     *   if we've never run inference. Used to avoid re-firing during the
+     *   same morning window.
+     */
+    fun decide(
+        nowMs: Long,
+        zoneId: ZoneId,
+        wakeHour: Int = DEFAULT_WAKE_HOUR,
+        lastInferredMidpointMs: Long? = null,
+    ): TriggerDecision {
+        val now = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(nowMs), zoneId)
+        val today = now.toLocalDate()
+
+        // Wake threshold for today (e.g. today at 09:00 local).
+        val wakeThreshold = today.atTime(LocalTime.of(wakeHour, 0)).atZone(zoneId)
+        if (now.isBefore(wakeThreshold)) return TriggerDecision.Skip
+
+        // Window for "last night" — noon yesterday → wakeHour today.
+        // Noon-to-noon split is robust to graveyard-shift / siesta
+        // sleepers whose sleep midpoint might land in the morning, not
+        // the middle of the night.
+        val windowStart = (today.minusDays(1).atTime(LocalTime.NOON)).atZone(zoneId)
+        val windowEnd = wakeThreshold
+        val windowStartMs = windowStart.toInstant().toEpochMilli()
+        val windowEndMs = windowEnd.toInstant().toEpochMilli()
+
+        // Dedupe: if we already produced a sleep reading whose midpoint
+        // sits inside the same overnight window, don't re-fire.
+        if (lastInferredMidpointMs != null &&
+            lastInferredMidpointMs in windowStartMs..windowEndMs
+        ) {
+            return TriggerDecision.Skip
+        }
+
+        return TriggerDecision.Fire(
+            windowStartMs = windowStartMs,
+            windowEndMs = windowEndMs,
+        )
+    }
+
+    /** Helper used by the worker after a successful inference to compute
+     *  the cutoff for sample pruning — drop everything older than two
+     *  windows back so a missed morning has a chance to recover. */
+    fun pruneCutoffMs(nowMs: Long, retentionDays: Int = DEFAULT_RETENTION_DAYS): Long =
+        nowMs - retentionDays.toLong() * MILLIS_PER_DAY
+
+    /** Reasonable default wake-hour for the morning trigger. Owner-
+     *  configurable surface is a follow-up; the constant is exposed for
+     *  tests + future settings wiring. */
+    const val DEFAULT_WAKE_HOUR: Int = 9
+
+    /** Two-day retention: a missed morning trigger can still recover if
+     *  the next morning's run sees yesterday's samples. */
+    const val DEFAULT_RETENTION_DAYS: Int = 2
+
+    private const val MILLIS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+
+    /** Convenience date conversion for callers that want to log the
+     *  inferred night as a calendar date. */
+    fun nightLabelFor(midpointMs: Long, zoneId: ZoneId): LocalDate =
+        ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(midpointMs), zoneId).toLocalDate()
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -1,0 +1,178 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import androidx.work.WorkerParameters
+import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.PhoneSleepInference
+import com.bios.app.model.DataSource
+import com.bios.app.model.PhoneSleepSample
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+import java.time.ZoneId
+import java.util.concurrent.TimeUnit
+
+/**
+ * Phone-only sleep auto-derivation (issue #134).
+ *
+ * Every WorkManager firing:
+ *
+ *  1. Collects one [PhoneSleepInference.Sample] via [PhoneSleepAdapter]
+ *     and appends it to `phone_sleep_samples`.
+ *  2. Asks [PhoneSleepScheduler] whether we just crossed the morning
+ *     trigger. If yes, reads the overnight buffer, hands it to
+ *     [PhoneSleepInference.infer], writes the resulting
+ *     `SLEEP_DURATION` (+ `SLEEP_STAGE`) rows under a registered
+ *     `PHONE_SENSOR_DERIVED` data source, and prunes the buffer.
+ *
+ * Cadence is 15 minutes — WorkManager's minimum periodic interval and
+ * good enough for the inference's 4 h minimum window + 5 min AWAKE
+ * bout merging. Doze-mode delays will cost a sample or two but the
+ * morning trigger still fires on the first post-wake-hour run.
+ *
+ * The worker self-installs idempotently via [enqueuePeriodicWork] so
+ * adding it to AppViewModel's init path is enough to opt the user in.
+ * No new permissions — accelerometer / light / charging / screen-state
+ * are all unprivileged reads.
+ */
+class PhoneSleepWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        val adapter = PhoneSleepAdapter(context)
+        if (!adapter.isAvailable) {
+            // No accelerometer → no inference possible. Succeed quietly so
+            // WorkManager keeps the periodic schedule (cheaper than
+            // re-enqueueing on every retry).
+            Log.d(TAG, "Accelerometer unavailable; skipping sample")
+            return Result.success()
+        }
+
+        val db = BiosDatabase.getInstance(context)
+        val sampleDao = db.phoneSleepSampleDao()
+        val readingDao = db.metricReadingDao()
+        val sourceDao = db.dataSourceDao()
+
+        return try {
+            // 1. Sample + persist.
+            val sample = adapter.sample()
+            sampleDao.insert(
+                PhoneSleepSample(
+                    timestamp = sample.timestamp,
+                    screenOff = sample.screenOff,
+                    charging = sample.charging,
+                    ambientLightLux = sample.ambientLightLux,
+                    accelMagnitudeVar = sample.accelMagnitudeVar,
+                )
+            )
+
+            // 2. Morning trigger? Bail early if not — keeps the common
+            //    path (sample-only) cheap. Dedupe key is the most-recent
+            //    phone-derived sleep midpoint; null on first run.
+            val zone = ZoneId.systemDefault()
+            val phoneSourceId = sourceDao.findByType(SourceType.PHONE_SENSOR_DERIVED.key)?.id
+            val lastMidpoint = phoneSourceId?.let { sid ->
+                readingDao.fetchLatest(MetricType.SLEEP_DURATION.key, limit = 5)
+                    .firstOrNull { it.sourceId == sid }
+                    ?.timestamp
+            }
+            val decision = PhoneSleepScheduler.decide(
+                nowMs = System.currentTimeMillis(),
+                zoneId = zone,
+                lastInferredMidpointMs = lastMidpoint,
+            )
+            if (decision !is PhoneSleepScheduler.TriggerDecision.Fire) {
+                return Result.success()
+            }
+
+            // 3. Inference window — read buffered samples, run inference,
+            //    write results under a stable PHONE_SENSOR_DERIVED source.
+            val samples = sampleDao
+                .fetchInRange(decision.windowStartMs, decision.windowEndMs)
+                .map {
+                    PhoneSleepInference.Sample(
+                        timestamp = it.timestamp,
+                        screenOff = it.screenOff,
+                        charging = it.charging,
+                        ambientLightLux = it.ambientLightLux,
+                        accelMagnitudeVar = it.accelMagnitudeVar,
+                    )
+                }
+            if (samples.size < MIN_SAMPLES_FOR_INFERENCE) {
+                Log.d(TAG, "Only ${samples.size} samples in window; skipping inference")
+                return Result.success()
+            }
+
+            val sourceId = ensurePhoneSleepSource(sourceDao)
+            val readings = adapter.infer(samples, sourceId)
+            if (readings.isNotEmpty()) {
+                readingDao.insertAll(readings)
+                Log.i(TAG, "Inferred phone sleep: ${readings.size} readings written")
+            }
+
+            // 4. Prune old samples so the buffer can't grow unbounded.
+            sampleDao.deleteOlderThan(
+                PhoneSleepScheduler.pruneCutoffMs(System.currentTimeMillis())
+            )
+            Result.success()
+        } catch (t: Throwable) {
+            Log.w(TAG, "PhoneSleepWorker failed: ${t.message}", t)
+            Result.retry()
+        }
+    }
+
+    private suspend fun ensurePhoneSleepSource(
+        dao: com.bios.app.data.dao.DataSourceDao,
+    ): String {
+        val existing = dao.findByType(SourceType.PHONE_SENSOR_DERIVED.key)
+        if (existing != null) return existing.id
+        val source = DataSource(
+            sourceType = SourceType.PHONE_SENSOR_DERIVED.key,
+            sensorType = "phone_sleep",
+            deviceName = "Phone sleep inference",
+            readingKind = ReadingKind.DERIVED.name,
+        )
+        dao.insert(source)
+        return source.id
+    }
+
+    companion object {
+        private const val TAG = "PhoneSleepWorker"
+        const val WORK_NAME = "bios_phone_sleep"
+        /** Below this many samples the inference can't honestly fit
+         *  a 4 h minimum window even at the 15-min cadence. */
+        internal const val MIN_SAMPLES_FOR_INFERENCE = 8
+
+        fun enqueuePeriodicWork(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiresBatteryNotLow(true)
+                .build()
+            val request = PeriodicWorkRequestBuilder<PhoneSleepWorker>(
+                15, TimeUnit.MINUTES
+            )
+                .setConstraints(constraints)
+                .setBackoffCriteria(
+                    BackoffPolicy.EXPONENTIAL,
+                    WorkRequest.MIN_BACKOFF_MILLIS,
+                    TimeUnit.MILLISECONDS,
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
+++ b/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
@@ -1,0 +1,31 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Persistent log of phone-state observations that
+ * [com.bios.app.engine.PhoneSleepInference] consumes once per morning to
+ * derive `SLEEP_DURATION` + `SLEEP_STAGE` readings (issue #134).
+ *
+ * Rows are tiny and the periodic worker writes ~96/day (every 15 min);
+ * old rows get pruned by [com.bios.app.data.dao.PhoneSleepSampleDao]
+ * after inference runs. Indexed by `timestamp` because every read fetches
+ * an overnight window.
+ *
+ * The schema mirrors [com.bios.app.engine.PhoneSleepInference.Sample]
+ * 1:1 so the worker maps row→Sample without translation logic.
+ */
+@Entity(
+    tableName = "phone_sleep_samples",
+    indices = [Index("timestamp")],
+)
+data class PhoneSleepSample(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val timestamp: Long,
+    val screenOff: Boolean,
+    val charging: Boolean,
+    val ambientLightLux: Float?,
+    val accelMagnitudeVar: Float?,
+)

--- a/android/app/src/test/java/com/bios/app/PhoneSleepSchedulerTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepSchedulerTest.kt
@@ -1,0 +1,117 @@
+package com.bios.app
+
+import com.bios.app.ingest.PhoneSleepScheduler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/**
+ * Pure-clock tests for [PhoneSleepScheduler] (#134).
+ *
+ * Exercises the morning-trigger contract: skip before the wake hour,
+ * fire once after it, then stay skipped for the rest of the day after
+ * a successful inference. Uses a fixed UTC zone so the wake-hour math
+ * is reproducible without depending on the host JVM's default zone.
+ */
+class PhoneSleepSchedulerTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+
+    @Test
+    fun `before wake hour returns Skip`() {
+        val now = LocalDateTime.of(2026, 5, 21, 7, 30).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 9,
+            lastInferredMidpointMs = null,
+        )
+        assertEquals(PhoneSleepScheduler.TriggerDecision.Skip, out)
+    }
+
+    @Test
+    fun `exactly at wake hour returns Fire`() {
+        val now = LocalDateTime.of(2026, 5, 21, 9, 0).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 9,
+            lastInferredMidpointMs = null,
+        )
+        assertTrue("expected Fire, got $out", out is PhoneSleepScheduler.TriggerDecision.Fire)
+    }
+
+    @Test
+    fun `fire window spans noon yesterday to wake hour today`() {
+        val now = LocalDateTime.of(2026, 5, 21, 9, 15).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 9,
+            lastInferredMidpointMs = null,
+        ) as PhoneSleepScheduler.TriggerDecision.Fire
+
+        val expectedStart = LocalDateTime.of(2026, 5, 20, 12, 0).atZone(zone).toInstant().toEpochMilli()
+        val expectedEnd = LocalDateTime.of(2026, 5, 21, 9, 0).atZone(zone).toInstant().toEpochMilli()
+        assertEquals(expectedStart, out.windowStartMs)
+        assertEquals(expectedEnd, out.windowEndMs)
+    }
+
+    @Test
+    fun `dedupes when last inference midpoint falls inside this morning's window`() {
+        // Already ran at 09:15 → midpoint was 04:00 local last night. The
+        // 09:30 firing should skip, not re-fire.
+        val now = LocalDateTime.of(2026, 5, 21, 9, 30).atZone(zone).toInstant().toEpochMilli()
+        val lastMidpoint = LocalDateTime.of(2026, 5, 21, 4, 0).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 9,
+            lastInferredMidpointMs = lastMidpoint,
+        )
+        assertEquals(PhoneSleepScheduler.TriggerDecision.Skip, out)
+    }
+
+    @Test
+    fun `fires again on a new morning after yesterday's inference`() {
+        // Last midpoint from May 20's night-of (e.g., 03:00 local) — the
+        // current window is May 21's overnight, which starts at noon
+        // May 20 → 09:00 May 21. The May-20 midpoint sits in the prior
+        // window, not this one, so dedupe doesn't trip.
+        val now = LocalDateTime.of(2026, 5, 22, 9, 5).atZone(zone).toInstant().toEpochMilli()
+        val lastMidpoint = LocalDateTime.of(2026, 5, 21, 3, 0).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 9,
+            lastInferredMidpointMs = lastMidpoint,
+        )
+        assertTrue("expected Fire after a new midnight, got $out",
+            out is PhoneSleepScheduler.TriggerDecision.Fire)
+    }
+
+    @Test
+    fun `custom wake hour shifts both the threshold and the window end`() {
+        // Configurable wake hour: an owner who wakes at 7 should get an
+        // earlier trigger and an earlier window end.
+        val now = LocalDateTime.of(2026, 5, 21, 7, 15).atZone(zone).toInstant().toEpochMilli()
+        val out = PhoneSleepScheduler.decide(
+            nowMs = now,
+            zoneId = zone,
+            wakeHour = 7,
+            lastInferredMidpointMs = null,
+        ) as PhoneSleepScheduler.TriggerDecision.Fire
+        val expectedEnd = LocalDateTime.of(2026, 5, 21, 7, 0).atZone(zone).toInstant().toEpochMilli()
+        assertEquals(expectedEnd, out.windowEndMs)
+    }
+
+    @Test
+    fun `pruneCutoffMs trails now by the retention window`() {
+        val now = LocalDateTime.of(2026, 5, 21, 12, 0).atZone(zone).toInstant().toEpochMilli()
+        val cutoff = PhoneSleepScheduler.pruneCutoffMs(now, retentionDays = 2)
+        val expected = LocalDateTime.of(2026, 5, 19, 12, 0).atZone(zone).toInstant().toEpochMilli()
+        assertEquals(expected, cutoff)
+    }
+}


### PR DESCRIPTION
Closes the orchestration gap deferred in #134's original commit. The `PhoneSleepInference` math and `PhoneSleepAdapter` sensor wrapper have been on main for weeks, but no scheduler ever invoked them — so phone-only owners (no wearable, no Health Connect, no W2F) saw an empty sleep bus. This PR wires the periodic worker that closes the loop.

## Architecture

- **`PhoneSleepSample`** (Room entity, [model/](android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt)) + **`PhoneSleepSampleDao`** — tiny sample buffer. ~96 rows/night at 15-min cadence; pruned to a 2-day retention after each successful inference.
- **`BiosDatabase`** bumped to version 11 with `MIGRATION_10_11` creating `phone_sleep_samples` + its `timestamp` index.
- **`PhoneSleepScheduler`** (pure): decides whether the current firing crosses the morning trigger for last night's window. Returns the *noon-yesterday → wake-hour-today* window to feed inference, with dedupe against the most-recent phone-derived sleep midpoint so the trigger fires *once* per night rather than every 15 minutes after the wake hour. Configurable wake hour (default 09:00 local).
- **`PhoneSleepWorker`** (`CoroutineWorker`): every 15 minutes, samples one phone-state observation via `PhoneSleepAdapter` and persists it. When the scheduler fires the morning trigger, reads the overnight buffer, runs `PhoneSleepInference.infer()`, writes results under a stable `PHONE_SENSOR_DERIVED` data-source row, and prunes the buffer. Self-skips when no accelerometer is present.
- **`BiosApplication`** enqueues the periodic work alongside `SyncWorker`. WorkManager unique-work policy keeps it idempotent across process restarts.

**No new manifest permissions** — accelerometer, light sensor, charging state, screen-on are all unprivileged reads. WorkManager constraints set `setRequiresBatteryNotLow(true)` so the worker yields when battery is low.

## Known limitations (next iterations)

- **Doze mode** — periodic workers can be deferred by Android's adaptive battery. The morning trigger still fires on the first post-wake-hour run, but mid-night samples can be skipped. Foreground service with a persistent notification is the robust answer; deferred so the default surface stays quiet.
- **No owner-facing settings yet** — toggle on/off, configurable wake hour, etc. The worker is always-on by default; owners can disable WorkManager-level via Android settings or app data wipe. A proper settings UI is the obvious follow-up.
- **Inference quality** — 15-min cadence vs the original design's 1-min target means brief AWAKE bouts get collapsed more aggressively. Published RMSE for comparable phone-only apps is ~30 min vs actigraphy; the trend math accepts that floor.

## Test plan

- [x] `:app:testStandaloneDebugUnitTest` — new `PhoneSleepSchedulerTest` (7 cases) pins skip-before-wake-hour, fire-at-wake-hour, fire-after-wake-hour, noon-to-noon window math, dedupe inside the current morning's window, re-fire next morning, custom wake hour, and prune-cutoff math.
- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [ ] Live device smoke (recommended over a few days): install, let the worker run overnight on a phone you actually sleep next to, open the sleep dashboard the next morning. With #147 also landed, the regularity score will populate from the derived nights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)