### PR TITLE
feat(data): risk-profile entry surface — family/personal history (#160)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -29,9 +29,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         PhoneSleepSample::class,
         MedicationAnnotation::class,
         ImmunizationRecord::class,
-        ScreeningEntry::class
+        ScreeningEntry::class,
+        RiskProfile::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = false
 )
 abstract class BiosDatabase : RoomDatabase() {
@@ -52,6 +53,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun medicationAnnotationDao(): MedicationAnnotationDao
     abstract fun immunizationRecordDao(): ImmunizationRecordDao
     abstract fun screeningEntryDao(): ScreeningEntryDao
+    abstract fun riskProfileDao(): RiskProfileDao
 
     companion object {
         @Volatile
@@ -74,7 +76,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged
@@ -359,6 +361,33 @@ abstract class BiosDatabase : RoomDatabase() {
                 """.trimIndent())
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_screening_entries_screeningKey ON screening_entries (screeningKey)")
                 db.execSQL("CREATE INDEX IF NOT EXISTS index_screening_entries_performedDate ON screening_entries (performedDate)")
+            }
+        }
+
+        // Owner-recorded risk profile (#160). Single-row table — the
+        // screening-cadence engine and pattern-explanation builder read
+        // this surface to compute risk-adjusted cadences and contextualise
+        // alerts. Pull-side only; never pushed.
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS risk_profile (
+                        id INTEGER NOT NULL PRIMARY KEY,
+                        firstDegreeCadEarly INTEGER NOT NULL,
+                        firstDegreeBreastOvarianCancer INTEGER NOT NULL,
+                        firstDegreeColorectalCancer INTEGER NOT NULL,
+                        firstDegreeDiabetes INTEGER NOT NULL,
+                        firstDegreeOsteoporosisHipFracture INTEGER NOT NULL,
+                        firstDegreeMelanoma INTEGER NOT NULL,
+                        personalTobaccoYears INTEGER,
+                        personalTobaccoPackYears INTEGER,
+                        personalTobaccoQuitDate INTEGER,
+                        personalCancerHistory TEXT,
+                        personalCardiacEventHistory TEXT,
+                        note TEXT,
+                        updatedAt INTEGER NOT NULL
+                    )
+                """.trimIndent())
             }
         }
 

--- a/android/app/src/main/java/com/bios/app/data/RiskProfileRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/RiskProfileRepo.kt
@@ -1,0 +1,27 @@
+package com.bios.app.data
+
+import com.bios.app.model.RiskProfile
+
+/**
+ * Repository for the owner's single-row risk profile (#160).
+ *
+ * The screening-cadence engine (#155) reads this to compute risk-
+ * adjusted cadences (e.g. colorectal screening from age 40 instead of
+ * 45 with first-degree family history). The pattern-explanation builder
+ * reads this to add context to alert text. Both integrations are
+ * follow-up PRs; this PR ships the data + UI surface.
+ */
+class RiskProfileRepo(private val db: BiosDatabase) {
+
+    private val dao get() = db.riskProfileDao()
+
+    suspend fun save(profile: RiskProfile) {
+        dao.save(profile.copy(id = RiskProfile.SINGLETON_ID, updatedAt = System.currentTimeMillis()))
+    }
+
+    suspend fun fetch(): RiskProfile? = dao.fetch()
+
+    suspend fun fetchOrEmpty(): RiskProfile = dao.fetch() ?: RiskProfile()
+
+    suspend fun clear() = dao.clear()
+}

--- a/android/app/src/main/java/com/bios/app/data/dao/RiskProfileDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/RiskProfileDao.kt
@@ -1,0 +1,24 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.bios.app.model.RiskProfile
+
+/**
+ * Persistence layer for the owner's risk profile (#160). Single-row
+ * table; the upsert via [save] always targets `id = SINGLETON_ID`.
+ */
+@Dao
+interface RiskProfileDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun save(profile: RiskProfile)
+
+    @Query("SELECT * FROM risk_profile WHERE id = :id")
+    suspend fun fetch(id: Long = RiskProfile.SINGLETON_ID): RiskProfile?
+
+    @Query("DELETE FROM risk_profile WHERE id = :id")
+    suspend fun clear(id: Long = RiskProfile.SINGLETON_ID)
+}

--- a/android/app/src/main/java/com/bios/app/model/RiskProfile.kt
+++ b/android/app/src/main/java/com/bios/app/model/RiskProfile.kt
@@ -1,0 +1,62 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Owner-recorded personal and family-history risk factors (#160, audit
+ * gap §2.6). Calibrated primary-care risk scores (ASCVD-pooled-cohort,
+ * FRAX, Gail, QRISK3) all take first-degree-relative history as input;
+ * Bios had nowhere to store it before this entity.
+ *
+ * **Single-row design.** Always `id = SINGLETON_ID`; the repo upserts.
+ * This is one owner's profile, not a history table — every save replaces
+ * the previous row. Owner-edits track `updatedAt` for surface-side
+ * "last updated N days ago" rendering.
+ *
+ * **Booleans only for the well-defined ASCVD-relevant family-history
+ * questions**; longer-context fields (personal cancer / cardiac event
+ * history) stay free-text so the owner can record what's relevant
+ * without Bios imposing a taxonomy. The screening-cadence engine (#155)
+ * and the future pattern-explanation builder read this surface.
+ *
+ * Manifesto guard: pull-side only. Setting these flags never pushes a
+ * notification. The owner navigates in, the owner edits.
+ */
+@Entity(tableName = "risk_profile")
+data class RiskProfile(
+    @PrimaryKey val id: Long = SINGLETON_ID,
+    /** First-degree relative with CAD <55 (♂) or <65 (♀) — strongest ASCVD risk multiplier. */
+    val firstDegreeCadEarly: Boolean = false,
+    /** First-degree breast or ovarian cancer — Gail / IBIS / Tyrer-Cuzick input. */
+    val firstDegreeBreastOvarianCancer: Boolean = false,
+    /** First-degree colorectal cancer — USPSTF colorectal-screening age shifts from 45 → 40. */
+    val firstDegreeColorectalCancer: Boolean = false,
+    /** First-degree type 2 diabetes — USPSTF HbA1c-cadence modifier. */
+    val firstDegreeDiabetes: Boolean = false,
+    /** First-degree osteoporosis or hip fracture — FRAX input. */
+    val firstDegreeOsteoporosisHipFracture: Boolean = false,
+    /** First-degree melanoma — skin-screening cadence input. */
+    val firstDegreeMelanoma: Boolean = false,
+    /** Owner's smoking duration in years; null = unknown / not applicable. */
+    val personalTobaccoYears: Int? = null,
+    /** Owner's pack-years (ASCVD + lung-cancer-screening input); null = unknown. */
+    val personalTobaccoPackYears: Int? = null,
+    /** Epoch millis when the owner quit; null = never quit / not applicable. */
+    val personalTobaccoQuitDate: Long? = null,
+    /** Owner's personal cancer history — free text. */
+    val personalCancerHistory: String? = null,
+    /** Owner's personal cardiac event history — free text. */
+    val personalCardiacEventHistory: String? = null,
+    /** Owner-set comment or extra context — free text. */
+    val note: String? = null,
+    val updatedAt: Long = System.currentTimeMillis(),
+) {
+    companion object {
+        /**
+         * Stable primary key for the single owner-profile row. The repo
+         * upserts on this id so save() always replaces the previous row.
+         */
+        const val SINGLETON_ID: Long = 1L
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -180,13 +180,9 @@ fun BiosApp(viewModel: AppViewModel) {
         }
     }
 
-    // Show errors as snackbar
     LaunchedEffect(error) {
         error?.let {
-            snackbarHostState.showSnackbar(
-                message = it,
-                duration = SnackbarDuration.Long
-            )
+            snackbarHostState.showSnackbar(message = it, duration = SnackbarDuration.Long)
             viewModel.clearError()
         }
     }
@@ -351,8 +347,12 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToBlePair = { navController.navigate("ble_pair") },
                     onNavigateToMedications = { navController.navigate("medications") },
                     onNavigateToImmunisations = { navController.navigate("immunisations") },
-                    onNavigateToPreventiveCare = { navController.navigate("preventive_care") }
+                    onNavigateToPreventiveCare = { navController.navigate("preventive_care") },
+                    onNavigateToRiskProfile = { navController.navigate("risk_profile") }
                 )
+            }
+            composable("risk_profile") {
+                com.bios.app.ui.risk.RiskProfileScreen(onBack = { navController.popBackStack() })
             }
             composable("medications") {
                 com.bios.app.ui.medications.MedicationsScreen(onBack = { navController.popBackStack() })

--- a/android/app/src/main/java/com/bios/app/ui/risk/RiskProfileScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/risk/RiskProfileScreen.kt
@@ -1,0 +1,245 @@
+package com.bios.app.ui.risk
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.RiskProfileRepo
+import com.bios.app.model.RiskProfile
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Risk profile. Closes audit gap §2.6.
+ *
+ * Pull-side surface for family-history + personal-history risk factors.
+ * Manifesto guard: nothing pushed; owner edits when they choose. The
+ * screening-cadence engine (#155) and pattern-explanation builder will
+ * read this in follow-up wire-up PRs.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RiskProfileScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val repo = remember(context) { RiskProfileRepo(BiosDatabase.getInstance(context)) }
+    val scope = rememberCoroutineScope()
+    val snackbar = remember { SnackbarHostState() }
+
+    var profile by remember { mutableStateOf(RiskProfile()) }
+    var loaded by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        profile = repo.fetchOrEmpty()
+        loaded = true
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Risk profile") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbar) }
+    ) { padding ->
+        if (!loaded) return@Scaffold
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            ManifestoCard()
+
+            FamilyHistoryCard(
+                profile = profile,
+                onChange = { profile = it },
+            )
+
+            TobaccoCard(
+                profile = profile,
+                onChange = { profile = it },
+            )
+
+            PersonalHistoryCard(
+                profile = profile,
+                onChange = { profile = it },
+            )
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        repo.save(profile)
+                        snackbar.showSnackbar("Risk profile saved")
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Save") }
+        }
+    }
+}
+
+@Composable
+private fun ManifestoCard() {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("How Bios uses this", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            Text(
+                "Calibrated primary-care risk scores (ASCVD, FRAX, Gail) and the " +
+                    "USPSTF screening schedule both take family history as input. " +
+                    "Recording these factors lets Bios surface earlier preventive-care " +
+                    "cadences when they apply. Nothing here triggers a notification — " +
+                    "the screen waits until you ask.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun FamilyHistoryCard(profile: RiskProfile, onChange: (RiskProfile) -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text("Family history", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            CheckRow(
+                label = "First-degree relative with early heart disease (♂ <55 / ♀ <65)",
+                checked = profile.firstDegreeCadEarly,
+                onChange = { onChange(profile.copy(firstDegreeCadEarly = it)) },
+            )
+            CheckRow(
+                label = "First-degree breast or ovarian cancer",
+                checked = profile.firstDegreeBreastOvarianCancer,
+                onChange = { onChange(profile.copy(firstDegreeBreastOvarianCancer = it)) },
+            )
+            CheckRow(
+                label = "First-degree colorectal cancer",
+                checked = profile.firstDegreeColorectalCancer,
+                onChange = { onChange(profile.copy(firstDegreeColorectalCancer = it)) },
+            )
+            CheckRow(
+                label = "First-degree type 2 diabetes",
+                checked = profile.firstDegreeDiabetes,
+                onChange = { onChange(profile.copy(firstDegreeDiabetes = it)) },
+            )
+            CheckRow(
+                label = "First-degree osteoporosis or hip fracture",
+                checked = profile.firstDegreeOsteoporosisHipFracture,
+                onChange = { onChange(profile.copy(firstDegreeOsteoporosisHipFracture = it)) },
+            )
+            CheckRow(
+                label = "First-degree melanoma",
+                checked = profile.firstDegreeMelanoma,
+                onChange = { onChange(profile.copy(firstDegreeMelanoma = it)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TobaccoCard(profile: RiskProfile, onChange: (RiskProfile) -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Tobacco history", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = profile.personalTobaccoYears?.toString() ?: "",
+                onValueChange = { v -> onChange(profile.copy(personalTobaccoYears = v.filter { it.isDigit() }.toIntOrNull())) },
+                label = { Text("Years smoked (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = profile.personalTobaccoPackYears?.toString() ?: "",
+                onValueChange = { v -> onChange(profile.copy(personalTobaccoPackYears = v.filter { it.isDigit() }.toIntOrNull())) },
+                label = { Text("Pack-years (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                "Pack-years input drives the USPSTF lung-cancer-screening cadence " +
+                    "(annual low-dose CT 50–80 with ≥20 pack-years) once the cadence " +
+                    "engine wires it up.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PersonalHistoryCard(profile: RiskProfile, onChange: (RiskProfile) -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Personal history", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = profile.personalCancerHistory.orEmpty(),
+                onValueChange = { onChange(profile.copy(personalCancerHistory = it.takeIf { s -> s.isNotBlank() })) },
+                label = { Text("Cancer history (free text)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = profile.personalCardiacEventHistory.orEmpty(),
+                onValueChange = { onChange(profile.copy(personalCardiacEventHistory = it.takeIf { s -> s.isNotBlank() })) },
+                label = { Text("Cardiac event history (free text)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = profile.note.orEmpty(),
+                onValueChange = { onChange(profile.copy(note = it.takeIf { s -> s.isNotBlank() })) },
+                label = { Text("Note (optional)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun CheckRow(label: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Checkbox(checked = checked, onCheckedChange = onChange)
+        Spacer(Modifier.height(0.dp))
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -43,7 +43,8 @@ fun SettingsScreen(
     onNavigateToBlePair: () -> Unit = {},
     onNavigateToMedications: () -> Unit = {},
     onNavigateToImmunisations: () -> Unit = {},
-    onNavigateToPreventiveCare: () -> Unit = {}
+    onNavigateToPreventiveCare: () -> Unit = {},
+    onNavigateToRiskProfile: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -55,21 +56,13 @@ fun SettingsScreen(
     var showOuraDialog by remember { mutableStateOf(false) }
     var isOuraConnected by remember { mutableStateOf(viewModel.ouraTokenStore.hasToken()) }
     var showWithingsDialog by remember { mutableStateOf(false) }
-    var isWithingsConnected by remember {
-        mutableStateOf(viewModel.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY))
-    }
+    var isWithingsConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY)) }
     var showWhoopDialog by remember { mutableStateOf(false) }
-    var isWhoopConnected by remember {
-        mutableStateOf(viewModel.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY))
-    }
+    var isWhoopConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY)) }
     var showGarminDialog by remember { mutableStateOf(false) }
-    var isGarminConnected by remember {
-        mutableStateOf(viewModel.apiTokenStore.hasToken(GarminApiAdapter.PROVIDER_KEY))
-    }
+    var isGarminConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(GarminApiAdapter.PROVIDER_KEY)) }
     var showPolarDialog by remember { mutableStateOf(false) }
-    var isPolarConnected by remember {
-        mutableStateOf(viewModel.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY))
-    }
+    var isPolarConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY)) }
     val companionGrants by viewModel.db.companionGrantDao()
         .observeAll()
         .collectAsState(initial = emptyList())
@@ -189,6 +182,7 @@ fun SettingsScreen(
                     "Current medications" to onNavigateToMedications,
                     "Immunisation record" to onNavigateToImmunisations,
                     "Preventive care" to onNavigateToPreventiveCare,
+                    "Risk profile" to onNavigateToRiskProfile,
                     "Data coverage" to onNavigateToDataCoverage,
                 ).forEachIndexed { idx, (label, action) ->
                     if (idx > 0) Spacer(Modifier.height(4.dp))

--- a/android/app/src/test/java/com/bios/app/RiskProfileEntityTest.kt
+++ b/android/app/src/test/java/com/bios/app/RiskProfileEntityTest.kt
@@ -1,0 +1,68 @@
+package com.bios.app
+
+import com.bios.app.model.RiskProfile
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the [RiskProfile] entity shape. The screening-cadence engine
+ * (#155) and the future pattern-explanation builder read this surface;
+ * field renames or default-value changes would silently shift which
+ * screenings the engine adjusts for which owners.
+ */
+class RiskProfileEntityTest {
+
+    @Test
+    fun default_constructor_uses_singleton_id() {
+        // Single-row table. Every save must target SINGLETON_ID so the
+        // upsert (REPLACE on conflict) always overwrites the previous row.
+        assertEquals(RiskProfile.SINGLETON_ID, RiskProfile().id)
+        assertEquals(1L, RiskProfile.SINGLETON_ID)
+    }
+
+    @Test
+    fun default_profile_has_no_risk_flags_set() {
+        // Empty defaults so a fresh owner's profile = no claimed risk
+        // factors. The engine reads "false" as "owner didn't say yes"
+        // rather than "owner said no" — same behavioral effect.
+        val p = RiskProfile()
+        assertFalse(p.firstDegreeCadEarly)
+        assertFalse(p.firstDegreeBreastOvarianCancer)
+        assertFalse(p.firstDegreeColorectalCancer)
+        assertFalse(p.firstDegreeDiabetes)
+        assertFalse(p.firstDegreeOsteoporosisHipFracture)
+        assertFalse(p.firstDegreeMelanoma)
+    }
+
+    @Test
+    fun default_profile_has_null_optional_fields() {
+        val p = RiskProfile()
+        assertNull(p.personalTobaccoYears)
+        assertNull(p.personalTobaccoPackYears)
+        assertNull(p.personalTobaccoQuitDate)
+        assertNull(p.personalCancerHistory)
+        assertNull(p.personalCardiacEventHistory)
+        assertNull(p.note)
+    }
+
+    @Test
+    fun updatedAt_advances_when_a_copy_is_made_with_a_later_time() {
+        val a = RiskProfile(updatedAt = 1_000L)
+        val b = a.copy(firstDegreeCadEarly = true, updatedAt = 2_000L)
+        assertNotEquals(a.updatedAt, b.updatedAt)
+        assertTrue(b.updatedAt > a.updatedAt)
+    }
+
+    @Test
+    fun copy_preserves_singleton_id() {
+        // Even when callers .copy() the entity (UI edit flows), the id
+        // stays at SINGLETON_ID — the repo's save() further enforces
+        // this on the persistence side.
+        val edited = RiskProfile().copy(firstDegreeCadEarly = true)
+        assertEquals(RiskProfile.SINGLETON_ID, edited.id)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #160. Foundation for risk-adjusted preventive care.

### What ships

- **\`RiskProfile\`** Room entity (single-row, \`SINGLETON_ID = 1\`, upsert) with:
  - Boolean flags: first-degree CAD <55/<65, breast/ovarian cancer, colorectal cancer, T2DM, osteoporosis, melanoma
  - Tobacco: years smoked, pack-years, quit date
  - Free-text: personal cancer history, cardiac event history, note
- **DAO + Repo** with \`fetchOrEmpty()\` ergonomics
- **DB version 14 → 15** with \`MIGRATION_14_15\`
- **\`RiskProfileScreen\`** — Settings → \"Risk profile\" pull-side UI
- 5 tests on the entity contract

### Manifesto guard

Pull-side only. Setting these flags never pushes a notification.

### Scope discipline (per audit issue)

ASCVD / FRAX / Gail calculators, pattern-explanation builder hook, screening-cadence engine integration (#155 wire-up), FHIR \`FamilyMemberHistory\` import — all deferred to sibling PRs that consume this entity. Genetic / pharmacogenomic / polygenic-risk-scores explicitly out of scope per audit body.

### Audit ref

[docs/audits/MEDICAL_PROFESSIONAL_POV.md §2.6 + §3.1](docs/audits/MEDICAL_PROFESSIONAL_POV.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)