### PR TITLE
feat(ui): Read-tab metric cards — info sheets, reading age, staleness UX

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -39,16 +39,21 @@ fun MetricCard(
     onInfoClick: (() -> Unit)? = null,
 ) {
     var latestValue by remember { mutableStateOf<Double?>(null) }
+    var latestTimestamp by remember { mutableStateOf<Long?>(null) }
     var baseline by remember { mutableStateOf<PersonalBaseline?>(null) }
 
     LaunchedEffect(metricType, refreshKey) {
-        latestValue = if (metricType in cumulativeDailyMetrics) {
+        if (metricType in cumulativeDailyMetrics) {
             // Cumulative-daily metrics emit per-sample-window: the latest
             // reading is whatever happened in the last bucket, not today's
-            // total. Sum since local midnight instead.
-            viewModel.getTodaySum(metricType)
+            // total. Sum since local midnight instead. Age would only mean
+            // "last bucket received," not "data freshness," so suppress it.
+            latestValue = viewModel.getTodaySum(metricType)
+            latestTimestamp = null
         } else {
-            viewModel.getLatestReading(metricType)?.value
+            val reading = viewModel.getLatestReading(metricType)
+            latestValue = reading?.value
+            latestTimestamp = reading?.timestamp
         }
         baseline = viewModel.getBaseline(metricType)
     }
@@ -59,11 +64,11 @@ fun MetricCard(
     val modifier = Modifier.fillMaxWidth()
     if (onClick != null) {
         Card(modifier = modifier, onClick = onClick, colors = colors) {
-            MetricCardBody(metricType, label, icon, latestValue, baseline, onInfoClick)
+            MetricCardBody(metricType, label, icon, latestValue, latestTimestamp, baseline, onInfoClick)
         }
     } else {
         Card(modifier = modifier, colors = colors) {
-            MetricCardBody(metricType, label, icon, latestValue, baseline, onInfoClick)
+            MetricCardBody(metricType, label, icon, latestValue, latestTimestamp, baseline, onInfoClick)
         }
     }
 }
@@ -74,6 +79,7 @@ private fun MetricCardBody(
     label: String,
     icon: ImageVector,
     latestValue: Double?,
+    latestTimestamp: Long?,
     baseline: PersonalBaseline?,
     onInfoClick: (() -> Unit)?,
 ) {
@@ -119,14 +125,24 @@ private fun MetricCardBody(
 
         Spacer(Modifier.height(8.dp))
 
+        val ageMillis = latestTimestamp?.let { System.currentTimeMillis() - it }
+        val stale = ageMillis != null && isStale(metricType, ageMillis)
+
         Text(
             text = latestValue?.let { formatValue(it, metricType) } ?: "--",
             style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.SemiBold
+            fontWeight = FontWeight.SemiBold,
+            color = if (stale) MaterialTheme.colorScheme.onSurfaceVariant
+                    else Color.Unspecified
         )
 
+        val ageText = ageMillis?.let { formatRelativeTime(it) }
         Text(
-            text = label,
+            text = when {
+                stale && ageText != null -> "$label · $ageText — open your watch app to refresh"
+                ageText != null -> "$label · $ageText"
+                else -> label
+            },
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -148,6 +164,46 @@ private fun DeviationIndicator(value: Double, baseline: PersonalBaseline) {
         color = color,
         fontWeight = FontWeight.Bold
     )
+}
+
+/**
+ * How old a reading can be before it stops being treated as "live" on the
+ * Read tab. Null means no staleness check — daily-rhythm metrics (sleep,
+ * skin-temp deviation) are inherently 12-36h old by design and shouldn't be
+ * dimmed for it. Returns the threshold in milliseconds.
+ *
+ * Why these specific metrics: vital signs that wearables emit continuously
+ * (HR, HRV, respiration, SpO2) should reflect the last few minutes — if
+ * they don't, the upstream companion app isn't syncing and the displayed
+ * value is misleading rather than informative.
+ */
+internal fun staleThresholdMillis(metricType: MetricType): Long? = when (metricType) {
+    MetricType.HEART_RATE,
+    MetricType.HEART_RATE_VARIABILITY,
+    MetricType.RESPIRATORY_RATE,
+    MetricType.BLOOD_OXYGEN -> 10L * 60_000L
+    else -> null
+}
+
+internal fun isStale(metricType: MetricType, ageMillis: Long): Boolean {
+    val threshold = staleThresholdMillis(metricType) ?: return false
+    return ageMillis > threshold
+}
+
+/**
+ * Reading age, in the smallest unit that's still legible.
+ * `ageMillis` may be negative if a sample's timestamp is slightly in the
+ * future (clock skew between Coros app and phone) — treat as "just now".
+ */
+internal fun formatRelativeTime(ageMillis: Long): String {
+    val seconds = ageMillis / 1000
+    if (seconds < 60) return "just now"
+    val minutes = seconds / 60
+    if (minutes < 60) return "${minutes}m ago"
+    val hours = minutes / 60
+    if (hours < 24) return "${hours}h ago"
+    val days = hours / 24
+    return "${days}d ago"
 }
 
 internal fun formatValue(value: Double, metricType: MetricType): String {

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -173,15 +173,21 @@ private fun DeviationIndicator(value: Double, baseline: PersonalBaseline) {
  * dimmed for it. Returns the threshold in milliseconds.
  *
  * Why these specific metrics: vital signs that wearables emit continuously
- * (HR, HRV, respiration, SpO2) should reflect the last few minutes — if
+ * (HR, HRV, respiration, SpO2) should reflect the last sync window — if
  * they don't, the upstream companion app isn't syncing and the displayed
  * value is misleading rather than informative.
+ *
+ * Why 30 min: typical wearable companion apps (Coros, Garmin) batch their
+ * Health Connect writes every ~20 min when allowed to wake in background.
+ * A 10-min threshold tripped on nearly every reading and turned the nudge
+ * into noise; 30 min lets the normal cadence breathe but still catches the
+ * "hours stale" cases the threshold is actually for.
  */
 internal fun staleThresholdMillis(metricType: MetricType): Long? = when (metricType) {
     MetricType.HEART_RATE,
     MetricType.HEART_RATE_VARIABILITY,
     MetricType.RESPIRATORY_RATE,
-    MetricType.BLOOD_OXYGEN -> 10L * 60_000L
+    MetricType.BLOOD_OXYGEN -> 30L * 60_000L
     else -> null
 }
 

--- a/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
@@ -1,8 +1,14 @@
 package com.bios.app
 
+import com.bios.app.ui.components.formatRelativeTime
 import com.bios.app.ui.components.formatValue
+import com.bios.app.ui.components.isStale
+import com.bios.app.ui.components.staleThresholdMillis
 import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MetricCardFormatTest {
@@ -32,5 +38,72 @@ class MetricCardFormatTest {
     @Test
     fun `heart rate formats as integer bpm`() {
         assertEquals("72", formatValue(72.4, MetricType.HEART_RATE))
+    }
+
+    @Test
+    fun `relative time under 60 seconds is just now`() {
+        assertEquals("just now", formatRelativeTime(0))
+        assertEquals("just now", formatRelativeTime(30_000))
+        assertEquals("just now", formatRelativeTime(59_000))
+    }
+
+    @Test
+    fun `relative time clock skew into the future treated as just now`() {
+        assertEquals("just now", formatRelativeTime(-5_000))
+    }
+
+    @Test
+    fun `relative time under an hour rounds down to minutes`() {
+        assertEquals("1m ago", formatRelativeTime(60_000))
+        assertEquals("5m ago", formatRelativeTime(5 * 60_000))
+        assertEquals("59m ago", formatRelativeTime(59 * 60_000 + 30_000))
+    }
+
+    @Test
+    fun `relative time under a day rounds down to hours`() {
+        assertEquals("1h ago", formatRelativeTime(60 * 60_000))
+        assertEquals("2h ago", formatRelativeTime(2 * 60 * 60_000 + 45 * 60_000))
+        assertEquals("23h ago", formatRelativeTime(23 * 60 * 60_000))
+    }
+
+    @Test
+    fun `relative time beyond a day rounds down to days`() {
+        assertEquals("1d ago", formatRelativeTime(24L * 60 * 60_000))
+        assertEquals("7d ago", formatRelativeTime(7L * 24 * 60 * 60_000))
+    }
+
+    @Test
+    fun `live vitals have a 10 minute stale threshold`() {
+        val tenMin = 10L * 60_000L
+        assertEquals(tenMin, staleThresholdMillis(MetricType.HEART_RATE))
+        assertEquals(tenMin, staleThresholdMillis(MetricType.HEART_RATE_VARIABILITY))
+        assertEquals(tenMin, staleThresholdMillis(MetricType.RESPIRATORY_RATE))
+        assertEquals(tenMin, staleThresholdMillis(MetricType.BLOOD_OXYGEN))
+    }
+
+    @Test
+    fun `daily-rhythm metrics have no stale threshold`() {
+        // Sleep and skin-temp deviation are reported once per night by design —
+        // flagging them as "stale" at 12+ hours would be noise, not signal.
+        assertNull(staleThresholdMillis(MetricType.SLEEP_DURATION))
+        assertNull(staleThresholdMillis(MetricType.SKIN_TEMPERATURE_DEVIATION))
+        assertNull(staleThresholdMillis(MetricType.RESTING_HEART_RATE))
+    }
+
+    @Test
+    fun `isStale is false for fresh HR`() {
+        assertFalse(isStale(MetricType.HEART_RATE, 30_000))
+        assertFalse(isStale(MetricType.HEART_RATE, 9 * 60_000L))
+    }
+
+    @Test
+    fun `isStale is true for HR older than threshold`() {
+        assertTrue(isStale(MetricType.HEART_RATE, 11 * 60_000L))
+        assertTrue(isStale(MetricType.HEART_RATE, 11L * 60 * 60_000L))
+    }
+
+    @Test
+    fun `isStale is false for metrics without a threshold regardless of age`() {
+        assertFalse(isStale(MetricType.SLEEP_DURATION, 48L * 60 * 60_000L))
     }
 }

--- a/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
@@ -73,12 +73,12 @@ class MetricCardFormatTest {
     }
 
     @Test
-    fun `live vitals have a 10 minute stale threshold`() {
-        val tenMin = 10L * 60_000L
-        assertEquals(tenMin, staleThresholdMillis(MetricType.HEART_RATE))
-        assertEquals(tenMin, staleThresholdMillis(MetricType.HEART_RATE_VARIABILITY))
-        assertEquals(tenMin, staleThresholdMillis(MetricType.RESPIRATORY_RATE))
-        assertEquals(tenMin, staleThresholdMillis(MetricType.BLOOD_OXYGEN))
+    fun `live vitals have a 30 minute stale threshold`() {
+        val thirtyMin = 30L * 60_000L
+        assertEquals(thirtyMin, staleThresholdMillis(MetricType.HEART_RATE))
+        assertEquals(thirtyMin, staleThresholdMillis(MetricType.HEART_RATE_VARIABILITY))
+        assertEquals(thirtyMin, staleThresholdMillis(MetricType.RESPIRATORY_RATE))
+        assertEquals(thirtyMin, staleThresholdMillis(MetricType.BLOOD_OXYGEN))
     }
 
     @Test
@@ -93,12 +93,13 @@ class MetricCardFormatTest {
     @Test
     fun `isStale is false for fresh HR`() {
         assertFalse(isStale(MetricType.HEART_RATE, 30_000))
-        assertFalse(isStale(MetricType.HEART_RATE, 9 * 60_000L))
+        assertFalse(isStale(MetricType.HEART_RATE, 20 * 60_000L))
+        assertFalse(isStale(MetricType.HEART_RATE, 29 * 60_000L))
     }
 
     @Test
     fun `isStale is true for HR older than threshold`() {
-        assertTrue(isStale(MetricType.HEART_RATE, 11 * 60_000L))
+        assertTrue(isStale(MetricType.HEART_RATE, 31 * 60_000L))
         assertTrue(isStale(MetricType.HEART_RATE, 11L * 60 * 60_000L))
     }
 


### PR DESCRIPTION
## Summary

Read-tab metric cards gain three things, all aimed at the same goal: making each value legible — not just visible.

- **Contextual info sheets.** Tap the (i) on a vital metric card to open a brief, owner-facing explanation of what the metric is and what its baseline drift means. Per-metric content in `MetricExplanation.kt`, sheet shell in `MetricInfoSheet.kt`.
- **Reading age on every card.** Subtitle now reads `Heart Rate · 5m ago` instead of just `Heart Rate`. Cumulative-daily metrics (steps, active calories, active minutes) stay label-only because their displayed value is today's sum, not the last sample. Helper: `formatRelativeTime(ageMillis)`.
- **Stale-vital UX.** Live vitals (HR, HRV, respiration, SpO2) past a 30-minute threshold dim the value to onSurfaceVariant and extend the subtitle to `Heart Rate · 11h ago — open your watch app to refresh`. Daily-rhythm metrics (sleep, RHR, skin temp) are exempt — 12-36h gaps are normal for them.

The 30-min threshold landed after a field test on Coros + Pixel 9a (#PR-conversation): an owner reported `HR 177` while their watch read `99` live. Diagnosis: Coros companion app was 11h stale in Health Connect because Android's battery optimizer was killing its background sync. Battery → Unrestricted dropped the gap to ~20 min (Coros's natural cadence). 30 min lets that cadence breathe without nagging.

Bundled into the same branch:

- **Sleep inference robustness** (5 commits): tolerate brief screen wakes during night, expose phone-inference buffer state on the dashboard, fuse motion + light + charging signals, render per-signal breakdown when no quiet window is found, and treat plugged-in as charging rather than active current draw. Adds `SleepEmptyState.kt` to surface why a night had no inferred sleep instead of a silent blank card.

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (lint + standalone+lethe build + unit tests)
- [x] New tests in `MetricCardFormatTest` cover `formatRelativeTime`, `staleThresholdMillis`, `isStale`
- [x] Field-verified on Pixel 9a — owner-reported `HR 177 vs watch 99` bug closed
- [ ] Visual check: tap (i) on HR card, info sheet opens; close, value still rendered
- [ ] Visual check: stale HR (>30m) dims and shows refresh nudge
- [ ] Visual check: fresh HR (<30m) renders bold with `· Nm ago` subtitle
- [ ] Verify sleep dashboard renders empty-state when a night has no inferred window

🤖 Generated with [Claude Code](https://claude.com/claude-code)