### PR TITLE
feat(alerts): neurology URGENT primitives (audit §3.2 #24)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ConditionPatterns.kt
@@ -74,6 +74,6 @@ object ConditionPatterns {
             HeartFailureDecompensationPattern.all + AcuteWindowPatterns.all +
             TropicalDiseasePatterns.all + EnvironmentalPatterns.all +
             PerioperativePatterns.all + CardioOncologyPatterns.all +
-            GrowthAndCompositionPatterns.all
+            GrowthAndCompositionPatterns.all + NeurologyUrgentPatterns.all
     }
 }

--- a/android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt
@@ -1,0 +1,148 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.AlertTier
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Neurology URGENT patterns (#216 / NEUROLOGY_POV.md §2.1+§2.3, Triage
+ * Inventory #24). Hard-cutoff URGENT alerts that fire on a single owner-
+ * logged event or single GCS reading crossing a literature-anchored
+ * clinical threshold. Same shape as [EmergencyVitalPatterns] — `required`
+ * absolute-threshold rules with `severityFloor = URGENT`.
+ *
+ * ## Scope discipline
+ *
+ * v1 ships event-presence URGENT patterns only. A duration-aware
+ * `status_epilepticus_convulsive` pattern (single seizure ≥ 5 min per the
+ * ILAE 2015 t1 operational definition) needs a per-rule duration filter
+ * in [SignalRule] that today's evaluator does not express; the
+ * conservative substitute below fires URGENT on **any** owner-logged
+ * SEIZURE_EVENT, which is the safety-leaning default (a known epileptic
+ * who logs a seizure still benefits from the notification surface
+ * documenting the time). Duration-specific status-epilepticus
+ * discrimination is a follow-up.
+ *
+ * Similarly the wearable convulsive-pattern detector (band-pass 2–8 Hz
+ * accelerometer + ictal-tachycardia corroborator, Empatica Embrace2
+ * shape) is deferred — the substrate exists but a calibrated detector
+ * needs its own design pass.
+ *
+ * ## References
+ *
+ * - Trinka E et al. (2015) — A definition and classification of status
+ *   epilepticus. *Epilepsia* 56(10):1515–1523. (ILAE t1 = 5 min for
+ *   convulsive SE.)
+ * - Jennett B, Teasdale G (1974) — Assessment of coma and impaired
+ *   consciousness. *Lancet* 304:81–84. (GCS canonical.)
+ * - International Headache Society (2018) — ICHD-3 §6.2.2: Headache
+ *   attributed to non-traumatic subarachnoid haemorrhage.
+ *
+ * All text obeys [AlertContentPolicy].
+ */
+object NeurologyUrgentPatterns {
+
+    val all by lazy {
+        listOf(
+            seizureEventLogged,
+            acuteAlteredConsciousnessLowGcs,
+            thunderclapHeadache,
+        )
+    }
+
+    /**
+     * Any owner-logged SEIZURE_EVENT in the last hour escalates URGENT.
+     * v1 substitute for the ILAE 2015 status-epilepticus pattern — the
+     * conservative shape until duration-aware rules ship.
+     */
+    val seizureEventLogged = ConditionPattern(
+        id = "neurology_seizure_event_logged",
+        title = "Seizure event logged",
+        category = ConditionCategory.MENTAL_HEALTH,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.SEIZURE_EVENT, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "ILAE 2015 / Trinka 2015 — any acute seizure event warrants URGENT clinical evaluation pending duration classification (t1 = 5 min defines convulsive status epilepticus)",
+                required = true,
+                absoluteAbove = 0.0,
+                absoluteWindowHours = 1,
+                absoluteMinReadings = 1,
+            ),
+        ),
+        minActiveSignals = 1,
+        severityFloor = AlertTier.URGENT,
+        explanation = "A seizure event was logged within the last hour. Acute seizures warrant prompt clinical evaluation: a single seizure of any duration is the threshold for an emergency-department visit when no prior diagnosis exists, and a single seizure lasting ≥5 minutes meets the ILAE 2015 operational definition of convulsive status epilepticus regardless of seizure history.",
+        suggestedAction = "Call emergency services or proceed to an emergency department immediately if the seizure lasted ≥5 minutes, repeated within an hour, occurred in an owner with no prior seizure diagnosis, or was followed by injury / sustained altered consciousness / breathing difficulty. For an owner with established epilepsy whose pattern matches their baseline, follow the seizure action plan from their neurologist; document the event for the next clinical visit.",
+        references = listOf(
+            "Trinka E et al. (2015) — A definition and classification of status epilepticus. Epilepsia 56(10):1515-1523",
+            "Glauser T et al. (2016) — Evidence-based guideline: treatment of convulsive status epilepticus in children and adults. Epilepsy Currents 16(1):48-61",
+        ),
+        earlyDetection = "Owner-logged seizure events serve two purposes: (1) timestamp documentation for clinical review and (2) URGENT-tier surfacing for the cases where the seizure represents either a new diagnosis or a status-epilepticus emergency. Duration-aware discrimination (ILAE t1 = 5 min for convulsive SE) is a planned engine extension; until it ships, the conservative pattern surfaces all logged events at URGENT severity.",
+    )
+
+    /**
+     * GCS ≤ 8 = "unable to protect own airway" threshold (Jennett 1974;
+     * NICE 2023 head-injury guideline). Single-reading URGENT — there is
+     * no clinically meaningful baseline for unconsciousness.
+     */
+    val acuteAlteredConsciousnessLowGcs = ConditionPattern(
+        id = "neurology_acute_altered_consciousness_gcs_le_8",
+        title = "Glasgow Coma Scale at or below 8",
+        category = ConditionCategory.MENTAL_HEALTH,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.CONSCIOUSNESS_LEVEL, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "Jennett & Teasdale 1974 (GCS canonical) + NICE 2023 head-injury guidance — GCS ≤ 8 is the airway-protection threshold and the operational definition of severe head injury / coma",
+                required = true,
+                absoluteBelow = 9.0,
+                absoluteWindowHours = 1,
+                absoluteMinReadings = 1,
+            ),
+        ),
+        minActiveSignals = 1,
+        severityFloor = AlertTier.URGENT,
+        explanation = "A Glasgow Coma Scale total of 8 or below was recorded within the last hour. GCS ≤ 8 is the canonical airway-protection threshold: at this level a person cannot reliably protect their own airway, and the NICE 2023 head-injury guideline classifies it as severe traumatic brain injury when the cause is trauma. Non-traumatic causes (post-ictal state, hypoxia, hypoglycaemia, intoxication, stroke, sepsis, hepatic encephalopathy, metabolic derangement) require the same immediate response.",
+        suggestedAction = "Call emergency services immediately. Place the person in the recovery position if no spinal injury is suspected. Do not give food or drink. If the GCS reading was taken by a bystander on a person who appears unconscious, treat as an emergency regardless of the apparent cause.",
+        references = listOf(
+            "Jennett B, Teasdale G (1974) — Assessment of coma and impaired consciousness. Lancet 304:81-84",
+            "Teasdale G et al. (2014) — The Glasgow Coma Scale at 40 years: standing the test of time. Lancet Neurology 13(8):844-854",
+            "NICE (2023) — Head injury: assessment and early management (NG232) §1.2.5 — severe head injury defined by GCS ≤ 8",
+        ),
+        earlyDetection = "GCS is the universal triage scale for acute neurological emergencies. A single observed GCS of 8 or below from a bystander or first responder is sufficient to escalate URGENT — the threshold is operationally equivalent to coma. Pattern uses the standard absoluteBelow cutoff at 9.0 (matching GCS integer semantics: 9 and above are above-threshold, 8 and below trigger the alert).",
+    )
+
+    /**
+     * Thunderclap headache event — IHS ICHD-3 §6.2.2 SAH screen.
+     * Owner-logged report of a sudden-onset headache reaching maximum
+     * intensity within 60 seconds. Subarachnoid haemorrhage is the
+     * primary differential and a time-sensitive emergency.
+     */
+    val thunderclapHeadache = ConditionPattern(
+        id = "neurology_thunderclap_headache",
+        title = "Thunderclap headache event logged",
+        category = ConditionCategory.MENTAL_HEALTH,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.THUNDERCLAP_HEADACHE_SUSPECTED, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "IHS ICHD-3 §6.2.2 + Edlow & Caplan 2000 — sudden-onset headache reaching peak intensity within 60 seconds is the SAH (subarachnoid haemorrhage) screening criterion, time-sensitive emergency",
+                required = true,
+                absoluteAbove = 0.0,
+                absoluteWindowHours = 1,
+                absoluteMinReadings = 1,
+            ),
+        ),
+        minActiveSignals = 1,
+        severityFloor = AlertTier.URGENT,
+        explanation = "A thunderclap headache (sudden-onset headache reaching peak intensity within 60 seconds) was logged within the last hour. The IHS ICHD-3 §6.2.2 screening criterion targets subarachnoid haemorrhage, the primary time-sensitive differential. Other emergent causes include reversible cerebral vasoconstriction syndrome (RCVS), cervical artery dissection, cerebral venous sinus thrombosis, pituitary apoplexy, and acute hypertensive crisis. CT within hours of onset is the standard diagnostic step; CSF analysis follows if CT is negative.",
+        suggestedAction = "Proceed to an emergency department or call emergency services immediately. Time-to-CT is the key prognostic variable for subarachnoid haemorrhage. Do not delay for symptom progression — thunderclap headache warrants imaging on the index event even when the headache subsequently resolves.",
+        references = listOf(
+            "International Headache Society (2018) — ICHD-3 §6.2.2: Headache attributed to non-traumatic subarachnoid haemorrhage",
+            "Edlow JA, Caplan LR (2000) — Avoiding pitfalls in the diagnosis of subarachnoid hemorrhage. NEJM 342(1):29-36",
+            "Connolly ES et al. (2012) — Guidelines for the management of aneurysmal subarachnoid hemorrhage. Stroke 43(6):1711-1737",
+        ),
+        earlyDetection = "Thunderclap headache is the canonical wearable-detectable owner-reported neurological emergency. The operational definition (peak intensity within 60 s from onset) is distinct from severity score on the headache NRS — a 10/10 migraine that built over an hour is not a thunderclap. The event-logging surface in the journal screen captures both fields; this pattern keys off the velocity flag.",
+    )
+}

--- a/android/app/src/test/java/com/bios/app/NeurologyUrgentPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/NeurologyUrgentPatternsTest.kt
@@ -1,0 +1,122 @@
+package com.bios.app
+
+import com.bios.app.alerts.AlertContentPolicy
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.DeviationDirection
+import com.bios.app.alerts.NeurologyUrgentPatterns
+import com.bios.app.alerts.ThresholdSource
+import com.bios.app.model.AlertTier
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the neurology URGENT patterns wired in #24 (NEUROLOGY_POV.md §2.1
+ * + §2.3). Same shape as `EmergencyVitalPatternsTest`: every pattern must
+ * declare `severityFloor = URGENT`, fire on a single required absolute
+ * rule, cite literature, and pass [AlertContentPolicy].
+ */
+class NeurologyUrgentPatternsTest {
+
+    @Test
+    fun all_neurology_urgent_patterns_register_in_global_all_list() {
+        assertTrue(NeurologyUrgentPatterns.seizureEventLogged in ConditionPatterns.all)
+        assertTrue(NeurologyUrgentPatterns.acuteAlteredConsciousnessLowGcs in ConditionPatterns.all)
+        assertTrue(NeurologyUrgentPatterns.thunderclapHeadache in ConditionPatterns.all)
+    }
+
+    @Test
+    fun every_neurology_pattern_declares_urgent_severity_floor() {
+        for (pattern in NeurologyUrgentPatterns.all) {
+            assertEquals(
+                "${pattern.id} should declare severityFloor = URGENT",
+                AlertTier.URGENT,
+                pattern.severityFloor,
+            )
+        }
+    }
+
+    @Test
+    fun every_neurology_pattern_is_a_single_rule_required_absolute_gate() {
+        for (pattern in NeurologyUrgentPatterns.all) {
+            assertEquals(
+                "${pattern.id} should fire on a single absolute rule",
+                1,
+                pattern.signalRules.size,
+            )
+            assertEquals(1, pattern.minActiveSignals)
+            val rule = pattern.signalRules.single()
+            assertTrue("${pattern.id} rule should be required", rule.required)
+            assertTrue("${pattern.id} rule should be absolute", rule.isAbsolute)
+            assertEquals(ThresholdSource.LITERATURE, rule.source)
+            assertTrue("${pattern.id} should ship a citation", rule.citation.isNotBlank())
+        }
+    }
+
+    @Test
+    fun every_neurology_pattern_passes_alert_content_policy() {
+        for (pattern in NeurologyUrgentPatterns.all) {
+            val violations = AlertContentPolicy.validate(pattern)
+            assertTrue(
+                "${pattern.id} must comply with AlertContentPolicy. Violations: $violations",
+                violations.isEmpty(),
+            )
+        }
+    }
+
+    // -- seizure_event_logged --
+
+    @Test
+    fun seizure_event_logged_fires_on_any_event_in_last_hour() {
+        val rule = NeurologyUrgentPatterns.seizureEventLogged.signalRules.single()
+        assertEquals(MetricType.SEIZURE_EVENT, rule.metricType)
+        assertEquals(DeviationDirection.ABOVE, rule.direction)
+        assertEquals(0.0, rule.absoluteAbove!!, 1e-9)
+        assertNull(rule.absoluteBelow)
+        assertEquals(1, rule.absoluteWindowHours)
+        assertEquals(1, rule.absoluteMinReadings)
+    }
+
+    // -- acute_altered_consciousness_gcs_le_8 --
+
+    @Test
+    fun acute_altered_consciousness_fires_at_gcs_le_8() {
+        val rule = NeurologyUrgentPatterns.acuteAlteredConsciousnessLowGcs.signalRules.single()
+        assertEquals(MetricType.CONSCIOUSNESS_LEVEL, rule.metricType)
+        assertEquals(DeviationDirection.BELOW, rule.direction)
+        // GCS integer semantics: cutoff of 9.0 (below) catches the 8 / 7 / …
+        // / 3 readings while leaving 9–15 above-threshold.
+        assertEquals(9.0, rule.absoluteBelow!!, 1e-9)
+        assertNull(rule.absoluteAbove)
+    }
+
+    // -- thunderclap_headache --
+
+    @Test
+    fun thunderclap_headache_fires_on_owner_logged_event() {
+        val rule = NeurologyUrgentPatterns.thunderclapHeadache.signalRules.single()
+        assertEquals(MetricType.THUNDERCLAP_HEADACHE_SUSPECTED, rule.metricType)
+        assertEquals(DeviationDirection.ABOVE, rule.direction)
+        assertEquals(0.0, rule.absoluteAbove!!, 1e-9)
+        assertNull(rule.absoluteBelow)
+        assertEquals(1, rule.absoluteWindowHours)
+    }
+
+    // -- text quality --
+
+    @Test
+    fun every_neurology_pattern_has_explanation_action_and_references() {
+        for (pattern in NeurologyUrgentPatterns.all) {
+            assertTrue("${pattern.id} needs an explanation", pattern.explanation.isNotBlank())
+            assertNotNull("${pattern.id} needs a suggested action", pattern.suggestedAction)
+            assertTrue("${pattern.id} suggested action is blank", pattern.suggestedAction!!.isNotBlank())
+            assertTrue(
+                "${pattern.id} should ship ≥2 references",
+                pattern.references.size >= 2,
+            )
+        }
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -137,24 +137,22 @@ enum class MetricType(
     CONSCIOUSNESS_LEVEL("consciousness_level", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
     // Neurology owner-symptom logging (#207, NEUROLOGY_POV §2.6 / §2.5 /
-    // §2.15). Owner-input only — Bios never derives any of these from
-    // biomarkers. The owner reports; Bios stores.
-    //
-    // HEADACHE_INTENSITY_NRS: 0–10 numeric rating scale for a headache the
-    // owner is logging. Shipped alongside the structured HeadacheLog /
-    // MigraineAttack entities so a clinician export and the trend view can
-    // read a flat metric row in addition to the structured record.
-    // MIGRAINE_ATTACK_EVENT: timestamp-shaped event recorded when the
-    // owner opens a MigraineAttack entry. Sidecar fields (aura, triggers,
-    // medication taken) live on the MigraineAttack row, not on
-    // event_payloads — the structured entity is the canonical record.
-    // FAST_STROKE_SUSPECTED: timestamp-shaped event recorded when the
-    // owner answers "yes" to any FAST screen item (Facial drooping, Arm
-    // weakness, Speech difficulty). Owner-input only — manifesto §3.3
-    // explicitly prohibits automated voice / face stroke detection.
+    // §2.15). Owner-input only — manifesto §3.3 prohibits automated voice /
+    // face stroke detection. HEADACHE_INTENSITY_NRS is the flat-metric
+    // shadow of the structured HeadacheLog / MigraineAttack entities;
+    // sidecar fields (aura, triggers, treatment, FAST item) live on the
+    // structured row, not in event_payloads.
     HEADACHE_INTENSITY_NRS("headache_intensity_nrs", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
     MIGRAINE_ATTACK_EVENT("migraine_attack_event", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
     FAST_STROKE_SUSPECTED("fast_stroke_suspected", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+
+    // Neurology URGENT primitives (audit §3.2 #24 / NEUROLOGY_POV §2.1+§2.3).
+    // Owner-logged EVENTs with value=1.0 + optional structured sidecar in
+    // event_payloads. Thunderclap is separate from HEADACHE_INTENSITY_NRS
+    // because the URGENT alert keys on onset velocity (IHS ICHD-3 §6.2.2
+    // SAH screen — peak intensity within 60 s) not severity score.
+    SEIZURE_EVENT("seizure_event", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+    THUNDERCLAP_HEADACHE_SUSPECTED("thunderclap_headache_suspected", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
     // Sleep
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -226,6 +226,9 @@ class MetricTypeKeysSnapshotTest {
         "headache_intensity_nrs",
         "migraine_attack_event",
         "fast_stroke_suspected",
+        // Neurology URGENT primitives (#216, audit §3.2 #24)
+        "seizure_event",
+        "thunderclap_headache_suspected",
         // Paediatric growth + body composition (#199)
         "height_cm",
         "head_circumference_cm",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -447,6 +447,19 @@ class MetricTypeTest {
     }
 
     @Test
+    fun neurology_urgent_primitives_are_neurological_events() {
+        // Audit §3.2 #24 — SEIZURE_EVENT and THUNDERCLAP_HEADACHE_SUSPECTED
+        // are owner-logged event-shape primitives that drive URGENT
+        // neurology patterns. Same shape as FAST_STROKE_SUSPECTED, FALL_EVENT.
+        for (t in setOf(MetricType.SEIZURE_EVENT, MetricType.THUNDERCLAP_HEADACHE_SUSPECTED)) {
+            assertEquals(MetricDomain.NEUROLOGICAL, t.domain)
+            assertEquals(MetricUnit.EVENT, t.unit)
+            assertTrue(t.allowsManualEntry, "${t.key} must allow manual entry — owner is the only producer")
+            assertEquals(t, MetricType.fromKey(t.key))
+        }
+    }
+
+    @Test
     fun augmentation_index_ppg_is_cardiovascular_percent() {
         // Blueprint audit §3.1 #8 — PPG-derived augmentation index. Lives on
         // the cardiovascular side (computed from camera-PPG morphology), not


### PR DESCRIPTION
## Summary
Closes Triage Inventory #24 — seizure events + neurology URGENT triggers. v1 ships the event-presence primitives and three URGENT patterns; the wearable convulsive-pattern detector and the duration-aware status-epilepticus discriminator stay as documented follow-ups.

### New MetricTypes (NEUROLOGICAL, EVENT, owner-manual-entry only)
- `SEIZURE_EVENT`
- `THUNDERCLAP_HEADACHE_SUSPECTED`

### New URGENT patterns in `alerts/NeurologyUrgentPatterns.kt`

Each is a single-rule absolute-threshold pattern with `severityFloor = URGENT`:

| Pattern | Trigger | Citation |
|---|---|---|
| `neurology_seizure_event_logged` | any logged SEIZURE_EVENT in the last hour | ILAE 2015 / Trinka 2015 — t1 = 5 min defines convulsive SE; v1 is the safety-leaning shape until duration-aware SignalRule filtering ships |
| `neurology_acute_altered_consciousness_gcs_le_8` | CONSCIOUSNESS_LEVEL ≤ 8 single reading | Jennett 1974 + NICE 2023 head-injury guideline — airway-protection threshold, operationally equivalent to coma |
| `neurology_thunderclap_headache` | owner-logged `THUNDERCLAP_HEADACHE_SUSPECTED` event | IHS ICHD-3 §6.2.2 — peak intensity within 60 s from onset, SAH screening criterion |

All three text bodies pass `AlertContentPolicy` (factual data statements, professional-referral language, no second-person judgment).

### Deferred (documented in file KDoc)
- Duration-aware `status_epilepticus_convulsive` pattern — needs a per-rule duration filter in `SignalRule` that today's evaluator doesn't express. v1 fires URGENT on any logged seizure as the conservative substitute.
- Wearable convulsive-pattern detector (band-pass 2–8 Hz accelerometer + ictal-tachycardia corroborator, Empatica Embrace2 shape) — substrate present, calibrated detector design is its own pass.

### Wiring
- `NeurologyUrgentPatterns.all` added to the `ConditionPatterns.all` aggregator
- `MetricTypeKeysSnapshotTest`, `MetricTypeTest`, and a new `NeurologyUrgentPatternsTest` cover the addition

## Test plan
- [x] `:bios-contracts:test` green
- [x] `:app:testStandaloneDebugUnitTest` green (snapshot, pattern, AlertContentPolicy)
- [x] `./scripts/code-quality-check.sh` passes end-to-end (file length, secrets, lint, lethe + standalone build, tests)
- [ ] On-device: log a seizure event from the journal screen, confirm URGENT alert fires
- [ ] On-device: log a thunderclap headache event, confirm URGENT alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)