### PR TITLE
feat(biomarkers): renal/hepatic/insulin-resistance panel (#158)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -28,7 +28,7 @@ object BiomarkerConditionPatterns {
             inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
             vitaminDDeficiencySignature, hypothyroidSignature, hyperthyroidSignature,
             anemiaSignature,
-        )
+        ) + Wave5BiomarkerPatterns.all
     }
 
     /**
@@ -375,4 +375,6 @@ object BiomarkerConditionPatterns {
         ),
         earlyDetection = "Chronic anemia develops slowly and the wearable signature (rising resting HR, declining activity) is nonspecific in isolation. Pairing it with a measured hemoglobin narrows the signal to the population where these proxies plausibly track oxygen-delivery shortfall.",
     )
+    // Wave 5 (renal / hepatic / insulin-resistance) lives in
+    // Wave5BiomarkerPatterns.kt to keep this file under the 500-line cap.
 }

--- a/android/app/src/main/java/com/bios/app/alerts/Wave5BiomarkerPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/Wave5BiomarkerPatterns.kt
@@ -1,0 +1,191 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Wave 5 biomarker condition patterns (#158, audit gap §2.8) — renal,
+ * hepatic, and insulin-resistance domains. Same absolute-threshold
+ * mechanism as the wave 1–4 patterns in [BiomarkerConditionPatterns];
+ * lives in its own file to keep that file under the 500-line cap.
+ *
+ * All three patterns are silent-disease detectors. eGFR catches CKD years
+ * before symptoms; ALT/AST/GGT catch NAFLD before it progresses to
+ * fibrosis; HOMA-IR catches insulin resistance before HbA1c shifts. Each
+ * gates on a lab anchor and pairs it with wearable / metabolic
+ * corroborators that on their own are too nonspecific to alert on.
+ */
+object Wave5BiomarkerPatterns {
+
+    val all by lazy {
+        listOf(
+            ckdProgressionSignature,
+            nafldSignature,
+            insulinResistanceSignature,
+        )
+    }
+
+    /**
+     * eGFR <60 mL/min/1.73m² (KDIGO 2024 G3a or worse — the threshold at
+     * which CKD is diagnosed when sustained ≥3 months). Paired with at
+     * least one of: creatinine above the universal upper bound (>1.3
+     * mg/dL — sex-stratified ranges are a future enhancement), or sustained
+     * resting-HR drift (cardiorenal axis — early CKD often presents with
+     * volume / autonomic shifts). Hemoglobin <12 g/dL completes the
+     * "anemia of CKD" presentation but is not required so isolated GFR
+     * decline still fires.
+     *
+     * eGFR is the single most important "preventive" lab for the >50
+     * cohort after lipids and HbA1c, but Bios had no condition pattern
+     * for it before this wave.
+     */
+    val ckdProgressionSignature = ConditionPattern(
+        id = "biomarker_ckd_progression_signature",
+        title = "Reduced eGFR with corroborating renal signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.EGFR, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "KDIGO 2024 — eGFR <60 mL/min/1.73m² sustained is the CKD diagnostic threshold (G3a or worse)",
+                required = true,
+                absoluteBelow = 60.0,
+            ),
+            SignalRule(
+                MetricType.CREATININE, DeviationDirection.ABOVE, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "Williams Hematology — creatinine >1.3 mg/dL is the conservative universal upper bound (male reference range; female reference is tighter)",
+                absoluteAbove = 1.3,
+            ),
+            SignalRule(
+                MetricType.HEMOGLOBIN, DeviationDirection.BELOW, 0.0, 0, 1.0,
+                ThresholdSource.LITERATURE,
+                "KDIGO 2024 — anemia of CKD develops as kidney function declines (reduced erythropoietin); hemoglobin <12 g/dL is the WHO anemia floor",
+                absoluteBelow = 12.0,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Drawz & Rahman 2015 — cardiorenal axis: sustained RHR drift corroborates declining kidney function via autonomic and volume changes",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent eGFR reading sits below 60 mL/min/1.73m² — the KDIGO threshold at which chronic kidney disease is diagnosed when sustained for at least 3 months — while at least one corroborating signal has appeared: elevated creatinine, low hemoglobin (anemia of CKD), or sustained resting-HR elevation. The lab anchors the pattern; the wearable signals on their own are nonspecific.",
+        suggestedAction = "Discuss the eGFR and creatinine values with a healthcare provider. KDIGO recommends repeating eGFR within 3 months to confirm sustained reduction; urine albumin-to-creatinine ratio is the standard companion test for staging. The lab and wearable trends from Bios are useful to share.",
+        references = listOf(
+            "KDIGO (2024) — Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease",
+            "Drawz PE, Rahman M (2015) — Chronic kidney disease (Ann Intern Med In the Clinic)",
+            "Inker LA et al. (2021) — New creatinine- and cystatin C-based equations to estimate GFR without race (CKD-EPI 2021)",
+        ),
+        earlyDetection = "CKD develops silently over years. eGFR is the canonical marker — by the time symptoms appear (fatigue, edema, nocturia), the owner is often at stage G3b or worse. Pairing a low eGFR with corroborating creatinine elevation or cardiorenal-axis signals (resting HR drift, anemia of CKD) raises confidence the lab finding reflects genuine kidney decline, not transient volume status or measurement artefact.",
+    )
+
+    /**
+     * NAFLD signature: elevated ALT/AST with sustained metabolic
+     * corroborators. ALT alone has the highest sensitivity for NAFLD;
+     * pairing with AST and GGT improves specificity. Required: ALT
+     * ≥50 U/L (the universal clinical-action threshold). At least one of:
+     * AST ≥50 (parallel hepatocellular injury), GGT ≥60 (cholestatic /
+     * alcohol-adjacent picture), or sustained metabolic backdrop (HbA1c
+     * elevated, sleep efficiency declining — the metabolic-syndrome
+     * milieu most NAFLD presents in).
+     *
+     * NAFLD is high-prevalence (~25 % of US adults) and silent until late
+     * stage; the lab signal is the screening path.
+     */
+    val nafldSignature = ConditionPattern(
+        id = "biomarker_nafld_signature",
+        title = "Elevated hepatic enzymes with metabolic corroboration",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.ALT, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "AASLD 2017 — ALT ≥50 U/L is the standard clinical-action threshold across most labs (true upper-limit is sex-stratified: 25 ♀ / 33 ♂; 50 captures both)",
+                required = true,
+                absoluteAbove = 50.0,
+            ),
+            SignalRule(
+                MetricType.AST, DeviationDirection.ABOVE, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "AASLD 2017 — AST ≥50 U/L corroborates hepatocellular injury; AST/ALT ratio >1 shifts the differential toward alcohol-related disease",
+                absoluteAbove = 50.0,
+            ),
+            SignalRule(
+                MetricType.GGT, DeviationDirection.ABOVE, 0.0, 0, 1.0,
+                ThresholdSource.LITERATURE,
+                "AASLD 2017 — GGT ≥60 U/L adds a cholestatic / alcohol-sensitive corroborator (rises with alcohol use, NAFLD, drug-induced cholestasis)",
+                absoluteAbove = 60.0,
+            ),
+            SignalRule(
+                MetricType.HBA1C, DeviationDirection.ABOVE, 0.0, 0, 0.8,
+                ThresholdSource.LITERATURE,
+                "Younossi et al. 2018 — NAFLD has bidirectional association with type 2 diabetes; HbA1c ≥5.7 % is the prediabetic threshold and the most common metabolic backdrop for NAFLD",
+                absoluteAbove = 5.7,
+            ),
+            SignalRule(
+                MetricType.SLEEP_EFFICIENCY, DeviationDirection.BELOW, 1.0, 168, 0.6,
+                ThresholdSource.LITERATURE,
+                "Marin-Alejandre et al. 2020 — sleep disruption is part of the metabolic-syndrome milieu most NAFLD develops in; not specific to NAFLD but corroborates the metabolic backdrop",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent ALT reading sits at or above 50 U/L — the standard clinical-action threshold — while at least one corroborating signal has appeared: AST elevation, GGT elevation, an elevated HbA1c metabolic backdrop, or declining sleep efficiency. The ALT anchors the pattern; isolated mild AST/GGT elevations have many causes.",
+        suggestedAction = "Discuss the hepatic panel with a healthcare provider. Confirming the AST/ALT ratio, repeating in 4–8 weeks, and evaluating common reversible causes (alcohol, medications, metabolic syndrome) is the standard workup. The lab values and metabolic trends from Bios are useful to share.",
+        references = listOf(
+            "Chalasani N et al. (2018) — AASLD Practice Guideline for the diagnosis and management of NAFLD",
+            "Younossi ZM et al. (2018) — Global epidemiology of NAFLD",
+            "Marin-Alejandre BA et al. (2020) — Sleep quality and NAFLD",
+        ),
+        earlyDetection = "NAFLD is the most common chronic liver condition in adults and is silent until late stage. ALT elevation is the highest-yield single screening signal; the AST/GGT/HbA1c corroborators distinguish NAFLD from acute injury, alcohol-related disease, or drug-induced patterns. Lifestyle intervention at the asymptomatic stage is the highest-leverage path.",
+    )
+
+    /**
+     * HOMA-IR ≥2.5 (Matthews 1985 — the canonical insulin-resistance index;
+     * Tam et al. 2012 — 2.5 is the conservative population threshold)
+     * paired with at least one of: elevated glucose variability (the
+     * earliest CGM-visible insulin-resistance signal), HbA1c above the
+     * prediabetic threshold, or sustained RHR elevation. HOMA-IR catches
+     * insulin resistance years before HbA1c shifts; pairing it with the
+     * wearable backdrop reduces the noise floor.
+     */
+    val insulinResistanceSignature = ConditionPattern(
+        id = "biomarker_insulin_resistance_signature",
+        title = "Elevated HOMA-IR with metabolic-load corroboration",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.HOMA_IR, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "Matthews 1985 + Tam et al. 2012 — HOMA-IR ≥2.5 is the conservative population threshold for insulin resistance (some cohorts use 2.6; 2.5 captures clinically meaningful resistance)",
+                required = true,
+                absoluteAbove = 2.5,
+            ),
+            SignalRule(
+                MetricType.GLUCOSE_CV, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Battelino et al. 2019 — elevated CGM glucose CV is an earlier marker than mean glucose in pre-diabetic transition; corroborates HOMA-IR",
+            ),
+            SignalRule(
+                MetricType.HBA1C, DeviationDirection.ABOVE, 0.0, 0, 1.0,
+                ThresholdSource.LITERATURE,
+                "ADA 2024 — HbA1c ≥5.7 % is the prediabetic threshold; pairing with HOMA-IR captures the resistance → glycemic-shift progression",
+                absoluteAbove = 5.7,
+            ),
+            SignalRule(
+                MetricType.RESTING_HEART_RATE, DeviationDirection.ABOVE, 1.0, 168, 0.6,
+                ThresholdSource.LITERATURE,
+                "Aune et al. 2017 — elevated resting HR associated with insulin resistance / metabolic syndrome",
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent HOMA-IR sits at or above 2.5 — the conservative population threshold for insulin resistance — while at least one corroborating signal has appeared: glucose-variability elevation, HbA1c at or above the prediabetic threshold, or sustained resting-HR drift. HOMA-IR catches the resistance phase years before HbA1c shifts; pairing it with the metabolic backdrop reduces the noise floor.",
+        suggestedAction = "Discuss the HOMA-IR (or its inputs — fasting glucose and fasting insulin) and the metabolic trends with a healthcare provider. Lifestyle modification at the insulin-resistance stage — before glycemic thresholds shift — is the highest-leverage path; the lab values and CGM/wearable trends from Bios are useful to share.",
+        references = listOf(
+            "Matthews DR et al. (1985) — Homeostasis model assessment: insulin resistance and beta-cell function",
+            "Tam CS et al. (2012) — Defining insulin resistance from hyperinsulinemic-euglycemic clamps",
+            "Battelino T et al. (2019) — Clinical targets for continuous glucose monitoring data interpretation",
+        ),
+        earlyDetection = "Insulin resistance is the silent first phase of the type-2-diabetes pathway. HbA1c stays normal for years while HOMA-IR climbs and post-meal glucose variability widens. The HOMA-IR + CGM combination is the highest-leverage early-detection surface for metabolic disease — months to years before the clinical thresholds shift.",
+    )
+}

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -137,6 +137,63 @@ object RegionConfigProvider {
             normalCeiling = 100.0, borderlineCeiling = 150.0,
             concerningDirection = BandDirection.BELOW,
         ),
+        // -- Renal / hepatic / insulin-resistance panel (#158) --
+        // eGFR (mL/min/1.73m²): KDIGO 2024 staging. <60 = G3a or worse
+        // (CONCERNING), 60–90 = G2 mildly decreased (BORDERLINE — common
+        // benign finding in older adults), ≥90 = G1 normal. CKD diagnosis
+        // requires <60 sustained ≥3 months *or* markers of kidney damage.
+        // (KDIGO 2024 CKD Guideline)
+        MetricType.EGFR to BiomarkerBands(
+            normalCeiling = 60.0, borderlineCeiling = 90.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // Creatinine (mg/dL): conservative single threshold using the upper
+        // bound of the female reference range (1.1) as BORDERLINE and the
+        // upper bound of the male reference range (1.3) as the CONCERNING
+        // cutoff. Sex-stratified ranges are a future enhancement; for
+        // screening, 1.3 captures both sexes without missing male anemia-
+        // adjacent renal disease. (KDIGO 2024 + Williams Hematology adult
+        // reference ranges)
+        MetricType.CREATININE to BiomarkerBands(
+            normalCeiling = 1.1, borderlineCeiling = 1.3,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // ALT (U/L): AASLD 2017 — true upper limit of normal is 25 ♀ / 33 ♂.
+        // Using the more conservative 33 as the normal ceiling so a male
+        // reading slightly above 25 doesn't false-flag. 50 is the threshold
+        // at which most clinical labs report "high" and where NAFLD / drug-
+        // induced liver injury workup is triggered.
+        MetricType.ALT to BiomarkerBands(
+            normalCeiling = 33.0, borderlineCeiling = 50.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // AST (U/L): AASLD 2017 — similar ranges to ALT. Conservative single
+        // threshold 35 normal / 50 borderline / ≥50 concerning. The AST/ALT
+        // ratio matters more than either value alone for differential
+        // (alcohol-related disease tends AST/ALT > 1), but ratio
+        // interpretation belongs in the condition pattern, not the bands.
+        MetricType.AST to BiomarkerBands(
+            normalCeiling = 35.0, borderlineCeiling = 50.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // GGT (U/L): sex-dependent reference ranges (~8–61 ♀ / 12–73 ♂);
+        // conservative universal 40 normal / 60 borderline / ≥60 concerning.
+        // GGT rises with alcohol use, NAFLD, cholestasis, and many
+        // medications — sensitive but not specific. (AASLD 2017)
+        MetricType.GGT to BiomarkerBands(
+            normalCeiling = 40.0, borderlineCeiling = 60.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // HOMA-IR (score, calculated): Matthews 1985 — <2.0 insulin-sensitive,
+        // 2.0–2.5 borderline, ≥2.5 insulin-resistant. Threshold varies by
+        // population (Tam et al. 2012 — 2.6 for some cohorts; conservative
+        // 2.5 captures clinically meaningful resistance). Lab value the
+        // owner enters directly OR computes from FASTING_INSULIN ×
+        // FASTING_GLUCOSE / 405.
+        MetricType.HOMA_IR to BiomarkerBands(
+            normalCeiling = 2.0, borderlineCeiling = 2.5,
+            concerningDirection = BandDirection.ABOVE,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -367,6 +367,14 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.VITAMIN_B12 -> "2132-9" to "Cobalamins [Mass/volume] in Serum or Plasma"
     MetricType.FOLATE -> "2284-8" to "Folate [Mass/volume] in Serum or Plasma"
     MetricType.MAGNESIUM -> "2601-3" to "Magnesium [Mass/volume] in Serum or Plasma"
+    // #158 — renal / hepatic. eGFR pairs with creatinine (creatinine is the
+    // raw input; eGFR is the body-surface-normalised derived value most labs
+    // report alongside it). ALT / AST / GGT are the core hepatic panel.
+    MetricType.EGFR -> "62238-1" to "Glomerular filtration rate/1.73 sq M.predicted by Creatinine-based formula (CKD-EPI 2021)"
+    MetricType.CREATININE -> "2160-0" to "Creatinine [Mass/volume] in Serum or Plasma"
+    MetricType.ALT -> "1742-6" to "Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
+    MetricType.AST -> "1920-8" to "Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
+    MetricType.GGT -> "2324-2" to "Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma"
     else -> null
 }
 
@@ -406,6 +414,8 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.LITERS_PER_MIN -> "L/min"
     MetricUnit.MILLIGRAMS -> "mg"
     MetricUnit.GRAMS -> "g"
+    MetricUnit.U_PER_L -> "U/L"
+    MetricUnit.ML_PER_MIN_PER_173 -> "mL/min/{1.73_m2}"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
@@ -89,6 +89,25 @@ object BiomarkerPanels {
         ),
     )
 
+    val renal = BiomarkerPanel(
+        id = "renal",
+        title = "Renal",
+        metrics = listOf(
+            MetricType.EGFR,
+            MetricType.CREATININE,
+        ),
+    )
+
+    val hepatic = BiomarkerPanel(
+        id = "hepatic",
+        title = "Hepatic",
+        metrics = listOf(
+            MetricType.ALT,
+            MetricType.AST,
+            MetricType.GGT,
+        ),
+    )
+
     val endocrine = BiomarkerPanel(
         id = "endocrine",
         title = "Endocrine",
@@ -120,6 +139,8 @@ object BiomarkerPanels {
         thyroid,
         vitamins,
         hematology,
+        renal,
+        hepatic,
         endocrine,
         epigenetic,
     )

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -44,6 +44,9 @@ class BiomarkerEntrySelectorsTest {
             MetricType.TESTOSTERONE_TOTAL, MetricType.ESTRADIOL,
             MetricType.CORTISOL, MetricType.IGF_1,
             MetricType.VITAMIN_B12, MetricType.FOLATE, MetricType.MAGNESIUM,
+            // Renal / hepatic (#158).
+            MetricType.EGFR, MetricType.CREATININE,
+            MetricType.ALT, MetricType.AST, MetricType.GGT,
             // Epigenetic age clocks (slow-rolling, lab-imported).
             MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
             MetricType.EPIGENETIC_AGE_GRIM,

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -356,6 +356,8 @@ class FhirExporterTest {
             MetricUnit.LITERS_PER_MIN -> "L/min"
             MetricUnit.MILLIGRAMS -> "mg"
             MetricUnit.GRAMS -> "g"
+            MetricUnit.U_PER_L -> "U/L"
+            MetricUnit.ML_PER_MIN_PER_173 -> "mL/min/{1.73_m2}"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/Wave5BiomarkerPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/Wave5BiomarkerPatternsTest.kt
@@ -1,0 +1,155 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.alerts.ThresholdSource
+import com.bios.app.alerts.Wave5BiomarkerPatterns
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the wave-5 biomarker patterns (renal / hepatic / insulin-
+ * resistance) shipped in #158. Same shape contract as the wave 1-4
+ * patterns in [com.bios.app.alerts.BiomarkerConditionPatterns]: lab
+ * anchors via `required = true` + absolute threshold; wearable /
+ * metabolic corroborators stay baseline-relative or absolute on their
+ * own clinical cutoffs. Audit gap §2.8.
+ */
+class Wave5BiomarkerPatternsTest {
+
+    // -- registration --
+
+    @Test
+    fun wave5_patterns_are_registered_in_global_all_list() {
+        assertTrue(Wave5BiomarkerPatterns.ckdProgressionSignature in ConditionPatterns.all)
+        assertTrue(Wave5BiomarkerPatterns.nafldSignature in ConditionPatterns.all)
+        assertTrue(Wave5BiomarkerPatterns.insulinResistanceSignature in ConditionPatterns.all)
+    }
+
+    @Test
+    fun every_wave5_pattern_carries_a_literature_citation_per_rule() {
+        for (pattern in Wave5BiomarkerPatterns.all) {
+            for (rule in pattern.signalRules) {
+                assertEquals(
+                    "${pattern.id}/${rule.metricType.key} should be LITERATURE-sourced",
+                    ThresholdSource.LITERATURE,
+                    rule.source
+                )
+                assertTrue(
+                    "${pattern.id}/${rule.metricType.key} should ship a citation string",
+                    rule.citation.isNotBlank()
+                )
+            }
+        }
+    }
+
+    // -- ckd_progression_signature --
+
+    @Test
+    fun ckd_signature_gates_on_eGFR_below_60() {
+        val rule = Wave5BiomarkerPatterns.ckdProgressionSignature.signalRules
+            .first { it.metricType == MetricType.EGFR }
+        assertTrue("eGFR rule should anchor the pattern", rule.required)
+        assertTrue(rule.isAbsolute)
+        assertEquals(60.0, rule.absoluteBelow!!, 1e-9)
+        assertNull(rule.absoluteAbove)
+    }
+
+    @Test
+    fun ckd_signature_carries_creatinine_hemoglobin_RHR_corroborators() {
+        val pattern = Wave5BiomarkerPatterns.ckdProgressionSignature
+        val corroborators = pattern.signalRules.filter { !it.required }.map { it.metricType }.toSet()
+        assertTrue(MetricType.CREATININE in corroborators)
+        assertTrue(MetricType.HEMOGLOBIN in corroborators)
+        assertTrue(MetricType.RESTING_HEART_RATE in corroborators)
+    }
+
+    @Test
+    fun ckd_signature_requires_at_least_one_corroborator() {
+        // eGFR alone (1 signal) won't fire; minActiveSignals=2 forces
+        // creatinine, anemia-of-CKD, or RHR drift to corroborate.
+        assertEquals(2, Wave5BiomarkerPatterns.ckdProgressionSignature.minActiveSignals)
+    }
+
+    // -- nafld_signature --
+
+    @Test
+    fun nafld_signature_gates_on_ALT_at_or_above_50_U_per_L() {
+        val rule = Wave5BiomarkerPatterns.nafldSignature.signalRules
+            .first { it.metricType == MetricType.ALT }
+        assertTrue("ALT rule should anchor the pattern", rule.required)
+        assertTrue(rule.isAbsolute)
+        assertEquals(50.0, rule.absoluteAbove!!, 1e-9)
+    }
+
+    @Test
+    fun nafld_signature_carries_AST_GGT_HbA1c_sleep_corroborators() {
+        val pattern = Wave5BiomarkerPatterns.nafldSignature
+        val corroborators = pattern.signalRules.filter { !it.required }.map { it.metricType }.toSet()
+        assertTrue(MetricType.AST in corroborators)
+        assertTrue(MetricType.GGT in corroborators)
+        assertTrue(MetricType.HBA1C in corroborators)
+        assertTrue(MetricType.SLEEP_EFFICIENCY in corroborators)
+    }
+
+    @Test
+    fun nafld_GGT_corroborator_uses_60_U_per_L_cutoff() {
+        val ggt = Wave5BiomarkerPatterns.nafldSignature.signalRules
+            .first { it.metricType == MetricType.GGT }
+        assertFalse("GGT is corroborating, not gating", ggt.required)
+        assertTrue(ggt.isAbsolute)
+        assertEquals(60.0, ggt.absoluteAbove!!, 1e-9)
+    }
+
+    // -- insulin_resistance_signature --
+
+    @Test
+    fun insulin_resistance_signature_gates_on_HOMA_IR_at_or_above_2_point_5() {
+        val rule = Wave5BiomarkerPatterns.insulinResistanceSignature.signalRules
+            .first { it.metricType == MetricType.HOMA_IR }
+        assertTrue("HOMA-IR rule should anchor the pattern", rule.required)
+        assertTrue(rule.isAbsolute)
+        assertEquals(2.5, rule.absoluteAbove!!, 1e-9)
+    }
+
+    @Test
+    fun insulin_resistance_signature_carries_glucose_CV_HbA1c_RHR_corroborators() {
+        val pattern = Wave5BiomarkerPatterns.insulinResistanceSignature
+        val corroborators = pattern.signalRules.filter { !it.required }.map { it.metricType }.toSet()
+        assertTrue(MetricType.GLUCOSE_CV in corroborators)
+        assertTrue(MetricType.HBA1C in corroborators)
+        assertTrue(MetricType.RESTING_HEART_RATE in corroborators)
+    }
+
+    @Test
+    fun insulin_resistance_glucose_CV_corroborator_is_baseline_relative() {
+        // Glucose CV is sensor-derived from CGM data, so use the standard
+        // z-score machinery — not an absolute cutoff.
+        val cv = Wave5BiomarkerPatterns.insulinResistanceSignature.signalRules
+            .first { it.metricType == MetricType.GLUCOSE_CV }
+        assertFalse(cv.isAbsolute)
+        assertEquals(DeviationDirection.ABOVE, cv.direction)
+        assertEquals(168, cv.minDurationHours)
+    }
+
+    @Test
+    fun insulin_resistance_requires_at_least_one_corroborator() {
+        assertEquals(2, Wave5BiomarkerPatterns.insulinResistanceSignature.minActiveSignals)
+    }
+
+    // -- LOINC + units --
+
+    @Test
+    fun wave5_metric_types_carry_their_clinically_conventional_units() {
+        assertEquals(com.bios.contracts.MetricUnit.ML_PER_MIN_PER_173, MetricType.EGFR.unit)
+        assertEquals(com.bios.contracts.MetricUnit.MG_PER_DL, MetricType.CREATININE.unit)
+        assertEquals(com.bios.contracts.MetricUnit.U_PER_L, MetricType.ALT.unit)
+        assertEquals(com.bios.contracts.MetricUnit.U_PER_L, MetricType.AST.unit)
+        assertEquals(com.bios.contracts.MetricUnit.U_PER_L, MetricType.GGT.unit)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -177,6 +177,19 @@ enum class MetricType(
     FOLATE("folate", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
     MAGNESIUM("magnesium", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
+    // Renal / hepatic / insulin-resistance panel (#158, audit gap §2.8). The
+    // highest-yield silent-disease detectors not yet covered: CKD develops
+    // years before symptoms (eGFR is the single most important "preventive"
+    // lab for the >50 cohort); NAFLD is high-prevalence and asymptomatic
+    // until late stage; HOMA-IR catches insulin resistance before HbA1c
+    // shifts. FASTING_INSULIN (#159) + HOMA_IR (#160) above complete the
+    // insulin-resistance pathway.
+    EGFR("egfr", MetricUnit.ML_PER_MIN_PER_173, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    CREATININE("creatinine", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ALT("alt", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    AST("ast", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    GGT("ggt", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
     // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
     // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
     // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age
@@ -275,7 +288,11 @@ enum class MetricUnit(val symbol: String) {
     PPB("ppb"),
     LITERS_PER_MIN("L/min"),
     MILLIGRAMS("mg"),
-    GRAMS("g")
+    GRAMS("g"),
+    /** Enzyme activity per litre — ALT, AST, GGT, etc. */
+    U_PER_L("U/L"),
+    /** eGFR normalized to body surface area — KDIGO 2024 standard. */
+    ML_PER_MIN_PER_173("mL/min/1.73m²")
 }
 
 enum class MetricDomain {


### PR DESCRIPTION
## Summary

Closes #158. Branches off \`main\` (no dependency on the Tier A stack).

Wave 5 of the BIOMARKER domain — the highest-yield silent-disease detectors not yet covered by Phase 8.6. **CKD develops silently for years**, **NAFLD is high-prevalence (~25 % of US adults) and asymptomatic until late stage**, and **insulin resistance precedes HbA1c shifts by years**. Each fills a hole in the preventive-medicine surface area.

### New MetricType keys (5)

| Key | LOINC | Unit | Source |
|---|---|---|---|
| \`EGFR\` | 62238-1 | mL/min/1.73m² | KDIGO 2024 CKD-EPI |
| \`CREATININE\` | 2160-0 | mg/dL | standard renal panel |
| \`ALT\` | 1742-6 | U/L | AASLD 2017 hepatic |
| \`AST\` | 1920-8 | U/L | AASLD 2017 hepatic |
| \`GGT\` | 2324-2 | U/L | AASLD 2017 hepatic |

Two new \`MetricUnit\` symbols: \`U_PER_L\` (enzymes) and \`ML_PER_MIN_PER_173\` (eGFR). UCUM mappings added in \`FhirExporter\` so the FHIR round-trip stays clean.

### Region-config biomarker bands

Universal bands (clinically identical across all 6 supported regions) for the 5 new keys + \`HOMA_IR\` (which already existed but had no bands). Threshold sourcing all literature-anchored.

### Two new dashboard panels

\`BiomarkerPanels\` gains \`renal\` (EGFR, CREATININE) and \`hepatic\` (ALT, AST, GGT) panels, ordered after Hematology to match the typical lab-report layout.

### Three new ConditionPatterns

In a new \`alerts/Wave5BiomarkerPatterns.kt\` file (kept the existing \`BiomarkerConditionPatterns.kt\` under the 500-line cap):

- **\`ckd_progression_signature\`** — eGFR <60 (KDIGO G3a) + at least one of: creatinine >1.3, hemoglobin <12 (anemia of CKD), sustained RHR drift
- **\`nafld_signature\`** — ALT ≥50 (universal clinical-action threshold) + at least one of: AST ≥50, GGT ≥60, HbA1c ≥5.7, sleep efficiency drift
- **\`insulin_resistance_signature\`** — HOMA-IR ≥2.5 (Tam et al. 2012 conservative threshold) + at least one of: glucose CV elevation, HbA1c ≥5.7, sustained RHR drift

Each follows the established §8.6 shape: lab anchor via \`required = true\` + absolute threshold; corroborators stay baseline-relative or use their own clinical cutoffs.

### Test plan

- [x] \`./gradlew :app:testLetheDebugUnitTest\` — all green
- [x] \`Wave5BiomarkerPatternsTest\` (13) — registration, gate thresholds, corroborator wiring, \`minActiveSignals\`, unit-type contracts, citation hygiene
- [x] \`BiomarkerConditionPatternsTest\` (30) — existing wave 1-4 still green
- [x] \`BiomarkerEntrySelectorsTest\` updated to expect the new keys (the entry screen and dashboard auto-include any \`BIOMARKER\`-domain key)
- [x] \`BiomarkerDashboardAggregatorTest\` (which enforces \"every BIOMARKER MetricType rendered exactly once across panels\") still green with the new \`renal\` + \`hepatic\` panels
- [x] \`FhirExporterTest\` UCUM mirror updated for the two new units
- [x] \`AlertContentPolicyTest\` auto-validates the new patterns
- [x] \`./scripts/code-quality-check.sh\` — file length, secret scan, lint, build, test (debug + release)
- [ ] Manual: import a FHIR lab bundle containing eGFR/ALT and confirm round-trip + dashboard render (deferred to QA on device)

### Audit ref

[docs/audits/MEDICAL_PROFESSIONAL_POV.md §2.8](docs/audits/MEDICAL_PROFESSIONAL_POV.md) (lives in #162's commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)