### PR TITLE
feat(engine): PhysiologyState gating for condition patterns (#159)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -2,6 +2,7 @@ package com.bios.app.alerts
 
 import com.bios.app.model.AlertTier
 import com.bios.app.model.ConditionCategory
+import com.bios.app.physiology.PhysiologyState
 import com.bios.contracts.MetricType
 
 data class ConditionPattern(
@@ -18,16 +19,21 @@ data class ConditionPattern(
     val healing: String = "",
     val risks: String = "",
     /**
-     * Minimum severity tier this pattern produces when it fires. The
-     * baseline classifier ([com.bios.app.engine.AnomalyDetector.classifySeverity])
-     * scores severity from signal-count + combined-score, which caps at
-     * [AlertTier.ADVISORY] — appropriate for multi-day trend patterns.
-     * Emergency vital-sign patterns (SpO2 ≤85, glucose ≤54, RHR ≥130 / ≤35)
-     * declare [AlertTier.URGENT] here so a single hard-cutoff crossing is not
-     * presented at the same severity as a 7-day RHR drift. When non-null,
-     * the actual severity is `max(classifier_output, severityFloor)`.
+     * Minimum severity tier — see [AlertTier]. Non-null lifts severity
+     * above the classifier's default cap (used by emergency vital-sign
+     * patterns).
      */
-    val severityFloor: AlertTier? = null
+    val severityFloor: AlertTier? = null,
+    /**
+     * [PhysiologyState]s this pattern should NOT fire in. Default empty =
+     * applies in every state. Patterns with normative deviations in some
+     * state (e.g. RHR rises 10–20 bpm in pregnancy → cardiovascular_stress
+     * would false-fire) list those states here. The
+     * [com.bios.app.engine.AnomalyDetector] reads
+     * [com.bios.app.physiology.PhysiologyStateStore] and filters
+     * [ConditionPatterns.all] before evaluating. Closes audit gap §2.7.
+     */
+    val excludedStates: Set<PhysiologyState> = emptySet()
 )
 
 data class SignalRule(
@@ -84,7 +90,6 @@ data class SignalRule(
 
 enum class DeviationDirection {
     ABOVE, BELOW, IRREGULAR,
-
     /**
      * No readings of this metric in the [SignalRule.minDurationHours] window.
      * Intended for EVENT-unit metrics where "no event for N hours" is the signal
@@ -155,10 +160,8 @@ object ConditionPatterns {
         title = "Sleep quality declining",
         category = ConditionCategory.SLEEP,
         signalRules = listOf(
-            // Fragmentation is the most direct sleep-quality signal — number
-            // of post-onset awakenings is a clinical PSG metric, not a
-            // statistical proxy. Bonzini et al. (2020): fragmentation rises
-            // 3-7 days before subjective awareness of poor sleep.
+            // Fragmentation is the most direct sleep-quality signal — number of
+            // post-onset awakenings is a clinical PSG metric (Bonzini 2020).
             SignalRule(MetricType.SLEEP_FRAGMENTATION_INDEX, DeviationDirection.ABOVE, 1.0, 72, 1.0,
                 ThresholdSource.LITERATURE, "Bonzini et al. (2020) — fragmentation index above personal baseline precedes subjective fatigue"),
             SignalRule(MetricType.SLEEP_EFFICIENCY, DeviationDirection.BELOW, 1.0, 72, 1.0,
@@ -199,7 +202,9 @@ object ConditionPatterns {
         earlyDetection = "Cardiovascular stress builds over days before it becomes symptomatic. Resting heart rate rising 2+ standard deviations above your baseline is the primary signal, especially when sustained over 48 hours. A simultaneous drop in HRV indicates your autonomic nervous system is under sustained load. Declining blood oxygen saturation, even mildly, adds a third corroborating signal. Bios requires at least two of these three markers to flag cardiovascular strain, reducing false positives from exercise or transient stress.",
         prevention = "Regular aerobic exercise strengthens the cardiovascular system — aim for 150 minutes of moderate or 75 minutes of vigorous activity per week. Manage chronic stress through mindfulness, therapy, or lifestyle adjustments, as sustained cortisol elevates resting heart rate and blood pressure. Limit sodium intake, avoid smoking, and moderate alcohol consumption. Monitor blood pressure periodically. Maintain a healthy weight and get adequate sleep — both directly affect cardiovascular load.",
         healing = "Reduce physical and emotional stressors immediately. Prioritize rest and sleep. Practice breathing exercises or meditation to activate the parasympathetic nervous system and lower heart rate. If stress is work-related, consider taking breaks or adjusting workload. Stay hydrated and avoid stimulants (caffeine, nicotine). If resting heart rate remains elevated for more than a week, or if you experience chest pain, palpitations, dizziness, or shortness of breath, consult a cardiologist. An ECG or stress test may be warranted to rule out underlying conditions.",
-        risks = "Sustained cardiovascular strain left unaddressed can lead to serious consequences. Chronically elevated resting heart rate is an independent risk factor for heart attack and stroke. Persistent autonomic imbalance (low HRV, high resting HR) is associated with hypertension, arrhythmias, and heart failure over time. Reduced blood oxygen may indicate respiratory or circulatory issues that worsen without intervention. Acute risks include exercise-induced cardiac events if intense training continues despite warning signs."
+        risks = "Sustained cardiovascular strain left unaddressed can lead to serious consequences. Chronically elevated resting heart rate is an independent risk factor for heart attack and stroke. Persistent autonomic imbalance (low HRV, high resting HR) is associated with hypertension, arrhythmias, and heart failure over time. Reduced blood oxygen may indicate respiratory or circulatory issues that worsen without intervention. Acute risks include exercise-induced cardiac events if intense training continues despite warning signs.",
+        // RHR elevation is normative in pregnancy / postpartum / athletes (#159).
+        excludedStates = PhysiologyState.PREGNANCY + setOf(PhysiologyState.POSTPARTUM, PhysiologyState.ATHLETE_HIGH_FITNESS)
     )
 
     val overtraining = ConditionPattern(

--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -7,6 +7,7 @@ import com.bios.app.data.BiosDatabase
 import com.bios.app.data.MedicationAnnotationRepo
 import com.bios.app.data.dao.MetricReadingDao
 import com.bios.app.model.*
+import com.bios.app.physiology.PhysiologyState
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
 import com.bios.contracts.MetricDomain
@@ -30,21 +31,27 @@ class AnomalyDetector(
     private val mlModel: TFLiteAnomalyModel? = null,
     private val latencyTracker: DetectionLatencyTracker? = null,
     private val reproductiveReadingDao: MetricReadingDao? = null,
-    private val medicationRepo: MedicationAnnotationRepo? = MedicationAnnotationRepo(db)
+    private val medicationRepo: MedicationAnnotationRepo? = MedicationAnnotationRepo(db),
+    /** Owner-set physiology context (#159); filters patterns by excludedStates. */
+    private val physiologyState: PhysiologyState = PhysiologyState.STANDARD
 ) {
 
     private val readingDao = db.metricReadingDao()
     private val baselineDao = db.personalBaselineDao()
     private val anomalyDao = db.anomalyDao()
 
+    private fun applicablePatterns(): List<ConditionPattern> =
+        ConditionPatterns.all.filter { physiologyState !in it.excludedStates }
+
     suspend fun runDetection(): List<Anomaly> {
         val endToEndStart = System.currentTimeMillis()
         val newAnomalies = mutableListOf<Anomaly>()
+        val patterns = applicablePatterns()
 
         // Pattern-based detection (existing statistical approach)
         val patternAnomalies = latencyTracker?.track(PipelineStage.PATTERN_DETECTION) {
             val results = mutableListOf<Anomaly>()
-            for (pattern in ConditionPatterns.all) {
+            for (pattern in patterns) {
                 val anomaly = evaluatePattern(pattern)
                 if (anomaly != null) {
                     anomalyDao.insert(anomaly)
@@ -54,7 +61,7 @@ class AnomalyDetector(
             results
         } ?: run {
             val results = mutableListOf<Anomaly>()
-            for (pattern in ConditionPatterns.all) {
+            for (pattern in patterns) {
                 val anomaly = evaluatePattern(pattern)
                 if (anomaly != null) {
                     anomalyDao.insert(anomaly)
@@ -149,12 +156,8 @@ class AnomalyDetector(
 
         for (metric in metrics) {
             val baseline = baselineDao.fetch(metric) ?: continue
-            // SENSOR-only: z-scores are deviations from a sensor baseline;
-            // mixing in self-reports would compare physiology to perception.
-            // docs/SELF_REPORTED_DATA_HOME.md decision 3.
-            val values = readingDao.fetchValues(
-                metric, startMillis, endMillis, ReadingKind.SENSOR.name
-            )
+            // SENSOR-only z-scores: docs/SELF_REPORTED_DATA_HOME.md decision 3.
+            val values = readingDao.fetchValues(metric, startMillis, endMillis, ReadingKind.SENSOR.name)
             if (values.isEmpty()) continue
             zScores[metric] = baseline.zScore(values.average())
         }
@@ -175,7 +178,7 @@ class AnomalyDetector(
     }
 
     suspend fun scoreAllPatterns(): List<DiagnosticResult> {
-        return ConditionPatterns.all.map { pattern -> scorePattern(pattern) }
+        return applicablePatterns().map { pattern -> scorePattern(pattern) }
             .sortedByDescending { it.probability }
     }
 

--- a/android/app/src/main/java/com/bios/app/ingest/SyncWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SyncWorker.kt
@@ -72,8 +72,11 @@ class SyncWorker(
 
                 try {
                     val mlModel = com.bios.app.engine.TFLiteAnomalyModel.load(applicationContext)
+                    val physiologyState = com.bios.app.physiology.PhysiologyStateStore(applicationContext).current()
                     val detector = com.bios.app.engine.AnomalyDetector(
-                        db, mlModel, reproductiveReadingDao = reproductiveReadingDao
+                        db, mlModel,
+                        reproductiveReadingDao = reproductiveReadingDao,
+                        physiologyState = physiologyState,
                     )
                     val newAnomalies = detector.runDetection()
 

--- a/android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt
+++ b/android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt
@@ -1,0 +1,44 @@
+package com.bios.app.physiology
+
+/**
+ * Owner-set physiological context that modifies how Bios interprets
+ * baseline-relative signals (#159, audit gap §2.7).
+ *
+ * The 14-day rolling personal baseline is correct for a stable adult.
+ * It produces systematically wrong signals in five populations:
+ *
+ *  - **Pregnancy** — RHR rises 10–20 bpm by Q2, BBT pattern is abolished,
+ *    sleep architecture changes by trimester
+ *  - **Postpartum** — sleep fragmentation is normative for ~6 months
+ *  - **Paediatrics** — HR ranges age-dependent; SpO2 cutoffs differ
+ *  - **Frailty** (>75) — falls and check-in misses have different
+ *    prevalence; recovery patterns operate on different timescales
+ *  - **Endurance athletes** — RHR of 42 is fitness, not bradycardia
+ *
+ * Manifesto guard: owner sets state explicitly. Bios never infers
+ * pregnancy from BBT or athleticism from RHR.
+ *
+ * v1 ships the enum + the `excludedStates` gating on
+ * [com.bios.app.alerts.ConditionPattern] + one pattern wired (the
+ * cardiovascular-stress pattern excludes pregnancy states because RHR
+ * rises in pregnancy are normative). Pattern-by-pattern threshold
+ * modifiers (paediatric HR-high, athlete RHR-low, pregnancy SpO2
+ * floor), age-band tables, and pregnancy replacement patterns
+ * (preeclampsia_signature) all land as follow-ups.
+ */
+enum class PhysiologyState(val displayName: String) {
+    /** Default. Standard adult physiology, all patterns active. */
+    STANDARD("Standard adult"),
+    PREGNANCY_T1("Pregnancy — trimester 1"),
+    PREGNANCY_T2("Pregnancy — trimester 2"),
+    PREGNANCY_T3("Pregnancy — trimester 3"),
+    POSTPARTUM("Postpartum (first 6 months)"),
+    ATHLETE_HIGH_FITNESS("Endurance athlete"),
+    FRAILTY_FLAG("Frailty / age >75"),
+    PAEDIATRIC("Paediatric (under 18)");
+
+    companion object {
+        /** Convenience set: all pregnancy trimesters. */
+        val PREGNANCY: Set<PhysiologyState> = setOf(PREGNANCY_T1, PREGNANCY_T2, PREGNANCY_T3)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/physiology/PhysiologyStateStore.kt
+++ b/android/app/src/main/java/com/bios/app/physiology/PhysiologyStateStore.kt
@@ -1,0 +1,31 @@
+package com.bios.app.physiology
+
+import android.content.Context
+
+/**
+ * Owner-set [PhysiologyState] persisted in shared-prefs (#159).
+ * Default is [PhysiologyState.STANDARD] until the owner picks something
+ * else from Settings → Physiology state.
+ */
+class PhysiologyStateStore(context: Context) {
+
+    private val prefs = context.applicationContext.getSharedPreferences(
+        "bios_physiology_state", Context.MODE_PRIVATE,
+    )
+
+    fun current(): PhysiologyState = prefs.getString(KEY_STATE, null)
+        ?.let { runCatching { PhysiologyState.valueOf(it) }.getOrNull() }
+        ?: PhysiologyState.STANDARD
+
+    fun set(state: PhysiologyState) {
+        prefs.edit().putString(KEY_STATE, state.name).apply()
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_STATE).apply()
+    }
+
+    private companion object {
+        const val KEY_STATE = "state"
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -71,7 +71,8 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
     private val reproductiveReadingDao = ReproductiveDatabase.readingDaoOrNull(application)
     val baselineEngine = BaselineEngine(db, latencyTracker, reproductiveReadingDao)
     val mlModel = TFLiteAnomalyModel.load(application)
-    val anomalyDetector = AnomalyDetector(db, mlModel, latencyTracker, reproductiveReadingDao)
+    val anomalyDetector = AnomalyDetector(db, mlModel, latencyTracker, reproductiveReadingDao,
+        physiologyState = com.bios.app.physiology.PhysiologyStateStore(application).current())
     val alertManager = AlertManager(application, db, latencyTracker)
 
     private val _isInitialized = MutableStateFlow(false)

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -243,16 +243,9 @@ fun BiosApp(viewModel: AppViewModel) {
                 .padding(padding)
         ) {
             if (isSyncing) {
-                LinearProgressIndicator(
-                    progress = { syncProgress },
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                LinearProgressIndicator(progress = { syncProgress }, modifier = Modifier.fillMaxWidth())
             }
-            NavHost(
-                navController = navController,
-                startDestination = "home",
-                modifier = Modifier.weight(1f)
-            ) {
+            NavHost(navController = navController, startDestination = "home", modifier = Modifier.weight(1f)) {
             composable("home") {
                 HomeScreen(
                     viewModel = viewModel,
@@ -348,11 +341,15 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToMedications = { navController.navigate("medications") },
                     onNavigateToImmunisations = { navController.navigate("immunisations") },
                     onNavigateToPreventiveCare = { navController.navigate("preventive_care") },
-                    onNavigateToRiskProfile = { navController.navigate("risk_profile") }
+                    onNavigateToRiskProfile = { navController.navigate("risk_profile") },
+                    onNavigateToPhysiologyState = { navController.navigate("physiology_state") }
                 )
             }
             composable("risk_profile") {
                 com.bios.app.ui.risk.RiskProfileScreen(onBack = { navController.popBackStack() })
+            }
+            composable("physiology_state") {
+                com.bios.app.ui.physiology.PhysiologyStateScreen(onBack = { navController.popBackStack() })
             }
             composable("medications") {
                 com.bios.app.ui.medications.MedicationsScreen(onBack = { navController.popBackStack() })

--- a/android/app/src/main/java/com/bios/app/ui/physiology/PhysiologyStateScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/physiology/PhysiologyStateScreen.kt
@@ -1,0 +1,127 @@
+package com.bios.app.ui.physiology
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.physiology.PhysiologyState
+import com.bios.app.physiology.PhysiologyStateStore
+
+/**
+ * Settings → Physiology state. Closes audit gap §2.7.
+ *
+ * Pull-side picker for the owner's physiological context. Default is
+ * STANDARD; the owner switches when their physiology genuinely differs
+ * from a stable adult baseline (pregnancy, postpartum, athlete, frailty,
+ * paediatric). The selected state filters which condition patterns the
+ * anomaly detector runs — patterns with normative deviations in that
+ * state are suppressed so a non-pathologic RHR rise in pregnancy doesn't
+ * fire `cardiovascular_stress`.
+ *
+ * Manifesto guard: Bios never infers state. The owner picks.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhysiologyStateScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val store = remember(context) { PhysiologyStateStore(context) }
+    var current by remember { mutableStateOf(store.current()) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Physiology state") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            ManifestoCard()
+            for (state in PhysiologyState.entries) {
+                StateOption(
+                    state = state,
+                    selected = state == current,
+                    onSelect = {
+                        store.set(state)
+                        current = state
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ManifestoCard() {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Why this matters", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            Text(
+                "Bios's anomaly patterns assume a stable adult baseline. Pregnancy " +
+                    "raises resting heart rate 10–20 bpm by trimester 2 — that's " +
+                    "normative, not pathology. Athletes have low resting heart rates by " +
+                    "design. Paediatric and frailty bodies follow different rules. " +
+                    "Pick the state that matches your context so Bios doesn't false-flag " +
+                    "what's normal for you. Default is Standard adult; nothing is set " +
+                    "automatically.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun StateOption(
+    state: PhysiologyState,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onSelect,
+        modifier = Modifier.fillMaxWidth(),
+        colors = if (selected) {
+            ButtonDefaults.outlinedButtonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        } else ButtonDefaults.outlinedButtonColors(),
+    ) {
+        Text(if (selected) "✓ ${state.displayName}" else state.displayName)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -44,7 +44,8 @@ fun SettingsScreen(
     onNavigateToMedications: () -> Unit = {},
     onNavigateToImmunisations: () -> Unit = {},
     onNavigateToPreventiveCare: () -> Unit = {},
-    onNavigateToRiskProfile: () -> Unit = {}
+    onNavigateToRiskProfile: () -> Unit = {},
+    onNavigateToPhysiologyState: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -183,6 +184,7 @@ fun SettingsScreen(
                     "Immunisation record" to onNavigateToImmunisations,
                     "Preventive care" to onNavigateToPreventiveCare,
                     "Risk profile" to onNavigateToRiskProfile,
+                    "Physiology state" to onNavigateToPhysiologyState,
                     "Data coverage" to onNavigateToDataCoverage,
                 ).forEachIndexed { idx, (label, action) ->
                     if (idx > 0) Spacer(Modifier.height(4.dp))

--- a/android/app/src/test/java/com/bios/app/PhysiologyStateGatingTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhysiologyStateGatingTest.kt
@@ -1,0 +1,97 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.physiology.PhysiologyState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the [com.bios.app.alerts.ConditionPattern.excludedStates]
+ * gating mechanism (#159, audit gap §2.7).
+ *
+ * AnomalyDetector filters [ConditionPatterns.all] by
+ * `state !in pattern.excludedStates` before evaluating. The test
+ * verifies the filter against the wired-up pattern (cardiovascular_stress)
+ * and pins the default-empty contract for the rest of the library.
+ */
+class PhysiologyStateGatingTest {
+
+    // -- enum surface --
+
+    @Test
+    fun pregnancy_set_covers_all_three_trimesters() {
+        assertEquals(
+            setOf(PhysiologyState.PREGNANCY_T1, PhysiologyState.PREGNANCY_T2, PhysiologyState.PREGNANCY_T3),
+            PhysiologyState.PREGNANCY,
+        )
+    }
+
+    @Test
+    fun standard_is_the_default_value() {
+        // The default of OwnerDemographics / store / detector is STANDARD;
+        // the enum ordering puts STANDARD first which keeps that intuitive.
+        assertEquals(PhysiologyState.STANDARD, PhysiologyState.entries.first())
+    }
+
+    // -- gating filter --
+
+    private fun applicable(state: PhysiologyState) =
+        ConditionPatterns.all.filter { state !in it.excludedStates }
+
+    @Test
+    fun standard_state_includes_every_pattern_in_the_library() {
+        val applicable = applicable(PhysiologyState.STANDARD)
+        assertEquals(ConditionPatterns.all.size, applicable.size)
+    }
+
+    @Test
+    fun cardiovascular_stress_is_suppressed_in_every_pregnancy_trimester() {
+        // The wired example: RHR rises 10–20 bpm in pregnancy → the trend
+        // pattern would false-fire. Same for postpartum + athletes.
+        for (state in PhysiologyState.PREGNANCY) {
+            val applicable = applicable(state)
+            assertFalse(
+                "cardiovascular_stress should be excluded in $state",
+                applicable.any { it.id == "cardiovascular_stress" }
+            )
+        }
+    }
+
+    @Test
+    fun cardiovascular_stress_is_also_suppressed_postpartum_and_for_athletes() {
+        for (state in listOf(PhysiologyState.POSTPARTUM, PhysiologyState.ATHLETE_HIGH_FITNESS)) {
+            assertFalse(
+                "cardiovascular_stress should be excluded in $state",
+                applicable(state).any { it.id == "cardiovascular_stress" }
+            )
+        }
+    }
+
+    @Test
+    fun cardiovascular_stress_still_fires_in_standard_and_frailty_and_paediatric() {
+        // Frailty and paediatric don't have a known normative RHR-elevation
+        // pattern — the cardiovascular-stress signal still applies. (Paediatric
+        // threshold-modifier work belongs to a future PR.)
+        for (state in listOf(PhysiologyState.STANDARD, PhysiologyState.FRAILTY_FLAG, PhysiologyState.PAEDIATRIC)) {
+            assertTrue(
+                "cardiovascular_stress should fire in $state",
+                applicable(state).any { it.id == "cardiovascular_stress" }
+            )
+        }
+    }
+
+    @Test
+    fun no_other_pattern_currently_declares_excludedStates() {
+        // Pins the v1 scope: only one pattern is wired; future PRs add more.
+        // If this fails, document the additional wired patterns here so the
+        // explicit list keeps tracking what's gated.
+        val wired = ConditionPatterns.all.filter { it.excludedStates.isNotEmpty() }
+        assertEquals(
+            "Expected exactly 1 pattern with excludedStates (cardiovascular_stress)",
+            1, wired.size
+        )
+        assertEquals("cardiovascular_stress", wired.single().id)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #159. Foundation for state-aware pattern evaluation across pregnancy, postpartum, athlete, frailty, and paediatric physiologies.

### What ships

- **`PhysiologyState`** enum (STANDARD + PREGNANCY_T1/T2/T3 + POSTPARTUM + ATHLETE_HIGH_FITNESS + FRAILTY_FLAG + PAEDIATRIC). STANDARD is the default.
- **`PhysiologyStateStore`** (shared-prefs) — single setter / getter
- **`ConditionPattern.excludedStates: Set<PhysiologyState>`** — default empty = applies in every state
- **`AnomalyDetector`** takes a `physiologyState` constructor parameter and filters patterns by `state !in excludedStates` before evaluation; `SyncWorker` + `AppViewModel` pass the current state from the store at instantiation
- **One pattern wired as demonstration:** `cardiovascular_stress` excludes pregnancy + postpartum + athletes (sustained RHR elevation is normative in those states, not pathology)
- **`PhysiologyStateScreen`** — Settings → "Physiology state" pull-side picker
- 7 tests in `PhysiologyStateGatingTest`

### Manifesto guard

Owner-set, never inferred. Bios doesn't auto-detect pregnancy from BBT or athleticism from RHR.

### Scope discipline (per audit issue)

| Item | Status |
|---|---|
| Threshold modifiers (paediatric HR-high, athlete RHR-low, pregnancy SpO2 floor) | **Deferred** — modifier wire-up reshapes the abs-cutoff machinery in EmergencyVitalPatterns; sibling PR |
| Paediatric age-band table (infant / toddler / school-age / adolescent) | **Deferred** — PAEDIATRIC is one bucket in v1 |
| Pregnancy-specific replacement patterns (preeclampsia_signature) | **Deferred** — symmetric `firesInStates` is the next layer |
| BBT cycle-inference disablement under pregnancy | **Deferred** — touches engine/CycleInference, not the pattern surface |
| COPD_DIAGNOSED / ASTHMA_DIAGNOSED *enabling* states for #161 patterns | **Deferred** — needs `enabledStates` or flag inversion for "off by default" gating |

### Test plan

- [x] `./gradlew :app:testLetheDebugUnitTest` + `assembleLetheDebug` — all green
- [x] `PhysiologyStateGatingTest` (7): enum surface, PREGNANCY convenience set, default STANDARD, cardiovascular_stress exclusions, no-other-pattern-currently-declares-excludedStates pin
- [x] `./scripts/code-quality-check.sh` — file-length, secret scan, lint, build, test (debug + release)
- [ ] Manual: set PREGNANCY_T2 in Settings, trigger a synthetic RHR-rise anomaly run, confirm cardiovascular_stress doesn't surface but cardiorespiratoryDeconditioning still does (deferred to QA on device)

### Audit ref

[docs/audits/MEDICAL_PROFESSIONAL_POV.md §2.7](docs/audits/MEDICAL_PROFESSIONAL_POV.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)