### PR TITLE
docs(audits): refresh _TRIAGE_INVENTORY.md (25 shipped, 2 partial, 5 open)

### DIFF
--- a/docs/audits/_TRIAGE_INVENTORY.md
+++ b/docs/audits/_TRIAGE_INVENTORY.md
@@ -1,27 +1,35 @@
 # Triage Inventory — Audit-Derived Issues
 
-Date: 2026-05-22
+Original date: 2026-05-22 · **Last refreshed: 2026-05-23**
 Source: 22 lens audits in /home/mia/Bios/docs/audits/
-Status: ready to file via `gh issue create`
 
-This inventory consolidates the actionable gaps surfaced across the 22 medical-perspective audits. Each entry represents a coherent body of work, not a single audit's flag — convergence count is the triage signal. Items already closed in code (URGENT-tier reachability, hypertension first-class, medication-context, region-aware screening cadence) are listed under "Closed / partially closed" with extension recommendations folded into appropriate Tier-A/B/C issues where extensions remain.
+This inventory consolidates the actionable gaps surfaced across the 22 medical-perspective audits. Each entry represents a coherent body of work, not a single audit's flag — convergence count is the triage signal.
 
 A large fraction of the tradition-medicine "gaps" are **pull-side vocabulary overlays on existing engine machinery** — most can be served by one or two shared primitives (e.g. a `TraditionalMedicineContext` projection layer, a generic `INTERVENTION_EVENT` metric, an extended `MedicationAnnotationRepo` substance vocabulary). They have been merged accordingly.
 
 Fundamental orthogonalities (divination, spirit-illness etiology, energy medicine, homeopathic repertorisation, anthroposophic threefoldness, miasms, marma anatomy, Vijjadhara alchemy) are deliberately **not** filed — multiple audits flag these as correct silence rather than gaps to close.
 
-## Summary
+## Summary (2026-05-23 refresh)
+
+The vast majority of the original 32 issues have shipped between the 2026-05-22 audit roll-up and this refresh. Tier A is fully closed; Tier B is essentially closed; the remaining open work is concentrated in Tier C and on a couple of partially-shipped items.
+
 - Total consolidated issues: **32**
-- Tier A (highest priority): **10**
-- Tier B: **13**
-- Tier C: **9**
-- Already closed / partially closed: see final section (URGENT escalation infrastructure, hypertension patterns, medication-annotation, screening-cadence engine, PhysiologyState scaffolding all shipped — extensions captured in B-tier issues below)
+- **✅ Shipped: 25** (#1–23, #25, #29)
+- **🟡 Partially shipped: 2** (#28 single-lead ECG done but RBD screen + tremor pipeline still missing; #31 menopause hints in alerts but no first-class contraception / menopause / PCOS / gender-affirming model)
+- **⏳ Open: 5** (#24 seizure events, #26 cardiology-advanced patterns, #27 psychiatry-specific patterns, #30 fall-risk / delirium / cognitive trajectory, #32 localization)
+- By tier — Tier A: **10/10 shipped**. Tier B: **12/13 shipped** (#32 open). Tier C: **3/9 shipped** (#24/26/27/30 open, #28/31 partial, #25/29 shipped, #32 open).
+
+### Verification methodology
+Status assignments below are based on (a) `find` over the source tree for entity / data-class / pattern filenames named in each item's "Suggested files" line, and (b) `grep` for the key clinical-string constants the audit recommended. A `✅ SHIPPED` annotation cites the canonical implementation file; the original body sketch is preserved unchanged so the historical rationale stays readable.
+
+The grep / find heuristic is not perfect — it will miss work that landed under unexpected names. Treat the partial / open list as the active backlog and treat shipped items as "very likely done; recheck before re-implementing per the no-re-implement rule."
 
 ---
 
 ## Tier A
 
 ### #1 — feat(alerts): wire URGENT escalation destination + emergency contact
+**Status (2026-05-23): ✅ SHIPPED** — [EmergencyContact.kt](../../android/app/src/main/java/com/bios/app/model/EmergencyContact.kt), [EmergencyContactRepo.kt](../../android/app/src/main/java/com/bios/app/data/EmergencyContactRepo.kt), [EmergencyContactsScreen.kt](../../android/app/src/main/java/com/bios/app/ui/emergency/EmergencyContactsScreen.kt), [UrgentAckTimeoutWorker.kt](../../android/app/src/main/java/com/bios/app/alerts/UrgentAckTimeoutWorker.kt) all in tree; `RegionConfig.emergencyNumber` populated across regional bundles.
 **Lens convergence:** Emergency/Critical Care, Geriatrics/Palliative, Primary Care, Cardiology, Ob/Gyn
 **Clinical impact:** The URGENT tier now fires but the notification terminates in the drawer. No `tel:` deep-link to the regional emergency number, no designated emergency-contact surface, no acknowledgement-timeout escalation. For hypoglycaemic, post-arrest, opioid-overdose, or hypoxic owners the alert reaches the wrong target because the owner may be cognitively impaired or alone. This is the single highest-impact EM-side recommendation across the corpus.
 **Suggested files:** [android/app/src/main/java/com/bios/app/config/RegionConfig.kt](android/app/src/main/java/com/bios/app/config/RegionConfig.kt), [android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt](android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt), [android/app/src/main/java/com/bios/app/alerts/AlertManager.kt](android/app/src/main/java/com/bios/app/alerts/AlertManager.kt), new `android/app/src/main/java/com/bios/app/model/EmergencyContact.kt`, new `android/app/src/main/java/com/bios/app/alerts/UrgentAckTimeoutWorker.kt`
@@ -38,6 +46,7 @@ Manifesto-aligned: prospective consent (owner sets the policy while competent), 
 ```
 
 ### #2 — feat(alerts): PPG-derived AFib screening over RR series
+**Status (2026-05-23): ✅ SHIPPED** — [RhythmClassifier.kt](../../android/app/src/main/java/com/bios/app/engine/RhythmClassifier.kt), [AfibRhythmPattern.kt](../../android/app/src/main/java/com/bios/app/alerts/AfibRhythmPattern.kt), `IRREGULAR_RHYTHM_BURDEN` MetricType registered in [MetricType.kt](../../android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt).
 **Lens convergence:** Cardiology, Neurology, Emergency Medicine (stroke prevention angle), TCM, Sowa Rigpa, Kampo, Korean Medicine, Siddha, Unani (latent-pulse-morphology angle)
 **Clinical impact:** Today's `atrialFibrillationScreen` is a baseline-deviation pattern on HRV irregularity that does not run a Poincaré/sample-entropy classifier over the RR series Bios already extracts. It claims the "AFib" name but produces a generic autonomic-shift signal that fires on infection, dehydration, thyrotoxicosis, etc. The actual FDA-cleared category (Apple Heart Study, mAFA-II, Fitbit Heart Study) runs a rhythm classifier on the IBI tachogram — Bios has the substrate and declines to use it. AFib is the dominant cardio-embolic stroke source; this is the upstream lever EM and Neurology both prioritise.
 **Suggested files:** [android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt), [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), new `android/app/src/main/java/com/bios/app/engine/RhythmClassifier.kt`
@@ -55,6 +64,7 @@ Cross-references docs/audits/NEUROLOGY_POV.md §1 (AFib screen is the upstream s
 ```
 
 ### #3 — feat(engine): preserve PPG waveform morphology features in PpgResult
+**Status (2026-05-23): ✅ SHIPPED** — Six morphology MetricTypes (PPG_PEAK_AMPLITUDE_MEAN/COV, PPG_RISE_TIME_MEAN/COV, PPG_DECAY_ASYMMETRY_INDEX, PPG_DICHROTIC_NOTCH_POSITION) + the PPG-derived augmentation index. Computed in [PpgSignalProcessor.kt](../../android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt) → [PulseWaveformFeatures.kt](../../android/app/src/main/java/com/bios/app/engine/PulseWaveformFeatures.kt), persisted via [CameraPpgAdapter.kt](../../android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt) (PR #256 + #258).
 **Lens convergence:** Cardiology, TCM, Sowa Rigpa, Kampo, Korean Medicine, Siddha, Unani, Ayurveda, Indonesian (Hilot), Mongolian, Modern Non-Allopathic (osteopathy)
 **Clinical impact:** [PpgSignalProcessor.kt:120-152](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt) computes peak amplitude, peak-amplitude CoV, RR CoV, and waveform morphology — and discards everything except `rrIntervalsMs` and SQI. Western cardiology wants these for arterial-stiffness proxies (augmentation index, pulse-wave-velocity proxy, dichrotic-notch position). Eight tradition-medicine audits independently flag the same finding from their pulse-quality angles. A single data-structure change unlocks every downstream surface.
 **Suggested files:** [android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt), [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt)
@@ -71,6 +81,7 @@ No new sensors, no new permissions, no push notifications. One data structure ch
 ```
 
 ### #4 — feat(alerts): sepsis screening (NEWS2 / qSOFA) URGENT pattern
+**Status (2026-05-23): ✅ SHIPPED** — [SepsisScreenPattern.kt](../../android/app/src/main/java/com/bios/app/alerts/SepsisScreenPattern.kt) wired into the [ConditionPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt) aggregator.
 **Lens convergence:** Emergency/Critical Care, Surgical, Primary Care, Geriatrics, Oncology (chemotherapy + neutropenic-fever overlap)
 **Clinical impact:** Every NEWS2 input is on the bus (RR, SpO2, OXYGEN_FLOW_RATE, BP-systolic, HR, skin-temp, CONSCIOUSNESS_LEVEL); qSOFA's three inputs are present too. No pattern composes them. For post-surgical, immunocompromised, indwelling-device, and elderly owners the Surviving Sepsis Campaign mortality arithmetic (Kumar 2006 — each hour of antibiotic delay) makes this the highest-leverage missing pattern.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/alerts/SepsisScreenPattern.kt`, [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt)
@@ -86,6 +97,7 @@ Deliverables:
 ```
 
 ### #5 — feat(alerts): peri-operative state + SSI/VTE/anastomotic-leak post-op patterns
+**Status (2026-05-23): ✅ SHIPPED** — [PerioperativePatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/PerioperativePatterns.kt), [PerioperativeBaselineFreezer.kt](../../android/app/src/main/java/com/bios/app/physiology/PerioperativeBaselineFreezer.kt), POD_0_30 / PREHAB_WINDOW states in [PhysiologyState.kt](../../android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt) (PR #249).
 **Lens convergence:** Surgical, Emergency Medicine (post-ED discharge), Cardiology (post-PCI/CABG rehab), Oncology (post-treatment surveillance)
 **Clinical impact:** Bios has no concept of "an operation happened." The infection-onset pattern false-fires constantly on a post-op patient whose RHR is normatively elevated for 2-4 weeks, or — if dialed down — misses the genuine POD7-14 SSI. NHSN 30-day SSI surveillance, anastomotic leak (POD3-7), and post-op VTE (Wells/Caprini) are the highest-value post-discharge wearable use cases.
 **Suggested files:** [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt), new `android/app/src/main/java/com/bios/app/alerts/PerioperativePatterns.kt`, [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt)
@@ -103,6 +115,7 @@ Suppress false-positive [cardiovascularStress](android/app/src/main/java/com/bio
 ```
 
 ### #6 — feat(model): GoalsOfCare + ClinicalDirective + hospice mode
+**Status (2026-05-23): ✅ SHIPPED** — [GoalsOfCare.kt](../../android/app/src/main/java/com/bios/app/model/GoalsOfCare.kt), [ClinicalDirective.kt](../../android/app/src/main/java/com/bios/app/model/ClinicalDirective.kt), [GoalsOfCareRepo.kt](../../android/app/src/main/java/com/bios/app/data/GoalsOfCareRepo.kt), [ClinicalDirectiveRepo.kt](../../android/app/src/main/java/com/bios/app/data/ClinicalDirectiveRepo.kt), [GoalsOfCareScreen.kt](../../android/app/src/main/java/com/bios/app/ui/goals/GoalsOfCareScreen.kt) all in tree.
 **Lens convergence:** Geriatrics/Palliative, Oncology, Emergency/Critical Care, Cardiology (HF prognosis), Modern Non-Allopathic (advance directives)
 **Clinical impact:** Today's URGENT alerts tell every owner to "seek immediate medical attention" — clinically and ethically wrong for documented DNAR/comfort-only owners. The palliative-care panel calls this the strongest single intervention they would ask for: a `GoalsOfCare` gate plus a "hospice mode" toggle that drops Bios into its most-silent posture for actively dying patients while preserving symptom-burden capture.
 **Suggested files:** [android/app/src/main/java/com/bios/app/model/Enums.kt](android/app/src/main/java/com/bios/app/model/Enums.kt), new `android/app/src/main/java/com/bios/app/model/ClinicalDirective.kt`, [android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt), [android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt), [android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt](android/app/src/main/java/com/bios/app/alerts/AlertContentPolicy.kt)
@@ -120,6 +133,7 @@ Manifesto reading: "owner is final" via prospective consent (advance-directive f
 ```
 
 ### #7 — feat(data): ESAS-r symptom-burden capture + PRO surfaces
+**Status (2026-05-23): ✅ SHIPPED** — [EsasReport.kt](../../android/app/src/main/java/com/bios/app/model/EsasReport.kt), [EsasReportRepo.kt](../../android/app/src/main/java/com/bios/app/data/EsasReportRepo.kt), [EsasReportDao.kt](../../android/app/src/main/java/com/bios/app/data/dao/EsasReportDao.kt), [EsasCaptureScreen.kt](../../android/app/src/main/java/com/bios/app/ui/esas/EsasCaptureScreen.kt) all in tree.
 **Lens convergence:** Geriatrics/Palliative, Oncology, Surgical (functional recovery PROs), Neurology (MS / concussion fatigue), Psychiatry
 **Clinical impact:** Palliative medicine runs on owner-reported symptom scores; Bios captures PAIN_SCORE and CONSCIOUSNESS_LEVEL but no dyspnea, nausea, fatigue, drowsiness, appetite, anxiety, or wellbeing. ESAS-r (Watanabe 2011) and IPOS (Murtagh 2019) are the dominant instruments. Oncology, post-ICU, MS, post-concussion, post-surgical, and chronic-pain owners all benefit from the same SCORE-unit primitive.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt](android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt)
@@ -140,6 +154,7 @@ Manifesto-clean: all self-reported, all owner-controlled, pull-side displayed. N
 ```
 
 ### #8 — feat(physiology): wire FRAILTY_FLAG + frailty assessment surface
+**Status (2026-05-23): ✅ SHIPPED** — `FRAILTY_FLAG` in [PhysiologyState.kt](../../android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt) with `excludedStates` gating across [BaselineDeviationPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/BaselineDeviationPatterns.kt).
 **Lens convergence:** Geriatrics/Palliative, Primary Care, Surgical (pre-op risk), Kampo (Japan ageing demographic), Cardiology (older HFrEF cohort)
 **Clinical impact:** [PhysiologyState.FRAILTY_FLAG](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt#L37) is declared and unwired — no pattern reads it, no threshold modifier consumes it. Every wearable pattern false-fires in the frail >75 cohort because normative aging sleep architecture, deconditioning, and bradycardia look like pathology. Geriatrics panel calls this the largest single false-firing source for older adults.
 **Suggested files:** [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt), [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), new `android/app/src/main/java/com/bios/app/ui/geriatrics/FrailtyAssessmentScreen.kt`
@@ -156,6 +171,7 @@ Cross-references docs/audits/SURGICAL_POV.md §2.7 (pre-op Fried surrogate), doc
 ```
 
 ### #9 — feat(alerts): heart-failure decompensation pattern (HeartLogic-lite)
+**Status (2026-05-23): ✅ SHIPPED** — [HeartFailureDecompensationPattern.kt](../../android/app/src/main/java/com/bios/app/alerts/HeartFailureDecompensationPattern.kt) gated on `PhysiologyState.KNOWN_HF`.
 **Lens convergence:** Cardiology, Geriatrics/Palliative, Emergency Medicine
 **Clinical impact:** Boston Scientific HeartLogic (Boehmer 2017 MultiSENSE; Gardner 2018) is FDA-cleared for CRT-D and predicts HF decompensation 7-14 days ahead. Bios has every wearable input HeartLogic uses except thoracic impedance (RHR, nocturnal RR, activity, body weight via Withings). For ~6.7M US HFrEF/HFpEF patients this is the single most consequential missing pattern.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/alerts/HeartFailurePatterns.kt`, [android/app/src/main/java/com/bios/app/model/RiskProfile.kt](android/app/src/main/java/com/bios/app/model/RiskProfile.kt) or [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt)
@@ -174,6 +190,7 @@ Framing per docs/audits/CARDIOLOGY_POV.md §3.2: data statement + referral, not 
 ```
 
 ### #10 — feat(adapter): single-lead ECG strip ingestion path
+**Status (2026-05-23): ✅ SHIPPED** — [HealthConnectEcgAdapter.kt](../../android/app/src/main/java/com/bios/app/ingest/HealthConnectEcgAdapter.kt), [AppleHealthEcgImporter.kt](../../android/app/src/main/java/com/bios/app/ingest/AppleHealthEcgImporter.kt); `ecg_strips` table with classification index (PR #248).
 **Lens convergence:** Cardiology, Emergency Medicine, Neurology (stroke workup)
 **Clinical impact:** Apple Watch, Samsung Galaxy Watch, Withings ScanWatch, KardiaMobile, WHOOP MG, Fitbit Sense all emit single-lead ECG strips with vendor-derived classifications. From the cardiology bench this is the single most clinically actionable signal a wearable produces. [DATA_MODEL.md](docs/DATA_MODEL.md) lists `ecg_waveform` as `[planned]`; no adapter consumes it. Owners currently take screenshots and email them.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/ingest/](android/app/src/main/java/com/bios/app/ingest/), [android/app/src/main/java/com/bios/app/export/FhirExporter.kt](android/app/src/main/java/com/bios/app/export/FhirExporter.kt)
@@ -193,6 +210,7 @@ Cross-references docs/audits/NEUROLOGY_POV.md (stroke FAST workup wants AFib evi
 ## Tier B
 
 ### #11 — feat(alerts): pregnancy-specific patterns (preeclampsia + complete pregnancy gating)
+**Status (2026-05-23): ✅ SHIPPED** — [PregnancyPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/PregnancyPatterns.kt) with `PREGNANCY_T1/T2/T3` states.
 **Lens convergence:** Ob/Gyn, Primary Care, Cardiology (peripartum cardiomyopathy)
 **Clinical impact:** No pre-eclampsia signature despite BP ingestion + PhysiologyState being ready — the #1 preventable maternal mortality cause in the developed world. Multiple class-2 patterns (`infectionOnset`, `chronicInflammation`, `recoveryDeficit`, `metabolicDrift`, `overtraining`) false-fire constantly in T2/T3 pregnancy and erode URGENT-tier credibility for the alert that actually matters (severe-range BP).
 **Suggested files:** [android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt), [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt)
@@ -207,6 +225,7 @@ docs/audits/OBGYN_POV.md §2.1-2.3 covers the gaps comprehensively.
 ```
 
 ### #12 — feat(alerts): acute-window patterns (anaphylaxis, opioid respiratory depression, DKA, hypotensive shock)
+**Status (2026-05-23): ✅ SHIPPED** — [AcuteWindowPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/AcuteWindowPatterns.kt).
 **Lens convergence:** Emergency/Critical Care, Psychiatry (addiction), Paediatrics (DKA), Endocrinology
 **Clinical impact:** Bios's pattern engine runs ≥12h windows. Anaphylaxis is a 5-minute multi-system event. Opioid overdose's bradypnea-to-apnea trajectory is ~5 minutes from RR <8 to anoxic injury. DKA in T1D children, hypotensive shock convergence — all need a fast-loop engine alongside the existing pattern engine.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/engine/VitalsAccelerationDetector.kt`, [android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt), [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt)
@@ -222,6 +241,7 @@ Patterns:
 ```
 
 ### #13 — feat(model): screening-cadence engine extensions (region + risk + immunization)
+**Status (2026-05-23): ✅ SHIPPED** — [ScreeningCadenceEngine.kt](../../android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt), [ScreeningCatalog.kt](../../android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt), [RiskProfile.kt](../../android/app/src/main/java/com/bios/app/model/RiskProfile.kt) (PR #229).
 **Lens convergence:** Primary Care, Oncology, Ob/Gyn, Paediatrics, Cardiology (one-time AAA/Lp(a)), Indigenous Americas (IHS cadence), African Traditional, Geriatrics
 **Clinical impact:** The screening-cadence scaffolding ships ([ScreeningCadenceEngine.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt), [ScreeningCatalog.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt)) but is USPSTF-only, missing hereditary-syndrome cadence shifts, missing paediatric ACIP/NIP vaccine schedules, missing Ob/Gyn-society cadences, missing IHS/PAHO/non-NHS regional alternatives, missing one-time cardiology screens (AAA, Lp(a)).
 **Suggested files:** [android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt), [android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt), [android/app/src/main/java/com/bios/app/model/RiskProfile.kt](android/app/src/main/java/com/bios/app/model/RiskProfile.kt), [android/app/src/main/java/com/bios/app/ui/immunisations/VaccineCatalog.kt](android/app/src/main/java/com/bios/app/ui/immunisations/VaccineCatalog.kt)
@@ -238,6 +258,7 @@ The cadence engine and `RiskProfile` exist; this is extension work across severa
 ```
 
 ### #14 — feat(data): generic INTERVENTION_EVENT + TreatmentCourse entities
+**Status (2026-05-23): ✅ SHIPPED** — [InterventionEventRepo.kt](../../android/app/src/main/java/com/bios/app/data/InterventionEventRepo.kt), [TreatmentCourseRepo.kt](../../android/app/src/main/java/com/bios/app/data/TreatmentCourseRepo.kt), [FhirInterventionMapping.kt](../../android/app/src/main/java/com/bios/app/export/FhirInterventionMapping.kt) (PR #231).
 **Lens convergence:** Modern Non-Allopathic (all 9 traditions), Sowa Rigpa, Ayurveda (Panchakarma), Siddha (thokkanam), Unani (Ilaj bil Tadbeer), Oceanic (Hoʻoponopono/karakia), Indigenous Americas (sweat lodge/ceremony), Other Asian (Nuad Thai/jamu/pijat), Oncology (chemo course), Surgical (peri-op)
 **Clinical impact:** The single highest-leverage cross-tradition addition. Manual therapies (chiropractic, OMT, Nuad Thai, hilot, pijat, thokkanam, sangkal putung, *me btsa'*, *gtar ga*), ceremonial events (sweat lodge, hoʻoponopono, karakia, joik, Reiki/TT), multi-week treatment courses (Panchakarma, mistletoe, elimination diet, IV protocols, IVF stimulation), and oncology/peri-op windows all need timestamped event anchors so wearable trends can be read against them.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), new `android/app/src/main/java/com/bios/app/model/InterventionEvent.kt`, new `android/app/src/main/java/com/bios/app/model/TreatmentCourse.kt`, [android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt](android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt)
@@ -255,6 +276,7 @@ One entity-pair closes a recurring gap across at least 10 audits.
 ```
 
 ### #15 — feat(data): TraditionalMedicineContext pull-side projection layer
+**Status (2026-05-23): ✅ SHIPPED** — [TraditionalMedicineContextRepo.kt](../../android/app/src/main/java/com/bios/app/data/TraditionalMedicineContextRepo.kt) in tree.
 **Lens convergence:** TCM, Ayurveda, Siddha, Sowa Rigpa, Unani, Korean Medicine, Kampo, African Traditional, Oceanic, Indigenous Americas, Modern Non-Allopathic
 **Clinical impact:** Eleven traditions independently ask for the same shape: a pull-side, owner-selected, never-pushed vocabulary overlay that re-projects existing signals (HRV, RHR, sleep, skin-temp, glucose, biomarkers) onto the tradition's diagnostic axes. Single shared primitive — a `TraditionalMedicineContext` annotation surface + a constitutional/Prakriti/Sasang/Mizaj enum + pull-side projection views — serves every tradition simultaneously and doesn't violate the manifesto.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/tradmed/TraditionalMedicineContext.kt`, new `android/app/src/main/java/com/bios/app/tradmed/Constitution.kt`, new `android/app/src/main/java/com/bios/app/ui/tradmed/TraditionalMedicineLensScreen.kt`, [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt)
@@ -285,6 +307,7 @@ Manifesto-clean throughout: pull-side, owner-asks, never pushed, never auto-clas
 ```
 
 ### #16 — feat(data): extend MedicationAnnotationRepo to traditional + functional pharmacopoeias
+**Status (2026-05-23): ✅ SHIPPED** — [MedicationAnnotationRepo.kt](../../android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt) with extended substance vocabulary.
 **Lens convergence:** Ayurveda, TCM, Kampo, Korean, Siddha, Unani, Sowa Rigpa, African Traditional, Indigenous Americas, Other Asian (Vietnamese/Thai/Burmese/Indonesian/Filipino), Modern Non-Allopathic (Western herbal, homeopathic, anthroposophic), Cardiology (QT-prolonging registry), Geriatrics (Beers/STOPP)
 **Clinical impact:** [MedicationAnnotationRepo](android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt) accepts free-text but is RxNorm-centric. Practitioners across 13+ traditions want the existing surface to *recognise* the substances they prescribe so the pattern-explanation builder can de-noise alerts. Cardiology wants QT-prolonging-class flagging; geriatrics wants Beers-AGS anticholinergic flagging.
 **Suggested files:** [android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt](android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt), new `android/app/src/main/java/com/bios/app/data/SubstanceRegistry.kt`, [android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt](android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt)
@@ -302,6 +325,7 @@ Manifesto-clean: Bios never prescribes; records what the owner annotates; surfac
 ```
 
 ### #17 — feat(model): RegionConfig coverage + emergencyNumber + Aboriginal/Indigenous/NZ/Pacific/Latin America/Africa
+**Status (2026-05-23): ✅ SHIPPED** — `emergencyNumber` field on [RegionConfig.kt](../../android/app/src/main/java/com/bios/app/config/RegionConfig.kt); regional bundles in [RegionConfigsAfrica.kt](../../android/app/src/main/java/com/bios/app/config/RegionConfigsAfrica.kt), [RegionConfigsAmericas.kt](../../android/app/src/main/java/com/bios/app/config/RegionConfigsAmericas.kt), [RegionConfigsEurope.kt](../../android/app/src/main/java/com/bios/app/config/RegionConfigsEurope.kt), plus [RegionConfigDefaults.kt](../../android/app/src/main/java/com/bios/app/config/RegionConfigDefaults.kt).
 **Lens convergence:** Indigenous Americas, African Traditional, Oceanic/Arctic, Other Asian, Primary Care (emergencyNumber), Cardiology, Ob/Gyn (Medsafe / SAHPRA / COFEPRIS / ANVISA)
 **Clinical impact:** RegionConfig has 6 entries (US/GB/EU/CA/AU/JP); silently falls back to EU for everything else, citing CE-mark and EMA for owners in Mexico, Nigeria, Indonesia, Mongolia, NZ, etc. The disclaimer text is meaningless to the user and the cardiovascular cutoffs are mis-sourced. Several audits also want region-specific emergency numbers (911/112/999/119/000/110), Aboriginal/IHS subflavours, and Pacific-NCD presets.
 **Suggested files:** [android/app/src/main/java/com/bios/app/config/RegionConfig.kt](android/app/src/main/java/com/bios/app/config/RegionConfig.kt), [android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt](android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt)
@@ -320,6 +344,7 @@ Cross-references docs/audits/INDIGENOUS_AMERICAS_POV.md §2.3, docs/audits/OTHER
 ```
 
 ### #18 — feat(alerts): tropical / endemic-disease pattern library
+**Status (2026-05-23): ✅ SHIPPED** — [TropicalDiseasePatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/TropicalDiseasePatterns.kt), gated on `RegionConfig.tropicalDiseaseRelevant`.
 **Lens convergence:** African Traditional, Indigenous Americas, Other Asian, Oceanic/Arctic, Siddha (Tamil-tropical), Emergency Medicine
 **Clinical impact:** The 33+ patterns are Northern-temperate-anchored (Mishra/Quer/Smarr/Ridker/ADA citations). No malaria (with quartan/tertian periodicity from skin-temp time-series), no dengue (biphasic saddleback fever-curve + WHO 2009 warning signs), no chikungunya, no typhoid, no scrub typhus, no leptospirosis, no melioidosis, no ciguatera (bradycardia + cold-allodynia), no Lassa, no severe-malaria URGENT escalation. Major morbidity in the regions traditional practitioners serve.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/alerts/TropicalEndemicPatterns.kt`, [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt)
@@ -339,6 +364,7 @@ Region-gated: silent in temperate-only cohorts to avoid false-fire on non-tropic
 ```
 
 ### #19 — feat(alerts): environmental context patterns (altitude, heat, cold, photoperiod)
+**Status (2026-05-23): ✅ SHIPPED** — [EnvironmentalPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/EnvironmentalPatterns.kt); `ELEVATION_M`, `AMBIENT_TEMPERATURE_C`, `AMBIENT_HUMIDITY_PCT`, `DAYLIGHT_HOURS` MetricTypes wired.
 **Lens convergence:** Sowa Rigpa, Indigenous Americas (Andes/Mesoamerica), Oceanic/Arctic (Sápmi/Sakha/Chukchi cold + polar photoperiod), Other Asian (Mongolia cold), Emergency/Critical Care (heat/wilderness), Ayurveda (Ritucharya), TCM (six pathogens), African Traditional (Sahel heat)
 **Clinical impact:** SpO2 cutoffs in [EmergencyVitalPatterns.spo2Critical](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt) cite WHO sea-level cutoffs that fire URGENT on healthy 3,500-4,500m residents (Leh, Lhasa, Cusco, La Paz, Quito, Santa Fe). Heat illness (ACSM, climate-change relevance), hypothermia in circumpolar populations, Sápmi/Sakha photoperiod extremes — all need owner-set environmental context to interpret baselines correctly.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/physiology/EnvironmentalContext.kt`, [android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt), [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt)
@@ -356,6 +382,7 @@ Deliverables:
 ```
 
 ### #20 — feat(physiology): age-banded paediatric sub-states + vital-sign norms
+**Status (2026-05-23): ✅ SHIPPED** — Paediatric sub-bands in [PhysiologyState.kt](../../android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt) + `PaediatricVitalBands` + [PaediatricEmergencyVitalPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/PaediatricEmergencyVitalPatterns.kt) (PR #232).
 **Lens convergence:** Paediatrics (entire audit), Primary Care, Emergency/Critical Care (PALS), Oncology (paediatric haem-onc), Ob/Gyn (adolescent confidentiality)
 **Clinical impact:** A 2-month-old with a normal RHR of 130 fires URGENT `tachycardiaCritical` (≥130). Bradycardia at ≤35 misses a 2-month-old at 80 bpm who is in genuine bradyarrhythmia (PALS infant cutoff <100). SpO2, BP (percentile-based), RR all need age-banded modifiers. PAEDIATRIC is one bucket covering 0-18 — clinically six bands.
 **Suggested files:** [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt), [android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt), new `android/app/src/main/java/com/bios/app/physiology/PaediatricVitalBands.kt`
@@ -373,6 +400,7 @@ Out of scope per paediatrics audit: SIDS/Owlet-class neonatal monitoring (correc
 ```
 
 ### #21 — feat(data): paediatric growth tracking + body-composition primitives
+**Status (2026-05-23): ✅ SHIPPED** — `HEIGHT_CM`, `HEAD_CIRCUMFERENCE_CM`, `BMI_KG_PER_M2`, `LEAN_BODY_MASS_KG`, `FAT_MASS_KG` MetricTypes; [GrowthAndCompositionPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/GrowthAndCompositionPatterns.kt) (PR #233).
 **Lens convergence:** Paediatrics, Primary Care, Geriatrics (sarcopenia/cachexia), Oncology (cachexia)
 **Clinical impact:** Paediatric primary care is principally growth surveillance — height, weight, head circumference (until 36mo), BMI percentile against WHO/CDC charts. Failure-to-thrive crosses two major percentile lines downward; obesity ≥95th percentile. Bios has BODY_MASS via Withings but no HEIGHT/BODY_LENGTH/HEAD_CIRCUMFERENCE/percentile computation/chart view. Same primitive serves geriatric sarcopenia (EWGSOP2) and oncology cachexia (Fearon 2011).
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), new `android/app/src/main/java/com/bios/app/engine/GrowthPercentileEngine.kt`, new `android/app/src/main/java/com/bios/app/alerts/WeightTrajectoryPatterns.kt`
@@ -390,6 +418,7 @@ Deliverables:
 ```
 
 ### #22 — feat(alerts): respiratory + AMBIENT_HUMIDITY + asthma/sleep apnea extensions
+**Status (2026-05-23): ✅ SHIPPED** — [RespiratoryExacerbationPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/RespiratoryExacerbationPatterns.kt), [SleepApneaPattern.kt](../../android/app/src/main/java/com/bios/app/alerts/SleepApneaPattern.kt); humidity + ambient temp + PEF + FEV1 keys all on the bus.
 **Lens convergence:** Cardiology (OSA = AFib/HF risk), Neurology (OSA = stroke risk), Paediatrics (asthma), TCM (six pathogens / damp), Emergency Medicine (COPD/asthma exacerbation, sleep apnea)
 **Clinical impact:** Sleep apnea pattern ships but vendor-derived AHI passthrough should be more explicit; paediatric-asthma exacerbation pattern is missing despite air-quality substrate being on the bus; AMBIENT_HUMIDITY would unlock damp/dry pathogen interpretation across TCM/Ayurveda/Siddha + heat-index for EM heat-illness.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/alerts/RespiratoryExacerbationPatterns.kt](android/app/src/main/java/com/bios/app/alerts/RespiratoryExacerbationPatterns.kt), [android/app/src/main/java/com/bios/app/ingest/](android/app/src/main/java/com/bios/app/ingest/)
@@ -401,6 +430,7 @@ Deliverables:
 ```
 
 ### #23 — feat(alerts): cardio-oncology + treatment-toxicity surveillance
+**Status (2026-05-23): ✅ SHIPPED** — [CardioOncologyPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/CardioOncologyPatterns.kt); `troponin_ng_per_l`, `nt_pro_bnp_pg_per_ml`, `absolute_neutrophil_count` MetricTypes; `CancerTherapyDrugClass` gating (PR #230).
 **Lens convergence:** Oncology, Cardiology, Emergency Medicine (chemo emergencies), Geriatrics (Beers + oncology overlap)
 **Clinical impact:** Anthracycline cardiomyopathy, trastuzumab LVEF decline, ICI fulminant myocarditis (0.3-1.1% incidence per JAMA Oncol 2018), chemotherapy myelosuppression / neutropenic fever (STAR trial Basch JAMA 2017: median 5-month OS benefit from wearable-adjacent monitoring), irAE pneumonitis/colitis/hepatitis/thyroiditis, radiation toxicity. Bios has nearly all the substrate; gates and patterns are missing.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/physiology/OncologyState.kt`, new `android/app/src/main/java/com/bios/app/alerts/OncologyPatterns.kt`, [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt)
@@ -421,6 +451,7 @@ docs/audits/ONCOLOGY_POV.md §2.3-2.6+§2.10-2.12 details the substrate.
 ## Tier C
 
 ### #24 — feat(alerts): seizure events + neurology URGENT triggers
+**Status (2026-05-23): ⏳ OPEN** — no `SEIZURE_EVENT` MetricType in [MetricType.kt](../../android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt); no `status_epilepticus_convulsive` URGENT pattern; FAST stroke event was added under #29 but seizure-side primitives remain unshipped.
 **Lens convergence:** Neurology, Emergency/Critical Care, Paediatrics
 **Clinical impact:** No SEIZURE_EVENT MetricType, no convulsive-pattern detector, no `status_epilepticus_convulsive` URGENT pattern, no GCS ≤8 URGENT, no thunderclap-headache event. Empatica Embrace2/EmbracePlus are FDA-cleared for GTCS detection from wrist accelerometer + HR; Bios has the substrate. SUDEP risk reduction is the load-bearing argument.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), new `android/app/src/main/java/com/bios/app/engine/SeizureDetector.kt`, [android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt)
@@ -439,6 +470,7 @@ Honest scope: focal/absence seizures not wearable-detectable, PNES discriminatio
 ```
 
 ### #25 — feat(biomarkers): expand panel (renal, hepatic, functional-medicine, cardio-oncology)
+**Status (2026-05-23): ✅ SHIPPED** — Renal / hepatic panel via [Wave5BiomarkerPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/Wave5BiomarkerPatterns.kt) + #158 keys. Wave-1 + Wave-2 biomarker expansions (PR #252, #255) brought total lab MetricTypes to ~87 across cardiometabolic / endocrine / renal / hepatic / iron / CBC / electrolytes / reproductive / neurology / aging.
 **Lens convergence:** Primary Care, Oncology, Cardiology, Modern Non-Allopathic, Geriatrics
 **Clinical impact:** eGFR/creatinine, ALT/AST/GGT (GGT present, ALT/AST missing), fasting insulin/HOMA-IR (present), hsCRP (present). Missing: reverse T3, TPO/Tg antibodies, homocysteine, uric acid, bilirubin, DHEA-S, omega-3 index, fasting leptin/adiponectin, troponin (hs-cTnI/hs-cTnT), NT-proBNP, Lp(a), Lp-PLA2, ferritin (present).
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt](android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt), [android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt](android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt)
@@ -460,6 +492,7 @@ Each requires one MetricType entry + universal/regional reference band entry. Ri
 ```
 
 ### #26 — feat(alerts): cardiology-specific advanced patterns (POTS, HRR, ectopy, QT-class)
+**Status (2026-05-23): ⏳ OPEN** — no POTS / orthostatic-intolerance pattern, no heart-rate-recovery (HRR) post-exercise pattern, no ectopy-burden pattern, no QT-prolongation pattern. Substrate (HR + posture + exercise session) is present; pattern files are not.
 **Lens convergence:** Cardiology, Neurology (POTS / long-COVID), Emergency Medicine
 **Clinical impact:** POTS criterion is sustained HR ≥30 bpm rise within 10 min of standing (Sheldon 2015; long-COVID prevalence-explosion population). HRR1/HRR2 (Cole 1999, Jouven 2005) is one of the strongest single prognostic indicators in non-invasive cardiology and is mechanically derivable. PVC-burden estimate from PPG-IBI compensatory-pause signature (Baman 2010 — 10% threshold for PVC-cardiomyopathy). QT-prolonging medication interaction view (CredibleMeds — covered in #16).
 **Suggested files:** new `android/app/src/main/java/com/bios/app/alerts/AdvancedCardiologyPatterns.kt`, [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), [android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt)
@@ -478,6 +511,7 @@ Deliverables:
 ```
 
 ### #27 — feat(alerts): psychiatry-specific patterns (bipolar / anxiety / perinatal / OUD)
+**Status (2026-05-23): ⏳ OPEN** — no `BipolarPattern`, `AnxietyPattern`, `PerinatalDepressionPattern`, or `OpioidUseDisorder` pattern in the alerts tree. Mental-health writers (W2F's `typing_cadence`, `mood_drift_score`) feed into baseline shift detection but not into condition-specific patterns.
 **Lens convergence:** Psychiatry, Ob/Gyn (perinatal), Emergency Medicine (OUD)
 **Clinical impact:** Existing `mental_health_correlate` is direction-agnostic and effectively unipolar-shaped (sleep down + activity down + HRV down). Misses bipolar mania prodrome (sleep down + activity up + circadian-phase shift — Seoul Nat'l Univ 2024 already cited in references but mania-direction rule not implemented). No dedicated anxiety pattern despite HRV being the most-validated wearable anxiety biomarker (Chalmers 2014). No perinatal-depression-specific pattern despite infrastructure being ready.
 **Suggested files:** [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), new `android/app/src/main/java/com/bios/app/alerts/PsychiatryPatterns.kt`
@@ -494,6 +528,7 @@ docs/audits/PSYCHIATRY_POV.md §2.1-2.5.
 ```
 
 ### #28 — feat(adapter): single-lead ECG, RBD screen, tremor pipeline (Apple/Roche-class)
+**Status (2026-05-23): 🟡 PARTIAL** — single-lead ECG strip ingestion done (covered by #10 — [HealthConnectEcgAdapter.kt](../../android/app/src/main/java/com/bios/app/ingest/HealthConnectEcgAdapter.kt), [AppleHealthEcgImporter.kt](../../android/app/src/main/java/com/bios/app/ingest/AppleHealthEcgImporter.kt)). RBD screen and tremor pipeline are still unshipped — no `RbdScreen`, `TremorClassifier`, or REM-behavior-disorder MetricType in tree.
 **Lens convergence:** Neurology (RBD prodrome, tremor pipeline), Cardiology (covered in #10)
 **Clinical impact:** RBD is the strongest known prodromal biomarker for synucleinopathy (~73-80% develop PD/DLB/MSA within 12 years — Postuma 2019). Bios has sleep staging but doesn't track movement DURING REM (the RBD signal). RBDSQ/RBD1Q questionnaires are validated owner-facing screens. Tremor pipeline: accelerometer/gyroscope are live, FFT in [engine/Spectral.kt](android/app/src/main/java/com/bios/app/engine/Spectral.kt) reusable; 4-6Hz rest tremor = PD, 4-12Hz postural = essential.
 **Suggested files:** new `android/app/src/main/java/com/bios/app/engine/TremorAnalyzer.kt`, new `android/app/src/main/java/com/bios/app/sleep/RbdMovementDetector.kt`, [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), new `android/app/src/main/java/com/bios/app/ui/neurology/RbdScreenScreen.kt`
@@ -516,6 +551,7 @@ Drug-induced parkinsonism + functional tremor differentials handed off, not adju
 ```
 
 ### #29 — feat(adapter): neurology owner-symptom logging (FAST stroke, headache diary, MIGRAINE_ATTACK_EVENT)
+**Status (2026-05-23): ✅ SHIPPED** — `FAST_STROKE_SUSPECTED`, `HEADACHE_INTENSITY_NRS`, `MIGRAINE_ATTACK_EVENT` MetricTypes in [MetricType.kt](../../android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt); [HeadachePatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt) + [HeadacheLogRepo.kt](../../android/app/src/main/java/com/bios/app/data/HeadacheLogRepo.kt).
 **Lens convergence:** Neurology, Emergency Medicine (stroke FAST), Primary Care (MOH prevalence)
 **Clinical impact:** No structured neurology-symptom vocabulary — stroke FAST/BE-FAST intake (time-of-last-known-well is the highest-value single data point for a 4.5h tPA window), migraine attack event (prodrome correlation), cluster-headache event (circadian periodicity histogram is diagnostic), medication-overuse-headache rate-counting per IHS ICHD-3 §8.2.
 **Suggested files:** [android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt), new `android/app/src/main/java/com/bios/app/ui/neurology/FastStrokeScreen.kt`, new `android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt`
@@ -536,6 +572,7 @@ docs/audits/NEUROLOGY_POV.md §2.2+§2.5+§2.6+§2.11+§2.12. Cross-references d
 ```
 
 ### #30 — feat(alerts): fall-risk prediction + delirium-risk + cognitive trajectory (geriatric pull-side)
+**Status (2026-05-23): ⏳ OPEN** — no `FallRiskPredictor`, `DeliriumRisk`, or `CognitiveTrajectory` engine; Virgil-fed `FALL_EVENT` / `NEAR_MISS_FALL` capture the negative outcome but no positive-test or prediction primitive (gait / Timed-Up-and-Go / clock-draw / 4AT) lands today.
 **Lens convergence:** Geriatrics/Palliative, Neurology (MCI), Emergency Medicine (post-discharge delirium)
 **Clinical impact:** Fall *detection* (Virgil FALL_EVENT) is event-shaped; fall *prediction* is the clinically valuable upstream signal (gait variability, postural sway, medication-class multiplier, STEADI). Delirium is the most underdiagnosed condition in hospitalised/SNF older adults; wearable-detectable risk signature (sleep-wake disruption + activity inversion + HRV instability). Cognitive trajectory needs pull-side surface, not push prediction (false-positive cost catastrophic).
 **Suggested files:** new `android/app/src/main/java/com/bios/app/alerts/GeriatricPatterns.kt`, new `android/app/src/main/java/com/bios/app/ui/geriatrics/CognitiveTrajectoryScreen.kt`
@@ -550,6 +587,7 @@ docs/audits/GERIATRICS_PALLIATIVE_POV.md §2.4+§2.5+§2.9. Cross-references doc
 ```
 
 ### #31 — feat(data): reproductive completeness (contraception, menopause, PCOS/endo, gender-affirming, anatomy labels)
+**Status (2026-05-23): 🟡 PARTIAL** — `MENOPAUSE` mentions exist in [BaselineDeviationPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/BaselineDeviationPatterns.kt) as a gating concept, but no first-class `Contraception`, `Menopause`, `PCOS`, or `GenderAffirmingTherapy` data classes. The reproductive isolation database stays minimal beyond cycle tracking.
 **Lens convergence:** Ob/Gyn, Primary Care, Endocrinology, Modern Non-Allopathic (perimenopause), Indigenous Americas (two-spirit accommodation), Cardiology (peripartum)
 **Clinical impact:** No CONTRACEPTION_METHOD annotation (OCP HRV depression + abolished BBT shift currently silent), no MENOPAUSAL_TRANSITION PhysiologyState despite vasomotor signature being detectable on skin-temp + HR, no PCOS biomarker signature, no pain-cycle correlation for endometriosis (median diagnostic delay 7-10 years). "Female-bodied / Male-bodied" UI labels exclude transmasculine + two-spirit + intersex + fourth-gender frames.
 **Suggested files:** [android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt), [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), [android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt), [android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt](android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt)
@@ -570,6 +608,7 @@ docs/audits/OBGYN_POV.md §2.6-2.13 + docs/audits/INDIGENOUS_AMERICAS_POV.md §2
 ```
 
 ### #32 — feat(localization): externalize alert text + add high-impact locales
+**Status (2026-05-23): ⏳ OPEN** — alerts are still English-only; `res/values-*` translations not in tree. The audit's high-impact-locale targets (es, zh-CN, hi, ar, pt, fr, sw) are unaddressed.
 **Lens convergence:** African Traditional, Indigenous Americas, Other Asian, Oceanic/Arctic, Ob/Gyn (maternal-mortality access framing)
 **Clinical impact:** [ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt) hardcodes 6 paragraphs per pattern in English (`explanation`, `suggestedAction`, `earlyDetection`, `prevention`, `healing`, `risks`) across 33+ patterns. Currently un-localisable in the existing architecture. Te Reo Māori is partially required under NZ Crown Treaty obligations; ʻōlelo Hawaiʻi is co-official in HI; Sámi languages are official in defined municipalities; Spanish absence affects most of Latin America + Indigenous Americas catchment. Same refactor unblocks every non-English locale.
 **Suggested files:** [android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt), [android/app/src/main/res/values/strings.xml](android/app/src/main/res/values/strings.xml), new locale-specific `values-*/strings.xml` overlays
@@ -589,19 +628,31 @@ Pairs with #17 (region configs name the regulatory body the prescriber actually 
 
 ---
 
-## Closed / partially closed
+## Foundations already shipped before the 2026-05-22 roll-up
 
-The following gaps were flagged in earlier audits and have shipped (the later specialty audits explicitly note these are closed):
+The following infrastructure pieces had landed before the original triage and are referenced repeatedly by the 32 items above. Status unchanged in the 2026-05-23 refresh.
 
-- **URGENT-tier reachability** — [EmergencyVitalPatterns.kt](android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt) ships SpO2/glucose/HR ≥130/HR ≤35 with literature-anchored absolute cutoffs. The remaining work (escalation destination, sepsis-screen, hypotensive-shock, acute-window patterns) is captured in issues #1, #4, #5, #12.
-- **Hypertension first-class** — [HypertensionPatterns.kt](android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt) ships `hypertensionEmerging` (median-of-multiple-readings, 7-day window, 3-reading floor) and `hypertensiveUrgency` (180/120 single-reading URGENT). The pregnancy-specific extension (#11) and region-aware threshold tightening are the only remaining work.
-- **Medication-annotation context** — [MedicationAnnotationRepo.kt](android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt) ships and is wired into [AnomalyDetector.kt:374-378](android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt). Extensions for traditional pharmacopoeias / Beers-AGS / CredibleMeds class flagging / TCM-Kampo-Ayurveda-Siddha-Unani formularies in #16.
-- **PhysiologyState scaffolding** — [PhysiologyState.kt](android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt) ships PREGNANCY_T1/T2/T3, POSTPARTUM, ATHLETE_HIGH_FITNESS, FRAILTY_FLAG, PAEDIATRIC + the `excludedStates` gate on ConditionPattern. Wiring (#8 frailty, #11 pregnancy, #20 paediatric sub-bands), new states (#5 peri-op, #6 goals-of-care + hospice, #9 HF, #23 oncology, #31 menopause + gender-affirming) all extend the existing mechanism.
-- **Screening-cadence engine** — [ScreeningCadenceEngine.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt), [ScreeningCatalog.kt](android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt), [RiskProfile.kt](android/app/src/main/java/com/bios/app/model/RiskProfile.kt) ship USPSTF-only with first-degree-CAD-early/BRCA-flag/colorectal/melanoma. Extensions (hereditary syndromes, paediatric vaccines, Ob/Gyn-society cadences, IHS/PAHO regional, cardiology one-time screens) in #13.
-- **Immunisation domain** — [ImmunizationRecord.kt](android/app/src/main/java/com/bios/app/model/ImmunizationRecord.kt) + [ImmunizationRepo.kt](android/app/src/main/java/com/bios/app/data/ImmunizationRepo.kt) ship; [VaccineCatalog.kt](android/app/src/main/java/com/bios/app/ui/immunisations/VaccineCatalog.kt) honestly defers paediatric vaccines as out of scope. Closure in #13.
-- **Sleep apnea passthrough** — [SleepApneaPattern.kt](android/app/src/main/java/com/bios/app/alerts/SleepApneaPattern.kt) ships with AHI ≥5 cited to Berry 2020 AASM + Somers 2008 AHA. Vendor-event ingestion explicitness in #22.
+- **URGENT-tier reachability** — [EmergencyVitalPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/EmergencyVitalPatterns.kt) — SpO2/glucose/HR ≥130/HR ≤35 with literature-anchored absolute cutoffs. Extension work absorbed by #1, #4, #5, #12 (all now ✅ shipped).
+- **Hypertension first-class** — [HypertensionPatterns.kt](../../android/app/src/main/java/com/bios/app/alerts/HypertensionPatterns.kt) — `hypertensionEmerging` (median-of-multiple-readings, 7-day window) and `hypertensiveUrgency` (180/120 single-reading URGENT). Pregnancy extension absorbed by #11 (✅ shipped).
+- **Medication-annotation context** — [MedicationAnnotationRepo.kt](../../android/app/src/main/java/com/bios/app/data/MedicationAnnotationRepo.kt) wired into AnomalyDetector. Traditional / Beers-AGS / CredibleMeds extension absorbed by #16 (✅ shipped).
+- **PhysiologyState scaffolding** — [PhysiologyState.kt](../../android/app/src/main/java/com/bios/app/physiology/PhysiologyState.kt) — PREGNANCY_T1/T2/T3, POSTPARTUM, ATHLETE_HIGH_FITNESS, FRAILTY_FLAG, PAEDIATRIC + `excludedStates` gate. Per-state wiring absorbed by #5/6/8/9/11/20/23/31.
+- **Screening-cadence engine** — [ScreeningCadenceEngine.kt](../../android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt), [ScreeningCatalog.kt](../../android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt), [RiskProfile.kt](../../android/app/src/main/java/com/bios/app/model/RiskProfile.kt). Extensions absorbed by #13 (✅ shipped).
+- **Immunisation domain** — [ImmunizationRecord.kt](../../android/app/src/main/java/com/bios/app/model/ImmunizationRecord.kt) + [ImmunizationRepo.kt](../../android/app/src/main/java/com/bios/app/data/ImmunizationRepo.kt). Closure in #13.
+- **Sleep apnea passthrough** — [SleepApneaPattern.kt](../../android/app/src/main/java/com/bios/app/alerts/SleepApneaPattern.kt) — AHI ≥5 cited to Berry 2020 AASM + Somers 2008 AHA. Vendor-event detail absorbed by #22 (✅ shipped).
 
-The remaining items below were named in earlier audits but are deliberately **not** filed per the consolidation rules:
+## Open backlog (after 2026-05-23 refresh)
+
+Five fully-open items + two partial items remain. Listed in suggested execution order — small / well-scoped first:
+
+1. **#24 Seizure events + neurology URGENT triggers** — Tier C, ⏳ OPEN. Add `SEIZURE_EVENT` MetricType + `status_epilepticus_convulsive` URGENT pattern.
+2. **#26 Cardiology-advanced patterns** — Tier C, ⏳ OPEN. POTS / HRR / ectopy / QT-class patterns. Substrate present.
+3. **#27 Psychiatry-specific patterns** — Tier C, ⏳ OPEN. Bipolar / anxiety / perinatal / OUD on top of W2F's mental-health writers.
+4. **#28 RBD screen + tremor pipeline** — Tier C, 🟡 PARTIAL. ECG strip side done; RBD + tremor still open.
+5. **#30 Fall-risk + delirium + cognitive trajectory** — Tier C, ⏳ OPEN. Positive-test primitives (gait, TUG, 4AT) missing.
+6. **#31 Reproductive completeness** — Tier C, 🟡 PARTIAL. Contraception / menopause / PCOS / gender-affirming first-class models missing.
+7. **#32 Localization** — Tier C, ⏳ OPEN. Externalise alert text + add high-impact locales.
+
+## Out of scope (not filed per consolidation rules)
 
 - **Divination, oracle, repertorisation surfaces** — flagged as correct silence across African Traditional §3.2, Indigenous Americas §3.2, Modern Non-Allopathic §2.11 (Hahnemannian totality), Other Asian §3 (Burmese Vijjadhara, Thai saiyasart, Khmer ritual purification).
 - **Energy medicine / biofield / chi-prana measurement** — flagged as orthogonal across Modern Non-Allopathic §2.12, Oceanic §3 (wairua), Indigenous Americas §3.3, TCM §4, Ayurveda §4.


### PR DESCRIPTION
## Summary
The audit-derived triage inventory was dated 2026-05-22 and had drifted significantly — most of the original 32 issues shipped between the roll-up and today, but the doc still read as "32 open." Re-grounds the backlog against current main.

### What changed
- **Status line on every item** citing the canonical implementation file (for shipped items) or the missing pattern names (for open items). All 32 items annotated.
- **Summary breakdown updated**: 25 shipped + 2 partial + 5 open. By tier: Tier A 10/10, Tier B 12/13, Tier C 3/9 shipped.
- **New "Open backlog" section** enumerates the seven remaining items in suggested execution order so the next pick is one grep away.
- **"Closed / partially closed" → "Foundations already shipped"** — pre-triage infrastructure that the 32 items reference. Stable.
- Fixed relative links so they resolve from `docs/audits/`.

### What's actually still open
1. **#24 Seizure events + neurology URGENT** — Tier C, ⏳ OPEN
2. **#26 Cardiology-advanced (POTS / HRR / ectopy / QT)** — Tier C, ⏳ OPEN
3. **#27 Psychiatry-specific (bipolar / anxiety / perinatal / OUD)** — Tier C, ⏳ OPEN
4. **#28 RBD screen + tremor pipeline** — Tier C, 🟡 PARTIAL (ECG side done)
5. **#30 Fall-risk + delirium + cognitive trajectory** — Tier C, ⏳ OPEN
6. **#31 Reproductive completeness** — Tier C, 🟡 PARTIAL (gating exists, first-class models missing)
7. **#32 Localization** — Tier C, ⏳ OPEN

### Verification methodology
Filename `find` + key clinical-string `grep` across `android/app/src/main` and `android/bios-contracts/src/main`. Heuristic is not perfect — items whose implementation landed under unexpected names may still be flagged open in error. Stated explicitly in the refreshed methodology block.

## Test plan
- [x] Doc-only change, pre-commit passes
- [ ] Next refresh trigger: when any of the 7 open items ships, mark it ✅ and prune from the "Open backlog" list

🤖 Generated with [Claude Code](https://claude.com/claude-code)