### PR TITLE
feat(contracts): Wave-2 biomarker expansion (Blueprint audit §3.2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -362,10 +362,9 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.WBC -> "6690-2" to "Leukocytes [#/volume] in Blood by Automated count"
     MetricType.RBC -> "789-8" to "Erythrocytes [#/volume] in Blood by Automated count"
     MetricType.PLATELETS -> "777-3" to "Platelets [#/volume] in Blood by Automated count"
-    // #24 — glycemic-extended, iron, endocrine, micronutrient.
-    // LOINC codes sourced from loinc.org's canonical lab-test catalog; each
-    // pairs the code with its official long-form display name so the FHIR
-    // round-trip is greppable in a Bundle.
+    // #24 — glycemic-extended, iron, endocrine, micronutrient. LOINC codes
+    // sourced from loinc.org's canonical catalog (display names ride along
+    // so the FHIR round-trip stays greppable in a Bundle).
     MetricType.FASTING_GLUCOSE -> "1558-6" to "Fasting glucose [Mass/volume] in Serum or Plasma"
     MetricType.FASTING_INSULIN -> "20448-7" to "Insulin [Units/volume] in Serum or Plasma --fasting"
     MetricType.HOMA_IR -> "81576-7" to "Homeostatic model assessment Insulin resistance Calculated"
@@ -377,22 +376,15 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.VITAMIN_B12 -> "2132-9" to "Cobalamins [Mass/volume] in Serum or Plasma"
     MetricType.FOLATE -> "2284-8" to "Folate [Mass/volume] in Serum or Plasma"
     MetricType.MAGNESIUM -> "2601-3" to "Magnesium [Mass/volume] in Serum or Plasma"
-    // #158 — renal / hepatic. eGFR pairs with creatinine (creatinine is the
-    // raw input; eGFR is the body-surface-normalised derived value most labs
-    // report alongside it). ALT / AST / GGT are the core hepatic panel.
+    // #158 — renal / hepatic. eGFR is the body-surface-normalised CKD-EPI 2021 form.
     MetricType.EGFR -> "62238-1" to "Glomerular filtration rate/1.73 sq M.predicted by Creatinine-based formula (CKD-EPI 2021)"
     MetricType.CREATININE -> "2160-0" to "Creatinine [Mass/volume] in Serum or Plasma"
     MetricType.ALT -> "1742-6" to "Alanine aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
     MetricType.AST -> "1920-8" to "Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma"
     MetricType.GGT -> "2324-2" to "Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma"
-    // #157 — apnea-hypopnea index. Universal sleep-medicine measure;
-    // 90562-0 is the standard PSG-derived LOINC ("Sleep apnea hypopnea
-    // index"). Wearable-derived passthrough uses the same code.
+    // #157 — apnea-hypopnea index; same LOINC for PSG-derived and wearable passthrough.
     MetricType.AHI -> "90562-0" to "Sleep apnea hypopnea index"
-    // Wave-1 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT.md §3.1).
-    // LOINC codes sourced from loinc.org's canonical lab-test catalog;
-    // Lp(a) uses the nmol/L LOINC (89594-4) since the MetricType is in
-    // NMOL_PER_L per ESC 2021 / NLA 2022 reporting guidance.
+    // Wave-1 expansion (audit §3.1). Lp(a) uses the nmol/L LOINC per ESC 2021 / NLA 2022.
     MetricType.LIPOPROTEIN_A -> "89594-4" to "Lipoprotein a [Moles/volume] in Serum or Plasma"
     MetricType.HOMOCYSTEINE -> "13965-9" to "Homocysteine [Moles/volume] in Serum or Plasma"
     MetricType.BUN -> "3094-0" to "Urea nitrogen [Mass/volume] in Serum or Plasma"
@@ -429,6 +421,16 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.TESTOSTERONE_FREE -> "2991-8" to "Testosterone.free [Mass/volume] in Serum or Plasma"
     MetricType.PROLACTIN -> "2842-3" to "Prolactin [Mass/volume] in Serum or Plasma"
     MetricType.DHEA_SULFATE -> "2191-5" to "Dehydroepiandrosterone sulfate [Mass/volume] in Serum or Plasma"
+    // Wave-2 (audit §3.2). Telomere length / bone-density T-score / vitamin
+    // K2 stay unmapped — proprietary scoring, site-specific, or no stable code.
+    MetricType.THYROID_PEROXIDASE_AB -> "8099-3" to "Thyroid peroxidase Ab [Units/volume] in Serum"
+    MetricType.THYROGLOBULIN_AB -> "8088-6" to "Thyroglobulin Ab [Units/volume] in Serum"
+    MetricType.PSA_TOTAL -> "2857-1" to "Prostate specific Ag [Mass/volume] in Serum or Plasma"
+    MetricType.PSA_FREE -> "10886-0" to "Prostate Specific Ag Free [Mass/volume] in Serum or Plasma"
+    MetricType.CORONARY_CALCIUM_SCORE -> "49595-2" to "Coronary artery calcium score by CT"
+    MetricType.PTAU_217 -> "102965-7" to "Phosphorylated tau 217 [Mass/volume] in Serum or Plasma"
+    MetricType.VITAMIN_A_RETINOL -> "2923-1" to "Retinol [Mass/volume] in Serum or Plasma"
+    MetricType.VITAMIN_E_ALPHA_TOCOPHEROL -> "1823-4" to "Tocopherol alpha [Mass/volume] in Serum or Plasma"
     else -> null
 }
 
@@ -488,6 +490,7 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.FEMTOLITERS -> "fL"
     MetricUnit.PICOGRAMS -> "pg"
     MetricUnit.MIU_PER_ML -> "m[IU]/mL"
+    MetricUnit.IU_PER_ML -> "[IU]/mL"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
@@ -35,6 +35,7 @@ object BiomarkerPanels {
             MetricType.APO_B,
             MetricType.LIPOPROTEIN_A,
             MetricType.HOMOCYSTEINE,
+            MetricType.CORONARY_CALCIUM_SCORE,
         ),
     )
 
@@ -68,6 +69,8 @@ object BiomarkerPanels {
             MetricType.TSH,
             MetricType.FREE_T4,
             MetricType.FREE_T3,
+            MetricType.THYROID_PEROXIDASE_AB,
+            MetricType.THYROGLOBULIN_AB,
         ),
     )
 
@@ -79,6 +82,9 @@ object BiomarkerPanels {
             MetricType.VITAMIN_B12,
             MetricType.FOLATE,
             MetricType.MAGNESIUM,
+            MetricType.VITAMIN_K2,
+            MetricType.VITAMIN_A_RETINOL,
+            MetricType.VITAMIN_E_ALPHA_TOCOPHEROL,
         ),
     )
 
@@ -185,12 +191,52 @@ object BiomarkerPanels {
 
     val epigenetic = BiomarkerPanel(
         id = "epigenetic",
-        title = "Epigenetic Age",
+        title = "Aging Biomarkers",
         metrics = listOf(
             MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
             MetricType.EPIGENETIC_AGE_GRIM,
             MetricType.EPIGENETIC_AGE_PHENO,
             MetricType.EPIGENETIC_AGE_HORVATH,
+            MetricType.TELOMERE_LENGTH,
+        ),
+    )
+
+    /**
+     * Men's prostate screening (Wave-2, audit §3.2). PSA Total is the
+     * routine men-50+ screen; PSA Free / Total ratio refines borderline
+     * elevated total PSA values.
+     */
+    val prostate = BiomarkerPanel(
+        id = "prostate",
+        title = "Prostate Screening",
+        metrics = listOf(
+            MetricType.PSA_TOTAL,
+            MetricType.PSA_FREE,
+        ),
+    )
+
+    /**
+     * Skeletal health (Wave-2, audit §3.2). DEXA T-score is the single-
+     * number osteoporosis screen; anatomical site rides in event_payloads.
+     */
+    val skeletal = BiomarkerPanel(
+        id = "skeletal",
+        title = "Bone Health",
+        metrics = listOf(
+            MetricType.BONE_DENSITY_T_SCORE,
+        ),
+    )
+
+    /**
+     * Plasma neurology (Wave-2, audit §3.2). pTau-217 is the emerging
+     * Alzheimer's blood biomarker; single-tile panel today, will fill
+     * out as additional neuro biomarkers ship (Aβ42/40 ratio, NfL, GFAP).
+     */
+    val neurology = BiomarkerPanel(
+        id = "neurology",
+        title = "Neurology",
+        metrics = listOf(
+            MetricType.PTAU_217,
         ),
     )
 
@@ -227,6 +273,9 @@ object BiomarkerPanels {
         hepatic,
         endocrine,
         reproductiveEndocrine,
+        prostate,
+        skeletal,
+        neurology,
         cardioOncology,
         epigenetic,
     )

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -69,6 +69,13 @@ class BiomarkerEntrySelectorsTest {
             MetricType.FSH, MetricType.LH, MetricType.SHBG,
             MetricType.AMH, MetricType.TESTOSTERONE_FREE,
             MetricType.PROLACTIN, MetricType.DHEA_SULFATE,
+            // Wave-2 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT §3.2).
+            MetricType.THYROID_PEROXIDASE_AB, MetricType.THYROGLOBULIN_AB,
+            MetricType.PSA_TOTAL, MetricType.PSA_FREE,
+            MetricType.TELOMERE_LENGTH, MetricType.CORONARY_CALCIUM_SCORE,
+            MetricType.BONE_DENSITY_T_SCORE, MetricType.PTAU_217,
+            MetricType.VITAMIN_K2, MetricType.VITAMIN_A_RETINOL,
+            MetricType.VITAMIN_E_ALPHA_TOCOPHEROL,
             // Epigenetic age clocks (slow-rolling, lab-imported).
             MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
             MetricType.EPIGENETIC_AGE_GRIM,

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -112,12 +112,13 @@ class FhirExporterTest {
 
     @Test
     fun `metric types with LOINC mappings include the AHI passthrough`() {
-        // 32 base + 5 wave-5 biomarkers (#158: eGFR, creatinine, ALT, AST, GGT)
-        // + AHI (#157) + 36 Wave-1 biomarker expansion (Blueprint audit §3.1)
-        // = 74. The count assertion is intentionally maintained alongside the
-        // loincCode() table so any unmapped new MetricType is caught.
+        // 32 base + 5 wave-5 biomarkers (#158) + AHI (#157) + 36 Wave-1
+        // (audit §3.1) + 8 Wave-2 (audit §3.2 — telomere/bone-T/vit K2
+        // intentionally unmapped) = 82. The count assertion is maintained
+        // alongside the loincCode() table so any unmapped new MetricType is
+        // caught.
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(74, mapped)
+        assertEquals(82, mapped)
     }
 
     @Test
@@ -154,6 +155,24 @@ class FhirExporterTest {
         assertEquals("2498-4", loincCode(MetricType.IRON_SERUM)!!.first)
         assertEquals("15067-2", loincCode(MetricType.FSH)!!.first)
         assertEquals("13967-5", loincCode(MetricType.SHBG)!!.first)
+    }
+
+    @Test
+    fun `Wave-2 mapped markers point to canonical LOINC codes`() {
+        // Audit §3.2 additions. Telomere length / bone-density T-score /
+        // vitamin K2 deliberately have no LOINC (proprietary / site-specific
+        // / no stable code) and stay in the unmapped-fallback path.
+        assertEquals("8099-3", loincCode(MetricType.THYROID_PEROXIDASE_AB)!!.first)
+        assertEquals("8088-6", loincCode(MetricType.THYROGLOBULIN_AB)!!.first)
+        assertEquals("2857-1", loincCode(MetricType.PSA_TOTAL)!!.first)
+        assertEquals("10886-0", loincCode(MetricType.PSA_FREE)!!.first)
+        assertEquals("49595-2", loincCode(MetricType.CORONARY_CALCIUM_SCORE)!!.first)
+        assertEquals("102965-7", loincCode(MetricType.PTAU_217)!!.first)
+        assertEquals("2923-1", loincCode(MetricType.VITAMIN_A_RETINOL)!!.first)
+        assertEquals("1823-4", loincCode(MetricType.VITAMIN_E_ALPHA_TOCOPHEROL)!!.first)
+        assertNull(loincCode(MetricType.TELOMERE_LENGTH))
+        assertNull(loincCode(MetricType.BONE_DENSITY_T_SCORE))
+        assertNull(loincCode(MetricType.VITAMIN_K2))
     }
 
     @Test
@@ -347,6 +366,15 @@ class FhirExporterTest {
             MetricType.TESTOSTERONE_FREE -> "2991-8" to "Testosterone.free [Mass/volume] in Serum or Plasma"
             MetricType.PROLACTIN -> "2842-3" to "Prolactin [Mass/volume] in Serum or Plasma"
             MetricType.DHEA_SULFATE -> "2191-5" to "Dehydroepiandrosterone sulfate [Mass/volume] in Serum or Plasma"
+            // Wave-2 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT §3.2).
+            MetricType.THYROID_PEROXIDASE_AB -> "8099-3" to "Thyroid peroxidase Ab [Units/volume] in Serum"
+            MetricType.THYROGLOBULIN_AB -> "8088-6" to "Thyroglobulin Ab [Units/volume] in Serum"
+            MetricType.PSA_TOTAL -> "2857-1" to "Prostate specific Ag [Mass/volume] in Serum or Plasma"
+            MetricType.PSA_FREE -> "10886-0" to "Prostate Specific Ag Free [Mass/volume] in Serum or Plasma"
+            MetricType.CORONARY_CALCIUM_SCORE -> "49595-2" to "Coronary artery calcium score by CT"
+            MetricType.PTAU_217 -> "102965-7" to "Phosphorylated tau 217 [Mass/volume] in Serum or Plasma"
+            MetricType.VITAMIN_A_RETINOL -> "2923-1" to "Retinol [Mass/volume] in Serum or Plasma"
+            MetricType.VITAMIN_E_ALPHA_TOCOPHEROL -> "1823-4" to "Tocopherol alpha [Mass/volume] in Serum or Plasma"
             else -> null
         }
     }
@@ -436,6 +464,7 @@ class FhirExporterTest {
             MetricUnit.FEMTOLITERS -> "fL"
             MetricUnit.PICOGRAMS -> "pg"
             MetricUnit.MIU_PER_ML -> "m[IU]/mL"
+            MetricUnit.IU_PER_ML -> "[IU]/mL"
         }
     }
 }

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -404,6 +404,31 @@ enum class MetricType(
     PROLACTIN("prolactin", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
     DHEA_SULFATE("dhea_sulfate", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
+    // Wave-2 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT.md §3.2) — medium-
+    // priority additions: thyroid autoimmunity, prostate screening, imaging-
+    // derived risk modifiers, plasma neurology, fat-soluble vitamins, and
+    // a cellular-aging clock. Manual entry + FHIR where a stable LOINC exists.
+    THYROID_PEROXIDASE_AB("thyroid_peroxidase_ab", MetricUnit.IU_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    THYROGLOBULIN_AB("thyroglobulin_ab", MetricUnit.IU_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    PSA_TOTAL("psa_total", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    PSA_FREE("psa_free", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // Telomere length stored as SCORE — every vendor (TeloYears, SpectraCell)
+    // ships a proprietary scale; no stable LOINC, manual entry only.
+    TELOMERE_LENGTH("telomere_length", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // Agatston CAC score (CT-derived, dimensionless) and DEXA bone-density
+    // T-score (WHO osteoporosis: ≤ -2.5). Anatomical site for the T-score
+    // rides in event_payloads when the import provides it.
+    CORONARY_CALCIUM_SCORE("coronary_calcium_score", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    BONE_DENSITY_T_SCORE("bone_density_t_score", MetricUnit.SCORE, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // pTau-217 (Quanterix Simoa / Lilly C2N) — emerging Alzheimer's plasma
+    // marker that tracks amyloid PET positivity.
+    PTAU_217("ptau_217", MetricUnit.PG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // Fat-soluble vitamin auxiliaries. Vitamin K2 (MK-7) lacks a stable
+    // canonical LOINC so the FHIR path is manual only.
+    VITAMIN_K2("vitamin_k2", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    VITAMIN_A_RETINOL("vitamin_a_retinol", MetricUnit.UG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    VITAMIN_E_ALPHA_TOCOPHEROL("vitamin_e_alpha_tocopherol", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
     // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
     // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
     // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricUnit.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricUnit.kt
@@ -75,4 +75,6 @@ enum class MetricUnit(val symbol: String) {
     PICOGRAMS("pg"),
     /** Pituitary gonadotropin activity — FSH, LH; numerically equal to IU/L. */
     MIU_PER_ML("mIU/mL"),
+    /** Antibody titer per millilitre — TPO Ab, Tg Ab thyroid autoimmunity panel. */
+    IU_PER_ML("IU/mL"),
 }

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -185,6 +185,18 @@ class MetricTypeKeysSnapshotTest {
         "testosterone_free",
         "prolactin",
         "dhea_sulfate",
+        // Wave-2 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT §3.2)
+        "thyroid_peroxidase_ab",
+        "thyroglobulin_ab",
+        "psa_total",
+        "psa_free",
+        "telomere_length",
+        "coronary_calcium_score",
+        "bone_density_t_score",
+        "ptau_217",
+        "vitamin_k2",
+        "vitamin_a_retinol",
+        "vitamin_e_alpha_tocopherol",
         // Epigenetic age clocks
         "epigenetic_age_dunedin_pace",
         "epigenetic_age_grim",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -417,6 +417,35 @@ class MetricTypeTest {
         assertEquals("mIU/mL", MetricUnit.MIU_PER_ML.symbol)
     }
 
+    // -- Wave-2 biomarker expansion (BLUEPRINT_PROTOCOL_AUDIT §3.2) --
+
+    @Test
+    fun wave2_biomarkers_use_canonical_per_assay_units() {
+        val expected = mapOf(
+            MetricType.THYROID_PEROXIDASE_AB to MetricUnit.IU_PER_ML,
+            MetricType.THYROGLOBULIN_AB to MetricUnit.IU_PER_ML,
+            MetricType.PSA_TOTAL to MetricUnit.NG_PER_ML,
+            MetricType.PSA_FREE to MetricUnit.NG_PER_ML,
+            MetricType.TELOMERE_LENGTH to MetricUnit.SCORE,
+            MetricType.CORONARY_CALCIUM_SCORE to MetricUnit.SCORE,
+            MetricType.BONE_DENSITY_T_SCORE to MetricUnit.SCORE,
+            MetricType.PTAU_217 to MetricUnit.PG_PER_ML,
+            MetricType.VITAMIN_K2 to MetricUnit.NG_PER_ML,
+            MetricType.VITAMIN_A_RETINOL to MetricUnit.UG_PER_DL,
+            MetricType.VITAMIN_E_ALPHA_TOCOPHEROL to MetricUnit.MG_PER_L,
+        )
+        for ((type, unit) in expected) {
+            assertEquals(MetricDomain.BIOMARKER, type.domain, "${type.key} must be a BIOMARKER")
+            assertEquals(unit, type.unit, "${type.key} must report in ${unit.name}")
+            assertTrue(type.allowsManualEntry, "${type.key} (biomarker) must allow manual entry")
+        }
+    }
+
+    @Test
+    fun wave2_new_unit_carries_expected_symbol() {
+        assertEquals("IU/mL", MetricUnit.IU_PER_ML.symbol)
+    }
+
     // -- ECG strip presence (#188, audit gap §2.8) --
 
     @Test


### PR DESCRIPTION
## Summary
Follow-up to #252. Lands the medium-priority biomarker additions from [BLUEPRINT_PROTOCOL_AUDIT.md §3.2](https://github.com/thdelmas/Bios/blob/main/docs/audits/BLUEPRINT_PROTOCOL_AUDIT.md): **11 new MetricType entries**, same enum + LOINC + dashboard shape as Wave-1. Brings Bios from ~74/140 to ~85/140 Blueprint baseline-panel coverage.

### New biomarkers (all `MetricDomain.BIOMARKER`, `allowsManualEntry = true`)

| Group | Markers |
|---|---|
| Thyroid autoimmunity | `THYROID_PEROXIDASE_AB`, `THYROGLOBULIN_AB` |
| Prostate screening | `PSA_TOTAL`, `PSA_FREE` |
| Cellular aging | `TELOMERE_LENGTH` |
| Imaging-derived risk | `CORONARY_CALCIUM_SCORE`, `BONE_DENSITY_T_SCORE` |
| Plasma neurology | `PTAU_217` |
| Fat-soluble vitamin auxiliaries | `VITAMIN_K2`, `VITAMIN_A_RETINOL`, `VITAMIN_E_ALPHA_TOCOPHEROL` |

### Wiring
- **1 new MetricUnit** (`IU_PER_ML` for thyroid antibody titres) with UCUM code in `FhirExporter`.
- **LOINC mappings for 8 of 11**. Three intentionally stay in the null-fallback path: telomere length (vendor-proprietary scoring across TeloYears / SpectraCell), bone density T-score (site-specific codes; site rides in `event_payloads`), Vitamin K2/MK-7 (no stable canonical LOINC).
- **Three new dashboard panels:** Prostate Screening, Bone Health, Neurology. Existing panels extended: Thyroid (+2 antibodies), Cardiometabolic (+CAC score), Vitamins & Minerals (+K2/A/E), Epigenetic Age renamed to "Aging Biomarkers" (+telomere length).
- Snapshot test + `BiomarkerEntrySelectorsTest` + `FhirExporterTest` mirror & count + new `MetricTypeTest.wave2_*` cases all updated.

## Test plan
- [x] `:bios-contracts:test` and `:app:testStandaloneDebugUnitTest` — all green
- [x] `./scripts/code-quality-check.sh` passes (file length, secrets, lint, lethe + standalone build, tests)
- [ ] On-device: enter a Wave-2 biomarker (e.g. PSA Total) and confirm it lands on the new Prostate Screening panel
- [ ] FHIR round-trip: export a bundle containing TPO Ab, re-import, verify LOINC↔MetricType resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)