### PR TITLE
chore(ci): allowlist screening-catalog key literals in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+title = "Bios gitleaks config"
+
+# Inherit gitleaks' default rule set; we only narrow it where the defaults
+# produce false positives on this codebase.
+[extend]
+useDefault = true
+
+# Screening catalog files contain catalog entry identifiers of the form
+# `key = "<snake_case_identifier>"`. When the identifier contains digits
+# (e.g. `men2a_surveillance`), the `key = "..."` literal + the value's
+# entropy crosses gitleaks' generic-api-key heuristic. These directories
+# only contain USPSTF / NCCN / ACS / ACOG / ACIP / PALS reference data —
+# no credentials of any kind.
+[allowlist]
+description = "Screening catalog identifier keys are not API keys"
+paths = [
+    '''android/app/src/main/java/com/bios/app/screening/.*Catalog\.kt''',
+]


### PR DESCRIPTION
## Summary
- Adds a narrow `.gitleaks.toml` allowlist for catalog entry identifiers like `key = "men2a_surveillance"` that trip the `generic-api-key` heuristic.
- Scoped to `android/app/src/main/java/com/bios/app/screening/*Catalog.kt` only — other files in the directory (engines, stores) are still scanned with defaults.
- Inherits gitleaks' full default rule set otherwise via `[extend] useDefault = true`.

## Why
The Dependency Audit job on #229 fails because gitleaks flags `key = "men2a_surveillance"` and `key = "men2b_surveillance"` in [HereditarySyndromeCatalog.kt](https://github.com/thdelmas/Bios/blob/feat/screening-cadence-extensions/android/app/src/main/java/com/bios/app/screening/HereditarySyndromeCatalog.kt) as generic API keys. They aren't — they're snake_case identifiers for NCCN/ATA-anchored catalog entries. The same pattern will keep tripping future PRs that add digit-bearing catalog keys, so a once-and-done config fix is cleaner than per-PR inline allows.

## Test plan
- [ ] CI runs the Dependency Audit job against this PR without false-positives (the diff itself doesn't introduce any digit-bearing catalog keys, so this is a baseline check)
- [ ] After merge, rebase #229 and confirm gitleaks no longer flags lines 138 / 150 of `HereditarySyndromeCatalog.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)