### PR TITLE
feat(ui): contextual info sheet for vital metrics on Read

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -1,6 +1,8 @@
 package com.bios.app.ui.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -33,7 +35,8 @@ fun MetricCard(
     icon: ImageVector,
     viewModel: AppViewModel,
     refreshKey: Any? = null,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
+    onInfoClick: (() -> Unit)? = null,
 ) {
     var latestValue by remember { mutableStateOf<Double?>(null) }
     var baseline by remember { mutableStateOf<PersonalBaseline?>(null) }
@@ -56,11 +59,11 @@ fun MetricCard(
     val modifier = Modifier.fillMaxWidth()
     if (onClick != null) {
         Card(modifier = modifier, onClick = onClick, colors = colors) {
-            MetricCardBody(metricType, label, icon, latestValue, baseline)
+            MetricCardBody(metricType, label, icon, latestValue, baseline, onInfoClick)
         }
     } else {
         Card(modifier = modifier, colors = colors) {
-            MetricCardBody(metricType, label, icon, latestValue, baseline)
+            MetricCardBody(metricType, label, icon, latestValue, baseline, onInfoClick)
         }
     }
 }
@@ -71,7 +74,8 @@ private fun MetricCardBody(
     label: String,
     icon: ImageVector,
     latestValue: Double?,
-    baseline: PersonalBaseline?
+    baseline: PersonalBaseline?,
+    onInfoClick: (() -> Unit)?,
 ) {
     Column(modifier = Modifier.padding(12.dp)) {
         Row(
@@ -85,14 +89,29 @@ private fun MetricCardBody(
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(20.dp)
             )
-            // Suppress the deviation indicator for cumulative-daily metrics:
-            // the value shown is today's sum but the baseline is computed
-            // from per-window readings — z-score across the two is nonsense.
-            // A daily-sum baseline is a future enhancement.
-            if (metricType !in cumulativeDailyMetrics) {
-                baseline?.let { bl ->
-                    latestValue?.let { v ->
-                        DeviationIndicator(v, bl)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // Suppress the deviation indicator for cumulative-daily metrics:
+                // the value shown is today's sum but the baseline is computed
+                // from per-window readings — z-score across the two is nonsense.
+                // A daily-sum baseline is a future enhancement.
+                if (metricType !in cumulativeDailyMetrics) {
+                    baseline?.let { bl ->
+                        latestValue?.let { v ->
+                            DeviationIndicator(v, bl)
+                        }
+                    }
+                }
+                if (onInfoClick != null && MetricExplanations.forMetric(metricType) != null) {
+                    IconButton(
+                        onClick = onInfoClick,
+                        modifier = Modifier.size(28.dp),
+                    ) {
+                        Icon(
+                            Icons.Outlined.Info,
+                            contentDescription = "About this metric",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(16.dp),
+                        )
                     }
                 }
             }

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricExplanation.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricExplanation.kt
@@ -1,0 +1,69 @@
+package com.bios.app.ui.components
+
+import com.bios.contracts.MetricType
+
+/**
+ * Short, non-prescriptive explanations for the vital metrics surfaced on
+ * Read. The voice is the manifesto's: the owner is reading an
+ * instrument. We describe what the metric measures and what shifts it.
+ * We never say "you should" — evaluation belongs to the owner.
+ *
+ * Content is intentionally concise (a few sentences each). The
+ * Longevity Reference screen is the deeper-read fallback for biomarkers.
+ */
+data class MetricExplanation(
+    val title: String,
+    val whatItMeasures: String,
+    val whyItVaries: String,
+    val howBiosUsesIt: String,
+)
+
+object MetricExplanations {
+
+    fun forMetric(metric: MetricType): MetricExplanation? = explanations[metric]
+
+    private val explanations: Map<MetricType, MetricExplanation> = mapOf(
+        MetricType.HEART_RATE to MetricExplanation(
+            title = "Heart rate",
+            whatItMeasures = "Beats per minute — how fast your heart contracts.",
+            whyItVaries = "Activity, stress, hydration, illness, temperature, hormones, breathing depth, and even moving from sitting to standing all shift it minute to minute.",
+            howBiosUsesIt = "Bios learns your personal range from your own data. A reading is interesting when it deviates from that range — not when it crosses a textbook threshold.",
+        ),
+        MetricType.HEART_RATE_VARIABILITY to MetricExplanation(
+            title = "Heart rate variability",
+            whatItMeasures = "The millisecond-level variation between consecutive heartbeats — a window onto how your autonomic nervous system is balancing stress and recovery.",
+            whyItVaries = "Lower HRV typically follows physical or emotional stress, illness, alcohol, or poor sleep. Higher HRV tends to follow rest. Night-to-night swings are normal even in healthy people.",
+            howBiosUsesIt = "Bios watches multi-day trends against your personal baseline rather than reacting to single nights.",
+        ),
+        MetricType.BLOOD_OXYGEN to MetricExplanation(
+            title = "Blood oxygen (SpO2)",
+            whatItMeasures = "The percentage of hemoglobin in your blood carrying oxygen.",
+            whyItVaries = "Altitude, illness, sleep-disordered breathing, and rarely cardiopulmonary conditions lower it. Most readings cluster between 95–100% at sea level.",
+            howBiosUsesIt = "Wrist optical sensors are noisy by design — Bios pays attention to sustained dips and patterns, not single low samples.",
+        ),
+        MetricType.RESPIRATORY_RATE to MetricExplanation(
+            title = "Respiratory rate",
+            whatItMeasures = "Breaths per minute, usually measured at rest or during sleep.",
+            whyItVaries = "Rises with fever, infection, exercise, and emotional state; falls with sleep depth. Healthy adult rest range is roughly 12–20 breaths/min.",
+            howBiosUsesIt = "A multi-day elevation against your baseline can precede respiratory illness by 24–48 hours in some studies — Bios surfaces the trend, you interpret it.",
+        ),
+        MetricType.STEPS to MetricExplanation(
+            title = "Steps",
+            whatItMeasures = "Total steps counted since local midnight.",
+            whyItVaries = "Daily movement patterns, exercise, schedule, weather, terrain. The cumulative count resets at midnight.",
+            howBiosUsesIt = "Bios shows today's cumulative total. The Trends drill-down shows day-over-day patterns.",
+        ),
+        MetricType.SKIN_TEMPERATURE_DEVIATION to MetricExplanation(
+            title = "Skin temperature deviation",
+            whatItMeasures = "Departure in degrees Celsius from your personal skin-temperature baseline, usually measured at the wrist during sleep.",
+            whyItVaries = "Hormonal cycles (notably the luteal phase), ambient room temperature, infection, and circadian phase all shift it. Bios reports the deviation, not the absolute temperature.",
+            howBiosUsesIt = "Persistent positive deviation can be an early signal of infection or hormonal shift; persistent negative can reflect cooler environments or recovery.",
+        ),
+        MetricType.SLEEP_DURATION to MetricExplanation(
+            title = "Sleep duration",
+            whatItMeasures = "Total time asleep, computed from your wearable's sleep stages or phone-based inference when no wearable reported.",
+            whyItVaries = "Schedule, stress, caffeine, alcohol, light exposure, and screen use shift it. Adult guidance is 7–9 hours but personal need varies.",
+            howBiosUsesIt = "Bios reports what you slept — not what you should sleep. The Sleep dashboard (tap the card) shows regularity, latency, and efficiency separately.",
+        ),
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricInfoSheet.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricInfoSheet.kt
@@ -1,0 +1,80 @@
+package com.bios.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.contracts.MetricType
+
+/**
+ * Pull-shaped explanation surface. Opens when the owner taps the info
+ * affordance on a metric card. Pure pedagogy — what the metric is, what
+ * shifts it, how Bios uses it. No prescription.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MetricInfoSheet(
+    metricType: MetricType,
+    onDismiss: () -> Unit,
+) {
+    val explanation = MetricExplanations.forMetric(metricType) ?: run {
+        onDismiss()
+        return
+    }
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                explanation.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            ExplanationSection("What it measures", explanation.whatItMeasures)
+            ExplanationSection("Why it varies", explanation.whyItVaries)
+            ExplanationSection("How Bios reads it", explanation.howBiosUsesIt)
+
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun ExplanationSection(label: String, body: String) {
+    Column {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            body,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -36,7 +36,9 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -46,6 +48,7 @@ import com.bios.app.engine.BaselineEngine
 import com.bios.app.ingest.SyncWorker
 import com.bios.app.ui.AppViewModel
 import com.bios.app.ui.components.MetricCard
+import com.bios.app.ui.components.MetricInfoSheet
 import com.bios.contracts.MetricType
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -72,6 +75,7 @@ fun HomeScreen(
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
     val lastSync by viewModel.ingestManager.lastSyncTime.collectAsState()
     val isSyncing by viewModel.ingestManager.isSyncing.collectAsState()
+    var infoMetric by remember { mutableStateOf<MetricType?>(null) }
 
     PullToRefreshBox(
         isRefreshing = isSyncing,
@@ -143,7 +147,8 @@ fun HomeScreen(
                         icon = icon,
                         viewModel = viewModel,
                         refreshKey = lastSync,
-                        onClick = { onNavigateToMetric(metricType) }
+                        onClick = { onNavigateToMetric(metricType) },
+                        onInfoClick = { infoMetric = metricType },
                     )
                 }
             }
@@ -169,6 +174,13 @@ fun HomeScreen(
                 )
             }
         }
+    }
+
+    infoMetric?.let { metric ->
+        MetricInfoSheet(
+            metricType = metric,
+            onDismiss = { infoMetric = null },
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Pedagogical layer for the Read tab — every vital card on Read now carries a small `info` icon. Tapping it opens a `ModalBottomSheet` with three descriptive sections for that specific metric:

- **What it measures** — one sentence
- **Why it varies** — descriptive, neutral
- **How Bios reads it** — what Bios actually does with the signal (baselines, trends, etc.), never what *you* should do

Covers the 7 vitals on Read: heart rate, HRV, SpO2, respiratory rate, steps, skin-temperature deviation, sleep duration. Content is intentionally short — the [Longevity Reference](https://github.com/thdelmas/Bios/blob/main/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt) (book icon on Notice) remains the deeper-read fallback for biomarkers.

## Why this shape

Per the manifesto: *Bios is the instrument; the owner reads it. It never withholds information the owner looks for.* Pedagogy is pull-shaped (tap to learn) and contextual (info attached to the thing being read), not pushed. A "Learn" tab would cross the instrument/coach line.

The voice is the manifesto's voice — descriptive, never prescriptive. No "you should". Compare:
- ✗ "You should aim for 7-9 hours of sleep."
- ✓ "Adult guidance is 7–9 hours but personal need varies. Bios reports what you slept — not what you should sleep."

## Files

- new `ui/components/MetricExplanation.kt` — content (per-metric `MetricExplanation` data class)
- new `ui/components/MetricInfoSheet.kt` — the bottom-sheet composable
- updated `ui/components/MetricCard.kt` — adds an optional `onInfoClick` + small info icon in the card's top-right next to the deviation indicator
- updated `ui/home/HomeScreen.kt` — hoists the sheet state and wires it

The info icon renders **only** for metrics with authored content, so future metrics added to the grid without an explanation entry simply stay clean.

## Out of scope (follow-up)

Same affordance on biomarker cards (Body Levels) and active-substance cards. Those need separate content authoring per biomarker / substance — natural Phase B.

## Test plan
- [ ] Build + install
- [ ] Open Read tab — each vital card shows an `i` icon in the top-right
- [ ] Tap the icon → bottom sheet opens with the three sections
- [ ] Tap outside the sheet → it dismisses
- [ ] Tap the card body (not the icon) → still drills to Trends as before
- [ ] Visually confirm the icon doesn't crowd the deviation indicator (the σ readout)
- [ ] Verify no info icon appears on cumulative-daily metrics if their explanation is omitted (currently STEPS has an explanation, so it shows — intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)