### PR TITLE
feat(engine): PVC-burden estimate + ectopy ADVISORY (Triage #26)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/AdvancedCardiologyPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/AdvancedCardiologyPatterns.kt
@@ -6,34 +6,40 @@ import com.bios.contracts.MetricType
 
 /**
  * Advanced cardiology patterns (#216 / CARDIOLOGY_POV §2.3+§2.5+§2.6,
- * Triage Inventory #26). This file is the home for the four sub-patterns
- * the audit grouped together — POTS, HRR, ectopy burden, and QT class —
- * but only HRR ships in v1 because it is the only one whose substrate is
- * already on the bus (continuous HR + EXERCISE_SESSION). POTS needs
- * accelerometer posture detection, ectopy needs beat-level PPG analysis,
- * QT needs ECG; each warrants its own design pass.
+ * Triage Inventory #26). Home for the four sub-patterns the audit
+ * grouped together — POTS, HRR, ectopy burden, and QT class. HRR shipped
+ * in the first PR and ectopy burden ships here. POTS needs accelerometer
+ * posture detection and QT needs ECG; each remains deferred.
  *
- * Pattern uses [SignalRule.absoluteWindowHours] with a 3-reading minimum
- * over 30 days so a single bad session doesn't fire. Cole 1999 used
- * multi-test averaging; the median-of-three shape is the closest the
- * existing SignalRule machinery expresses to that protocol.
+ * HRR pattern uses [SignalRule.absoluteWindowHours] with a 3-reading
+ * minimum over 30 days so a single bad session doesn't fire — Cole 1999
+ * used multi-test averaging.
+ *
+ * Ectopy-burden pattern fires at the Niwano 2009 10 % threshold across a
+ * 7-day window with ≥ 3 PPG captures. The shorter window matches the
+ * higher cadence of PPG sessions (HRR is gated by exercise sessions; PPG
+ * captures can happen daily) and reflects the clinical convention of
+ * Holter-burden averaging over days, not weeks.
  *
  * ## References
  *
  * - Cole CR et al. (1999) — Heart-rate recovery immediately after exercise
- *   as a predictor of mortality. NEJM 341(18):1351-1357. (HRR1 ≤ 12 bpm
- *   identified 4-fold mortality risk over 6 years.)
+ *   as a predictor of mortality. NEJM 341(18):1351-1357.
  * - Imai K et al. (1994) — Vagally mediated heart rate recovery after
- *   exercise is accelerated in athletes but blunted in patients with
- *   chronic heart failure. JACC 24(6):1529-1535.
+ *   exercise. JACC 24(6):1529-1535.
  * - Jouven X et al. (2005) — Heart-rate profile during exercise as a
  *   predictor of sudden death. NEJM 352(19):1951-1958.
+ * - Baman TS et al. (2010) — Relationship between burden of premature
+ *   ventricular complexes and left ventricular function. Heart Rhythm
+ *   7(7):865-869.
+ * - Niwano S et al. (2009) — Prognostic significance of frequent PVCs in
+ *   patients with normal LV function. Heart 95(15):1230-1237.
  *
  * All text obeys [AlertContentPolicy].
  */
 object AdvancedCardiologyPatterns {
 
-    val all by lazy { listOf(hrRecoveryImpaired) }
+    val all by lazy { listOf(hrRecoveryImpaired, ectopyBurdenElevated) }
 
     /**
      * Sustained HRR1 below the Cole 1999 cutoff (12 bpm) across multiple
@@ -64,5 +70,37 @@ object AdvancedCardiologyPatterns {
             "Jouven X et al. (2005) — Heart-rate profile during exercise as a predictor of sudden death. NEJM 352(19):1951-1958",
         ),
         earlyDetection = "HRR is a continuous wearable-derivable surrogate for autonomic-recovery health. Cole's multi-test averaging is mimicked by the median-of-three-sessions gate (`absoluteMinReadings = 3` across a 30-day window) so a single sub-threshold session — possibly explained by illness, dehydration, or a low-effort workout — does not fire the pattern.",
+    )
+
+    /**
+     * Sustained ECTOPY_BURDEN_ESTIMATE above the Niwano 2009 10 % cutoff
+     * across ≥ 3 PPG captures in the last 7 days. ADVISORY tier — high
+     * PVC burden is the trigger for outpatient Holter / 12-lead workup,
+     * not an acute event.
+     */
+    val ectopyBurdenElevated = ConditionPattern(
+        id = "advanced_cardiology_ectopy_burden_elevated",
+        title = "Ventricular ectopy burden above clinical screening threshold",
+        category = ConditionCategory.CARDIOVASCULAR,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.ECTOPY_BURDEN_ESTIMATE, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "Niwano 2009 Heart 95:1230 / Baman 2010 Heart Rhythm 7:865 — PVC burden ≥ 10 % is the screening threshold for PVC-induced cardiomyopathy concern and is the conventional trigger for outpatient Holter / 12-lead workup; median across recent PPG sessions filters single-session motion artefacts",
+                required = true,
+                absoluteAbove = 10.0,
+                absoluteWindowHours = 168,
+                absoluteMinReadings = 3,
+            ),
+        ),
+        minActiveSignals = 1,
+        explanation = "The median ventricular-ectopy-burden estimate across recent PPG captures is at or above 10 %. Niwano 2009 (Heart) and Baman 2010 (Heart Rhythm) identify this threshold as the screening anchor for PVC-induced cardiomyopathy concern. Bios's PPG-derived estimate looks for short-RR-then-compensatory-pause pairs in the inter-beat-interval series — the same signature automated Holter algorithms key off — but the PPG cannot distinguish PVCs from atrial premature complexes with concealed conduction or from non-respiratory sinus arrhythmia, and motion artefacts can produce false short-long pairs.",
+        suggestedAction = "Discuss the trend with a clinician — outpatient 24-hour Holter or 12-lead ECG is the standard confirmation step. The 10 % cutoff is a screening anchor, not a diagnosis; many owners with sustained PVC burden at this level have structurally normal hearts on echocardiography. Confounders worth ruling out before clinical concern: caffeine-rich days, stimulant medications, sleep deprivation, recent alcohol intake, electrolyte derangement.",
+        references = listOf(
+            "Baman TS et al. (2010) — Relationship between burden of premature ventricular complexes and left ventricular function. Heart Rhythm 7(7):865-869",
+            "Niwano S et al. (2009) — Prognostic significance of frequent PVCs originating from the ventricular outflow tract in patients with normal LV function. Heart 95(15):1230-1237",
+            "Park KM et al. (2018) — Frequent premature ventricular complex-induced cardiomyopathy. Korean Circulation Journal 48(8):1-19",
+        ),
+        earlyDetection = "PPG-derived PVC burden lets a wearable surface a Holter-cardinal signal between clinic visits. The screening threshold (10 %) is intentionally conservative — most owners spend their PVC burden well below 1 %; sustained readings at or above 10 % across several captures are the conventional referral anchor for outpatient cardiology. Suppressed automatically on PPG windows the existing RhythmClassifier scores IRREGULARLY_IRREGULAR — AFib's randomness dominates and would otherwise inflate the burden estimate.",
     )
 }

--- a/android/app/src/main/java/com/bios/app/engine/EctopyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/EctopyDetector.kt
@@ -1,0 +1,122 @@
+package com.bios.app.engine
+
+import kotlin.math.abs
+
+/**
+ * PVC-burden estimator from a PPG-derived RR-interval series.
+ *
+ * Premature ventricular contractions (PVCs) produce a characteristic
+ * RR signature: a short interval (the ectopic beat arriving early)
+ * followed by a longer interval (the compensatory pause as the SA node
+ * resets). This is the same pattern automated Holter algorithms key off
+ * and the smartwatch-PPG literature (Han 2020, Sološenko 2017) confirms
+ * the PPG-IBI series preserves it for non-fusion PVCs.
+ *
+ * The detector iterates the series and counts pairs where:
+ *
+ * ```
+ * RR[i]   ≤ shortRatio × median(RR)
+ * RR[i+1] ≥ longRatio  × median(RR)
+ * ```
+ *
+ * Burden is `100 × candidate_pairs / analysable_beats`, returned as a
+ * percent ∈ [0, 100]. The shipping cutoffs follow Niwano 2009 (10 % ≥
+ * threshold for PVC-induced cardiomyopathy concern) and Park 2018 (15 %
+ * stricter cutoff). The downstream pattern in
+ * [com.bios.app.alerts.AdvancedCardiologyPatterns] reads the 10 %
+ * literature anchor.
+ *
+ * ## Honest scope
+ *
+ * The detector cannot distinguish a single ectopic focus from
+ * non-respiratory sinus arrhythmia, atrial premature complexes with
+ * concealed conduction, or PPG motion artefacts that mimic the
+ * short-long signature. It is a **screening surrogate**, not a Holter
+ * substitute. The pattern text recommends 12-lead / Holter confirmation
+ * before any clinical conclusion. AFib's irregularly-irregular signature
+ * dominates this short-long signal; the existing [RhythmClassifier] runs
+ * upstream and the [com.bios.app.ingest.CameraPpgAdapter] should suppress
+ * ECTOPY_BURDEN_ESTIMATE emission on windows the rhythm classifier scores
+ * IRREGULARLY_IRREGULAR (handled by the adapter, not this detector).
+ *
+ * ## References
+ *
+ * - Baman TS et al. (2010) — Relationship between burden of premature
+ *   ventricular complexes and left ventricular function. Heart Rhythm
+ *   7(7):865-869.
+ * - Niwano S et al. (2009) — Prognostic significance of frequent
+ *   premature ventricular contractions originating from the ventricular
+ *   outflow tract in patients with normal LV function. Heart 95(15):1230-7.
+ * - Park KM et al. (2018) — Frequent premature ventricular complex–
+ *   induced cardiomyopathy. Korean Circulation Journal 48(8):1-19.
+ * - Sološenko A et al. (2017) — Detection of atrial fibrillation using
+ *   short-term ECGs and PPG. Annual Int. Conf. IEEE EMBC.
+ */
+object EctopyDetector {
+
+    /** Hard floor on the RR series length; below this the median anchor is unreliable. */
+    const val MIN_RR_INTERVALS: Int = 30
+
+    /** Short-beat ratio threshold: RR ≤ 0.80 × median is the canonical "premature" anchor. */
+    const val SHORT_RATIO_CUTOFF: Double = 0.80
+
+    /** Compensatory-pause ratio threshold: RR ≥ 1.15 × median is the canonical "pause" anchor. */
+    const val LONG_RATIO_CUTOFF: Double = 1.15
+
+    data class EctopyResult(
+        val burdenPercent: Double,
+        val candidatePairs: Int,
+        val beatsAnalysed: Int,
+    )
+
+    /**
+     * Compute the burden estimate from an RR-interval series (milliseconds).
+     * Returns null when the series is too short to anchor against the
+     * median — picking a candidate without a robust mean rate would
+     * surface noise. The caller (CameraPpgAdapter) emits the value as a
+     * MetricReading on `MetricType.ECTOPY_BURDEN_ESTIMATE`.
+     */
+    fun analyse(rrIntervalsMs: List<Double>): EctopyResult? {
+        if (rrIntervalsMs.size < MIN_RR_INTERVALS) return null
+
+        val median = medianOf(rrIntervalsMs)
+        if (median <= 0.0) return null
+
+        val shortFloor = SHORT_RATIO_CUTOFF * median
+        val longFloor = LONG_RATIO_CUTOFF * median
+
+        var candidates = 0
+        // Iterate pairs (i, i+1). The last interval has no successor and is
+        // excluded from the candidate count but still contributes to the
+        // analysable-beats denominator below.
+        for (i in 0 until rrIntervalsMs.size - 1) {
+            val current = rrIntervalsMs[i]
+            val next = rrIntervalsMs[i + 1]
+            if (current <= shortFloor && next >= longFloor) {
+                candidates++
+            }
+        }
+
+        val analysable = rrIntervalsMs.size
+        val burden = 100.0 * candidates / analysable
+        return EctopyResult(
+            burdenPercent = burden.coerceIn(0.0, 100.0),
+            candidatePairs = candidates,
+            beatsAnalysed = analysable,
+        )
+    }
+
+    /** Median of a list of doubles. Internal helper; mean would be biased by ectopics themselves. */
+    internal fun medianOf(values: List<Double>): Double {
+        if (values.isEmpty()) return 0.0
+        val sorted = values.sorted()
+        val n = sorted.size
+        return if (n % 2 == 1) sorted[n / 2] else (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+
+    /** Convenience: absolute deviation, used by sibling tests; kept here so this object is self-contained. */
+    internal fun absDevFromMedian(values: List<Double>): List<Double> {
+        val med = medianOf(values)
+        return values.map { abs(it - med) }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -10,6 +10,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.concurrent.futures.await
 import androidx.lifecycle.LifecycleOwner
 import com.bios.app.engine.CaptureQuality
+import com.bios.app.engine.EctopyDetector
 import com.bios.app.engine.HrvAnalyzer
 import com.bios.app.engine.PpgResult
 import com.bios.app.engine.PpgSignalProcessor
@@ -195,6 +196,24 @@ class CameraPpgAdapter(private val context: Context) {
                     confidence = ConfidenceTier.LOW.level
                 )
             }
+            // PVC-burden estimate (#216 / Triage #26). Skipped on rhythms
+            // the classifier scores irregularly-irregular — AFib's
+            // randomness inflates the short-long pair count and would
+            // confound the PVC interpretation.
+            val ectopyReading = if (rhythmVerdict.verdict != RhythmClassifier.WindowVerdict.REGULAR) {
+                null
+            } else {
+                EctopyDetector.analyse(ppg.rrIntervalsMs)?.let { result ->
+                    MetricReading(
+                        metricType = MetricType.ECTOPY_BURDEN_ESTIMATE.key,
+                        value = result.burdenPercent,
+                        timestamp = timestamp,
+                        durationSec = durSec,
+                        sourceId = sourceId,
+                        confidence = ConfidenceTier.LOW.level,
+                    )
+                }
+            }
             val readings = listOfNotNull(
                 MetricReading(
                     metricType = MetricType.HEART_RATE.key,
@@ -253,6 +272,7 @@ class CameraPpgAdapter(private val context: Context) {
                     confidence = ConfidenceTier.LOW.level
                 ),
                 burdenReading,
+                ectopyReading,
                 // PPG pulse-wave morphology (#181, CARDIOLOGY_POV.md §2.2).
                 // Statistical summaries that PpgSignalProcessor surfaces
                 // alongside HRV. Written only when waveformFeatures is

--- a/android/app/src/test/java/com/bios/app/AdvancedCardiologyPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/AdvancedCardiologyPatternsTest.kt
@@ -12,9 +12,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Guards [AdvancedCardiologyPatterns]. v1 ships only the HRR pattern; the
- * three deferred members (POTS, ectopy burden, QT-prolongation) gate the
- * test surface here when they ship.
+ * Guards [AdvancedCardiologyPatterns]. HRR and ectopy-burden are
+ * shipped; POTS and QT-prolongation remain deferred.
  */
 class AdvancedCardiologyPatternsTest {
 
@@ -58,6 +57,49 @@ class AdvancedCardiologyPatternsTest {
     @Test
     fun hr_recovery_carries_explanation_action_and_references() {
         val p = AdvancedCardiologyPatterns.hrRecoveryImpaired
+        assertTrue("explanation blank", p.explanation.isNotBlank())
+        assertTrue("suggested action blank", p.suggestedAction!!.isNotBlank())
+        assertTrue("≥2 references", p.references.size >= 2)
+    }
+
+    // -- ectopy_burden_elevated --
+
+    @Test
+    fun ectopy_burden_pattern_is_registered_in_global_all_list() {
+        assertTrue(AdvancedCardiologyPatterns.ectopyBurdenElevated in ConditionPatterns.all)
+    }
+
+    @Test
+    fun ectopy_burden_fires_at_or_above_10_percent_cutoff() {
+        val rule = AdvancedCardiologyPatterns.ectopyBurdenElevated.signalRules.single()
+        assertEquals(MetricType.ECTOPY_BURDEN_ESTIMATE, rule.metricType)
+        assertEquals(DeviationDirection.ABOVE, rule.direction)
+        assertEquals(10.0, rule.absoluteAbove!!, 1e-9)
+        assertNull(rule.absoluteBelow)
+        // 7-day rolling window with ≥ 3 captures — matches the higher
+        // PPG-session cadence and Holter-burden averaging convention.
+        assertEquals(168, rule.absoluteWindowHours)
+        assertEquals(3, rule.absoluteMinReadings)
+        assertEquals(ThresholdSource.LITERATURE, rule.source)
+        assertTrue("citation must be non-empty", rule.citation.isNotBlank())
+        assertTrue("rule must be required", rule.required)
+    }
+
+    @Test
+    fun ectopy_burden_is_advisory_not_urgent() {
+        // Holter-referral trigger, not an acute event.
+        assertNull(AdvancedCardiologyPatterns.ectopyBurdenElevated.severityFloor)
+    }
+
+    @Test
+    fun ectopy_burden_passes_alert_content_policy() {
+        val violations = AlertContentPolicy.validate(AdvancedCardiologyPatterns.ectopyBurdenElevated)
+        assertTrue("$violations", violations.isEmpty())
+    }
+
+    @Test
+    fun ectopy_burden_carries_explanation_action_and_references() {
+        val p = AdvancedCardiologyPatterns.ectopyBurdenElevated
         assertTrue("explanation blank", p.explanation.isNotBlank())
         assertTrue("suggested action blank", p.suggestedAction!!.isNotBlank())
         assertTrue("≥2 references", p.references.size >= 2)

--- a/android/app/src/test/java/com/bios/app/EctopyDetectorTest.kt
+++ b/android/app/src/test/java/com/bios/app/EctopyDetectorTest.kt
@@ -1,0 +1,146 @@
+package com.bios.app
+
+import com.bios.app.engine.EctopyDetector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-state tests for [EctopyDetector]. Synthetic RR series cover the
+ * canonical PVC + compensatory-pause signature, motion-artefact mimics,
+ * and edge cases (too few beats, all-regular rhythm).
+ */
+class EctopyDetectorTest {
+
+    /** 60 bpm steady-state RR series, no ectopy. */
+    private fun regularSeries(count: Int, baseMs: Double = 1000.0): List<Double> =
+        List(count) { baseMs }
+
+    /**
+     * Insert a PVC + compensatory pause at [pvcIndex]. The short interval
+     * is 0.65 × base (well below the 0.80 short-ratio cutoff) and the
+     * compensatory pause is 1.30 × base (above the 1.15 long-ratio cutoff).
+     */
+    private fun withPvcAt(series: List<Double>, pvcIndex: Int, base: Double = 1000.0): List<Double> {
+        val out = series.toMutableList()
+        out[pvcIndex] = 0.65 * base
+        out[pvcIndex + 1] = 1.30 * base
+        return out
+    }
+
+    @Test
+    fun regular_rhythm_yields_zero_burden() {
+        val result = EctopyDetector.analyse(regularSeries(60))
+        assertNotNull(result)
+        assertEquals(0.0, result!!.burdenPercent, 1e-9)
+        assertEquals(0, result.candidatePairs)
+        assertEquals(60, result.beatsAnalysed)
+    }
+
+    @Test
+    fun single_pvc_in_60_beat_window_produces_small_nonzero_burden() {
+        var series = regularSeries(60)
+        series = withPvcAt(series, pvcIndex = 30)
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        assertEquals(1, result!!.candidatePairs)
+        // 1 candidate / 60 beats = 1.6667 % — well below the 10 % pattern cutoff
+        assertEquals(100.0 / 60.0, result.burdenPercent, 1e-6)
+    }
+
+    @Test
+    fun pvc_bigeminy_pattern_crosses_the_clinical_threshold() {
+        // Bigeminy = every other beat is a PVC. Insert a PVC at every
+        // even index past the median anchor (need a critical mass of
+        // regular beats first so the median stays at base).
+        val base = 1000.0
+        val series = (0 until 60).map { i ->
+            when {
+                i < 20 -> base
+                i % 2 == 0 -> 0.65 * base
+                else -> 1.30 * base
+            }
+        }
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        // Expect ~ 19 short-long pairs across the 40-beat bigeminy stretch.
+        assertTrue(
+            "bigeminy burden should land well above the 10 % clinical cutoff",
+            result!!.burdenPercent > 25.0,
+        )
+        assertTrue(result.candidatePairs >= 15)
+    }
+
+    @Test
+    fun too_few_intervals_returns_null() {
+        // 20 beats < MIN_RR_INTERVALS = 30: median anchor is unreliable.
+        val result = EctopyDetector.analyse(regularSeries(20))
+        assertNull(result)
+    }
+
+    @Test
+    fun all_zero_series_returns_null() {
+        // Degenerate input — median is 0, signal-to-noise is undefined.
+        val result = EctopyDetector.analyse(List(60) { 0.0 })
+        assertNull(result)
+    }
+
+    @Test
+    fun short_only_without_compensatory_pause_does_not_count() {
+        // A short beat alone (e.g., respiratory sinus arrhythmia speed-up
+        // without compensatory pause) must not register as a PVC. Insert
+        // a short interval but follow it with a normal-rate beat.
+        var series = regularSeries(60).toMutableList()
+        series[30] = 700.0  // short
+        series[31] = 1000.0 // normal — no compensatory pause
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        assertEquals(0, result!!.candidatePairs)
+    }
+
+    @Test
+    fun long_only_without_preceding_short_does_not_count() {
+        // A single long beat (e.g., yawn pause) must not register without
+        // a preceding short-RR ectopic.
+        var series = regularSeries(60).toMutableList()
+        series[30] = 1300.0
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        assertEquals(0, result!!.candidatePairs)
+    }
+
+    @Test
+    fun burden_is_bounded_to_percent_range() {
+        // Stress test: contrive a series of mostly short-long pairs. The
+        // burden must stay in [0, 100].
+        val base = 1000.0
+        val series = List(60) { i ->
+            if (i % 2 == 0) 0.65 * base else 1.30 * base
+        }
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        assertTrue("burden=${result!!.burdenPercent} must be ≤ 100", result.burdenPercent <= 100.0)
+        assertTrue("burden=${result.burdenPercent} must be ≥ 0", result.burdenPercent >= 0.0)
+    }
+
+    @Test
+    fun median_anchor_resists_outlier_inflation() {
+        // A single very long beat (say 3 seconds — paroxysmal pause) must
+        // not inflate the median so far that subsequent normal beats look
+        // "short" by comparison. Median resists this; mean would not.
+        var series = regularSeries(60).toMutableList()
+        series[30] = 3000.0 // single 3-second pause
+        val result = EctopyDetector.analyse(series)
+        assertNotNull(result)
+        assertEquals(
+            "median anchor ignores the single outlier",
+            1000.0,
+            EctopyDetector.medianOf(series),
+            1e-9,
+        )
+        // No PVC-pair signature emerges (the long beat has no preceding short).
+        assertEquals(0, result!!.candidatePairs)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -92,6 +92,9 @@ enum class MetricType(
     HR_RECOVERY_1MIN("hr_recovery_1min", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
     HR_RECOVERY_2MIN("hr_recovery_2min", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR),
 
+    // PVC-burden estimate from PPG IBI short-long-pair detection (Triage #26).
+    ECTOPY_BURDEN_ESTIMATE("ectopy_burden_estimate", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR),
+
     // Respiratory
     RESPIRATORY_RATE("respiratory_rate", MetricUnit.BREATHS_PER_MIN, MetricDomain.RESPIRATORY, allowsManualEntry = true),
     // Administered supplemental O2 (cannula/mask). Contextualises SpO2:

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -54,6 +54,8 @@ class MetricTypeKeysSnapshotTest {
         // Heart-rate recovery (Triage Inventory #26)
         "hr_recovery_1min",
         "hr_recovery_2min",
+        // PVC-burden estimate (Triage Inventory #26)
+        "ectopy_burden_estimate",
         // Respiratory
         "respiratory_rate",
         "oxygen_flow_rate",


### PR DESCRIPTION
## Summary
Second sub-pattern of Triage Inventory #26. PR #261 shipped HRR; this PR ships ectopy burden. POTS (needs posture detection) and QT (needs ECG) remain deferred.

### New MetricType
- `ECTOPY_BURDEN_ESTIMATE` — CARDIOVASCULAR, PERCENT (0–100 % of analysable beats matching the PVC + compensatory-pause signature)

### New engine `EctopyDetector.kt`
- Pure function over an RR-interval series.
- Counts short-RR (≤ 0.80 × median) followed by long-RR (≥ 1.15 × median) pairs — the canonical Holter PVC signature, confirmed for PPG-IBI in Han 2020 / Sološenko 2017.
- Median anchor resists single-outlier inflation (mean would not).
- Returns null when < 30 RR intervals — too short for a credible rate anchor.
- **9 synthetic-series tests** cover regular / single-PVC / bigeminy / short-only-without-pause / long-only-without-short / median-outlier-resistance paths.

### `CameraPpgAdapter` wiring
Persists `ECTOPY_BURDEN_ESTIMATE` on every accepted capture *unless* the existing `RhythmClassifier` scored the window `IRREGULARLY_IRREGULAR` — AFib's randomness inflates the short-long count and would confound PVC interpretation, so the metric is suppressed on those windows.

### New pattern in `AdvancedCardiologyPatterns`
`ectopy_burden_elevated` (ADVISORY) — fires when the median across ≥ 3 PPG captures in the last 7 days is at or above **10 %** (Niwano 2009 *Heart* 95:1230 + Baman 2010 *Heart Rhythm* 7:865). 7-day window matches the higher PPG-session cadence and Holter-burden averaging convention. Text passes \`AlertContentPolicy\`.

### Honest scope
The PPG-derived estimate cannot distinguish PVCs from atrial premature complexes with concealed conduction, non-respiratory sinus arrhythmia, or PPG motion artefacts mimicking the short-long signature. Documented in \`EctopyDetector\` KDoc and in the pattern explanation text. Outpatient Holter / 12-lead remains the confirmation step the alert recommends.

## Test plan
- [x] \`:bios-contracts:test\` green
- [x] \`:app:testStandaloneDebugUnitTest\` green (detector + pattern + snapshot + AlertContentPolicy)
- [x] \`./scripts/code-quality-check.sh\` passes end-to-end
- [ ] On-device camera PPG capture: confirm \`ectopy_burden_estimate\` rows land on REGULAR-rhythm sessions and are absent on IRREGULARLY_IRREGULAR-classified ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)