### PR TITLE
feat(alerts): URGENT escalation destination + emergency contacts

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -168,6 +168,17 @@
                 <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
             </intent-filter>
         </activity-alias>
+        <!-- URGENT-alert notification-action handler (#179). Owner taps
+             "I'm OK" → cancels the pending UrgentAckTimeoutWorker so no
+             SMS-compose prompt fires. Not exported — only Bios itself
+             builds PendingIntents pointing here. -->
+        <receiver
+            android:name=".alerts.AlertActionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.bios.app.alerts.ACTION_ACKNOWLEDGE" />
+            </intent-filter>
+        </receiver>
         <!-- UnifiedPush service for Google-free push notifications.
              The connector library's internal receiver forwards events here.
              Not exported — only the library binds to it. -->

--- a/android/app/src/main/java/com/bios/app/alerts/AlertActionReceiver.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/AlertActionReceiver.kt
@@ -1,0 +1,63 @@
+package com.bios.app.alerts
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.bios.app.data.BiosDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Handles notification-action taps for URGENT alerts (#179, EM/CC §2.1):
+ *
+ *  - [ACTION_ACKNOWLEDGE] — owner taps "I'm OK". Marks the anomaly
+ *    acknowledged, cancels the pending [UrgentAckTimeoutWorker] so the
+ *    escalation does not fire, and dismisses the notification.
+ *
+ * Registered in [com.bios.app.alerts.AlertManager] via PendingIntent.
+ * Declared in AndroidManifest with android:exported="false" — only Bios
+ * itself fires these intents.
+ */
+class AlertActionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val anomalyId = intent.getStringExtra(EXTRA_ANOMALY_ID) ?: return
+        val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, anomalyId.hashCode())
+
+        when (intent.action) {
+            ACTION_ACKNOWLEDGE -> handleAcknowledge(context, anomalyId, notificationId)
+        }
+    }
+
+    private fun handleAcknowledge(context: Context, anomalyId: String, notificationId: Int) {
+        // Dismiss the notification immediately for owner feedback.
+        NotificationManagerCompat.from(context).cancel(notificationId)
+
+        // Cancel the pending escalation — must happen before the worker
+        // would otherwise fire.
+        UrgentAckTimeoutWorker.cancel(context, anomalyId)
+
+        // Persist the acknowledgement asynchronously. Using a detached
+        // scope is acceptable here: the broadcast is short-lived and the
+        // DAO call is idempotent.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        scope.launch {
+            try {
+                val db = BiosDatabase.getInstance(context.applicationContext)
+                db.anomalyDao().acknowledge(anomalyId)
+            } catch (_: Exception) {
+                // The acknowledgement is best-effort persistence; the
+                // escalation cancellation above is the load-bearing side.
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_ACKNOWLEDGE = "com.bios.app.alerts.ACTION_ACKNOWLEDGE"
+        const val EXTRA_ANOMALY_ID = "anomaly_id"
+        const val EXTRA_NOTIFICATION_ID = "notification_id"
+    }
+}

--- a/android/app/src/main/java/com/bios/app/alerts/UrgentAckTimeoutWorker.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/UrgentAckTimeoutWorker.kt
@@ -1,0 +1,184 @@
+package com.bios.app.alerts
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.EmergencyContactRepo
+import com.bios.app.model.AlertTier
+import com.bios.app.model.EmergencyContact
+import java.util.concurrent.TimeUnit
+
+/**
+ * Per-contact URGENT-acknowledgement timeout worker (#179, EM/CC audit
+ * gap §2.1).
+ *
+ * Scheduled when [AlertManager] fires an URGENT alert and the owner has
+ * configured at least one [EmergencyContact] with a non-null
+ * [EmergencyContact.acknowledgementTimeoutMinutes] eligible for that
+ * tier. On timeout *without* the owner having tapped "I'm OK" (which
+ * cancels the worker by tag), this worker surfaces a notification whose
+ * tap action opens the system SMS chooser pre-populated with a short
+ * message to the contact.
+ *
+ * **Bios never sends a message.** The system SMS chooser hands the dial
+ * decision back to the owner — the owner taps Send. This is the owner-
+ * mediated path the manifesto requires: prospective consent (the owner
+ * set the contact and the timeout while competent), final consent (the
+ * owner — or a bystander who finds the phone — actively confirms the
+ * send through Android's system UI).
+ *
+ * No cloud, no SMS gateway, no Bios server. Pure local
+ * [Intent.ACTION_SENDTO] with an `smsto:` URI.
+ */
+class UrgentAckTimeoutWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val anomalyId = inputData.getString(KEY_ANOMALY_ID) ?: return Result.failure()
+        val alertTitle = inputData.getString(KEY_ALERT_TITLE) ?: "Urgent health alert"
+        val tierLevel = inputData.getInt(KEY_TIER_LEVEL, AlertTier.URGENT.level)
+
+        val db = BiosDatabase.getInstance(applicationContext)
+
+        // Skip if the owner already acknowledged the alert. AlertManager
+        // sets acknowledgedAt when the "I'm OK" action fires; if that
+        // happened before the worker ran (race window between
+        // ExistingWorkPolicy.REPLACE and tag cancellation), bail.
+        val anomaly = db.anomalyDao().fetchRecent(100).find { it.id == anomalyId }
+        if (anomaly == null || anomaly.acknowledged) return Result.success()
+
+        val repo = EmergencyContactRepo(db)
+        val contacts = repo.eligibleForTier(tierLevel)
+        if (contacts.isEmpty()) return Result.success()
+
+        for (contact in contacts) {
+            surfaceEscalationPrompt(contact, alertTitle, anomalyId)
+        }
+        return Result.success()
+    }
+
+    private fun surfaceEscalationPrompt(
+        contact: EmergencyContact,
+        alertTitle: String,
+        anomalyId: String,
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    applicationContext, Manifest.permission.POST_NOTIFICATIONS
+                ) != PackageManager.PERMISSION_GRANTED
+            ) return
+        }
+
+        // Factual SMS body — no diagnosis, no speculation. The owner set
+        // this person as their contact while competent; the contact gets
+        // the same factual statement Bios uses internally.
+        val body = "Bios on this phone hasn't received an acknowledgement on an urgent " +
+            "health alert (\"$alertTitle\"). The owner asked me to let you know."
+        val smsUri = Uri.parse(
+            "smsto:" + Uri.encode(contact.phoneNumber)
+        )
+        val composeIntent = Intent(Intent.ACTION_SENDTO, smsUri).apply {
+            putExtra("sms_body", body)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val pi = PendingIntent.getActivity(
+            applicationContext,
+            ("escalate_${contact.id}_$anomalyId").hashCode(),
+            composeIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(
+            applicationContext, AlertManager.CHANNEL_URGENT
+        )
+            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+            .setContentTitle("No acknowledgement on urgent alert")
+            .setContentText("Tap to text ${contact.name} (${contact.relationship}).")
+            .setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    "An urgent alert from Bios has not been acknowledged. " +
+                        "You designated ${contact.name} (${contact.relationship}) as a " +
+                        "contact for this case. Tap to compose a text — your phone will " +
+                        "ask you to confirm before sending."
+                )
+            )
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pi)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(applicationContext)
+            .notify(("escalate_${contact.id}_$anomalyId").hashCode(), notification)
+    }
+
+    companion object {
+        const val KEY_ANOMALY_ID = "anomaly_id"
+        const val KEY_ALERT_TITLE = "alert_title"
+        const val KEY_TIER_LEVEL = "tier_level"
+
+        /** Unique-work tag for a given anomaly. Lets [cancel] dismiss
+         *  the pending escalation when the owner acknowledges the alert. */
+        fun workName(anomalyId: String): String = "urgent_ack_$anomalyId"
+
+        /**
+         * Schedule a per-anomaly escalation timeout. Uses the *minimum*
+         * timeout across all eligible contacts so the first contact's
+         * window dictates the schedule — subsequent contacts are surfaced
+         * in the same fire (the worker iterates eligible contacts).
+         *
+         * Caller is expected to query [EmergencyContactRepo.eligibleForTier]
+         * first; this method is a no-op if [delayMinutes] is null or ≤ 0.
+         */
+        fun schedule(
+            context: Context,
+            anomalyId: String,
+            alertTitle: String,
+            tierLevel: Int,
+            delayMinutes: Int?,
+        ) {
+            val delay = delayMinutes ?: return
+            if (delay <= 0) return
+
+            val data = workDataOf(
+                KEY_ANOMALY_ID to anomalyId,
+                KEY_ALERT_TITLE to alertTitle,
+                KEY_TIER_LEVEL to tierLevel,
+            )
+
+            val request = OneTimeWorkRequestBuilder<UrgentAckTimeoutWorker>()
+                .setInitialDelay(delay.toLong(), TimeUnit.MINUTES)
+                .setInputData(data)
+                .addTag(workName(anomalyId))
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                workName(anomalyId),
+                ExistingWorkPolicy.REPLACE,
+                request,
+            )
+        }
+
+        /** Cancel a pending escalation — called when the owner taps
+         *  "I'm OK" / acknowledges the alert. Safe to call when no work
+         *  was scheduled. */
+        fun cancel(context: Context, anomalyId: String) {
+            WorkManager.getInstance(context).cancelUniqueWork(workName(anomalyId))
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -37,9 +37,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         HeadacheLog::class,
         FastStrokeEvent::class,
         EsasReport::class,
-        TraditionalMedicineContext::class
+        TraditionalMedicineContext::class,
+        EmergencyContact::class,
     ],
-    version = 20,
+    version = 21,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -69,6 +70,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun fastStrokeEventDao(): FastStrokeEventDao
     abstract fun esasReportDao(): EsasReportDao
     abstract fun traditionalMedicineContextDao(): TraditionalMedicineContextDao
+    abstract fun emergencyContactDao(): EmergencyContactDao
 
     companion object {
         @Volatile
@@ -91,7 +93,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged
@@ -487,14 +489,12 @@ abstract class BiosDatabase : RoomDatabase() {
             }
         }
 
-        // Owner-PRO migrations live in sibling files to keep this one under 500 lines.
+        // Migrations live in sibling files to keep this one under 500 lines.
         private val MIGRATION_16_17 = NeurologyMigrations.MIGRATION_16_17
         private val MIGRATION_17_18 = EsasMigrations.MIGRATION_17_18
         private val MIGRATION_18_19 = TraditionalMedicineMigrations.MIGRATION_18_19
-
-        /** In-memory instance for testing. */
-        fun buildInMemory(context: Context): BiosDatabase {
-            return Room.inMemoryDatabaseBuilder(context.applicationContext, BiosDatabase::class.java).build()
-        }
+        private val MIGRATION_20_21 = EmergencyContactMigrations.MIGRATION_20_21
+        fun buildInMemory(context: Context): BiosDatabase =
+            Room.inMemoryDatabaseBuilder(context.applicationContext, BiosDatabase::class.java).build()
     }
 }

--- a/android/app/src/main/java/com/bios/app/data/EmergencyContactMigrations.kt
+++ b/android/app/src/main/java/com/bios/app/data/EmergencyContactMigrations.kt
@@ -1,0 +1,34 @@
+package com.bios.app.data
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Schema migration that creates the `emergency_contacts` table (#179, EM/CC
+ * audit gap §2.1). Stored in the main DB so the table is wiped alongside
+ * everything else by [DataDestroyer]. Off by default: an empty table means
+ * no escalation path; the URGENT-ack-timeout worker no-ops on empty.
+ */
+internal object EmergencyContactMigrations {
+    val MIGRATION_20_21 = object : Migration(20, 21) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS emergency_contacts (
+                    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    relationship TEXT NOT NULL,
+                    phoneNumber TEXT NOT NULL,
+                    minTierLevel INTEGER NOT NULL,
+                    acknowledgementTimeoutMinutes INTEGER,
+                    createdAt INTEGER NOT NULL,
+                    note TEXT
+                )
+                """.trimIndent(),
+            )
+            db.execSQL(
+                "CREATE INDEX IF NOT EXISTS index_emergency_contacts_createdAt ON emergency_contacts (createdAt)",
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/data/EmergencyContactRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/EmergencyContactRepo.kt
@@ -1,0 +1,107 @@
+package com.bios.app.data
+
+import com.bios.app.model.EmergencyContact
+
+/**
+ * Thin repository wrapper over [com.bios.app.data.dao.EmergencyContactDao]
+ * for the Settings → Emergency contacts screen and the URGENT-escalation
+ * pipeline (audit gap EM/CC §2.1).
+ *
+ * Off-by-default semantics: an empty contact list = no escalation. The
+ * UrgentAckTimeoutWorker queries [eligibleForTier] before scheduling
+ * anything; an empty result means nothing fires.
+ */
+class EmergencyContactRepo(private val db: BiosDatabase) {
+
+    private val dao get() = db.emergencyContactDao()
+
+    /**
+     * Records a new emergency contact.
+     *
+     * @param name owner-recognisable display name; required, non-blank
+     * @param relationship free-text relationship label; required, non-blank
+     * @param phoneNumber phone number as the owner enters it; required,
+     *   non-blank. Bios doesn't validate format — the owner knows what
+     *   reaches their person.
+     * @param minTierLevel minimum alert tier at which this contact may
+     *   surface (defaults to URGENT). Clamped to ADVISORY..URGENT.
+     * @param acknowledgementTimeoutMinutes minutes Bios waits before
+     *   composing an SMS to this contact on an unacknowledged URGENT
+     *   alert. Null = never escalate (default). When non-null, clamped
+     *   to [EmergencyContact.MIN_ACK_TIMEOUT_MIN]..[EmergencyContact.MAX_ACK_TIMEOUT_MIN].
+     * @param note optional owner annotation
+     */
+    suspend fun add(
+        name: String,
+        relationship: String,
+        phoneNumber: String,
+        minTierLevel: Int = EmergencyContact.MIN_TIER_URGENT,
+        acknowledgementTimeoutMinutes: Int? = null,
+        note: String? = null,
+    ): Long {
+        require(name.isNotBlank()) { "Name cannot be blank" }
+        require(relationship.isNotBlank()) { "Relationship cannot be blank" }
+        require(phoneNumber.isNotBlank()) { "Phone number cannot be blank" }
+        return dao.insert(
+            EmergencyContact(
+                name = name.trim(),
+                relationship = relationship.trim(),
+                phoneNumber = phoneNumber.trim(),
+                minTierLevel = clampTier(minTierLevel),
+                acknowledgementTimeoutMinutes = clampTimeout(acknowledgementTimeoutMinutes),
+                note = note?.takeIf { it.isNotBlank() }?.trim(),
+            )
+        )
+    }
+
+    suspend fun update(contact: EmergencyContact) {
+        require(contact.name.isNotBlank()) { "Name cannot be blank" }
+        require(contact.relationship.isNotBlank()) { "Relationship cannot be blank" }
+        require(contact.phoneNumber.isNotBlank()) { "Phone number cannot be blank" }
+        dao.update(
+            contact.copy(
+                name = contact.name.trim(),
+                relationship = contact.relationship.trim(),
+                phoneNumber = contact.phoneNumber.trim(),
+                minTierLevel = clampTier(contact.minTierLevel),
+                acknowledgementTimeoutMinutes = clampTimeout(contact.acknowledgementTimeoutMinutes),
+                note = contact.note?.takeIf { it.isNotBlank() }?.trim(),
+            )
+        )
+    }
+
+    suspend fun remove(id: Long) {
+        val existing = dao.fetchById(id) ?: return
+        dao.delete(existing)
+    }
+
+    suspend fun fetchAll(): List<EmergencyContact> = dao.fetchAll()
+
+    /**
+     * Contacts the [com.bios.app.alerts.UrgentAckTimeoutWorker] may surface
+     * for an alert at [tierLevel]. Filters by per-contact tier opt-in and
+     * by non-null ack-timeout.
+     */
+    suspend fun eligibleForTier(tierLevel: Int): List<EmergencyContact> =
+        dao.fetchEligibleForTier(tierLevel)
+
+    suspend fun count(): Int = dao.count()
+
+    companion object {
+
+        /** Clamp owner-supplied tier floor to ADVISORY..URGENT inclusive. */
+        fun clampTier(level: Int): Int = level.coerceIn(
+            EmergencyContact.MIN_TIER_ADVISORY,
+            EmergencyContact.MIN_TIER_URGENT,
+        )
+
+        /**
+         * Clamp owner-supplied timeout to a sensible window. Null passes
+         * through (escalation off for this contact).
+         */
+        fun clampTimeout(minutes: Int?): Int? = minutes?.coerceIn(
+            EmergencyContact.MIN_ACK_TIMEOUT_MIN,
+            EmergencyContact.MAX_ACK_TIMEOUT_MIN,
+        )
+    }
+}

--- a/android/app/src/main/java/com/bios/app/data/dao/EmergencyContactDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/EmergencyContactDao.kt
@@ -1,0 +1,56 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.bios.app.model.EmergencyContact
+
+/**
+ * Persistence layer for owner-designated emergency contacts (#179, EM/CC
+ * audit gap §2.1).
+ *
+ * Queries the URGENT-escalation pipeline consumes:
+ *
+ *  - [fetchAll] — Settings screen listing
+ *  - [fetchEligibleForTier] — when an alert fires, return the contacts
+ *    whose [EmergencyContact.minTierLevel] is at or below the alert's
+ *    tier *and* whose [EmergencyContact.acknowledgementTimeoutMinutes]
+ *    is non-null. These are the rows the timeout worker may surface.
+ */
+@Dao
+interface EmergencyContactDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(contact: EmergencyContact): Long
+
+    @Update
+    suspend fun update(contact: EmergencyContact)
+
+    @Delete
+    suspend fun delete(contact: EmergencyContact)
+
+    @Query("SELECT * FROM emergency_contacts WHERE id = :id")
+    suspend fun fetchById(id: Long): EmergencyContact?
+
+    @Query("SELECT * FROM emergency_contacts ORDER BY createdAt ASC")
+    suspend fun fetchAll(): List<EmergencyContact>
+
+    /**
+     * Contacts eligible to be surfaced for an alert at [tierLevel] —
+     * i.e. their [EmergencyContact.minTierLevel] is at or below the
+     * alert's tier *and* they have a non-null ack timeout.
+     */
+    @Query("""
+        SELECT * FROM emergency_contacts
+        WHERE minTierLevel <= :tierLevel
+          AND acknowledgementTimeoutMinutes IS NOT NULL
+        ORDER BY createdAt ASC
+    """)
+    suspend fun fetchEligibleForTier(tierLevel: Int): List<EmergencyContact>
+
+    @Query("SELECT COUNT(*) FROM emergency_contacts")
+    suspend fun count(): Int
+}

--- a/android/app/src/main/java/com/bios/app/model/EmergencyContact.kt
+++ b/android/app/src/main/java/com/bios/app/model/EmergencyContact.kt
@@ -1,0 +1,97 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Owner-designated emergency contact (#179, audit gap EM/CC §2.1).
+ *
+ * The five-audit convergence — EM/CC §2.1, Geriatrics/Palliative §2.13,
+ * Primary Care, Cardiology, Ob/Gyn — flagged that URGENT alerts currently
+ * terminate at the notification drawer with no escalation path. For owners
+ * most likely to benefit (elderly, living alone, post-discharge, on insulin,
+ * on opioids) the owner being the only escalation target is structurally
+ * the wrong answer when the alert fires while the owner can no longer act.
+ *
+ * This entity is the owner-set policy half of the answer:
+ *
+ *  - The owner picks the contact (name + relationship label + phone) while
+ *    they are competent — prospective consent.
+ *  - The owner picks the per-tier opt-in: which tiers (URGENT only by
+ *    default, optionally ADVISORY too) may surface this contact.
+ *  - The owner picks the [acknowledgementTimeoutMinutes] — how long Bios
+ *    waits for an "I'm OK" tap before composing a local SMS. Null = never
+ *    escalate; default for new contacts.
+ *
+ * No row in this table = no escalation. The feature is off by default. The
+ * owner is final — Bios never auto-sends; the SMS is composed locally and
+ * handed to the system SMS chooser for owner confirmation.
+ *
+ * Storage is the main encrypted DB (SQLCipher), so the row wipes alongside
+ * everything else when LETHE burner mode, dead man's switch, or the
+ * standalone "Delete all data" action fires — see
+ * [com.bios.app.platform.DataDestroyer.destroyDatabase].
+ *
+ * **Not** stored in [com.bios.app.data.ReproductiveDatabase]: emergency
+ * contacts apply across all health domains, not the reproductive subset.
+ */
+@Entity(
+    tableName = "emergency_contacts",
+    indices = [Index("createdAt")],
+)
+data class EmergencyContact(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    /** Free-text display name (e.g. "Alex" or "Dr. Patel"). Required. */
+    val name: String,
+    /**
+     * Free-text relationship label (e.g. "Partner", "Daughter", "Neighbor",
+     * "Cardiologist"). Surfaced for owner recognition only — Bios does not
+     * branch on this value.
+     */
+    val relationship: String,
+    /**
+     * E.164-or-local-format phone number. Stored verbatim as the owner
+     * entered it; the `smsto:` URI handed to the system SMS chooser
+     * passes it through unchanged. Bios does not validate the number —
+     * the owner knows what number reaches their person.
+     */
+    val phoneNumber: String,
+    /**
+     * Minimum alert-tier level (matching [AlertTier.level]) at which this
+     * contact may surface. Default = [AlertTier.URGENT].level (3) so the
+     * common case is URGENT-only. An owner can opt this contact in at
+     * ADVISORY (2) for higher-touch scenarios — never at NOTICE/OBSERVATION
+     * (the audit explicitly scopes escalation to alerts that matter).
+     */
+    val minTierLevel: Int = MIN_TIER_URGENT,
+    /**
+     * Minutes Bios waits for owner acknowledgement on an URGENT alert
+     * before composing a local SMS for this contact. Null = never escalate
+     * (notify-the-owner-only). Default for new contacts is null — the
+     * owner has to opt in to escalation explicitly per contact.
+     *
+     * Range when non-null: 1..120. Anything outside is clamped at the
+     * repository boundary; the entity itself doesn't enforce it so test
+     * harnesses can probe edge values directly.
+     */
+    val acknowledgementTimeoutMinutes: Int? = null,
+    /** Epoch millis when the row was created. Used for stable ordering. */
+    val createdAt: Long = System.currentTimeMillis(),
+    /** Optional owner note (e.g. "Has spare key", "Works night shift"). */
+    val note: String? = null,
+) {
+    companion object {
+        /** Default tier floor: URGENT only. Matches [AlertTier.URGENT.level]. */
+        const val MIN_TIER_URGENT = 3
+
+        /** Owner-overridable lower bound: ADVISORY-and-above. */
+        const val MIN_TIER_ADVISORY = 2
+
+        /** Smallest accepted ack-timeout, in minutes. */
+        const val MIN_ACK_TIMEOUT_MIN = 1
+
+        /** Largest accepted ack-timeout, in minutes. */
+        const val MAX_ACK_TIMEOUT_MIN = 120
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/IdentityRoutes.kt
+++ b/android/app/src/main/java/com/bios/app/ui/IdentityRoutes.kt
@@ -41,6 +41,9 @@ internal fun NavGraphBuilder.identityRoutes(navController: NavController) {
     composable("traditional_medicine_context") {
         com.bios.app.ui.traditional.TraditionalMedicineContextScreen(onBack = { navController.popBackStack() })
     }
+    composable("emergency_contacts") {
+        com.bios.app.ui.emergency.EmergencyContactsScreen(onBack = { navController.popBackStack() })
+    }
     composable("medications") {
         com.bios.app.ui.medications.MedicationsScreen(onBack = { navController.popBackStack() })
     }

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -304,7 +304,8 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToHeadacheDiary = { navController.navigate("headache_diary") },
                     onNavigateToFastStroke = { navController.navigate("fast_stroke") },
                     onNavigateToEsasCapture = { navController.navigate("esas_capture") },
-                    onNavigateToTraditionalMedicine = { navController.navigate("traditional_medicine_context") }
+                    onNavigateToTraditionalMedicine = { navController.navigate("traditional_medicine_context") },
+                    onNavigateToEmergencyContacts = { navController.navigate("emergency_contacts") }
                 )
             }
             // Self-surface routes — extracted to IdentityRoutes.kt to keep this file

--- a/android/app/src/main/java/com/bios/app/ui/emergency/EmergencyContactsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/emergency/EmergencyContactsScreen.kt
@@ -1,0 +1,356 @@
+package com.bios.app.ui.emergency
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.EmergencyContactRepo
+import com.bios.app.model.EmergencyContact
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Identity → Emergency contacts (#179, audit gap EM/CC §2.1).
+ *
+ * Owner-set, owner-revocable, off by default. No row = no escalation.
+ *
+ * Each contact carries a per-tier opt-in (ADVISORY-or-URGENT vs.
+ * URGENT-only) and an optional acknowledgement timeout in minutes. When
+ * the timeout is null, the row is informational only — Bios will not
+ * surface this contact for an unacknowledged alert. When non-null, the
+ * timeout is the window Bios waits before composing a local SMS draft;
+ * the system SMS chooser then hands the send decision back to the owner.
+ *
+ * Sibling of the existing Identity surfaces (Current medications,
+ * Immunisation record, Preventive care, Risk profile, Physiology state).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmergencyContactsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val repo = remember(context) {
+        EmergencyContactRepo(BiosDatabase.getInstance(context))
+    }
+    val scope = rememberCoroutineScope()
+
+    var contacts by remember { mutableStateOf<List<EmergencyContact>>(emptyList()) }
+    var showAddDialog by remember { mutableStateOf(false) }
+    var editing by remember { mutableStateOf<EmergencyContact?>(null) }
+
+    suspend fun refresh() {
+        contacts = repo.fetchAll()
+    }
+
+    LaunchedEffect(Unit) { refresh() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Emergency contacts") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Emergency contacts", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+                    Text(
+                        "If you'd like Bios to surface a contact when an urgent alert goes " +
+                            "unacknowledged, name them here. Bios never sends a message on its " +
+                            "own — your phone's text app opens with a draft, and you (or " +
+                            "someone with your phone) confirm before it sends.\n\n" +
+                            "Off until you add a contact. Each contact opts in to a minimum " +
+                            "alert tier and a wait time. Leaving the wait time blank keeps " +
+                            "this contact on record without ever escalating.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    OutlinedButton(
+                        onClick = { showAddDialog = true },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Add contact")
+                    }
+                }
+            }
+
+            if (contacts.isEmpty()) {
+                Text(
+                    "No emergency contacts on record. Tap \"Add contact\" to designate one.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                contacts.forEach { c ->
+                    ContactRow(
+                        contact = c,
+                        onEdit = { editing = c },
+                        onDelete = {
+                            scope.launch {
+                                repo.remove(c.id)
+                                refresh()
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        ContactDialog(
+            initial = null,
+            title = "Add contact",
+            onDismiss = { showAddDialog = false },
+            onSave = { draft ->
+                scope.launch {
+                    repo.add(
+                        name = draft.name,
+                        relationship = draft.relationship,
+                        phoneNumber = draft.phoneNumber,
+                        minTierLevel = draft.minTierLevel,
+                        acknowledgementTimeoutMinutes = draft.acknowledgementTimeoutMinutes,
+                        note = draft.note,
+                    )
+                    refresh()
+                }
+                showAddDialog = false
+            }
+        )
+    }
+
+    editing?.let { current ->
+        ContactDialog(
+            initial = current,
+            title = "Edit contact",
+            onDismiss = { editing = null },
+            onSave = { draft ->
+                scope.launch {
+                    repo.update(current.copy(
+                        name = draft.name,
+                        relationship = draft.relationship,
+                        phoneNumber = draft.phoneNumber,
+                        minTierLevel = draft.minTierLevel,
+                        acknowledgementTimeoutMinutes = draft.acknowledgementTimeoutMinutes,
+                        note = draft.note,
+                    ))
+                    refresh()
+                }
+                editing = null
+            }
+        )
+    }
+}
+
+@Composable
+private fun ContactRow(
+    contact: EmergencyContact,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp).fillMaxWidth()) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    contact.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    contact.relationship,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(Modifier.height(2.dp))
+            Text(
+                contact.phoneNumber,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                buildString {
+                    append(
+                        if (contact.minTierLevel <= EmergencyContact.MIN_TIER_ADVISORY) {
+                            "Advisory + Urgent"
+                        } else {
+                            "Urgent only"
+                        }
+                    )
+                    val t = contact.acknowledgementTimeoutMinutes
+                    if (t != null) append(" · escalates after ${t}m unacknowledged")
+                    else append(" · never escalates")
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            contact.note?.takeIf { it.isNotBlank() }?.let {
+                Spacer(Modifier.height(2.dp))
+                Text(it, style = MaterialTheme.typography.bodySmall)
+            }
+            Spacer(Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onEdit) { Text("Edit") }
+                OutlinedButton(onClick = onDelete) { Text("Delete") }
+            }
+        }
+    }
+}
+
+internal data class ContactDraft(
+    val name: String,
+    val relationship: String,
+    val phoneNumber: String,
+    val minTierLevel: Int,
+    val acknowledgementTimeoutMinutes: Int?,
+    val note: String?,
+)
+
+@Composable
+private fun ContactDialog(
+    initial: EmergencyContact?,
+    title: String,
+    onDismiss: () -> Unit,
+    onSave: (ContactDraft) -> Unit,
+) {
+    var name by remember { mutableStateOf(initial?.name.orEmpty()) }
+    var relationship by remember { mutableStateOf(initial?.relationship.orEmpty()) }
+    var phone by remember { mutableStateOf(initial?.phoneNumber.orEmpty()) }
+    var advisoryOptIn by remember {
+        mutableStateOf((initial?.minTierLevel ?: EmergencyContact.MIN_TIER_URGENT) <= EmergencyContact.MIN_TIER_ADVISORY)
+    }
+    var timeoutText by remember {
+        mutableStateOf(initial?.acknowledgementTimeoutMinutes?.toString().orEmpty())
+    }
+    var note by remember { mutableStateOf(initial?.note.orEmpty()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it.take(60) },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = relationship,
+                    onValueChange = { relationship = it.take(40) },
+                    label = { Text("Relationship") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = phone,
+                    onValueChange = { phone = it.take(32) },
+                    label = { Text("Phone number") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text("Tier opt-in", style = MaterialTheme.typography.labelMedium)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = !advisoryOptIn,
+                        onClick = { advisoryOptIn = false },
+                        label = { Text("Urgent only") },
+                    )
+                    FilterChip(
+                        selected = advisoryOptIn,
+                        onClick = { advisoryOptIn = true },
+                        label = { Text("Advisory + Urgent") },
+                    )
+                }
+                OutlinedTextField(
+                    value = timeoutText,
+                    onValueChange = { v ->
+                        timeoutText = v.filter { it.isDigit() }.take(3)
+                    },
+                    label = { Text("Escalate after (minutes, blank = never)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it.take(160) },
+                    label = { Text("Note (optional)") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank() && relationship.isNotBlank() && phone.isNotBlank(),
+                onClick = {
+                    onSave(
+                        ContactDraft(
+                            name = name.trim(),
+                            relationship = relationship.trim(),
+                            phoneNumber = phone.trim(),
+                            minTierLevel = if (advisoryOptIn) {
+                                EmergencyContact.MIN_TIER_ADVISORY
+                            } else {
+                                EmergencyContact.MIN_TIER_URGENT
+                            },
+                            acknowledgementTimeoutMinutes = timeoutText.toIntOrNull(),
+                            note = note.trim().takeIf { it.isNotBlank() },
+                        )
+                    )
+                }
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
@@ -36,6 +36,7 @@ internal fun IdentityCard(
     onNavigateToFastStroke: () -> Unit = {},
     onNavigateToEsasCapture: () -> Unit = {},
     onNavigateToTraditionalMedicine: () -> Unit = {},
+    onNavigateToEmergencyContacts: () -> Unit = {},
 ) {
     Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -53,6 +54,7 @@ internal fun IdentityCard(
                 "FAST stroke check" to onNavigateToFastStroke,
                 "Symptom report (ESAS-r)" to onNavigateToEsasCapture,
                 "Traditional medicine" to onNavigateToTraditionalMedicine,
+                "Emergency contacts" to onNavigateToEmergencyContacts,
             ).forEachIndexed { idx, (label, action) ->
                 if (idx > 0) Spacer(Modifier.height(4.dp))
                 OutlinedButton(onClick = action, modifier = Modifier.fillMaxWidth()) { Text(label) }

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -46,7 +46,8 @@ fun SettingsScreen(
     onNavigateToHeadacheDiary: () -> Unit = {},
     onNavigateToFastStroke: () -> Unit = {},
     onNavigateToEsasCapture: () -> Unit = {},
-    onNavigateToTraditionalMedicine: () -> Unit = {}
+    onNavigateToTraditionalMedicine: () -> Unit = {},
+    onNavigateToEmergencyContacts: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -101,6 +102,7 @@ fun SettingsScreen(
             onNavigateToFastStroke = onNavigateToFastStroke,
             onNavigateToEsasCapture = onNavigateToEsasCapture,
             onNavigateToTraditionalMedicine = onNavigateToTraditionalMedicine,
+            onNavigateToEmergencyContacts = onNavigateToEmergencyContacts,
         )
 
         // Privacy — what can leave, and who can access. Highest-stakes surface.

--- a/android/app/src/test/java/com/bios/app/EmergencyContactTest.kt
+++ b/android/app/src/test/java/com/bios/app/EmergencyContactTest.kt
@@ -1,0 +1,122 @@
+package com.bios.app
+
+import com.bios.app.data.EmergencyContactRepo
+import com.bios.app.model.AlertTier
+import com.bios.app.model.EmergencyContact
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Guards the [EmergencyContact] entity defaults and the
+ * [EmergencyContactRepo] clamping helpers (#179, EM/CC §2.1).
+ *
+ * Field renames or default-value drift here silently change which contacts
+ * a fired URGENT alert surfaces — exactly the failure mode the audits flagged.
+ */
+class EmergencyContactTest {
+
+    @Test
+    fun default_min_tier_is_urgent() {
+        val c = EmergencyContact(
+            name = "n", relationship = "r", phoneNumber = "+15551234567",
+        )
+        assertEquals(EmergencyContact.MIN_TIER_URGENT, c.minTierLevel)
+        assertEquals(AlertTier.URGENT.level, c.minTierLevel)
+    }
+
+    @Test
+    fun default_ack_timeout_is_null_off_by_default() {
+        // Manifesto: nothing escalates unless the owner opts in. A
+        // brand-new contact carries a null timeout, which the worker
+        // schedule path treats as "never escalate."
+        val c = EmergencyContact(
+            name = "n", relationship = "r", phoneNumber = "+15551234567",
+        )
+        assertNull(c.acknowledgementTimeoutMinutes)
+    }
+
+    @Test
+    fun tier_clamp_below_advisory_clamps_to_advisory() {
+        // Owner can pick URGENT-only or ADVISORY+URGENT. NOTICE and
+        // OBSERVATION are explicitly excluded by the audit — escalation
+        // is for alerts that matter.
+        assertEquals(
+            EmergencyContact.MIN_TIER_ADVISORY,
+            EmergencyContactRepo.clampTier(0),
+        )
+        assertEquals(
+            EmergencyContact.MIN_TIER_ADVISORY,
+            EmergencyContactRepo.clampTier(1),
+        )
+        assertEquals(
+            EmergencyContact.MIN_TIER_ADVISORY,
+            EmergencyContactRepo.clampTier(2),
+        )
+    }
+
+    @Test
+    fun tier_clamp_above_urgent_clamps_to_urgent() {
+        assertEquals(
+            EmergencyContact.MIN_TIER_URGENT,
+            EmergencyContactRepo.clampTier(99),
+        )
+    }
+
+    @Test
+    fun ack_timeout_null_passes_through() {
+        assertNull(EmergencyContactRepo.clampTimeout(null))
+    }
+
+    @Test
+    fun ack_timeout_below_minimum_clamps_up() {
+        assertEquals(
+            EmergencyContact.MIN_ACK_TIMEOUT_MIN,
+            EmergencyContactRepo.clampTimeout(0),
+        )
+    }
+
+    @Test
+    fun ack_timeout_above_maximum_clamps_down() {
+        assertEquals(
+            EmergencyContact.MAX_ACK_TIMEOUT_MIN,
+            EmergencyContactRepo.clampTimeout(10_000),
+        )
+    }
+
+    @Test
+    fun ack_timeout_in_range_passes_through() {
+        assertEquals(15, EmergencyContactRepo.clampTimeout(15))
+        assertEquals(60, EmergencyContactRepo.clampTimeout(60))
+    }
+
+    @Test
+    fun ack_timeout_bounds_are_sane() {
+        // Documented bounds — if either drifts, the UI hint text in the
+        // Settings screen has to change too. Test pins the contract.
+        assertEquals(1, EmergencyContact.MIN_ACK_TIMEOUT_MIN)
+        assertEquals(120, EmergencyContact.MAX_ACK_TIMEOUT_MIN)
+    }
+
+    @Test
+    fun contact_preserves_phone_number_verbatim_on_copy() {
+        // Phone-number normalization is explicitly out of scope (the
+        // owner knows what reaches their person). copy() must not mutate.
+        val original = EmergencyContact(
+            name = "n", relationship = "r", phoneNumber = "(555) 123-4567",
+        )
+        val edited = original.copy(name = "n2")
+        assertEquals("(555) 123-4567", edited.phoneNumber)
+    }
+
+    @Test
+    fun ack_timeout_set_non_null_is_round_tripped() {
+        val c = EmergencyContact(
+            name = "n", relationship = "r", phoneNumber = "+15551234567",
+            acknowledgementTimeoutMinutes = 30,
+        )
+        assertNotNull(c.acknowledgementTimeoutMinutes)
+        assertEquals(30, c.acknowledgementTimeoutMinutes)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/RegionConfigEmergencyNumberTest.kt
+++ b/android/app/src/test/java/com/bios/app/RegionConfigEmergencyNumberTest.kt
@@ -1,0 +1,62 @@
+package com.bios.app
+
+import com.bios.app.config.RegionConfigProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+/**
+ * Guards the `emergencyNumber` field on [com.bios.app.config.RegionConfig]
+ * for all six built-in regions (#179, EM/CC §2.1).
+ *
+ * A typo or accidental null here is a clinical bug: it silently strips the
+ * tap-to-call action off the URGENT notification. CI must catch this.
+ */
+class RegionConfigEmergencyNumberTest {
+
+    @Test
+    fun us_emergency_number_is_911() {
+        assertEquals("911", RegionConfigProvider.forRegion("US").emergencyNumber)
+    }
+
+    @Test
+    fun ca_emergency_number_is_911() {
+        assertEquals("911", RegionConfigProvider.forRegion("CA").emergencyNumber)
+    }
+
+    @Test
+    fun gb_emergency_number_is_999() {
+        assertEquals("999", RegionConfigProvider.forRegion("GB").emergencyNumber)
+    }
+
+    @Test
+    fun eu_emergency_number_is_112() {
+        assertEquals("112", RegionConfigProvider.forRegion("EU").emergencyNumber)
+    }
+
+    @Test
+    fun au_emergency_number_is_000() {
+        assertEquals("000", RegionConfigProvider.forRegion("AU").emergencyNumber)
+    }
+
+    @Test
+    fun jp_emergency_number_is_119() {
+        // 119 dispatches Japanese ambulance / fire. Police is 110;
+        // the audit specifies the medical-emergency number for tap-to-call.
+        assertEquals("119", RegionConfigProvider.forRegion("JP").emergencyNumber)
+    }
+
+    @Test
+    fun every_supported_region_carries_an_emergency_number() {
+        // Catches: a future region added without emergencyNumber populated.
+        // No supported region should ship with a null — the field is
+        // nullable for *unsupported* (fallback) locales only.
+        for (code in RegionConfigProvider.supportedRegions()) {
+            val cfg = RegionConfigProvider.forRegion(code)
+            assertNotNull(
+                "Region $code is missing emergencyNumber",
+                cfg.emergencyNumber,
+            )
+        }
+    }
+}

--- a/android/app/src/test/java/com/bios/app/UrgentAckTimeoutWorkerTest.kt
+++ b/android/app/src/test/java/com/bios/app/UrgentAckTimeoutWorkerTest.kt
@@ -1,0 +1,44 @@
+package com.bios.app
+
+import com.bios.app.alerts.UrgentAckTimeoutWorker
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins [UrgentAckTimeoutWorker]'s public contract — the schedule/cancel
+ * tag and the input-data keys (#179, EM/CC §2.1). These strings are the
+ * coupling between [com.bios.app.alerts.AlertManager] (which schedules)
+ * and [com.bios.app.alerts.AlertActionReceiver] (which cancels on ack).
+ *
+ * If either side renames a key, the cancellation silently misses and an
+ * SMS-compose prompt fires for an already-acknowledged alert — exactly
+ * the failure mode the manifesto's owner-mediated escalation forbids.
+ */
+class UrgentAckTimeoutWorkerTest {
+
+    @Test
+    fun input_data_keys_are_stable() {
+        assertEquals("anomaly_id", UrgentAckTimeoutWorker.KEY_ANOMALY_ID)
+        assertEquals("alert_title", UrgentAckTimeoutWorker.KEY_ALERT_TITLE)
+        assertEquals("tier_level", UrgentAckTimeoutWorker.KEY_TIER_LEVEL)
+    }
+
+    @Test
+    fun work_name_is_namespaced_per_anomaly() {
+        // Tag is what cancel() targets — if it diverged from
+        // ExistingWorkPolicy.REPLACE's unique name, ack-cancellation
+        // would silently miss.
+        val id = "abc-123"
+        assertEquals("urgent_ack_abc-123", UrgentAckTimeoutWorker.workName(id))
+    }
+
+    @Test
+    fun work_name_differs_across_anomalies() {
+        // Two URGENT alerts in quick succession must schedule under
+        // distinct unique names — otherwise the second alert's worker
+        // would silently REPLACE the first's, losing escalation on
+        // whichever alert was first.
+        assertEquals("urgent_ack_a", UrgentAckTimeoutWorker.workName("a"))
+        assertEquals("urgent_ack_b", UrgentAckTimeoutWorker.workName("b"))
+    }
+}


### PR DESCRIPTION
## Summary

Five audits converge on the same gap: `AlertManager.sendNotification` routes `AlertTier.URGENT` to the high-priority channel and stops. No tap-to-call, no "I'm OK" acknowledgement, no designated-contact path. For the populations most likely to benefit — elderly living alone, post-discharge, hypoglycaemia-unaware, on opioids — the owner being the only escalation target is structurally the wrong answer when the alert fires while the owner can no longer act.

Fixes #179.

Source audits:
- [EMERGENCY_CRITICAL_CARE_POV.md §2.1](docs/audits/EMERGENCY_CRITICAL_CARE_POV.md) — the primary recommendation
- [GERIATRICS_PALLIATIVE_POV.md §2.13](docs/audits/GERIATRICS_PALLIATIVE_POV.md) — convergent finding
- Primary Care, Cardiology, Ob/Gyn audits endorse the same fix

### What changed

- **`RegionConfig.emergencyNumber`** (nullable). Populated per locale: 911 (US/CA), 999 (GB), 112 (EU + worldwide fallback), 000 (AU), 119 (JP — the audit's specified medical-dispatch number). Null tolerated for under-supported regions.
- **`EmergencyContact` entity + DAO + repo**. Stored in the main encrypted SQLCipher DB (not the reproductive sidecar — contacts apply broadly). Wipes alongside `bios.db` via `DataDestroyer.destroyDatabase`. Fields: name, relationship, phoneNumber, minTierLevel (URGENT-only or ADVISORY+URGENT), acknowledgementTimeoutMinutes (nullable = never escalate, the default).
- **`UrgentAckTimeoutWorker`** — `OneTimeWorkRequest` scheduled per URGENT alert when at least one eligible contact has a non-null ack timeout. On timeout without owner acknowledgement, surfaces a notification whose tap fires `Intent.ACTION_SENDTO smsto:`. **The system SMS chooser asks the owner to confirm before sending. Bios never auto-sends; no cloud, no SMS gateway.**
- **`AlertManager` URGENT actions** — "Call <number>" (`tel:` PendingIntent — opens the dialer, owner taps to dial) and "I'm OK" (cancels the pending worker via the new `AlertActionReceiver` and marks the anomaly acknowledged).
- **Settings → Identity → "Emergency contacts"** screen, sibling of Current medications / Immunisation record / Risk profile / Physiology state. Off by default — empty list means no escalation.

### Manifesto considerations

- **Prospective consent** — the owner picks the contact, the relationship label, the per-tier opt-in, and the timeout while competent.
- **Final consent** — even after the timeout fires, the SMS draft passes through Android's system SMS chooser; nothing sends without a tap.
- **Owner-revocable** — Settings UI supports edit/delete; the row wipes alongside everything else on LETHE burner / dead-man's-switch / standalone Delete-all-data.
- **Off by default** — empty contact list = no escalation; null timeout per contact = no escalation. The worker no-ops on both.
- **No cloud, no telemetry, no Bios server in the path.** Pure local Intent.

### Tests

- `RegionConfigEmergencyNumberTest` — all six built-in regions carry the right number; future regions can't be added without one.
- `EmergencyContactTest` — entity defaults, tier-clamp bounds (ADVISORY..URGENT), timeout-clamp bounds (1..120 min), null-passthrough behaviour, copy-preserves-phone semantics.
- `UrgentAckTimeoutWorkerTest` — input-data keys stable, unique-work tag namespaced per anomaly.

## Test plan

- [ ] Manual: configure one contact with a 1-minute timeout, fire a synthetic URGENT alert; verify the timeout notification appears and tapping it opens the system SMS chooser with a draft to the contact's number.
- [ ] Manual: tap "I'm OK" on an URGENT notification within the timeout window; verify the escalation notification does **not** appear and the anomaly is marked acknowledged.
- [ ] Manual: tap "Call 911" on an URGENT notification; verify the dialer opens with 911 pre-filled (no auto-dial).
- [ ] Manual: empty contact list; fire URGENT; verify no worker is scheduled and only the standard URGENT notification appears.
- [ ] Manual: trigger Delete-all-data; verify the contacts table is gone (re-launch and check Settings → Emergency contacts is empty).

## Notes for reviewers

- One conflict risk noted in the issue: PR #213 also touches `SettingsScreen.kt` (adding a "FRAIL assessment" row). I matched the same Identity-card list pattern, so the conflict should be a trivial three-way merge.
- `AlertManager.kt` grew from 127 → 228 lines, still well under the 500-line cap. If a reviewer prefers, the URGENT-specific helpers could split into an `UrgentAlertActions.kt` extension file — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)