### PR TITLE
docs(subjects): reorganize for multi-subject, add Don't Die + Strava/Yazio

### DIFF
--- a/docs/subjects/README.md
+++ b/docs/subjects/README.md
@@ -1,0 +1,47 @@
+# Subjects
+
+Per-subject documentation: living profiles of what Bios is actually ingesting
+on a given device, study writeups, baselines, observation logs.
+
+## Structure
+
+One directory per subject, keyed by a stable pseudonym (`owner`, `subject-002`,
+etc.). Never use real names, exact birth dates, addresses, or any identifier
+that ties to a person outside this repo. Year of birth and self-described
+demographic context are fine if relevant to the study.
+
+```
+docs/subjects/
+├── README.md                  (this file)
+└── <subject>/
+    ├── PROFILE.md             living snapshot of ingestion + gaps
+    ├── studies/               individual intervention / study writeups
+    ├── baselines/             periodic baseline snapshots
+    └── observations.md        chronological event log
+```
+
+Only `PROFILE.md` is required. Add the other files / directories the first
+time you actually have content for them — don't pre-create empty scaffolding.
+
+## Current subjects
+
+| Subject | Status | Notes |
+|---|---|---|
+| [`owner`](owner/PROFILE.md) | Active | The primary device owner. Dogfood + self-baseline subject. |
+
+## Adding a new subject
+
+1. Create `docs/subjects/<pseudonym>/PROFILE.md`. Start from
+   [`owner/PROFILE.md`](owner/PROFILE.md) as a template.
+2. Confirm consent and scope before adding anyone other than the device
+   owner. Bios's manifesto puts owner autonomy first; that constraint applies
+   doubly to anyone Bios is *measuring*.
+3. Add an entry to the table above.
+
+## What belongs here vs. in code
+
+- **Here:** observations, hypotheses, intervention logs, lab-panel results
+  (manually redacted as needed), per-subject action queues, "what's connected,
+  what's missing" snapshots.
+- **Not here:** raw sensor data, full lab CSVs, anything containing PII.
+  Those live on-device in the encrypted Bios DB, never in the repo.

--- a/docs/subjects/owner/PROFILE.md
+++ b/docs/subjects/owner/PROFILE.md
@@ -19,16 +19,29 @@ self-directed health-baseline / improvement plan.
 
 ## Companion Apps Installed on Same Phone
 
+### Bios companions (writers via `BiosHealthProvider`)
+
 | Package | Role | Status |
 |---|---|---|
 | `com.w2f.app` | Mood / cognitive (typing cadence, mood drift, PVT) | Installed |
 | `com.virgil.app` | Safety (fall, near-miss, check-in) | Installed |
 | `com.smokless.smokeless` | Substance-use events (tobacco/cannabis) | Installed |
-| `com.fitbit.FitbitMobile` | Wearable → Health Connect upstream | Installed |
 
 Companion grants in Bios: confirm via Bios → Settings → Companion Apps. The
 provider permission is `signature`-protected, so `adb` cannot query the
 allowlist directly from outside the app.
+
+### Third-party health apps (data sources or adjacent context)
+
+| Package | Role | Bios relevance |
+|---|---|---|
+| `com.fitbit.FitbitMobile` | Wearable hub | **Primary upstream** — feeds HC, which Bios reads |
+| `com.google.android.apps.fitness` | Google Fit | Secondary HC writer (steps, activity); usually redundant with Fitbit |
+| `com.google.android.apps.healthdata` | Health Connect | The HC platform itself — Bios's main read surface |
+| `com.strava` | Activity (run/ride) | Writes workouts to HC if granted; feeds `exercise_session`, `active_minutes` |
+| `com.yazio.android` | Nutrition tracking | No HC bridge today; reference for `caffeine_intake`, `alcohol_intake` manual entry (will feed FuelLog once W2F integration ships) |
+| `com.technogym.mywellness.metropolitanwellness` | Gym equipment / strength workouts | No direct integration; reference for manual exercise logging |
+| `org.bryanjohnson.blueprint` | Blueprint protocol (Bryan Johnson) | **Not a Bios data source.** Triggered the [Blueprint protocol audit](audits/BLUEPRINT_PROTOCOL_AUDIT.md) that's shaping Bios's lab-panel roadmap. Bios's posture (instrument, owner-baseline) differs from Blueprint's (coach, population percentiles) — see audit for the philosophical delta |
 
 ## Active Ingestion Routes
 


### PR DESCRIPTION
## Summary
Follow-up to #250.

- Move `docs/SUBJECT_PROFILE.md` → `docs/subjects/owner/PROFILE.md` so the docs tree can hold multiple subjects and multiple study documents per subject.
- Add `docs/subjects/README.md` describing the convention: one directory per subject (stable pseudonym, no PII), `PROFILE.md` required, `studies/` / `baselines/` / `observations.md` added on first use.
- Split the "Companion Apps Installed on Same Phone" section into **Bios companions** (writers via `BiosHealthProvider`) vs. **Third-party health apps** (data sources or adjacent context). Add apps that were actually installed on the device but missing from the doc:
  - `org.bryanjohnson.blueprint` — Don't Die / Blueprint protocol. Not a Bios data source, but it's what triggered the [Blueprint protocol audit](https://github.com/thdelmas/Bios/blob/main/docs/audits/BLUEPRINT_PROTOCOL_AUDIT.md).
  - `com.strava`, `com.yazio.android`, `com.technogym.mywellness.metropolitanwellness`, Google Fit, Health Connect platform.

## Test plan
- [x] Doc-only change, pre-commit passes (file length, no secrets, lint, build).
- [x] Verified no other files reference the old `docs/SUBJECT_PROFILE.md` path before moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)