### PR TITLE
fix(ingest): tolerate single-axis sensors in collectSamples

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
@@ -200,7 +200,15 @@ class PhoneSensorAdapter(context: Context) {
 
                 val listener = object : SensorEventListener {
                     override fun onSensorChanged(event: SensorEvent) {
-                        samples.add(Triple(event.values[0], event.values[1], event.values[2]))
+                        // Single-axis sensors (TYPE_STEP_COUNTER) only populate
+                        // values[0]; pad missing axes with 0f so callers that
+                        // share this collector across multi- and single-axis
+                        // sensors don't crash with IOOBE.
+                        val v = event.values
+                        val x = if (v.size > 0) v[0] else 0f
+                        val y = if (v.size > 1) v[1] else 0f
+                        val z = if (v.size > 2) v[2] else 0f
+                        samples.add(Triple(x, y, z))
                         if (System.currentTimeMillis() - startTime >= durationMs) {
                             sensorManager.unregisterListener(this)
                             if (cont.isActive) cont.resume(samples)


### PR DESCRIPTION
## Summary

Fixes an `ArrayIndexOutOfBoundsException` that crashed the app the first time `TYPE_STEP_COUNTER` fired.

Root cause: [PhoneSensorAdapter.kt:191](https://github.com/thdelmas/Bios/blob/main/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt#L191)'s `collectSamples()` is shared between `sampleAccelerometer()` (3-axis) and `readStepCounter()` (1-axis), but the inner `onSensorChanged` listener unconditionally read `event.values[0..2]`. When the step counter fired, `values.size == 1` and indexing `[1]` threw.

Fix: read each axis with a size guard, padding with `0f`. Step counter callers already only read `samples.last().first` (= `values[0]`), so the padded zeros are invisible to them. Accelerometer callers continue to get the real x/y/z.

## Crash signature
```
java.lang.ArrayIndexOutOfBoundsException: length=1; index=1
  at PhoneSensorAdapter$collectSamples$2$1$listener$1.onSensorChanged(PhoneSensorAdapter.kt:203)
```

## Test plan
- [ ] Build + install on a device with a working step counter
- [ ] Trigger a sync that calls `readStepCounter()` (typically: walk a few steps then open the app)
- [ ] App does not crash
- [ ] Step counter reading lands in the metric bus normally
- [ ] Accelerometer-based ACTIVE_MINUTES reading still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)