### PR TITLE
fix(home): sum today's steps instead of latest sample

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -77,43 +77,30 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _isInitialized = MutableStateFlow(false)
     val isInitialized: StateFlow<Boolean> = _isInitialized
-
     private val _isSyncing = MutableStateFlow(false)
     val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
-
     private val _initStatus = MutableStateFlow("")
     val initStatus: StateFlow<String> = _initStatus
-
     private val _initProgress = MutableStateFlow(0f)
     val initProgress: StateFlow<Float> = _initProgress
-
     private val _hasPermissions = MutableStateFlow(false)
     val hasPermissions: StateFlow<Boolean> = _hasPermissions
-
     private val _unacknowledgedAlerts = MutableStateFlow<List<Anomaly>>(emptyList())
     val unacknowledgedAlerts: StateFlow<List<Anomaly>> = _unacknowledgedAlerts
-
     private val _recentAlerts = MutableStateFlow<List<Anomaly>>(emptyList())
     val recentAlerts: StateFlow<List<Anomaly>> = _recentAlerts
-
     private val _baselines = MutableStateFlow<List<PersonalBaseline>>(emptyList())
     val baselines: StateFlow<List<PersonalBaseline>> = _baselines
-
     private val _timelineEntries = MutableStateFlow<List<Anomaly>>(emptyList())
     val timelineEntries: StateFlow<List<Anomaly>> = _timelineEntries
-
     private val _healthEvents = MutableStateFlow<List<HealthEvent>>(emptyList())
     val healthEvents: StateFlow<List<HealthEvent>> = _healthEvents
-
     private val _pendingActionItems = MutableStateFlow<List<ActionItem>>(emptyList())
     val pendingActionItems: StateFlow<List<ActionItem>> = _pendingActionItems
-
     private val _diagnosticResults = MutableStateFlow<List<DiagnosticResult>>(emptyList())
     val diagnosticResults: StateFlow<List<DiagnosticResult>> = _diagnosticResults
-
     private val _pipelineSummary = MutableStateFlow<List<LatencyPercentiles>>(emptyList())
     val pipelineSummary: StateFlow<List<LatencyPercentiles>> = _pipelineSummary
-
     private val _anomalyForReview = MutableStateFlow<Anomaly?>(null)
     val anomalyForReview: StateFlow<Anomaly?> = _anomalyForReview
 
@@ -292,6 +279,19 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
 
     suspend fun getLatestReading(metricType: MetricType): MetricReading? {
         return db.metricReadingDao().fetchLatest(metricType.key).firstOrNull()
+    }
+
+    /**
+     * Sums today's readings (since local midnight). Used by Home for cumulative-
+     * daily metrics — Health Connect emits one StepsRecord per sample bucket,
+     * so the latest is the last hour, not the day total. Null when no readings.
+     */
+    suspend fun getTodaySum(metricType: MetricType): Double? {
+        val startOfDay = java.time.LocalDate.now()
+            .atStartOfDay(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val values = db.metricReadingDao()
+            .fetchValues(metricType.key, startOfDay, System.currentTimeMillis())
+        return if (values.isEmpty()) null else values.sum()
     }
 
     suspend fun getBaseline(metricType: MetricType): PersonalBaseline? {

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -14,6 +14,17 @@ import com.bios.app.model.PersonalBaseline
 import com.bios.app.ui.AppViewModel
 import kotlin.math.abs
 
+/**
+ * Metrics that arrive as per-window samples but represent a cumulative
+ * day count — the card should sum today's values, not show the latest.
+ * `internal` so tests can pin the set's contents directly.
+ */
+internal val cumulativeDailyMetrics = setOf(
+    MetricType.STEPS,
+    MetricType.ACTIVE_CALORIES,
+    MetricType.ACTIVE_MINUTES,
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MetricCard(
@@ -28,7 +39,14 @@ fun MetricCard(
     var baseline by remember { mutableStateOf<PersonalBaseline?>(null) }
 
     LaunchedEffect(metricType, refreshKey) {
-        latestValue = viewModel.getLatestReading(metricType)?.value
+        latestValue = if (metricType in cumulativeDailyMetrics) {
+            // Cumulative-daily metrics emit per-sample-window: the latest
+            // reading is whatever happened in the last bucket, not today's
+            // total. Sum since local midnight instead.
+            viewModel.getTodaySum(metricType)
+        } else {
+            viewModel.getLatestReading(metricType)?.value
+        }
         baseline = viewModel.getBaseline(metricType)
     }
 
@@ -67,9 +85,15 @@ private fun MetricCardBody(
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(20.dp)
             )
-            baseline?.let { bl ->
-                latestValue?.let { v ->
-                    DeviationIndicator(v, bl)
+            // Suppress the deviation indicator for cumulative-daily metrics:
+            // the value shown is today's sum but the baseline is computed
+            // from per-window readings — z-score across the two is nonsense.
+            // A daily-sum baseline is a future enhancement.
+            if (metricType !in cumulativeDailyMetrics) {
+                baseline?.let { bl ->
+                    latestValue?.let { v ->
+                        DeviationIndicator(v, bl)
+                    }
                 }
             }
         }

--- a/android/app/src/test/java/com/bios/app/CumulativeDailyMetricsTest.kt
+++ b/android/app/src/test/java/com/bios/app/CumulativeDailyMetricsTest.kt
@@ -1,0 +1,71 @@
+package com.bios.app
+
+import com.bios.app.ui.components.cumulativeDailyMetrics
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the set of metrics that the Home/MetricCard surface treats as
+ * cumulative-daily — these get summed across today's readings, not
+ * rendered as the latest sample. Surfaced by a real bug report: watch
+ * showed 11000 steps, Bios card showed 94 (the most recent ~hourly
+ * StepsRecord bucket from Health Connect).
+ *
+ * If a future metric joins the set (e.g. `cough_count` when the mic
+ * adapter ships), update this test alongside the production set so the
+ * contract stays explicit.
+ */
+class CumulativeDailyMetricsTest {
+
+    @Test
+    fun set_contains_steps_active_calories_active_minutes() {
+        assertEquals(
+            setOf(
+                MetricType.STEPS,
+                MetricType.ACTIVE_CALORIES,
+                MetricType.ACTIVE_MINUTES,
+            ),
+            cumulativeDailyMetrics,
+        )
+    }
+
+    @Test
+    fun every_member_is_a_count_or_duration_unit() {
+        // Pin the type-shape: STEPS = COUNT, KCAL for calories, SECONDS for
+        // active-minutes-as-duration. Anything else in this set would be a
+        // category error (you can't usefully "sum" a HR reading across the
+        // day to get a daily total).
+        for (m in cumulativeDailyMetrics) {
+            assertTrue(
+                "${m.key} unit ${m.unit} not in the expected cumulative-shape set",
+                m.unit in setOf(MetricUnit.COUNT, MetricUnit.KCAL, MetricUnit.SECONDS)
+            )
+        }
+    }
+
+    @Test
+    fun non_cumulative_metrics_stay_out_of_the_set() {
+        // Spot-check: HR, HRV, SpO2 are instantaneous readings; SkinTemp,
+        // BBT, and biomarkers are point measurements. None should appear
+        // in the cumulative set — summing them would produce a number with
+        // no clinical meaning.
+        val excluded = listOf(
+            MetricType.HEART_RATE,
+            MetricType.HEART_RATE_VARIABILITY,
+            MetricType.BLOOD_OXYGEN,
+            MetricType.SKIN_TEMPERATURE_DEVIATION,
+            MetricType.SLEEP_DURATION,
+            MetricType.HBA1C,
+        )
+        for (m in excluded) {
+            assertFalse(
+                "${m.key} should NOT be in cumulativeDailyMetrics",
+                m in cumulativeDailyMetrics,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Owner reported: watch shows 11000 steps, Bios card shows 94 (~117× off). \`MetricCard\` calls \`getLatestReading(STEPS)\`; Health Connect emits one \`StepsRecord\` per sample bucket — \"latest\" is the last bucket's count, not the day total.

### Ships

- **\`AppViewModel.getTodaySum(metricType)\`** — sums \`fetchValues\` since local-midnight; null on no readings (empty state, not \"0\").
- **\`MetricCard\`** routes \`cumulativeDailyMetrics\` (STEPS, ACTIVE_CALORIES, ACTIVE_MINUTES) through \`getTodaySum\`.
- **\`DeviationIndicator\` suppressed** for those metrics — baseline is per-window-shaped; z-score against today's sum is nonsense. Daily-sum baseline is a future enhancement.
- 3 tests in \`CumulativeDailyMetricsTest\` pinning the set + unit shape.

### Scope

Home card only. TrendsScreen daily aggregation is separate and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)