### PR TITLE
fix(ui): promote Anthropometry to top of Identity card (#263 cut 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
@@ -49,6 +49,7 @@ internal fun IdentityCard(
             Text("Identity", style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(8.dp))
             listOf(
+                "Anthropometry" to onNavigateToAnthropometry,
                 "Current medications" to onNavigateToMedications,
                 "Immunisation record" to onNavigateToImmunisations,
                 "Preventive care" to onNavigateToPreventiveCare,
@@ -66,7 +67,6 @@ internal fun IdentityCard(
                 "Surgical recovery" to onNavigateToSurgicalRecovery,
                 "Intervention events" to onNavigateToInterventionEvents,
                 "Treatment courses" to onNavigateToTreatmentCourses,
-                "Anthropometry" to onNavigateToAnthropometry,
             ).forEachIndexed { idx, (label, action) ->
                 if (idx > 0) Spacer(Modifier.height(4.dp))
                 OutlinedButton(onClick = action, modifier = Modifier.fillMaxWidth()) { Text(label) }


### PR DESCRIPTION
## Summary

Cut 1 of #263 — bleed-stopper for the owner-side report that height_cm was undiscoverable behind 17 rows of unrelated Identity surfaces.

Move \`Anthropometry\` from row 18 → row 1 of the [IdentityCard](android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt#L51-L72) list. Order of the other 17 rows is unchanged.

## Why this row first

Anthropometry is the only Identity surface that **every** owner needs to use within their first session — \`height_cm\` is a once-set value that unblocks BMI derivation, sarcopenia thresholds, the cachexia trajectory math, and (eventually) Cockcroft-Gault for drug-dosing reference. Burying it at row 18 trades a 1-second tap for a scrolling treasure hunt.

## Why not jump straight to grouping (Cut 2)

Cut 2 (sub-section grouping into Body / Risk / Care / Diary / Episodic) is the proper fix and is scoped in #263. This PR is deliberately minimal so it lands today without coupling to the broader UX restructure.

## Test plan

- [x] Diff is a single one-line move; no nav-graph or string changes.
- [x] \`assembleDebug\` passes (pre-commit hook).
- [x] No tests reference the row order — \`grep -rn "IdentityCard.*listOf\|Anthropometry.*to onNavigate" android/app/src/test\` returns nothing.
- [ ] Visual verification on device after merge (open Settings → Identity → "Anthropometry" should be first button under the "Identity" heading).

Closes #263 (cut 1 only — cut 2 stays open under the same issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)