### PR TITLE
chore: ignore .claude/worktrees session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ __pycache__/
 # OS
 .DS_Store
 Thumbs.db
+
+# Claude Code session artifacts
+.claude/worktrees/


### PR DESCRIPTION
## Summary
Adds `.claude/worktrees/` to .gitignore. These are Claude Code session artifacts (agent worktree directories) that shouldn't be tracked. Followup from #235 — kept showing as untracked in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)