### PR TITLE
feat(ingest): session-triggered HrRecoveryPersister (#267)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/HrRecoveryPersister.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrRecoveryPersister.kt
@@ -1,0 +1,89 @@
+package com.bios.app.engine
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.util.UUID
+
+/**
+ * Producer wiring for [HrRecoveryComputer] (#267). PR #261 shipped the
+ * computer and the `advanced_cardiology_hr_recovery_impaired` pattern, but
+ * left no producer writing HR_RECOVERY_1MIN / HR_RECOVERY_2MIN
+ * [MetricReading]s — the readings table stayed empty for those keys and
+ * the pattern could never fire.
+ *
+ * This persister is session-triggered: after [IngestManager] lands an
+ * [ExerciseSession], it queries the HR samples bracketing the session end
+ * and writes the HRR readings keyed to the session-end timestamp.
+ *
+ * ## Idempotency
+ *
+ * Each HRR reading is keyed by a deterministic UUID derived from
+ * (metricType, sourceId, sessionEndMs). Re-running the persister on the
+ * same session produces the same id; Room's `REPLACE` strategy keeps the
+ * row count flat. This matters because [IngestManager.persistSessions]
+ * does not yet dedupe exercise-session rows — a re-ingested session would
+ * otherwise double-write HRR.
+ */
+object HrRecoveryPersister {
+
+    /**
+     * Extra window after session end included in the HR query so
+     * [HrRecoveryComputer]'s ±5 s tolerance has post-exercise samples
+     * available at both the HRR1 (60 s) and HRR2 (120 s) anchors.
+     */
+    private const val POST_EXERCISE_QUERY_PAD_MS: Long =
+        HrRecoveryComputer.HRR2_TAU_MS + HrRecoveryComputer.POST_EXERCISE_SAMPLE_TOLERANCE_MS
+
+    /**
+     * Compute and persist HRR readings for the given [sessions]. Returns
+     * the rows written so callers can fold them into existing pipelines
+     * (logging, derivation counters). Empty when no session yields a
+     * computable result.
+     */
+    suspend fun persistFor(
+        sessions: List<ExerciseSession>,
+        readingDao: MetricReadingDao,
+    ): List<MetricReading> {
+        if (sessions.isEmpty()) return emptyList()
+        val rows = mutableListOf<MetricReading>()
+        for (session in sessions) {
+            val parent = session.reading
+            val durationSec = parent.durationSec ?: continue
+            val startMs = parent.timestamp
+            val endMs = startMs + durationSec * 1000L
+            val hrReadings = readingDao.fetch(
+                metricType = MetricType.HEART_RATE.key,
+                startMillis = startMs,
+                endMillis = endMs + POST_EXERCISE_QUERY_PAD_MS,
+            )
+            val result = HrRecoveryComputer.compute(startMs, endMs, hrReadings) ?: continue
+            result.hrr1BpmDelta?.let {
+                rows += hrrReading(MetricType.HR_RECOVERY_1MIN, it, endMs, parent)
+            }
+            result.hrr2BpmDelta?.let {
+                rows += hrrReading(MetricType.HR_RECOVERY_2MIN, it, endMs, parent)
+            }
+        }
+        if (rows.isNotEmpty()) readingDao.insertAll(rows)
+        return rows
+    }
+
+    private fun hrrReading(
+        type: MetricType,
+        bpmDelta: Double,
+        sessionEndMs: Long,
+        parent: MetricReading,
+    ): MetricReading = MetricReading(
+        id = stableId(type, parent.sourceId, sessionEndMs),
+        metricType = type.key,
+        value = bpmDelta,
+        timestamp = sessionEndMs,
+        sourceId = parent.sourceId,
+        confidence = parent.confidence,
+    )
+
+    internal fun stableId(type: MetricType, sourceId: String, sessionEndMs: Long): String =
+        UUID.nameUUIDFromBytes("${type.key}|$sourceId|$sessionEndMs".toByteArray()).toString()
+}

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -4,6 +4,7 @@ import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.CircadianEngine
 import com.bios.app.engine.DetectionLatencyTracker
 import com.bios.app.engine.GlucoseVariability
+import com.bios.app.engine.HrRecoveryPersister
 import com.bios.app.engine.PipelineStage
 import com.bios.app.engine.SignalQualityFilter
 import com.bios.app.engine.SleepDerivations
@@ -377,6 +378,7 @@ class IngestManager(
         if (sessions.isEmpty()) return
         readingDao.insertAll(sessions.map { it.reading })
         payloadDao.insertAll(sessions.flatMap { it.payload })
+        HrRecoveryPersister.persistFor(sessions, readingDao)
     }
 
     // MARK: - Helpers

--- a/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
@@ -1,0 +1,174 @@
+package com.bios.app
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.HrRecoveryPersister
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.ExerciseSession
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wiring tests for [HrRecoveryPersister] — the producer that turns
+ * landed [ExerciseSession]s into HR_RECOVERY_1MIN/2MIN MetricReadings.
+ *
+ * Pure-math behaviour for HRR1/HRR2 deltas is already covered by
+ * [HrRecoveryComputerTest]; these tests exercise the DAO interaction:
+ * query window, write-back, and idempotency under re-ingest.
+ */
+class HrRecoveryPersisterTest {
+
+    private val sourceId = "test-source"
+    private val sessionStart = 1_700_000_000_000L
+    private val sessionDurationSec = 30 * 60
+    private val sessionEnd = sessionStart + sessionDurationSec * 1000L
+
+    @Test
+    fun happy_path_writes_hrr1_and_hrr2_rows() = runBlocking {
+        // Healthy recovery shape: peak 165 during session, drops to 130 at
+        // +60 s (HRR1 = 35), 115 at +120 s (HRR2 = 50).
+        val hrReadings = listOf(
+            hr(sessionStart + 5 * 60_000L, 140.0),
+            hr(sessionStart + 10 * 60_000L, 155.0),
+            hr(sessionStart + 15 * 60_000L, 160.0),
+            hr(sessionStart + 20 * 60_000L, 165.0),
+            hr(sessionStart + 25 * 60_000L, 162.0),
+            hr(sessionEnd, 158.0),
+            hr(sessionEnd + 60_000L, 130.0),
+            hr(sessionEnd + 120_000L, 115.0),
+        )
+        val dao = FakeReadingDao(hrReadings)
+        val rows = HrRecoveryPersister.persistFor(listOf(session()), dao)
+
+        assertEquals("HRR1 + HRR2 should both be emitted", 2, rows.size)
+        val byType = rows.associateBy { it.metricType }
+        assertEquals(35.0, byType[MetricType.HR_RECOVERY_1MIN.key]!!.value, 1e-9)
+        assertEquals(50.0, byType[MetricType.HR_RECOVERY_2MIN.key]!!.value, 1e-9)
+        assertEquals(
+            "HRR rows must inherit the session's sourceId",
+            sourceId,
+            rows.first().sourceId,
+        )
+        assertEquals(
+            "HRR rows are anchored to the session end timestamp",
+            sessionEnd,
+            rows.first().timestamp,
+        )
+        assertEquals("DAO insert should be called exactly once", 1, dao.insertAllCallCount)
+    }
+
+    @Test
+    fun too_few_session_samples_writes_nothing() = runBlocking {
+        // Only two HR samples land inside the session — below
+        // HrRecoveryComputer.MIN_SESSION_READINGS. Persister must skip
+        // silently rather than writing partial / unreliable HRR rows.
+        val hrReadings = listOf(
+            hr(sessionStart + 5 * 60_000L, 140.0),
+            hr(sessionStart + 10 * 60_000L, 150.0),
+            hr(sessionEnd + 60_000L, 120.0),
+            hr(sessionEnd + 120_000L, 110.0),
+        )
+        val dao = FakeReadingDao(hrReadings)
+        val rows = HrRecoveryPersister.persistFor(listOf(session()), dao)
+
+        assertTrue("No HRR rows when session is too short", rows.isEmpty())
+        assertEquals("DAO should not be written to", 0, dao.insertAllCallCount)
+    }
+
+    @Test
+    fun rerunning_on_same_session_is_idempotent() = runBlocking {
+        // Same session ingested twice (e.g. HC re-fetch after a retry).
+        // Stable id keying + Room REPLACE means the readings table ends
+        // up with the same rows, not duplicates.
+        val hrReadings = listOf(
+            hr(sessionStart + 5 * 60_000L, 140.0),
+            hr(sessionStart + 10 * 60_000L, 155.0),
+            hr(sessionStart + 15 * 60_000L, 160.0),
+            hr(sessionStart + 20 * 60_000L, 165.0),
+            hr(sessionStart + 25 * 60_000L, 162.0),
+            hr(sessionEnd + 60_000L, 130.0),
+            hr(sessionEnd + 120_000L, 115.0),
+        )
+        val dao = FakeReadingDao(hrReadings)
+        val first = HrRecoveryPersister.persistFor(listOf(session()), dao)
+        val second = HrRecoveryPersister.persistFor(listOf(session()), dao)
+
+        assertEquals(
+            "Re-running must produce the same ids (REPLACE-friendly)",
+            first.map { it.id }.toSet(),
+            second.map { it.id }.toSet(),
+        )
+        assertEquals(2, first.size)
+        assertEquals(2, second.size)
+    }
+
+    // ---- Helpers ----
+
+    private fun hr(timestamp: Long, value: Double): MetricReading = MetricReading(
+        metricType = MetricType.HEART_RATE.key,
+        value = value,
+        timestamp = timestamp,
+        sourceId = sourceId,
+        confidence = ConfidenceTier.LOW.level,
+    )
+
+    private fun session(): ExerciseSession = ExerciseSession(
+        reading = MetricReading(
+            metricType = MetricType.EXERCISE_SESSION.key,
+            value = 1.0,
+            timestamp = sessionStart,
+            durationSec = sessionDurationSec,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        ),
+        payload = emptyList<EventPayloadField>(),
+    )
+}
+
+/**
+ * Minimal in-memory [MetricReadingDao] for [HrRecoveryPersisterTest].
+ * Implements only the methods the persister exercises (`fetch`,
+ * `insertAll`); other DAO methods throw if hit so test drift is loud.
+ */
+private class FakeReadingDao(
+    private val seed: List<MetricReading>,
+) : MetricReadingDao {
+
+    val inserted = mutableListOf<MetricReading>()
+    var insertAllCallCount: Int = 0
+        private set
+
+    override suspend fun fetch(
+        metricType: String,
+        startMillis: Long,
+        endMillis: Long,
+    ): List<MetricReading> = seed.filter {
+        it.metricType == metricType && it.timestamp in startMillis..endMillis
+    }
+
+    override suspend fun insertAll(readings: List<MetricReading>) {
+        insertAllCallCount++
+        inserted += readings
+    }
+
+    override suspend fun insert(reading: MetricReading): Unit = notUsed()
+    override suspend fun fetchValues(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun fetchLatest(metricType: String, limit: Int): List<MetricReading> = notUsed()
+    override suspend fun count(metricType: String): Int = notUsed()
+    override suspend fun countAll(): Int = notUsed()
+    override suspend fun countInRange(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): Int = notUsed()
+    override suspend fun fetchBucketedMeans(metricType: String, startMillis: Long, endMillis: Long, bucketMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun lastTimestampFor(metricType: String): Long? = notUsed()
+    override suspend fun oldestTimestamp(): Long? = notUsed()
+    override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
+    override suspend fun sourceFreshness(): List<MetricReadingDao.SourceFreshnessRow> = notUsed()
+    override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
+    override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteAll(): Unit = notUsed()
+
+    private fun <T> notUsed(): T = error("FakeReadingDao: method not exercised by HrRecoveryPersisterTest")
+}


### PR DESCRIPTION
## Summary
- Hook `HrRecoveryPersister` into `IngestManager.persistSessions` so every landed `EXERCISE_SESSION` derives and writes its HRR readings — closes the PR #261 follow-up that left `HR_RECOVERY_1MIN/2MIN` without a producer.
- Idempotent on re-ingest: HRR ids are `UUID.nameUUIDFromBytes(metricType|sourceId|sessionEndMs)`; Room `REPLACE` keeps the readings table flat.
- Three new unit tests cover the happy path, sub-`MIN_SESSION_READINGS` skip, and re-ingest idempotency.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — all suites green; `HrRecoveryPersisterTest` 3/3 PASSED.
- [x] `./scripts/code-quality-check.sh` — file-length / secrets / lint / build / unit tests all pass.
- [ ] Smoke: with HC `ExerciseSession` ingest enabled and 1 Hz HR coverage, confirm `metric_readings` gains an `hr_recovery_1min` row anchored to session end.
- [ ] Smoke: with a session re-ingested via HC retry, confirm no duplicate HRR rows.

Closes #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)