### PR TITLE
fix(db): backfill missing ecg_strips classification index

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -45,7 +45,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         TreatmentCourse::class,
         GrowthMeasurement::class,
     ],
-    version = 26,
+    version = 27,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -103,7 +103,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged

--- a/android/app/src/main/java/com/bios/app/data/EcgStripMigrations.kt
+++ b/android/app/src/main/java/com/bios/app/data/EcgStripMigrations.kt
@@ -31,6 +31,18 @@ internal object EcgStripMigrations {
                 """.trimIndent(),
             )
             db.execSQL("CREATE INDEX IF NOT EXISTS index_ecg_strips_timestamp ON ecg_strips (timestamp)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_ecg_strips_classification ON ecg_strips (classification)")
+        }
+    }
+
+    // Backfills the `index_ecg_strips_classification` index for installs that
+    // already crossed MIGRATION_21_22 before the index was added to the
+    // declaration. Without it Room's schema validator throws at first DAO
+    // call (the entity declares Index("classification") but the table has
+    // only the timestamp index).
+    val MIGRATION_26_27 = object : Migration(26, 27) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_ecg_strips_classification ON ecg_strips (classification)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- `EcgStrip` declares `Index(\"classification\")` in [model/EcgStrip.kt:47](android/app/src/main/java/com/bios/app/model/EcgStrip.kt#L47), but `MIGRATION_21_22` only ever created `index_ecg_strips_timestamp`. Room's schema validator rejected the table on first DAO call with `IllegalStateException: Migration didn't properly handle: ecg_strips`, crashing the app on every cold start.
- Fixed the original migration so fresh installs get both indices, and added `MIGRATION_26_27` (DB version bump 26→27) so devices that already crossed v22 backfill the missing index. Both DDL statements use `IF NOT EXISTS` and are safe regardless of arrival path.

## Test plan
- [x] `./scripts/code-quality-check.sh` (lint, build, unit tests, secrets scan, file-length)
- [ ] Install on a device that had previously upgraded to v22+ without the classification index — verify cold start no longer crashes and `index_ecg_strips_classification` is present in `sqlite_master`
- [ ] Fresh install — confirm both `ecg_strips` indices exist after first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)