### PR TITLE
fix(alerts): clearer MOH explanation and structured AlertCard

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
@@ -103,7 +103,9 @@ object HeadachePatterns {
         signalRules = emptyList(),
         minActiveSignals = 0,
         severityFloor = AlertTier.ADVISORY,
-        explanation = "Diary entries show 10 or more days per month of acute headache treatment (triptan, NSAID, paracetamol, ergot, opioid, or combination analgesic) across the most recent 3 calendar months. The IHS International Classification of Headache Disorders, 3rd edition (ICHD-3) §8.2 uses that threshold as the medication-overuse-headache screen. This is a data observation against the published clinical screen — not a medication-overuse-headache diagnosis. The owner is the one who decides whether to discuss this pattern with a neurologist or primary-care clinician.",
+        explanation = "Diary entries show 10 or more days per month of acute headache treatment (triptan, NSAID, paracetamol, ergot, opioid, or combination analgesic) across the most recent 3 calendar months.\n\n" +
+            "That frequency is the published IHS ICHD-3 §8.2 medication-overuse-headache (MOH) screening threshold. The mechanism behind the threshold: frequent acute-headache medication can paradoxically maintain or worsen the underlying primary headache — central pain pathways become more sensitised, attacks become more frequent and harder to abort, and the medication that initially worked stops working. The pattern is reversible on withdrawal, which is the literature's reason for surfacing it early.\n\n" +
+            "This is a data observation against the published clinical screen — not a medication-overuse-headache diagnosis. The owner decides whether to discuss the pattern with a neurologist or primary-care clinician.",
         suggestedAction = "If headache frequency has been rising despite acute treatment, a neurology or primary-care visit can review the medication pattern and discuss preventive options. Bring the diary entries — the full record of dates, intensities, and what was taken is the substrate the clinical conversation needs.",
         references = listOf(
             "IHS International Classification of Headache Disorders, 3rd edition (ICHD-3) §8.2 — Medication-overuse headache",

--- a/android/app/src/main/java/com/bios/app/ui/components/AlertCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/AlertCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -13,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.bios.app.alerts.ConditionPatterns
 import com.bios.app.model.AlertTier
 import com.bios.app.model.Anomaly
 import org.json.JSONObject
@@ -32,13 +34,19 @@ fun AlertCard(
     anomaly: Anomaly,
     onAcknowledge: () -> Unit,
     onSaveFeedback: (FeedbackInput) -> Unit = {},
-    onRequestReview: (() -> Unit)? = null
+    onRequestReview: (() -> Unit)? = null,
+    onOpenPattern: ((String) -> Unit)? = null
 ) {
     var expanded by remember { mutableStateOf(false) }
     var showFeedback by remember { mutableStateOf(false) }
     val tier = AlertTier.fromLevel(anomaly.severity)
     val tierColor = tierColor(tier)
     val hasFeedback = anomaly.feedbackAt != null
+    val pattern = remember(anomaly.patternId) {
+        anomaly.patternId?.let { id ->
+            ConditionPatterns.all.firstOrNull { it.id == id }
+        }
+    }
 
     Card(
         modifier = Modifier
@@ -73,27 +81,47 @@ fun AlertCard(
             }
 
             AnimatedVisibility(visible = expanded) {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Spacer(Modifier.height(8.dp))
 
-                    // Explanation
-                    Text(
-                        anomaly.explanation,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
+                    // What Bios noticed — the data statement that triggered the alert.
+                    // Rendered as paragraphs so longer explanations stay scannable.
+                    AlertSection(label = "What Bios noticed") {
+                        ParagraphText(anomaly.explanation)
+                    }
 
-                    // Deviation scores
+                    // Why this matters — pulled from the underlying ConditionPattern's
+                    // `risks` field when available. Surfacing the mechanism here is what
+                    // turns the data statement into something an owner can act on.
+                    pattern?.takeIf { it.risks.isNotBlank() }?.let { p ->
+                        AlertSection(label = "Why this matters") {
+                            ParagraphText(p.risks)
+                        }
+                    }
+
+                    // Deviation scores (signal-rule alerts only)
                     DeviationScoresList(anomaly.deviationScores)
 
-                    // Suggested action
+                    // Suggested next step
                     anomaly.suggestedAction?.let { action ->
-                        Row(verticalAlignment = Alignment.Top) {
-                            Text("💡 ", style = MaterialTheme.typography.bodySmall)
-                            Text(
-                                action,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                        AlertSection(label = "Suggested next step") {
+                            ParagraphText(action)
+                        }
+                    }
+
+                    // Full context — navigates to ConditionDetailScreen which renders
+                    // earlyDetection / prevention / healing / risks / clinical context.
+                    if (pattern != null && onOpenPattern != null) {
+                        TextButton(
+                            onClick = { onOpenPattern(pattern.id) },
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text("Read full context")
+                            Spacer(Modifier.width(4.dp))
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowForward,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
                             )
                         }
                     }
@@ -146,6 +174,36 @@ fun AlertCard(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun AlertSection(label: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        content()
+    }
+}
+
+/** Renders body text split on blank lines so long explanations are scannable. */
+@Composable
+private fun ParagraphText(text: String) {
+    val paragraphs = remember(text) {
+        text.split("\n\n").map { it.trim() }.filter { it.isNotEmpty() }
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        paragraphs.forEach { para ->
+            Text(
+                para,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/notice/NoticeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/notice/NoticeScreen.kt
@@ -123,6 +123,7 @@ fun NoticeScreen(
                             outcomeAccurate = input.outcomeAccurate,
                         )
                     },
+                    onOpenPattern = onNavigateToCondition,
                 )
             }
         }
@@ -153,6 +154,7 @@ fun NoticeScreen(
                             outcomeAccurate = input.outcomeAccurate,
                         )
                     },
+                    onOpenPattern = onNavigateToCondition,
                 )
             }
         }


### PR DESCRIPTION
## Summary
- MOH advisory copy now spells out **why** the threshold matters (paradoxical maintenance of the underlying headache via central sensitisation, reversibility on withdrawal) and is broken into three scannable paragraphs.
- `AlertCard` expanded view restructured into labeled mini-sections — **What Bios noticed**, **Why this matters**, **Suggested next step** — with paragraph-aware body rendering, so long explanations no longer surface as a wall of text.
- New **Read full context** link on alerts backed by a `ConditionPattern`, navigating into the existing `ConditionDetailScreen` (Early Detection / Prevention / Healing / Risks / Clinical Context / References were previously orphaned from the alert surface).
- `NoticeScreen` pipes its existing `onNavigateToCondition` callback through to `AlertCard`; `TimelineScreen` leaves the new callback null and continues to work unchanged.

Triggered by an owner-reported pain point: the MOH notice title (`Acute-headache-treatment days meet MOH screening threshold`) gave no sense of why the warning existed. The mechanism was already written in `ConditionPattern.risks` but never reached the alert UI.

## Test plan
- [x] `./gradlew :app:compileStandaloneDebugKotlin` — green
- [x] `./gradlew :app:testStandaloneDebugUnitTest --tests AlertContentPolicyTest --tests MedicationOveruseHeadacheEvaluatorTest --tests NeurologySymptomLoggingTest` — green
- [x] `./scripts/code-quality-check.sh` (via pre-commit) — all checks passed
- [ ] Visually verify the redesigned expanded AlertCard on the Notice tab (spacing, "Read full context" navigation into ConditionDetailScreen) — **not yet exercised in a running app**

🤖 Generated with [Claude Code](https://claude.com/claude-code)