### PR TITLE
fix(phone-sensors): wire ACTIVITY_RECOGNITION for step counter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,12 @@
     <!-- Background work -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Step counter. Android 10+ silently delivers zero events to
+         Sensor.TYPE_STEP_COUNTER without this permission, even though
+         the sensor itself reports `hasStepCounter = true`. Without this
+         declaration the phone-side step source stays empty forever. -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+
     <!-- Camera (fingertip-PPG HRV snapshots via rear camera + flash) -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
@@ -180,33 +180,45 @@ class PhoneSensorAdapter(context: Context) {
 
     /**
      * Collects sensor samples for the given duration and returns them.
+     *
+     * Wrapped in a wall-clock timeout so a sensor that never fires (most
+     * commonly: TYPE_STEP_COUNTER without ACTIVITY_RECOGNITION permission,
+     * but also any silent sensor failure) can't hang the calling sync
+     * forever. The timeout is twice the requested duration with a 5 s
+     * floor — generous enough to absorb listener-registration latency
+     * without blocking the periodic sync if the sensor is silent.
      */
     private suspend fun collectSamples(
         sensor: Sensor,
         durationMs: Long
-    ): List<Triple<Float, Float, Float>> = suspendCancellableCoroutine { cont ->
-        val samples = mutableListOf<Triple<Float, Float, Float>>()
-        val startTime = System.currentTimeMillis()
+    ): List<Triple<Float, Float, Float>> {
+        val timeoutMs = (durationMs * 2L).coerceAtLeast(SAMPLE_TIMEOUT_FLOOR_MS)
+        return kotlinx.coroutines.withTimeoutOrNull(timeoutMs) {
+            suspendCancellableCoroutine<List<Triple<Float, Float, Float>>> { cont ->
+                val samples = mutableListOf<Triple<Float, Float, Float>>()
+                val startTime = System.currentTimeMillis()
 
-        val listener = object : SensorEventListener {
-            override fun onSensorChanged(event: SensorEvent) {
-                samples.add(Triple(event.values[0], event.values[1], event.values[2]))
-                if (System.currentTimeMillis() - startTime >= durationMs) {
-                    sensorManager.unregisterListener(this)
-                    if (cont.isActive) cont.resume(samples)
+                val listener = object : SensorEventListener {
+                    override fun onSensorChanged(event: SensorEvent) {
+                        samples.add(Triple(event.values[0], event.values[1], event.values[2]))
+                        if (System.currentTimeMillis() - startTime >= durationMs) {
+                            sensorManager.unregisterListener(this)
+                            if (cont.isActive) cont.resume(samples)
+                        }
+                    }
+
+                    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+                }
+
+                sensorManager.registerListener(
+                    listener, sensor, SensorManager.SENSOR_DELAY_NORMAL
+                )
+
+                cont.invokeOnCancellation {
+                    sensorManager.unregisterListener(listener)
                 }
             }
-
-            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
-        }
-
-        sensorManager.registerListener(
-            listener, sensor, SensorManager.SENSOR_DELAY_NORMAL
-        )
-
-        cont.invokeOnCancellation {
-            sensorManager.unregisterListener(listener)
-        }
+        } ?: emptyList()
     }
 
     companion object {
@@ -214,5 +226,9 @@ class PhoneSensorAdapter(context: Context) {
         private const val ACTIVITY_THRESHOLD = 1.5 // m/s^2 above gravity
         private const val STEP_SAMPLE_MS = 500L
         private const val AMBIENT_LIGHT_TIMEOUT_MS = 1_000L
+        /** Hard wall-clock cap for collectSamples so a silent sensor
+         *  (e.g. TYPE_STEP_COUNTER without ACTIVITY_RECOGNITION) doesn't
+         *  hang the calling sync. */
+        private const val SAMPLE_TIMEOUT_FLOOR_MS = 5_000L
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/ActivityRecognitionGate.kt
+++ b/android/app/src/main/java/com/bios/app/ui/ActivityRecognitionGate.kt
@@ -1,0 +1,43 @@
+package com.bios.app.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * Requests the runtime `ACTIVITY_RECOGNITION` permission once after the
+ * owner has cleared Health Connect onboarding.
+ *
+ * Android 10+ silently delivers zero events to `TYPE_STEP_COUNTER`
+ * without this permission, even when the sensor itself reports
+ * `hasStepCounter = true`. Without the runtime grant the phone-side
+ * step source stayed empty forever in production.
+ *
+ * The outcome surfaces naturally — if the owner declines, the next
+ * sync's step reading stays null and the rest of the bus keeps
+ * working. The launcher block is empty by design; this is a one-shot
+ * passive opt-in, not a gate on app functionality.
+ *
+ * Extracted from MainActivity to keep that file under the 500-line cap
+ * and so the runtime-perm pattern is reusable when more sensor perms
+ * land (e.g. `BODY_SENSORS` if Bios ever supports phone PPG).
+ */
+@Composable
+fun MaybeRequestActivityRecognition(hasPermissions: Boolean) {
+    val ctx = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { /* result surfaces via the next sync's step reading */ }
+    LaunchedEffect(hasPermissions) {
+        if (hasPermissions && ContextCompat.checkSelfPermission(
+                ctx, Manifest.permission.ACTIVITY_RECOGNITION
+            ) != PackageManager.PERMISSION_GRANTED) {
+            launcher.launch(Manifest.permission.ACTIVITY_RECOGNITION)
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -74,6 +74,8 @@ fun BiosRoot(viewModel: AppViewModel = viewModel()) {
         }
     }
 
+    MaybeRequestActivityRecognition(hasPermissions)
+
     // Check permissions on first composition
     LaunchedEffect(Unit) {
         try {


### PR DESCRIPTION
Real-world bug from a phone-only smoke test: step count was empty despite `hasStepCounter` being true and `PhoneSensorAdapter.readStepCounter()` being invoked on every sync. Root cause: Android 10+ **silently** delivers zero events to `TYPE_STEP_COUNTER` without `ACTIVITY_RECOGNITION` runtime permission — the listener registers fine and reports no error, it just never receives events.

## Summary

- **`AndroidManifest.xml`** declares `android.permission.ACTIVITY_RECOGNITION`.
- **`ui/ActivityRecognitionGate.kt`** is a one-shot Composable that requests the runtime grant after Health Connect onboarding clears. Quiet decline is fine — the rest of the bus keeps working; the next sync's step reading just stays null.
- **`MainActivity`** calls the gate from `BiosRoot` in a single line. Extracted helper keeps `MainActivity` under the 500-line cap and makes the pattern reusable for future sensor perms (e.g. `BODY_SENSORS` if Bios ever supports phone PPG).
- **`PhoneSensorAdapter.collectSamples`** wraps the listener wait in `withTimeoutOrNull`. Without `ACTIVITY_RECOGNITION` the listener registered fine but never fired, and the coroutine had **no timeout** — the call hung forever and dragged the periodic sync with it. Floored at 5 s so registration latency doesn't trip it; otherwise twice the requested sample duration.

## Heart rate (separate problem)

The user also reported empty heart-rate data. This is **not the same kind of bug**: Bios has no continuous phone-only HR producer by design. Background HR comes from a wearable, Health Connect, or the user-initiated camera-PPG fingertip snapshot. Empty HR on a phone-only setup is a UX gap (the PPG snapshot exists but isn't discoverable from the HR dashboard's empty state), not a permission bug. A separate PR will improve the empty state and surface the PPG snapshot as the manual fallback.

## Test plan

- [x] `./scripts/code-quality-check.sh` — clean (file-length, secret scan, lint, `assembleDebug` lethe + standalone, unit tests).
- [x] Existing unit tests pass.
- [ ] Live UI smoke (recommended): fresh install on a phone with a step counter — the runtime grant dialog should appear right after the Health Connect onboarding completes. Approve, walk around, and step readings should appear in the next sync (≤ 15 min). Decline path: app keeps working, steps stay null, no hang on the periodic sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)