### PR TITLE
feat(alerts): COPD / asthma exacerbation patterns (#161)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -115,7 +115,7 @@ object ConditionPatterns {
         ) + CircadianConditionPattern.all +
             CompanionConditionPatterns.all + BiomarkerConditionPatterns.all +
             EmergencyVitalPatterns.all + HypertensionPatterns.all +
-            SleepApneaPattern.all
+            SleepApneaPattern.all + RespiratoryExacerbationPatterns.all
     }
 
     /** Infection / illness onset: the Phase 1 primary detection target. */

--- a/android/app/src/main/java/com/bios/app/alerts/RespiratoryExacerbationPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/RespiratoryExacerbationPatterns.kt
@@ -1,0 +1,141 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Chronic-respiratory exacerbation patterns (#161, audit gap §2.8). COPD
+ * and asthma both present with multi-day wearable-detectable patterns —
+ * SpO2 drift downward, respiratory-rate elevation, sleep-fragmentation
+ * rise from nocturnal symptoms, activity-tolerance reduction — that are
+ * complementary to (but distinct from) the existing
+ * [ConditionPatterns.respiratoryInfection] pattern. Both patterns gate
+ * on multi-signal convergence so a one-off SpO2 dip on a hike doesn't
+ * fire them; both surface as screening signals, same shape as
+ * [ConditionPatterns.atrialFibrillationScreen].
+ *
+ * **Owner-set chronic-respiratory flag** (#159 PhysiologyState — defer):
+ * the audit issue specifies that these patterns should only fire when
+ * the owner has set `COPD_DIAGNOSED` / `ASTHMA_DIAGNOSED`. Without that
+ * gating, the patterns fire as general screening signals — a non-COPD
+ * owner with multi-day SpO2 drift + RR up + activity drop is still in
+ * the right population for clinical evaluation. The PhysiologyState
+ * gating layers on once #159 ships.
+ *
+ * Cough_count (planned microphone-adapter signal) is deferred — the
+ * adapter doesn't exist yet, so adding it as a SignalRule would create
+ * dead weight. Pattern can be extended when the mic surface lands.
+ *
+ * `smoking_cessation_respiratory_recovery` (positive-direction pattern
+ * gated on `TOBACCO_USE` ABSENT for 30+ days + positive trends) is a
+ * separate follow-up — builds on the existing `cessation_recovery_pattern`
+ * from §7.7 and needs careful tuning to stay on the manifesto side of
+ * "information, not praise."
+ *
+ * All text obeys [AlertContentPolicy].
+ */
+object RespiratoryExacerbationPatterns {
+
+    val all by lazy {
+        listOf(
+            copdExacerbationSignature,
+            asthmaExacerbationSignature,
+        )
+    }
+
+    /**
+     * COPD exacerbation: multi-day SpO2 baseline-relative drift down
+     * + respiratory-rate baseline-relative rise + activity-minutes
+     * baseline-relative drop, over a 7-day window. The personal-baseline
+     * machinery handles the well-known issue that COPD owners have a
+     * lower SpO2 baseline than non-COPD owners (a 92 % baseline drifting
+     * to 88 % is the exacerbation signal, not the absolute 88).
+     *
+     * Differentiated from [ConditionPatterns.respiratoryInfection] by:
+     * the *absence* of an acute-infection SpO2 cutoff (this pattern is
+     * trend-based, not threshold-based), longer window (168h vs 12-24h),
+     * and the activity-tolerance signal (canonical COPD symptom).
+     */
+    val copdExacerbationSignature = ConditionPattern(
+        id = "copd_exacerbation",
+        title = "Sustained respiratory pattern shift detected",
+        category = ConditionCategory.RESPIRATORY,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.BLOOD_OXYGEN, DeviationDirection.BELOW, 1.0, 168, 1.2,
+                ThresholdSource.LITERATURE,
+                "GOLD 2024 — sustained SpO2 drift below personal baseline is the canonical wearable signature of COPD exacerbation; personal-baseline framing handles the lower-baseline-than-population characteristic of COPD owners",
+            ),
+            SignalRule(
+                MetricType.RESPIRATORY_RATE, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Cretikos et al. 2008 — respiratory rate is the most sensitive vital sign for respiratory compromise; sustained elevation over multi-day window distinguishes exacerbation from transient elevation",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "Garcia-Aymerich et al. 2006 — declining activity tolerance is one of the dominant COPD exacerbation symptoms and corroborates the respiratory signals",
+            ),
+            SignalRule(
+                MetricType.SLEEP_FRAGMENTATION_INDEX, DeviationDirection.ABOVE, 1.0, 168, 0.6,
+                ThresholdSource.LITERATURE,
+                "Krachman et al. 2014 — nocturnal COPD symptoms (dyspnoea, cough) elevate sleep fragmentation even when total sleep time appears normal",
+            ),
+        ),
+        minActiveSignals = 3,
+        explanation = "Several respiratory signals are drifting from your personal baseline over the past week: blood oxygen below baseline, respiratory rate above baseline, and activity below baseline. This combination is consistent with a chronic-respiratory exacerbation pattern in clinical literature. The personal-baseline framing handles the fact that COPD owners often have lower SpO2 baselines than the general population — the *drift*, not the absolute value, is the signal.",
+        suggestedAction = "Discuss with a healthcare provider. If you have a rescue-inhaler or supplemental-oxygen prescription and the pattern matches your usual exacerbation prodrome, the standard clinical guidance is to follow that plan. If accompanied by chest pain, severe shortness of breath, confusion, or bluish lips, seek immediate medical attention.",
+        references = listOf(
+            "Global Initiative for Chronic Obstructive Lung Disease (2024) — GOLD Report",
+            "Cretikos MA et al. (2008) — Respiratory rate: the neglected vital sign",
+            "Garcia-Aymerich J et al. (2006) — Risk factors of readmission to hospital for a COPD exacerbation",
+            "Krachman SL et al. (2014) — Sleep and COPD",
+        ),
+        earlyDetection = "COPD exacerbations have a prodromal phase of 1–2 weeks during which baseline-relative drift across multiple respiratory signals is detectable before the owner subjectively recognises the exacerbation. SpO2 dropping 2–4 points below personal baseline, respiratory rate creeping up, activity dropping — none alone is alarming, the convergence is. Bios uses a 7-day window and requires 3 of 4 signals to flag the pattern, reducing false positives from short-term illness or environmental factors.",
+    )
+
+    /**
+     * Asthma exacerbation: multi-day respiratory-rate elevation + sleep
+     * fragmentation + activity-tolerance drop. SpO2 desaturation is a
+     * late sign in asthma (often normal until acutely severe), so this
+     * pattern emphasises the symptom-cluster signals (nocturnal symptoms
+     * via sleep fragmentation, declining exercise tolerance, sustained
+     * tachypnea) over absolute oxygenation.
+     */
+    val asthmaExacerbationSignature = ConditionPattern(
+        id = "asthma_exacerbation",
+        title = "Sustained airway pattern shift detected",
+        category = ConditionCategory.RESPIRATORY,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.RESPIRATORY_RATE, DeviationDirection.ABOVE, 1.0, 168, 1.2,
+                ThresholdSource.LITERATURE,
+                "GINA 2024 — sustained respiratory-rate elevation is a canonical exacerbation marker even in well-controlled asthma; precedes the acute attack",
+            ),
+            SignalRule(
+                MetricType.SLEEP_FRAGMENTATION_INDEX, DeviationDirection.ABOVE, 1.0, 168, 1.0,
+                ThresholdSource.LITERATURE,
+                "Reddel et al. 2009 — nocturnal asthma symptoms (wheezing, cough, dyspnoea) are a hallmark of poor control and rising exacerbation risk; sleep fragmentation captures the wearable-detectable version",
+            ),
+            SignalRule(
+                MetricType.ACTIVE_MINUTES, DeviationDirection.BELOW, 1.0, 168, 0.8,
+                ThresholdSource.LITERATURE,
+                "GINA 2024 — declining exercise tolerance is part of the exacerbation prodrome; the symptom commonly precedes the acute attack by 1–3 days",
+            ),
+            SignalRule(
+                MetricType.BLOOD_OXYGEN, DeviationDirection.BELOW, 1.0, 168, 0.6,
+                ThresholdSource.LITERATURE,
+                "GINA 2024 — SpO2 desaturation is a late sign in asthma but corroborating when present; weighted lower than the symptom-cluster signals",
+            ),
+        ),
+        minActiveSignals = 3,
+        explanation = "Several airway signals are drifting from your personal baseline over the past week: respiratory rate above baseline, sleep fragmentation above baseline, and activity below baseline. The combination is consistent with the prodromal phase of an asthma exacerbation in clinical literature. SpO2 desaturation is intentionally not required — it's a late sign in asthma and waiting for it would miss the early window.",
+        suggestedAction = "Discuss with a healthcare provider. If you have a controller-medication or rescue-inhaler plan and the pattern matches your usual exacerbation prodrome, the standard clinical guidance is to follow that plan. Acute severe symptoms (audible wheezing, difficulty speaking in full sentences, chest tightness, severe dyspnea) warrant immediate medical attention.",
+        references = listOf(
+            "Global Initiative for Asthma (2024) — GINA Strategy",
+            "Reddel HK et al. (2009) — An official American Thoracic Society / European Respiratory Society statement on asthma control",
+            "Cretikos MA et al. (2008) — Respiratory rate: the neglected vital sign",
+        ),
+        earlyDetection = "Asthma exacerbations have a prodromal phase characterised by symptom-cluster drift before the acute attack: nocturnal symptoms rise (sleep fragmentation up), respiratory rate creeps up, and activity tolerance drops. SpO2 stays normal until late. Bios uses a 7-day window and requires 3 of 4 signals to flag — catching the prodrome window where the owner can act on their asthma plan early, before the acute event.",
+    )
+}

--- a/android/app/src/test/java/com/bios/app/RespiratoryExacerbationPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/RespiratoryExacerbationPatternsTest.kt
@@ -1,0 +1,129 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.alerts.RespiratoryExacerbationPatterns
+import com.bios.app.alerts.ThresholdSource
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the COPD / asthma exacerbation patterns (#161, audit gap §2.8).
+ * Both patterns gate on multi-signal convergence of baseline-relative
+ * respiratory signals — distinct from the existing
+ * [com.bios.app.alerts.ConditionPatterns.respiratoryInfection] pattern
+ * which uses acute thresholds and temperature.
+ */
+class RespiratoryExacerbationPatternsTest {
+
+    @Test
+    fun both_patterns_register_in_global_all_list() {
+        assertTrue(RespiratoryExacerbationPatterns.copdExacerbationSignature in ConditionPatterns.all)
+        assertTrue(RespiratoryExacerbationPatterns.asthmaExacerbationSignature in ConditionPatterns.all)
+    }
+
+    @Test
+    fun every_rule_carries_a_literature_citation() {
+        for (pattern in RespiratoryExacerbationPatterns.all) {
+            for (rule in pattern.signalRules) {
+                assertEquals(
+                    "${pattern.id}/${rule.metricType.key} should be LITERATURE-sourced",
+                    ThresholdSource.LITERATURE,
+                    rule.source
+                )
+                assertTrue(rule.citation.isNotBlank())
+            }
+        }
+    }
+
+    // -- copd_exacerbation --
+
+    @Test
+    fun copd_signature_uses_baseline_relative_SpO2_below_not_absolute_cutoff() {
+        // Key clinical point: COPD owners have lower SpO2 baselines than
+        // non-COPD owners. The pattern fires on baseline-relative drift,
+        // not absolute SpO2 cutoffs — that's the differentiator from the
+        // emergency-vital absolute-cutoff path.
+        val spo2 = RespiratoryExacerbationPatterns.copdExacerbationSignature.signalRules
+            .first { it.metricType == MetricType.BLOOD_OXYGEN }
+        assertFalse(
+            "SpO2 rule must be baseline-relative, not absolute — COPD owners have lower baselines",
+            spo2.isAbsolute
+        )
+        assertEquals(DeviationDirection.BELOW, spo2.direction)
+        assertEquals(168, spo2.minDurationHours)
+    }
+
+    @Test
+    fun copd_signature_carries_RR_activity_fragmentation_corroborators() {
+        val pattern = RespiratoryExacerbationPatterns.copdExacerbationSignature
+        val metrics = pattern.signalRules.map { it.metricType }.toSet()
+        assertTrue(MetricType.BLOOD_OXYGEN in metrics)
+        assertTrue(MetricType.RESPIRATORY_RATE in metrics)
+        assertTrue(MetricType.ACTIVE_MINUTES in metrics)
+        assertTrue(MetricType.SLEEP_FRAGMENTATION_INDEX in metrics)
+    }
+
+    @Test
+    fun copd_signature_requires_at_least_three_signals_to_fire() {
+        // 4-signal pattern with 3-of-4 requirement — single-signal noise
+        // doesn't fire (a 1-day flu, a strenuous-hike SpO2 drop).
+        assertEquals(3, RespiratoryExacerbationPatterns.copdExacerbationSignature.minActiveSignals)
+    }
+
+    @Test
+    fun copd_signature_does_not_declare_a_severity_floor() {
+        // Trend / screening pattern, not an emergency — uses the
+        // classifier output. The emergency SpO2 path lives in
+        // EmergencyVitalPatterns.spo2Critical with absolute cutoff.
+        assertNull(RespiratoryExacerbationPatterns.copdExacerbationSignature.severityFloor)
+    }
+
+    // -- asthma_exacerbation --
+
+    @Test
+    fun asthma_signature_weights_RR_and_fragmentation_higher_than_SpO2() {
+        // SpO2 is a LATE sign in asthma — symptom cluster (nocturnal
+        // symptoms via fragmentation, RR up) leads. The pattern weights
+        // the symptom-cluster signals higher than SpO2.
+        val pattern = RespiratoryExacerbationPatterns.asthmaExacerbationSignature
+        val rr = pattern.signalRules.first { it.metricType == MetricType.RESPIRATORY_RATE }
+        val fragmentation = pattern.signalRules.first { it.metricType == MetricType.SLEEP_FRAGMENTATION_INDEX }
+        val spo2 = pattern.signalRules.first { it.metricType == MetricType.BLOOD_OXYGEN }
+        assertTrue(
+            "RR (${rr.weight}) should be weighted ≥ SpO2 (${spo2.weight}) — SpO2 is a late sign in asthma",
+            rr.weight >= spo2.weight,
+        )
+        assertTrue(
+            "Fragmentation (${fragmentation.weight}) should be weighted ≥ SpO2 (${spo2.weight})",
+            fragmentation.weight >= spo2.weight,
+        )
+    }
+
+    @Test
+    fun asthma_signature_requires_at_least_three_signals_to_fire() {
+        assertEquals(3, RespiratoryExacerbationPatterns.asthmaExacerbationSignature.minActiveSignals)
+    }
+
+    @Test
+    fun every_rule_is_baseline_relative_over_a_seven_day_window() {
+        // Both patterns are trend-based; nothing should be a single-
+        // reading absolute cutoff (those live in EmergencyVitalPatterns).
+        for (pattern in RespiratoryExacerbationPatterns.all) {
+            for (rule in pattern.signalRules) {
+                assertFalse(
+                    "${pattern.id}/${rule.metricType.key} should be baseline-relative",
+                    rule.isAbsolute
+                )
+                assertEquals(
+                    "${pattern.id}/${rule.metricType.key} should use 7-day window",
+                    168, rule.minDurationHours
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #161. Two trend-based screening patterns for COPD and asthma — both build on existing signal-correlation machinery, no new MetricType keys, no DB change.

### What ships

In a new `alerts/RespiratoryExacerbationPatterns.kt`:

- **`copd_exacerbation_signature`** — baseline-relative SpO2 drift down + RR elevation + activity drop + sleep fragmentation, 7d window, 3-of-4 required. Personal-baseline framing handles the well-known lower-SpO2-than-population characteristic of COPD owners (a 92 % baseline drifting to 88 % is the signal, not the absolute 88).
- **`asthma_exacerbation_signature`** — RR elevation + sleep fragmentation + activity drop + (corroborating) SpO2 drift, 7d window, 3-of-4 required. Symptom-cluster signals weighted higher than SpO2 because desaturation is a *late* sign in asthma — waiting for it would miss the prodrome window.

Both: trend-based, no `severityFloor` (screening shape). Citations per rule (GOLD 2024, GINA 2024, Cretikos 2008, Reddel 2009, Krachman 2014).

### Scope discipline (per audit issue)

- **`cough_count` microphone signal** — deferred; mic adapter doesn't exist yet. Patterns are forward-compatible
- **`smoking_cessation_respiratory_recovery`** — separate follow-up; needs careful manifesto-aligned tuning (Smokeless §7.7 template)
- **`COPD_DIAGNOSED` / `ASTHMA_DIAGNOSED` PhysiologyState gating** — depends on #159; without it patterns fire as general screening signals (manifesto-defensible: multi-signal convergence + non-COPD owner is still in the right population for clinical evaluation)
- Peak-flow / inhaler / CPAP — out of scope per audit body

### Test plan

- [x] `RespiratoryExacerbationPatternsTest` (9): registration, baseline-relative-vs-absolute contract, signal coverage, `minActiveSignals`, asthma-specific symptom-weighting-above-SpO2 invariant
- [x] `AlertContentPolicyTest` auto-validates the new patterns
- [x] `./scripts/code-quality-check.sh` — all green

### Audit ref

[docs/audits/MEDICAL_PROFESSIONAL_POV.md §2.8](docs/audits/MEDICAL_PROFESSIONAL_POV.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)