### PR TITLE
fix(data): recover from DB downgrade instead of crashing

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -69,6 +69,18 @@ abstract class BiosDatabase : RoomDatabase() {
             )
                 .openHelperFactory(factory)
                 .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11)
+                // Downgrades happen when the owner installs a build whose
+                // DB schema is older than the one already on disk —
+                // typical when bouncing between a dev build and a tagged
+                // release. Without recovery, Room throws
+                // IllegalStateException at the first DAO call and the
+                // app is unrunnable. Recovery beats crash for a health
+                // app: wearable / Health Connect / companion sources
+                // re-populate the bus on the next sync; the local copy
+                // is a cache, not the source of truth. Encrypted-prefs
+                // passphrase survives the wipe so the rebuilt DB stays
+                // encrypted under the same key.
+                .fallbackToDestructiveMigrationOnDowngrade()
                 .build()
         }
 


### PR DESCRIPTION
Real crash from a phone-only smoke test:

\`\`\`
java.lang.IllegalStateException:
  A migration from 11 to 10 was required but not found.
  Please provide the necessary Migration path via
  RoomDatabase.Builder.addMigration(Migration ...) or allow for
  destructive migrations via one of the
  RoomDatabase.Builder.fallbackToDestructiveMigration* methods.
\`\`\`

The device DB was at v11 (from a build that included the
\`PhoneSleepWorker\` schema bump in #148) and a later launch loaded
an APK whose code still thought the DB was at v10. Downgrades happen
whenever the owner bounces between a dev build and a tagged release;
without recovery the app crashes at the first DAO call and is
unrunnable.

## Decision

For Bios specifically, the local DB is a cache — wearable / Health
Connect / companion sources re-populate the bus on the next sync.
**Recovery beats crash** for an app whose entire purpose is to keep
running and watching health signals.

\`fallbackToDestructiveMigrationOnDowngrade()\` wipes only on the
downgrade path. Regular upgrade migrations are unchanged. The
encrypted-prefs passphrase survives the DB wipe so the rebuilt DB
stays encrypted under the same key.

## Test plan

- [x] \`./scripts/code-quality-check.sh\` — clean.
- [ ] Live device recovery: install latest main on a device that previously crashed with the version-11 → version-10 downgrade — the app should open cleanly with a fresh v10 DB; the next sync repopulates from wearable / HC / companions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)