### PR TITLE
fix(sleep): derive durationSec on companion writes

### DIFF
--- a/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
+++ b/android/app/src/main/java/com/bios/app/provider/BiosHealthProvider.kt
@@ -186,6 +186,7 @@ class BiosHealthProvider : ContentProvider() {
             metricType = metricType,
             value = value,
             timestamp = timestamp,
+            durationSec = companionDurationSecFor(metricType, value),
             sourceId = companion.sourceId,
             confidence = ConfidenceTier.MEDIUM.level,
             isPrimary = true
@@ -299,3 +300,18 @@ class BiosHealthProvider : ContentProvider() {
     override fun delete(uri: Uri, sel: String?, args: Array<out String>?): Int =
         throw UnsupportedOperationException("Companion apps cannot delete Bios data")
 }
+
+/**
+ * Derives the `durationSec` column for a companion-written reading from
+ * its `value`. The companion-insert contract only carries `value` and
+ * `timestamp`, but consumers like `SleepRegularityCalculator` filter rows
+ * by `(durationSec ?: 0) > 0`. Without this derivation, every W2F-pushed
+ * `sleep_duration` row would land with `durationSec = null` and never
+ * feed regularity. Confined to keys whose unit is seconds and whose
+ * value-as-duration semantics are well-defined — currently sleep_duration.
+ *
+ * Top-level so unit tests exercise it without touching the provider's
+ * Android dependencies (UriMatcher / Uri / ContentResolver).
+ */
+internal fun companionDurationSecFor(metricType: String, value: Double): Int? =
+    if (metricType == MetricType.SLEEP_DURATION.key && value > 0.0) value.toInt() else null

--- a/android/app/src/test/java/com/bios/app/CompanionDurationSecTest.kt
+++ b/android/app/src/test/java/com/bios/app/CompanionDurationSecTest.kt
@@ -1,0 +1,69 @@
+package com.bios.app
+
+import com.bios.app.provider.companionDurationSecFor
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the companion-insert duration derivation behind the
+ * BiosHealthProvider. SleepRegularityCalculator filters rows by
+ * `(durationSec ?: 0) > 0`, so a W2F-pushed sleep_duration that lands
+ * with durationSec = null gets silently dropped from the regularity
+ * window. The provider derives durationSec from value at insert time;
+ * these tests pin that contract so the derivation can't quietly
+ * regress and break the regularity score for phone-only owners.
+ */
+class CompanionDurationSecTest {
+
+    @Test
+    fun `sleep_duration positive value seeds durationSec`() {
+        // 7h * 3600 = 25200 seconds. The value comes from W2F's screen-off
+        // estimate or a wearable's seconds field; either way the
+        // derivation must round-trip cleanly.
+        val out = companionDurationSecFor(MetricType.SLEEP_DURATION.key, 25_200.0)
+        assertEquals(25_200, out)
+    }
+
+    @Test
+    fun `sleep_duration zero or negative value yields null durationSec`() {
+        // Defensive against bad pushes — a zero/negative value can't
+        // describe a real night and shouldn't feed regularity as if it
+        // were one second of sleep.
+        assertNull(companionDurationSecFor(MetricType.SLEEP_DURATION.key, 0.0))
+        assertNull(companionDurationSecFor(MetricType.SLEEP_DURATION.key, -1.0))
+    }
+
+    @Test
+    fun `fractional seconds truncate to whole seconds`() {
+        // The Int column can't hold sub-second precision. Truncation
+        // (not rounding) is the conservative choice — undercount over
+        // overstate.
+        val out = companionDurationSecFor(MetricType.SLEEP_DURATION.key, 25_200.9)
+        assertEquals(25_200, out)
+    }
+
+    @Test
+    fun `non sleep_duration keys never get a durationSec`() {
+        // Other companion-written keys are event markers (tobacco_use,
+        // fall_event) or scalar samples (typing_cadence) — duration has
+        // no defined meaning there. Only sleep_duration carries seconds
+        // as its value semantics.
+        val intakeOrEvent = listOf(
+            MetricType.TOBACCO_USE.key,
+            MetricType.CANNABIS_USE.key,
+            MetricType.FALL_EVENT.key,
+            MetricType.TYPING_CADENCE.key,
+            MetricType.MOOD_DRIFT_SCORE.key,
+            MetricType.CIRCADIAN_PHASE_SHIFT.key,
+            MetricType.CAFFEINE_INTAKE.key,
+        )
+        for (k in intakeOrEvent) {
+            assertNull(
+                "durationSec must be null for $k",
+                companionDurationSecFor(k, 100.0)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`BiosHealthProvider.insert()` was inserting rows with `durationSec = null` because `BiosHealthContract.CompanionInsert` only carries `value` and `timestamp`. `SleepRegularityCalculator` filters rows via `(durationSec ?: 0) > 0`, so every W2F-pushed `sleep_duration` row was silently dropped from regularity.

The fix derives `durationSec` from `value` for metric types whose unit is seconds and whose value-as-duration semantics are well-defined (currently `sleep_duration` only).

## Provenance

Salvaged from #147, which originally bundled this bug fix with an empty-state UX change for `SleepDashboardScreen`. That UX portion is intentionally dropped — main has since shipped a richer empty state via `PhoneSleepInference` (#134-derived) and restructured `MainActivity`, both of which supersede the original UX. The provider-side bug fix is the unique remaining contribution; this PR isolates it. #147 will be closed in favor of this one.

## Test plan

- [x] `CompanionDurationSecTest` covers the helper (positive/negative/non-sleep-key cases)
- [x] `./scripts/code-quality-check.sh` green locally
- [ ] CI green