### PR TITLE
Recover from DB downgrade + add Infer-now path for phone sleep

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -48,6 +48,16 @@ class PhoneSleepWorker(
     workerParams: WorkerParameters,
 ) : CoroutineWorker(appContext, workerParams) {
 
+    /** Outcome of [Companion.runImmediateInference]. Surfaced to the
+     *  dashboard so the owner gets a concrete reason when no reading
+     *  lands from a force-now request. */
+    sealed interface ImmediateResult {
+        object NoSensor : ImmediateResult
+        object NotEnoughSamples : ImmediateResult
+        object NoSleepWindow : ImmediateResult
+        data class Written(val count: Int) : ImmediateResult
+    }
+
     override suspend fun doWork(): Result {
         val context = applicationContext
         val adapter = PhoneSleepAdapter(context)
@@ -114,7 +124,7 @@ class PhoneSleepWorker(
                 return Result.success()
             }
 
-            val sourceId = ensurePhoneSleepSource(sourceDao)
+            val sourceId = ensureSource(sourceDao)
             val readings = adapter.infer(samples, sourceId)
             if (readings.isNotEmpty()) {
                 readingDao.insertAll(readings)
@@ -132,27 +142,83 @@ class PhoneSleepWorker(
         }
     }
 
-    private suspend fun ensurePhoneSleepSource(
-        dao: com.bios.app.data.dao.DataSourceDao,
-    ): String {
-        val existing = dao.findByType(SourceType.PHONE_SENSOR_DERIVED.key)
-        if (existing != null) return existing.id
-        val source = DataSource(
-            sourceType = SourceType.PHONE_SENSOR_DERIVED.key,
-            sensorType = "phone_sleep",
-            deviceName = "Phone sleep inference",
-            readingKind = ReadingKind.DERIVED.name,
-        )
-        dao.insert(source)
-        return source.id
-    }
-
     companion object {
         private const val TAG = "PhoneSleepWorker"
         const val WORK_NAME = "bios_phone_sleep"
         /** Below this many samples the inference can't honestly fit
          *  a 4 h minimum window even at the 15-min cadence. */
         internal const val MIN_SAMPLES_FOR_INFERENCE = 8
+
+        /** Wider window for the on-demand "Infer now" path: covers up
+         *  to ~1.5 days back so an owner who slept late, just installed,
+         *  or had a DB wipe has a chance of producing a reading from a
+         *  partial buffer instead of waiting until tomorrow morning. */
+        internal const val FORCE_WINDOW_MS: Long = 36L * 60L * 60L * 1000L
+
+        /**
+         * On-demand inference path for owners who don't want to wait
+         * until the periodic morning trigger fires at the next wake hour.
+         * Takes one fresh sample, then runs inference over the last
+         * [FORCE_WINDOW_MS] using whatever's in the buffer. Skips both
+         * the morning-trigger gate and the lastMidpoint dedupe — the
+         * owner asked for an inference, so produce one if the math
+         * allows. Writes results under the same PHONE_SENSOR_DERIVED
+         * source the periodic worker uses.
+         */
+        suspend fun runImmediateInference(context: Context): ImmediateResult {
+            val adapter = PhoneSleepAdapter(context)
+            if (!adapter.isAvailable) return ImmediateResult.NoSensor
+
+            val db = BiosDatabase.getInstance(context)
+            val sampleDao = db.phoneSleepSampleDao()
+            val readingDao = db.metricReadingDao()
+            val sourceDao = db.dataSourceDao()
+
+            val fresh = adapter.sample()
+            sampleDao.insert(
+                PhoneSleepSample(
+                    timestamp = fresh.timestamp,
+                    screenOff = fresh.screenOff,
+                    charging = fresh.charging,
+                    ambientLightLux = fresh.ambientLightLux,
+                    accelMagnitudeVar = fresh.accelMagnitudeVar,
+                )
+            )
+
+            val end = System.currentTimeMillis()
+            val start = end - FORCE_WINDOW_MS
+            val samples = sampleDao.fetchInRange(start, end).map {
+                PhoneSleepInference.Sample(
+                    timestamp = it.timestamp,
+                    screenOff = it.screenOff,
+                    charging = it.charging,
+                    ambientLightLux = it.ambientLightLux,
+                    accelMagnitudeVar = it.accelMagnitudeVar,
+                )
+            }
+            if (samples.size < MIN_SAMPLES_FOR_INFERENCE) {
+                return ImmediateResult.NotEnoughSamples
+            }
+
+            val sourceId = ensureSource(sourceDao)
+            val readings = adapter.infer(samples, sourceId)
+            if (readings.isEmpty()) return ImmediateResult.NoSleepWindow
+            readingDao.insertAll(readings)
+            return ImmediateResult.Written(readings.size)
+        }
+
+        private suspend fun ensureSource(dao: com.bios.app.data.dao.DataSourceDao): String {
+            val existing = dao.findByType(SourceType.PHONE_SENSOR_DERIVED.key)
+            if (existing != null) return existing.id
+            val source = DataSource(
+                sourceType = SourceType.PHONE_SENSOR_DERIVED.key,
+                sensorType = "phone_sleep",
+                deviceName = "Phone sleep inference",
+                readingKind = ReadingKind.DERIVED.name,
+            )
+            dao.insert(source)
+            return source.id
+        }
 
         fun enqueuePeriodicWork(context: Context) {
             val constraints = Constraints.Builder()

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -14,9 +14,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,16 +32,20 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.engine.SleepRegularityCalculator
+import com.bios.app.ingest.PhoneSleepWorker
 import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.MetricReading
 import com.bios.app.ui.AppViewModel
 import com.bios.contracts.MetricType
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -63,11 +70,16 @@ fun SleepDashboardScreen(
     viewModel: AppViewModel,
     onBack: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var windowDays by remember { mutableStateOf(7) }
+    var refreshTick by remember { mutableStateOf(0) }
     var nights by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
     var sourceLabels by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var inferring by remember { mutableStateOf(false) }
+    var inferenceMessage by remember { mutableStateOf<String?>(null) }
 
-    LaunchedEffect(windowDays) {
+    LaunchedEffect(windowDays, refreshTick) {
         val end = System.currentTimeMillis()
         val start = end - windowDays.toLong() * 24L * 3600L * 1000L
         nights = viewModel.db.metricReadingDao()
@@ -75,6 +87,19 @@ fun SleepDashboardScreen(
             .sortedByDescending { it.timestamp }
         sourceLabels = viewModel.db.dataSourceDao().getAll()
             .associate { it.id to (it.deviceName ?: it.sourceType) }
+    }
+
+    val onInferNow: () -> Unit = {
+        if (!inferring) {
+            scope.launch {
+                inferring = true
+                inferenceMessage = null
+                val result = PhoneSleepWorker.runImmediateInference(context)
+                inferenceMessage = describe(result)
+                inferring = false
+                refreshTick++
+            }
+        }
     }
 
     val regularity = remember(nights, windowDays) {
@@ -91,6 +116,21 @@ fun SleepDashboardScreen(
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
                     }
+                },
+                actions = {
+                    IconButton(onClick = onInferNow, enabled = !inferring) {
+                        if (inferring) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.padding(4.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = "Run phone inference now"
+                            )
+                        }
+                    }
                 }
             )
         }
@@ -103,6 +143,15 @@ fun SleepDashboardScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item { WindowSelector(windowDays) { windowDays = it } }
+            inferenceMessage?.let { msg ->
+                item {
+                    Text(
+                        msg,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
             item { RegularityCard(regularity) }
             item { SummaryCard(nights) }
             item {
@@ -113,14 +162,7 @@ fun SleepDashboardScreen(
                 )
             }
             if (nights.isEmpty()) {
-                item {
-                    Text(
-                        "No sleep readings in the selected window. Connect a " +
-                            "wearable, sync Health Connect, or log a night manually.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                item { EmptyStateCard(inferring = inferring, onInferNow = onInferNow) }
             } else {
                 items(nights, key = { it.id }) { night ->
                     NightRow(night, sourceLabels)
@@ -295,3 +337,50 @@ private fun formatDuration(seconds: Long): String {
 
 private val dateFormat = SimpleDateFormat("EEE, MMM d", Locale.US)
 private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))
+
+@Composable
+private fun EmptyStateCard(inferring: Boolean, onInferNow: () -> Unit) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "No sleep readings in the selected window.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                "Connect a wearable, sync Health Connect, log a night manually, " +
+                    "or run phone inference now against whatever samples already buffered.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            FilledTonalButton(
+                onClick = onInferNow,
+                enabled = !inferring,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (inferring) "Running inference…" else "Run phone inference now")
+            }
+        }
+    }
+}
+
+private fun describe(result: PhoneSleepWorker.ImmediateResult): String = when (result) {
+    is PhoneSleepWorker.ImmediateResult.Written ->
+        "Inferred ${result.count} reading(s) from the last 36h buffer."
+    PhoneSleepWorker.ImmediateResult.NoSensor ->
+        "No accelerometer on this device — phone-only inference can't run."
+    PhoneSleepWorker.ImmediateResult.NotEnoughSamples ->
+        "Not enough samples buffered yet (need ${PhoneSleepWorker.MIN_SAMPLES_FOR_INFERENCE}+). " +
+            "Keep the app installed through a night and try again."
+    PhoneSleepWorker.ImmediateResult.NoSleepWindow ->
+        "No 4h+ continuous screen-off stretch found in the last 36h — " +
+            "the inference needs a long quiet window."
+}


### PR DESCRIPTION
## Summary

Two paired changes that came out of a phone-only smoke test:

- **`fix(data)`:** Room crashed at the first DAO call (`A migration from 11 to 10 was required but not found`) when bouncing between a dev build (v11, with PhoneSleepWorker) and an older release (v10). Now `fallbackToDestructiveMigrationOnDowngrade()` lets the rebuilt DB stay encrypted under the same passphrase. Recovery beats crash — but for phone-only owners, derived sleep history is permanently gone after the wipe with no upstream to re-sync from, which motivated the second change.
- **`feat(sleep)`:** `PhoneSleepWorker.runImmediateInference()` skips the morning-trigger gate (09:00 local) and runs over the last 36h of buffered samples. Wired to a refresh icon in the sleep dashboard's top bar (always visible, swaps to a spinner while running) and a CTA in the empty-state card. Surfaces a concrete reason inline when no reading lands (`NoSensor` / `NotEnoughSamples` / `NoSleepWindow`).

## Test plan
- [x] `./scripts/code-quality-check.sh` passes (file length, secrets, lint, both flavor builds, unit tests).
- [x] All `PhoneSleep*` unit tests still pass — no test regression from hoisting `ensureSource()` to the companion.
- [ ] Manual on-device verification: open Sleep → tap refresh → confirm one of the four `ImmediateResult` strings renders below the window selector and the night row populates if the buffer covered a 4h+ screen-off stretch.
- [ ] Manual on-device verification of the downgrade path: install v11 → install v10 → confirm no crash and dashboard repopulates as sources re-sync (phone-derived will require waiting for the next morning trigger or tapping Infer now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)