### PR TITLE
feat(sleep+ui): contextual info sheets + phone-inference diagnostics & AOD fix

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/PhoneSleepSampleDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/PhoneSleepSampleDao.kt
@@ -32,4 +32,7 @@ interface PhoneSleepSampleDao {
 
     @Query("SELECT COUNT(*) FROM phone_sleep_samples")
     suspend fun count(): Int
+
+    @Query("SELECT MAX(timestamp) FROM phone_sleep_samples")
+    suspend fun lastTimestamp(): Long?
 }

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -224,6 +224,38 @@ object PhoneSleepInference {
         return sorted[range.second].timestamp - sorted[range.first].timestamp
     }
 
+    /** Per-signal breakdown of the buffer so owners can diagnose which
+     *  signal is keeping the inference from firing. */
+    data class SignalBreakdown(
+        val total: Int,
+        val screenInactive: Int,
+        val lowMotion: Int,
+        val dark: Int,
+        val charging: Int,
+        val quiet: Int,
+    )
+
+    fun signalBreakdown(samples: List<Sample>): SignalBreakdown {
+        val total = samples.size
+        val screenInactive = samples.count { it.screenOff }
+        val lowMotion = samples.count {
+            (it.accelMagnitudeVar ?: Float.MAX_VALUE) < ACTIVITY_THRESHOLD
+        }
+        val dark = samples.count {
+            (it.ambientLightLux ?: Float.MAX_VALUE) < DARK_LUX_THRESHOLD
+        }
+        val charging = samples.count { it.charging }
+        val quiet = samples.count { isQuietSample(it) }
+        return SignalBreakdown(
+            total = total,
+            screenInactive = screenInactive,
+            lowMotion = lowMotion,
+            dark = dark,
+            charging = charging,
+            quiet = quiet,
+        )
+    }
+
     /**
      * Two booster signals confirm "this was actual sleep, not a long
      * powered-off phone in a drawer":

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -138,28 +138,67 @@ object PhoneSleepInference {
 
     /**
      * Walk the samples and return the index range of the longest contiguous
-     * stretch where [Sample.screenOff] is true. Returns null when no
-     * screen-off stretch exists at all.
+     * stretch where [Sample.screenOff] is true, **tolerating brief screen-on
+     * flickers** shorter than [SCREEN_ON_FLICKER_MS]. A notification, AOD
+     * wake, or "lift to wake" event mid-sleep would otherwise split a clean
+     * overnight stretch in two; treating those single-sample flickers as
+     * part of the surrounding sleep matches owner intent.
+     *
+     * Returns null when no screen-off stretch exists at all.
      */
     private fun longestScreenOffStretch(samples: List<Sample>): Pair<Int, Int>? {
         var best: Pair<Int, Int>? = null
         var bestLen = 0L
         var runStart = -1
-        for (i in samples.indices) {
+        var i = 0
+        while (i < samples.size) {
             if (samples[i].screenOff) {
                 if (runStart == -1) runStart = i
                 if (i == samples.lastIndex) {
                     val len = samples[i].timestamp - samples[runStart].timestamp
                     if (len > bestLen) { best = runStart to i; bestLen = len }
                 }
+                i++
             } else if (runStart != -1) {
-                val runEnd = i - 1
+                // Look ahead: how long is this screen-on gap, and does
+                // screen-off resume after? If the gap is brief and screen-off
+                // resumes, treat it as a flicker and keep the run going.
+                val gapStart = i
+                while (i < samples.size && !samples[i].screenOff) i++
+                val gapEndExclusive = i
+                val gapDurMs = if (gapEndExclusive < samples.size) {
+                    samples[gapEndExclusive].timestamp - samples[gapStart].timestamp
+                } else {
+                    Long.MAX_VALUE
+                }
+                val resumes = gapEndExclusive < samples.size
+                if (resumes && gapDurMs < SCREEN_ON_FLICKER_MS) {
+                    // Brief flicker, sleep resumes → keep the run alive.
+                    continue
+                }
+                // Real screen-on segment ended the stretch.
+                val runEnd = gapStart - 1
                 val len = samples[runEnd].timestamp - samples[runStart].timestamp
                 if (len > bestLen) { best = runStart to runEnd; bestLen = len }
                 runStart = -1
+            } else {
+                i++
             }
         }
         return best
+    }
+
+    /**
+     * Public helper: returns the duration in milliseconds of the longest
+     * (flicker-tolerant) screen-off stretch in the given samples, or 0 when
+     * no stretch exists. Used by the dashboard diagnostic so the owner can
+     * see how close the buffer is to crossing the 4h floor.
+     */
+    fun longestScreenOffMs(samples: List<Sample>): Long {
+        if (samples.size < 2) return 0L
+        val sorted = samples.sortedBy { it.timestamp }
+        val range = longestScreenOffStretch(sorted) ?: return 0L
+        return sorted[range.second].timestamp - sorted[range.first].timestamp
     }
 
     /**
@@ -196,6 +235,11 @@ object PhoneSleepInference {
     internal const val MIN_SLEEP_DURATION_MS: Long = 1L * 60L * 60L * 1000L
     // Brief movement bouts (< 5 min) are posture shifts, not wake events.
     internal const val AWAKE_BOUT_MIN_MS: Long = 5L * 60L * 1000L
+    // Single notification waking the screen, AOD, or a "lift to wake" event
+    // shouldn't bisect an otherwise clean overnight stretch. ~20 min covers
+    // one missed sample at the 15-min cadence plus a small buffer for clock
+    // drift; longer gaps imply real wake activity.
+    internal const val SCREEN_ON_FLICKER_MS: Long = 20L * 60L * 1000L
     // Accel-magnitude variance above this counts a sample as AWAKE. Hand-
     // tuned for ~5 Hz sampled accelerometer; the variance unit is (m/s^2)^2.
     internal const val ACTIVITY_THRESHOLD: Float = 0.5f

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -137,14 +137,37 @@ object PhoneSleepInference {
     }
 
     /**
+     * Per-sample "owner is likely quiet / not actively using the device"
+     * predicate. Display-off is the primary signal; when it reads "on" we
+     * fall back to a strict three-way fusion to cover phones whose display
+     * state is unreliable (always-on-display devices report STATE_ON even
+     * during sleep on some OEMs):
+     *
+     *   - phone is stationary (low accelerometer variance)
+     *   - room is dark
+     *   - device is charging
+     *
+     * Requiring all three of the fallback signals keeps "watching a movie
+     * in a dark room" from being misclassified as sleep — that scenario
+     * fails the stationary check the moment the owner adjusts position.
+     * "Phone on nightstand showing AOD" passes all three.
+     */
+    internal fun isQuietSample(s: Sample): Boolean {
+        if (s.screenOff) return true
+        val lowMotion = (s.accelMagnitudeVar ?: Float.MAX_VALUE) < ACTIVITY_THRESHOLD
+        val dark = (s.ambientLightLux ?: Float.MAX_VALUE) < DARK_LUX_THRESHOLD
+        return s.charging && lowMotion && dark
+    }
+
+    /**
      * Walk the samples and return the index range of the longest contiguous
-     * stretch where [Sample.screenOff] is true, **tolerating brief screen-on
+     * stretch where [isQuietSample] holds, **tolerating brief activity
      * flickers** shorter than [SCREEN_ON_FLICKER_MS]. A notification, AOD
      * wake, or "lift to wake" event mid-sleep would otherwise split a clean
      * overnight stretch in two; treating those single-sample flickers as
      * part of the surrounding sleep matches owner intent.
      *
-     * Returns null when no screen-off stretch exists at all.
+     * Returns null when no quiet stretch exists at all.
      */
     private fun longestScreenOffStretch(samples: List<Sample>): Pair<Int, Int>? {
         var best: Pair<Int, Int>? = null
@@ -152,7 +175,7 @@ object PhoneSleepInference {
         var runStart = -1
         var i = 0
         while (i < samples.size) {
-            if (samples[i].screenOff) {
+            if (isQuietSample(samples[i])) {
                 if (runStart == -1) runStart = i
                 if (i == samples.lastIndex) {
                     val len = samples[i].timestamp - samples[runStart].timestamp
@@ -160,11 +183,11 @@ object PhoneSleepInference {
                 }
                 i++
             } else if (runStart != -1) {
-                // Look ahead: how long is this screen-on gap, and does
-                // screen-off resume after? If the gap is brief and screen-off
-                // resumes, treat it as a flicker and keep the run going.
+                // Look ahead: how long is this active gap, and does the
+                // quiet stretch resume after? If the gap is brief, treat it
+                // as a flicker and keep the run going.
                 val gapStart = i
-                while (i < samples.size && !samples[i].screenOff) i++
+                while (i < samples.size && !isQuietSample(samples[i])) i++
                 val gapEndExclusive = i
                 val gapDurMs = if (gapEndExclusive < samples.size) {
                     samples[gapEndExclusive].timestamp - samples[gapStart].timestamp
@@ -176,7 +199,7 @@ object PhoneSleepInference {
                     // Brief flicker, sleep resumes → keep the run alive.
                     continue
                 }
-                // Real screen-on segment ended the stretch.
+                // Real active segment ended the stretch.
                 val runEnd = gapStart - 1
                 val len = samples[runEnd].timestamp - samples[runStart].timestamp
                 if (len > bestLen) { best = runStart to runEnd; bestLen = len }

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -1,6 +1,8 @@
 package com.bios.app.ingest
 
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -38,8 +40,6 @@ class PhoneSleepAdapter(private val context: Context) {
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     private val displayManager =
         context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-    private val batteryManager =
-        context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
 
     private val accelerometer: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
@@ -64,7 +64,7 @@ class PhoneSleepAdapter(private val context: Context) {
         return PhoneSleepInference.Sample(
             timestamp = now,
             screenOff = isScreenInactive(),
-            charging = batteryManager.isCharging,
+            charging = isPluggedIn(),
             ambientLightLux = readOnce(lightSensor, AMBIENT_LIGHT_TIMEOUT_MS),
             accelMagnitudeVar = sampleAccelVariance(accelWindowMs),
         )
@@ -87,6 +87,26 @@ class PhoneSleepAdapter(private val context: Context) {
             Display.STATE_ON_SUSPEND -> true
             else -> false
         }
+    }
+
+    /**
+     * `BatteryManager.isCharging()` returns false the moment a topped-off
+     * battery stops actively drawing current — and most phones reach 100%
+     * within a few hours of plug-in, so a 6h "is charging" signal would
+     * miss the entire second half of the night. The right "phone is on a
+     * nightstand dock" signal is plug state, not current draw.
+     *
+     * Reads the sticky [Intent.ACTION_BATTERY_CHANGED] (null receiver
+     * returns the cached value, no broadcast registration cost) and treats
+     * any non-zero plugged source (AC / USB / wireless / dock) as plugged.
+     */
+    private fun isPluggedIn(): Boolean {
+        val intent = context.registerReceiver(
+            null,
+            IntentFilter(Intent.ACTION_BATTERY_CHANGED),
+        ) ?: return false
+        val plugged = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0)
+        return plugged != 0
     }
 
     /**

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -5,8 +5,9 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.hardware.display.DisplayManager
 import android.os.BatteryManager
-import android.os.PowerManager
+import android.view.Display
 import com.bios.app.engine.PhoneSleepInference
 import com.bios.app.model.MetricReading
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -35,8 +36,8 @@ class PhoneSleepAdapter(private val context: Context) {
 
     private val sensorManager =
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
-    private val powerManager =
-        context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val displayManager =
+        context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
     private val batteryManager =
         context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
 
@@ -62,11 +63,30 @@ class PhoneSleepAdapter(private val context: Context) {
         val now = System.currentTimeMillis()
         return PhoneSleepInference.Sample(
             timestamp = now,
-            screenOff = !powerManager.isInteractive,
+            screenOff = isScreenInactive(),
             charging = batteryManager.isCharging,
             ambientLightLux = readOnce(lightSensor, AMBIENT_LIGHT_TIMEOUT_MS),
             accelMagnitudeVar = sampleAccelVariance(accelWindowMs),
         )
+    }
+
+    /**
+     * Phones with always-on display keep `PowerManager.isInteractive()`
+     * true through the night, which collapsed the inference's screen-off
+     * stretch to a few minutes between unlocks. Read the actual display
+     * state instead: OFF / DOZE / DOZE_SUSPEND / ON_SUSPEND are all
+     * "owner isn't actively using the device" — only [Display.STATE_ON]
+     * (and the unknown fallback) count as truly interactive.
+     */
+    private fun isScreenInactive(): Boolean {
+        val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY) ?: return false
+        return when (display.state) {
+            Display.STATE_OFF,
+            Display.STATE_DOZE,
+            Display.STATE_DOZE_SUSPEND,
+            Display.STATE_ON_SUSPEND -> true
+            else -> false
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -80,6 +79,7 @@ fun SleepDashboardScreen(
     var inferenceMessage by remember { mutableStateOf<String?>(null) }
     var bufferedSamples by remember { mutableStateOf(0) }
     var lastSampleMs by remember { mutableStateOf<Long?>(null) }
+    var longestQuietMs by remember { mutableStateOf(0L) }
 
     LaunchedEffect(windowDays, refreshTick) {
         val end = System.currentTimeMillis()
@@ -91,6 +91,22 @@ fun SleepDashboardScreen(
             .associate { it.id to (it.deviceName ?: it.sourceType) }
         bufferedSamples = viewModel.db.phoneSleepSampleDao().count()
         lastSampleMs = viewModel.db.phoneSleepSampleDao().lastTimestamp()
+        // Compute the longest screen-off stretch in the inference window so
+        // the empty-state diagnostic can show how close the buffer is to the
+        // 4h floor — turns "NoSleepWindow" into "you have 2h 30m, need 4h".
+        val bufferStart = end - PhoneSleepWorker.FORCE_WINDOW_MS
+        val samples = viewModel.db.phoneSleepSampleDao()
+            .fetchInRange(bufferStart, end)
+            .map {
+                com.bios.app.engine.PhoneSleepInference.Sample(
+                    timestamp = it.timestamp,
+                    screenOff = it.screenOff,
+                    charging = it.charging,
+                    ambientLightLux = it.ambientLightLux,
+                    accelMagnitudeVar = it.accelMagnitudeVar,
+                )
+            }
+        longestQuietMs = com.bios.app.engine.PhoneSleepInference.longestScreenOffMs(samples)
     }
 
     val onInferNow: () -> Unit = {
@@ -166,6 +182,7 @@ fun SleepDashboardScreen(
                         onInferNow = onInferNow,
                         bufferedSamples = bufferedSamples,
                         lastSampleMs = lastSampleMs,
+                        longestQuietMs = longestQuietMs,
                     )
                 }
             } else {
@@ -342,111 +359,6 @@ private fun formatDuration(seconds: Long): String {
 
 private val dateFormat = SimpleDateFormat("EEE, MMM d", Locale.US)
 private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))
-
-@Composable
-private fun EmptyStateCard(
-    inferring: Boolean,
-    onInferNow: () -> Unit,
-    bufferedSamples: Int,
-    lastSampleMs: Long?,
-) {
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
-        ),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Text(
-                "No sleep readings in the selected window.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Text(
-                "Connect a wearable, sync Health Connect, log a night manually, " +
-                    "or run phone inference now against whatever samples already buffered.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            PhoneInferenceDiagnostics(bufferedSamples, lastSampleMs)
-            FilledTonalButton(
-                onClick = onInferNow,
-                enabled = !inferring,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(if (inferring) "Running inference…" else "Run phone inference now")
-            }
-        }
-    }
-}
-
-@Composable
-private fun PhoneInferenceDiagnostics(bufferedSamples: Int, lastSampleMs: Long?) {
-    val minNeeded = PhoneSleepWorker.MIN_SAMPLES_FOR_INFERENCE
-    val lastSampleText = lastSampleMs?.let { relativeTime(it) } ?: "never"
-    val statusColor = if (bufferedSamples >= minNeeded) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.tertiary
-    }
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(
-            "Phone inference buffer: $bufferedSamples / $minNeeded samples",
-            style = MaterialTheme.typography.labelSmall,
-            color = statusColor,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Text(
-            "Last sample collected: $lastSampleText",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        if (bufferedSamples == 0) {
-            Text(
-                "The background worker hasn't recorded any sensor samples yet. " +
-                    "On Android, periodic work can be delayed by battery savers or " +
-                    "aggressive app-killing — check that Bios isn't restricted in " +
-                    "battery/optimization settings, then wait ~15 min for the next run.",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
-}
-
-private fun relativeTime(timestampMs: Long): String {
-    val deltaMs = System.currentTimeMillis() - timestampMs
-    if (deltaMs < 0) return "in the future"
-    val minutes = deltaMs / 60_000L
-    val hours = minutes / 60L
-    val days = hours / 24L
-    return when {
-        minutes < 1 -> "just now"
-        minutes < 60 -> "${minutes}m ago"
-        hours < 24 -> "${hours}h ago"
-        else -> "${days}d ago"
-    }
-}
-
-@Composable
-private fun InferenceResultCard(message: String) {
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer
-        ),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Text(
-            message,
-            modifier = Modifier.padding(12.dp),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
-        )
-    }
-}
 
 private fun describe(result: PhoneSleepWorker.ImmediateResult): String = when (result) {
     is PhoneSleepWorker.ImmediateResult.Written ->

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -78,6 +78,8 @@ fun SleepDashboardScreen(
     var sourceLabels by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var inferring by remember { mutableStateOf(false) }
     var inferenceMessage by remember { mutableStateOf<String?>(null) }
+    var bufferedSamples by remember { mutableStateOf(0) }
+    var lastSampleMs by remember { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(windowDays, refreshTick) {
         val end = System.currentTimeMillis()
@@ -87,6 +89,8 @@ fun SleepDashboardScreen(
             .sortedByDescending { it.timestamp }
         sourceLabels = viewModel.db.dataSourceDao().getAll()
             .associate { it.id to (it.deviceName ?: it.sourceType) }
+        bufferedSamples = viewModel.db.phoneSleepSampleDao().count()
+        lastSampleMs = viewModel.db.phoneSleepSampleDao().lastTimestamp()
     }
 
     val onInferNow: () -> Unit = {
@@ -144,13 +148,7 @@ fun SleepDashboardScreen(
         ) {
             item { WindowSelector(windowDays) { windowDays = it } }
             inferenceMessage?.let { msg ->
-                item {
-                    Text(
-                        msg,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                item { InferenceResultCard(msg) }
             }
             item { RegularityCard(regularity) }
             item { SummaryCard(nights) }
@@ -162,7 +160,14 @@ fun SleepDashboardScreen(
                 )
             }
             if (nights.isEmpty()) {
-                item { EmptyStateCard(inferring = inferring, onInferNow = onInferNow) }
+                item {
+                    EmptyStateCard(
+                        inferring = inferring,
+                        onInferNow = onInferNow,
+                        bufferedSamples = bufferedSamples,
+                        lastSampleMs = lastSampleMs,
+                    )
+                }
             } else {
                 items(nights, key = { it.id }) { night ->
                     NightRow(night, sourceLabels)
@@ -339,7 +344,12 @@ private val dateFormat = SimpleDateFormat("EEE, MMM d", Locale.US)
 private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))
 
 @Composable
-private fun EmptyStateCard(inferring: Boolean, onInferNow: () -> Unit) {
+private fun EmptyStateCard(
+    inferring: Boolean,
+    onInferNow: () -> Unit,
+    bufferedSamples: Int,
+    lastSampleMs: Long?,
+) {
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant
@@ -361,6 +371,7 @@ private fun EmptyStateCard(inferring: Boolean, onInferNow: () -> Unit) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            PhoneInferenceDiagnostics(bufferedSamples, lastSampleMs)
             FilledTonalButton(
                 onClick = onInferNow,
                 enabled = !inferring,
@@ -369,6 +380,71 @@ private fun EmptyStateCard(inferring: Boolean, onInferNow: () -> Unit) {
                 Text(if (inferring) "Running inference…" else "Run phone inference now")
             }
         }
+    }
+}
+
+@Composable
+private fun PhoneInferenceDiagnostics(bufferedSamples: Int, lastSampleMs: Long?) {
+    val minNeeded = PhoneSleepWorker.MIN_SAMPLES_FOR_INFERENCE
+    val lastSampleText = lastSampleMs?.let { relativeTime(it) } ?: "never"
+    val statusColor = if (bufferedSamples >= minNeeded) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.tertiary
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            "Phone inference buffer: $bufferedSamples / $minNeeded samples",
+            style = MaterialTheme.typography.labelSmall,
+            color = statusColor,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "Last sample collected: $lastSampleText",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (bufferedSamples == 0) {
+            Text(
+                "The background worker hasn't recorded any sensor samples yet. " +
+                    "On Android, periodic work can be delayed by battery savers or " +
+                    "aggressive app-killing — check that Bios isn't restricted in " +
+                    "battery/optimization settings, then wait ~15 min for the next run.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun relativeTime(timestampMs: Long): String {
+    val deltaMs = System.currentTimeMillis() - timestampMs
+    if (deltaMs < 0) return "in the future"
+    val minutes = deltaMs / 60_000L
+    val hours = minutes / 60L
+    val days = hours / 24L
+    return when {
+        minutes < 1 -> "just now"
+        minutes < 60 -> "${minutes}m ago"
+        hours < 24 -> "${hours}h ago"
+        else -> "${days}d ago"
+    }
+}
+
+@Composable
+private fun InferenceResultCard(message: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            message,
+            modifier = Modifier.padding(12.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -80,6 +80,9 @@ fun SleepDashboardScreen(
     var bufferedSamples by remember { mutableStateOf(0) }
     var lastSampleMs by remember { mutableStateOf<Long?>(null) }
     var longestQuietMs by remember { mutableStateOf(0L) }
+    var signalBreakdown by remember {
+        mutableStateOf<com.bios.app.engine.PhoneSleepInference.SignalBreakdown?>(null)
+    }
 
     LaunchedEffect(windowDays, refreshTick) {
         val end = System.currentTimeMillis()
@@ -107,6 +110,7 @@ fun SleepDashboardScreen(
                 )
             }
         longestQuietMs = com.bios.app.engine.PhoneSleepInference.longestScreenOffMs(samples)
+        signalBreakdown = com.bios.app.engine.PhoneSleepInference.signalBreakdown(samples)
     }
 
     val onInferNow: () -> Unit = {
@@ -183,6 +187,7 @@ fun SleepDashboardScreen(
                         bufferedSamples = bufferedSamples,
                         lastSampleMs = lastSampleMs,
                         longestQuietMs = longestQuietMs,
+                        signalBreakdown = signalBreakdown,
                     )
                 }
             } else {

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepEmptyState.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepEmptyState.kt
@@ -23,6 +23,7 @@ internal fun EmptyStateCard(
     bufferedSamples: Int,
     lastSampleMs: Long?,
     longestQuietMs: Long,
+    signalBreakdown: PhoneSleepInference.SignalBreakdown?,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -45,7 +46,12 @@ internal fun EmptyStateCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            PhoneInferenceDiagnostics(bufferedSamples, lastSampleMs, longestQuietMs)
+            PhoneInferenceDiagnostics(
+                bufferedSamples,
+                lastSampleMs,
+                longestQuietMs,
+                signalBreakdown,
+            )
             FilledTonalButton(
                 onClick = onInferNow,
                 enabled = !inferring,
@@ -62,6 +68,7 @@ private fun PhoneInferenceDiagnostics(
     bufferedSamples: Int,
     lastSampleMs: Long?,
     longestQuietMs: Long,
+    signalBreakdown: PhoneSleepInference.SignalBreakdown?,
 ) {
     val minNeeded = PhoneSleepWorker.MIN_SAMPLES_FOR_INFERENCE
     val minWindowMs = PhoneSleepInference.MIN_SLEEP_WINDOW_MS
@@ -105,16 +112,55 @@ private fun PhoneInferenceDiagnostics(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         } else if (longestQuietMs < minWindowMs && bufferedSamples >= minNeeded) {
+            signalBreakdown?.let { SignalBreakdownText(it) }
             Text(
-                "Inference needs a continuous screen-off stretch — single " +
-                    "screen-on flickers under 20 min are tolerated, but " +
-                    "longer wake periods split the stretch. Notifications, " +
-                    "always-on-display, or lift-to-wake during sleep are the " +
-                    "usual culprits.",
+                "Inference needs a continuous quiet stretch — fused from " +
+                    "display-off OR (stationary + dark + charging). The " +
+                    "breakdown above shows which signals your samples pass; " +
+                    "the weak link is the bottleneck.",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+@Composable
+private fun SignalBreakdownText(b: PhoneSleepInference.SignalBreakdown) {
+    if (b.total == 0) return
+    Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(
+            "Per-signal sample counts (out of ${b.total}):",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "  • display inactive: ${b.screenInactive}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "  • stationary (low motion): ${b.lowMotion}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "  • dark environment: ${b.dark}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "  • charging: ${b.charging}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "  → passes fused quiet predicate: ${b.quiet}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepEmptyState.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepEmptyState.kt
@@ -1,0 +1,157 @@
+package com.bios.app.ui.sleep
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.PhoneSleepInference
+import com.bios.app.ingest.PhoneSleepWorker
+
+@Composable
+internal fun EmptyStateCard(
+    inferring: Boolean,
+    onInferNow: () -> Unit,
+    bufferedSamples: Int,
+    lastSampleMs: Long?,
+    longestQuietMs: Long,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                "No sleep readings in the selected window.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                "Connect a wearable, sync Health Connect, log a night manually, " +
+                    "or run phone inference now against whatever samples already buffered.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            PhoneInferenceDiagnostics(bufferedSamples, lastSampleMs, longestQuietMs)
+            FilledTonalButton(
+                onClick = onInferNow,
+                enabled = !inferring,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (inferring) "Running inference…" else "Run phone inference now")
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhoneInferenceDiagnostics(
+    bufferedSamples: Int,
+    lastSampleMs: Long?,
+    longestQuietMs: Long,
+) {
+    val minNeeded = PhoneSleepWorker.MIN_SAMPLES_FOR_INFERENCE
+    val minWindowMs = PhoneSleepInference.MIN_SLEEP_WINDOW_MS
+    val lastSampleText = lastSampleMs?.let { relativeTime(it) } ?: "never"
+    val sampleColor = if (bufferedSamples >= minNeeded) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.tertiary
+    }
+    val quietColor = if (longestQuietMs >= minWindowMs) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.tertiary
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            "Phone inference buffer: $bufferedSamples / $minNeeded samples",
+            style = MaterialTheme.typography.labelSmall,
+            color = sampleColor,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            "Last sample collected: $lastSampleText",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "Longest quiet window: ${formatDurationMs(longestQuietMs)} / " +
+                "need ${formatDurationMs(minWindowMs)}+",
+            style = MaterialTheme.typography.labelSmall,
+            color = quietColor,
+            fontWeight = FontWeight.SemiBold,
+        )
+        if (bufferedSamples == 0) {
+            Text(
+                "The background worker hasn't recorded any sensor samples yet. " +
+                    "On Android, periodic work can be delayed by battery savers or " +
+                    "aggressive app-killing — check that Bios isn't restricted in " +
+                    "battery/optimization settings, then wait ~15 min for the next run.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else if (longestQuietMs < minWindowMs && bufferedSamples >= minNeeded) {
+            Text(
+                "Inference needs a continuous screen-off stretch — single " +
+                    "screen-on flickers under 20 min are tolerated, but " +
+                    "longer wake periods split the stretch. Notifications, " +
+                    "always-on-display, or lift-to-wake during sleep are the " +
+                    "usual culprits.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun InferenceResultCard(message: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+        ),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Text(
+            message,
+            modifier = Modifier.padding(12.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
+        )
+    }
+}
+
+private fun formatDurationMs(ms: Long): String {
+    val totalMinutes = ms / 60_000L
+    val h = totalMinutes / 60L
+    val m = totalMinutes % 60L
+    return if (h > 0) "${h}h ${m}m" else "${m}m"
+}
+
+private fun relativeTime(timestampMs: Long): String {
+    val deltaMs = System.currentTimeMillis() - timestampMs
+    if (deltaMs < 0) return "in the future"
+    val minutes = deltaMs / 60_000L
+    val hours = minutes / 60L
+    val days = hours / 24L
+    return when {
+        minutes < 1 -> "just now"
+        minutes < 60 -> "${minutes}m ago"
+        hours < 24 -> "${hours}h ago"
+        else -> "${days}d ago"
+    }
+}

--- a/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
@@ -50,11 +50,43 @@ class PhoneSleepInferenceTest {
     }
 
     @Test
-    fun `screen-on samples are not counted as sleep`() {
-        // Same 8h but screen is ON throughout — long meeting, not sleep.
+    fun `screen-on samples in a lit room are not counted as sleep`() {
+        // 8h, screen on, in a lit room (desk or meeting). The fused-quiet
+        // fallback rejects this because the dark-room booster fails.
         val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = false, charging = true,
+            lux = 200f, accelVar = 0f)
+        assertTrue(PhoneSleepInference.infer(samples, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `phone-in-hand in a dark room is not counted as sleep`() {
+        // Owner reading / scrolling in bed: screen on, dark room, but the
+        // hand-held device generates motion. Fused-quiet must reject this.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = false, charging = true,
+            lux = 0f, accelVar = 2f)
+        assertTrue(PhoneSleepInference.infer(samples, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `unplugged screen-on phone is not counted as sleep`() {
+        // Without the charging booster, screen-on phone in a dark still
+        // room is too ambiguous (pocket, drawer, bag) to claim as sleep.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = false, charging = false,
             lux = 0f, accelVar = 0f)
         assertTrue(PhoneSleepInference.infer(samples, sourceId).isEmpty())
+    }
+
+    @Test
+    fun `always-on-display phone on a charged nightstand is counted as sleep`() {
+        // The bug that triggered the fused-quiet fallback: phones with AOD
+        // keep the display reading STATE_ON through the night even when
+        // the owner is asleep. If they're stationary, the room is dark,
+        // and they're charging, that's the AOD-on-nightstand signature.
+        val samples = trace(durationMs = 8 * 60 * minuteMs, screenOff = false, charging = true,
+            lux = 0f, accelVar = 0f)
+        val readings = PhoneSleepInference.infer(samples, sourceId)
+        val duration = readings.firstOrNull { it.metricType == MetricType.SLEEP_DURATION.key }
+        assertNotNull("Expected the AOD-on-nightstand window to land", duration)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bundles two threads of work that landed on the same branch:

**1. Contextual info sheets on Read** ([`50a29d3`](https://github.com/thdelmas/Bios/commit/50a29d3))
- Per-metric "what is this?" affordance on each vital card.
- Tap the info icon → bottom sheet describing what the metric measures, why it varies, and how Bios reads it.
- Covers HR, HRV, SpO2, respiratory rate, steps, skin temperature deviation, and sleep duration.
- Pedagogy is pull-shaped and contextual — never prescriptive.

**2. Phone-only sleep inference robustness + diagnostics** (5 commits)
Triggered by an owner reporting "sleep card stays empty" despite the worker collecting samples through a full night. Root-caused two real bugs and added the diagnostic surface needed to debug the next one without guessing.

| Commit | Fix |
| --- | --- |
| [`4027382`](https://github.com/thdelmas/Bios/commit/4027382) | `BatteryManager.isCharging()` returns false the moment a battery tops off at 100% — second half of every night looked unplugged. Swapped to sticky `ACTION_BATTERY_CHANGED` + `EXTRA_PLUGGED`. |
| [`dce9b09`](https://github.com/thdelmas/Bios/commit/dce9b09) | `PowerManager.isInteractive()` returns true on phones with always-on-display through the night → no overnight stretch ever crossed the 4h floor. Switched to `DisplayManager.getDisplay().state` and added a strict motion+dark+charging fallback when display reads ON. |
| [`f185b42`](https://github.com/thdelmas/Bios/commit/f185b42) | Single notification / AOD wake samples no longer bisect an otherwise clean overnight stretch — 20-min flicker tolerance, mirroring the existing AWAKE-bout merging. Plus the empty-state diagnostic now shows the actual longest quiet window. |
| [`3ab636e`](https://github.com/thdelmas/Bios/commit/3ab636e) | Per-signal breakdown on the empty-state card: how many of N samples pass each of display-inactive / stationary / dark / charging, plus the fused predicate. Turns "still empty" into actionable diagnosis. |
| [`de4f66a`](https://github.com/thdelmas/Bios/commit/de4f66a) | Buffered-sample counter + last-sample relative time + battery-saver guidance on the empty-state card. |

## Test plan

- [x] `./gradlew :app:compileStandaloneDebugKotlin` + `:app:assembleDebug` clean
- [x] Existing `PhoneSleepInferenceTest` suite passes, including three new cases (AOD nightstand acceptance, lit-room rejection, in-hand-dark rejection, unplugged-dark rejection)
- [x] All pre-commit checks pass (file lengths, secret scan, lint, unit tests)
- [ ] Sleep through one night with the new APK on an AOD-enabled phone → confirm Sleep dashboard populates without pressing "Run phone inference now"
- [ ] Verify Read tab Sleep card shows the inferred night after the next sync
- [ ] Tap each vital card's info icon on Read → confirm bottom sheet renders the right copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)