### PR TITLE
fix(db): replace stale perioperative_baseline schema

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -45,7 +45,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         TreatmentCourse::class,
         GrowthMeasurement::class,
     ],
-    version = 27,
+    version = 28,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -103,7 +103,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged

--- a/android/app/src/main/java/com/bios/app/data/PerioperativeMigrations.kt
+++ b/android/app/src/main/java/com/bios/app/data/PerioperativeMigrations.kt
@@ -4,28 +4,57 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
- * Schema migration that creates the `perioperative_baseline` table (#205,
- * SURGICAL_POV §2.1). Stores the frozen pre-op baseline (RHR, HRV,
- * SkinTemp, RR) so post-op-windowed patterns can detect re-elevation
- * after normalisation. Wiped alongside everything else by [DataDestroyer].
+ * Schema migration that creates the `perioperative_baselines` table (#205,
+ * SURGICAL_POV §2.1). Stores the frozen pre-op baseline (RHR/HRV/SkinTemp/
+ * RR/SpO2/sleep/steps/body-mass means + SDs) so post-op-windowed patterns
+ * can detect re-elevation after normalisation. Wiped alongside everything
+ * else by [DataDestroyer].
  */
 internal object PerioperativeMigrations {
+    private const val CREATE_PERIOPERATIVE_BASELINES =
+        """
+        CREATE TABLE IF NOT EXISTS perioperative_baselines (
+            id INTEGER NOT NULL PRIMARY KEY,
+            procedureDate INTEGER NOT NULL,
+            procedureTag TEXT,
+            snapshotAt INTEGER NOT NULL,
+            restingHeartRateMean REAL,
+            restingHeartRateSd REAL,
+            heartRateVariabilityMean REAL,
+            heartRateVariabilitySd REAL,
+            skinTemperatureMean REAL,
+            skinTemperatureSd REAL,
+            respiratoryRateMean REAL,
+            respiratoryRateSd REAL,
+            bloodOxygenMean REAL,
+            bloodOxygenSd REAL,
+            sleepDurationMean REAL,
+            sleepDurationSd REAL,
+            sleepEfficiencyMean REAL,
+            sleepEfficiencySd REAL,
+            stepsMean REAL,
+            stepsSd REAL,
+            bodyMassMean REAL,
+            bodyMassSd REAL
+        )
+        """
+
     val MIGRATION_22_23 = object : Migration(22, 23) {
         override fun migrate(db: SupportSQLiteDatabase) {
-            db.execSQL(
-                """
-                CREATE TABLE IF NOT EXISTS perioperative_baseline (
-                    id INTEGER NOT NULL PRIMARY KEY,
-                    procedureName TEXT,
-                    procedureDateMillis INTEGER,
-                    restingHeartRate REAL,
-                    heartRateVariability REAL,
-                    skinTemperatureDeviation REAL,
-                    respiratoryRate REAL,
-                    frozenAt INTEGER NOT NULL
-                )
-                """.trimIndent(),
-            )
+            db.execSQL(CREATE_PERIOPERATIVE_BASELINES.trimIndent())
+        }
+    }
+
+    // Repairs installs that ran the original (broken) MIGRATION_22_23 — it
+    // created `perioperative_baseline` (singular) with a stale schema that
+    // never matched the entity. The DAO points at `perioperative_baselines`
+    // (plural), so the old table was unreachable; dropping it loses nothing
+    // an engine ever read. Creating the plural table makes Room's schema
+    // validator happy on devices already past v23.
+    val MIGRATION_27_28 = object : Migration(27, 28) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("DROP TABLE IF EXISTS perioperative_baseline")
+            db.execSQL(CREATE_PERIOPERATIVE_BASELINES.trimIndent())
         }
     }
 }


### PR DESCRIPTION
## Summary
- `MIGRATION_22_23` created `perioperative_baseline` (singular) with the pre-rewrite schema — single scalar values for RHR/HRV/SkinTemp/RR plus `procedureName`/`procedureDateMillis`/`frozenAt`. The entity was later rewritten to `perioperative_baselines` (plural) with mean+SD pairs across 9 metrics, plus `procedureDate`/`procedureTag`/`snapshotAt`, but the migration was never updated. Devices that crossed v23 ended up with an unreachable singular table and no plural table, so Room's validator threw `IllegalStateException: Migration didn't properly handle: perioperative_baselines` on first DAO call.
- Repaired the original `MIGRATION_22_23` so fresh paths create the correct plural table.
- Added `MIGRATION_27_28` (DB version 27→28) that drops the orphan singular table and creates the plural one for installs already past v23. The DAO ([PerioperativeBaselineDao.kt:20](android/app/src/main/java/com/bios/app/data/dao/PerioperativeBaselineDao.kt#L20)) only ever pointed at the plural name, so the orphan held no readable data — dropping it loses nothing.

## Test plan
- [x] `./scripts/code-quality-check.sh` (lint, build, unit tests, secrets, file-length)
- [ ] Install on a device that crossed the broken v22→v23 — verify cold start no longer crashes and `perioperative_baselines` exists in `sqlite_master` while `perioperative_baseline` does not
- [ ] Fresh install — confirm `perioperative_baselines` is created with the full column set on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)