### PR TITLE
feat: metric info sheets, sleep diagnostics, step delta fix

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/DirectSensorAdapter.kt
@@ -39,6 +39,8 @@ class DirectSensorAdapter(context: Context) {
     private val stepCounter: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
 
+    private val stepDelta = StepCounterDelta(context)
+
     val hasHeartRate: Boolean get() = heartRateSensor != null
     val hasHeartBeat: Boolean get() = heartBeatSensor != null
     val hasStepCounter: Boolean get() = stepCounter != null
@@ -147,16 +149,22 @@ class DirectSensorAdapter(context: Context) {
     }
 
     /**
-     * Read cumulative step count from hardware pedometer.
+     * Read steps from the hardware pedometer as a delta since the previous
+     * sample. TYPE_STEP_COUNTER is cumulative since boot, so emitting the
+     * raw value on every sync would double-count; the delta tracker
+     * persists the last seen cumulative per source and handles reboot
+     * resets.
      */
     suspend fun readSteps(sourceId: String): MetricReading? {
         val sensor = stepCounter ?: return null
         val samples = collectFloatSamples(sensor, STEP_SAMPLE_MS)
         if (samples.isEmpty()) return null
 
+        val cumulative = samples.last().toLong()
+        val delta = stepDelta.computeDelta(cumulative, sourceId) ?: return null
         return MetricReading(
             metricType = MetricType.STEPS.key,
-            value = samples.last(),
+            value = delta.toDouble(),
             timestamp = System.currentTimeMillis(),
             sourceId = sourceId,
             confidence = ConfidenceTier.LOW.level

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSensorAdapter.kt
@@ -41,6 +41,8 @@ class PhoneSensorAdapter(context: Context) {
     private val stepCounter: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
 
+    private val stepDelta = StepCounterDelta(context)
+
     private val lightSensor: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
 
@@ -90,19 +92,22 @@ class PhoneSensorAdapter(context: Context) {
     }
 
     /**
-     * Reads the hardware step counter and returns accumulated steps.
-     * The step counter is cumulative since boot, so we return the raw value
-     * and let IngestManager handle delta computation.
+     * Reads the hardware step counter and returns the delta since the
+     * previous sample. TYPE_STEP_COUNTER is cumulative since boot, so
+     * emitting the raw value on every sync would double-count — the
+     * delta tracker persists the last seen cumulative per source and
+     * handles reboot resets.
      */
     suspend fun readStepCounter(sourceId: String): MetricReading? {
         val sensor = stepCounter ?: return null
         val samples = collectSamples(sensor, STEP_SAMPLE_MS)
         if (samples.isEmpty()) return null
 
-        val stepCount = samples.last().first // step counter uses values[0]
+        val cumulative = samples.last().first.toLong()
+        val delta = stepDelta.computeDelta(cumulative, sourceId) ?: return null
         return MetricReading(
             metricType = MetricType.STEPS.key,
-            value = stepCount.toDouble(),
+            value = delta.toDouble(),
             timestamp = System.currentTimeMillis(),
             sourceId = sourceId,
             confidence = ConfidenceTier.LOW.level

--- a/android/app/src/main/java/com/bios/app/ingest/StepCounterDelta.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/StepCounterDelta.kt
@@ -1,0 +1,85 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import android.os.SystemClock
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Converts cumulative TYPE_STEP_COUNTER readings (steps since device boot)
+ * into per-sample deltas, persisting the last-seen value per source so that
+ * repeat reads don't double-count.
+ *
+ * The hardware counter resets on every reboot, so we also persist boot time
+ * and detect resets by either a counter decrease or a boot-time shift.
+ *
+ * On the first reading for a source (or right after a detected reboot) we
+ * emit the full cumulative as today's delta only if boot happened on or
+ * after today's local midnight — in that case the cumulative count *is*
+ * today's steps so far. Otherwise we suppress and wait for the next
+ * reading so a genuine delta can be measured.
+ */
+class StepCounterDelta(context: Context) {
+
+    private val prefs = context.applicationContext
+        .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+
+    /**
+     * Records [cumulative] as the new baseline for [sourceId] and returns
+     * the number of new steps to emit (or null when none should be).
+     */
+    fun computeDelta(cumulative: Long, sourceId: String): Long? {
+        val bootMs = System.currentTimeMillis() - SystemClock.elapsedRealtime()
+        val todayStartMs = LocalDate.now()
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+        val lastCumulative = prefs.getLong(cumKey(sourceId), -1L)
+        val lastBootMs = prefs.getLong(bootKey(sourceId), -1L)
+
+        val delta = computePure(
+            cumulative, bootMs, lastCumulative, lastBootMs, todayStartMs
+        )
+
+        prefs.edit()
+            .putLong(cumKey(sourceId), cumulative)
+            .putLong(bootKey(sourceId), bootMs)
+            .apply()
+
+        return delta
+    }
+
+    private fun cumKey(sourceId: String) = "cum_$sourceId"
+    private fun bootKey(sourceId: String) = "boot_$sourceId"
+
+    companion object {
+        private const val PREFS_FILE = "bios_step_counter_delta"
+
+        // Boot-time jitter below this is clock noise, not a real reboot.
+        private const val BOOT_JITTER_MS = 5_000L
+
+        /**
+         * Pure delta logic, exposed for unit tests.
+         * @return new steps to emit, or null to emit nothing.
+         */
+        internal fun computePure(
+            cumulative: Long,
+            bootMs: Long,
+            lastCumulative: Long,
+            lastBootMs: Long,
+            todayStartMs: Long
+        ): Long? {
+            if (cumulative <= 0L) return null
+            val firstReading = lastCumulative < 0L
+            val rebooted = !firstReading && (
+                cumulative < lastCumulative ||
+                    kotlin.math.abs(bootMs - lastBootMs) > BOOT_JITTER_MS
+                )
+            return when {
+                firstReading || rebooted ->
+                    if (bootMs >= todayStartMs) cumulative else null
+                else -> (cumulative - lastCumulative).takeIf { it > 0L }
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/bios/app/StepCounterDeltaTest.kt
+++ b/android/app/src/test/java/com/bios/app/StepCounterDeltaTest.kt
@@ -1,0 +1,152 @@
+package com.bios.app
+
+import com.bios.app.ingest.StepCounterDelta
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Covers the pure step-delta computation that fixes the
+ * "+5000 steps every app open" cumulative-counter bug.
+ */
+class StepCounterDeltaTest {
+
+    private val todayStart = 1_000_000_000_000L
+    private val bootToday = todayStart + 60_000L
+    private val bootYesterday = todayStart - 86_400_000L
+
+    @Test
+    fun `first reading after install with boot today emits cumulative`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 3_200L,
+            bootMs = bootToday,
+            lastCumulative = -1L,
+            lastBootMs = -1L,
+            todayStartMs = todayStart
+        )
+        assertEquals(3_200L, delta)
+    }
+
+    @Test
+    fun `first reading after install with boot before today suppresses`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 25_000L,
+            bootMs = bootYesterday,
+            lastCumulative = -1L,
+            lastBootMs = -1L,
+            todayStartMs = todayStart
+        )
+        assertNull(delta)
+    }
+
+    @Test
+    fun `subsequent reading emits only the new steps`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 8_700L,
+            bootMs = bootYesterday,
+            lastCumulative = 8_500L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        assertEquals(200L, delta)
+    }
+
+    @Test
+    fun `repeat read with no movement emits nothing`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 8_500L,
+            bootMs = bootYesterday,
+            lastCumulative = 8_500L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        assertNull(delta)
+    }
+
+    @Test
+    fun `reboot detected by counter decrease emits cumulative when boot today`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 1_200L,
+            bootMs = bootToday,
+            lastCumulative = 40_000L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        assertEquals(1_200L, delta)
+    }
+
+    @Test
+    fun `reboot detected with boot before today suppresses`() {
+        val rebootedBeforeToday = todayStart - 3_600_000L
+        val delta = StepCounterDelta.computePure(
+            cumulative = 4_000L,
+            bootMs = rebootedBeforeToday,
+            lastCumulative = 40_000L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        assertNull(delta)
+    }
+
+    @Test
+    fun `reboot detected by boot-time shift even if counter rises`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 500L,
+            bootMs = bootToday,
+            lastCumulative = 400L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        // Detected as reboot because boot-time jumped a full day,
+        // so the 500 is treated as steps-since-boot (today), not 100 delta.
+        assertEquals(500L, delta)
+    }
+
+    @Test
+    fun `tiny boot-time jitter is not treated as reboot`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 8_700L,
+            bootMs = bootYesterday + 1_000L,
+            lastCumulative = 8_500L,
+            lastBootMs = bootYesterday,
+            todayStartMs = todayStart
+        )
+        assertEquals(200L, delta)
+    }
+
+    @Test
+    fun `zero cumulative emits nothing`() {
+        val delta = StepCounterDelta.computePure(
+            cumulative = 0L,
+            bootMs = bootToday,
+            lastCumulative = -1L,
+            lastBootMs = -1L,
+            todayStartMs = todayStart
+        )
+        assertNull(delta)
+    }
+
+    @Test
+    fun `regression - five opens in a row do not balloon the total`() {
+        // Simulate: device booted yesterday, user has ~30k steps cumulative,
+        // walks ~200 steps between opens. The old code would have added 30k
+        // on every open. The new code emits 0 on first open (boot before
+        // today, no baseline) then 200 per subsequent open.
+        val sequence = listOf(30_000L, 30_200L, 30_400L, 30_600L, 30_800L)
+        var last = -1L
+        val emitted = mutableListOf<Long>()
+        for (cum in sequence) {
+            val d = StepCounterDelta.computePure(
+                cumulative = cum,
+                bootMs = bootYesterday,
+                lastCumulative = last,
+                lastBootMs = if (last < 0L) -1L else bootYesterday,
+                todayStartMs = todayStart
+            )
+            if (d != null) emitted.add(d)
+            last = cum
+        }
+        assertEquals(listOf(200L, 200L, 200L, 200L), emitted)
+        assertEquals(800L, emitted.sum())
+    }
+}


### PR DESCRIPTION
## Summary

Branch bundles three threads that all surfaced while making Read more honest about what the user is looking at:

- **Read screen** — contextual info sheets on each vital, reading-age timestamps, stale vitals dimmed (30m live-vital threshold).
- **Sleep dashboard** — phone-inference buffer state exposed, per-signal breakdown when no quiet window is found, AOD screen-noise fused through motion + light + charging, brief screen wakes tolerated, plugged-in correctly treated as charging.
- **Step counter** — `TYPE_STEP_COUNTER` is cumulative since boot but both phone and direct sensor adapters were writing the raw value on every sync. `getTodaySum` then summed all of today's rows, so each app open inflated the count by the entire boot-cumulative. New `StepCounterDelta` persists last seen value + boot time per source and emits only deltas, with reboot/midnight-aware suppression on first reading.

## Test plan

- [x] `StepCounterDeltaTest` — 10 cases covering first read, repeat reads, reboot detection (counter decrease and boot-time shift), midnight-aware suppression, and a five-opens-in-a-row regression
- [x] `MetricCardFormatTest`, `PhoneSleepInferenceTest` updated
- [x] `./scripts/code-quality-check.sh` passes (build + tests for both flavors)
- [ ] Manual: open app multiple times in a row, confirm step count no longer balloons
- [ ] Manual: tap a vital on Read, confirm info sheet content
- [ ] Manual: sleep dashboard shows quiet-window diagnostic when inference can't pick one

## Caveat

Pre-fix inflated step rows already in the DB will persist until tomorrow's local midnight (or until the owner wipes via Settings → Delete all data). The bug just stops growing on future opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)