### PR TITLE
feat(engine): wearable convulsive-seizure detector (#269 Cut 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SeizureDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SeizureDetector.kt
@@ -1,0 +1,274 @@
+package com.bios.app.engine
+
+import kotlin.math.sqrt
+
+/**
+ * Wearable convulsive-seizure detector (issue #269 / NEUROLOGY_POV §2.12).
+ *
+ * Closest analogue in published literature: the Empatica Embrace2 /
+ * EmbracePlus FDA-cleared GTCS detector, which corroborates rhythmic
+ * accelerometer motion with ictal-tachycardia (autonomic surge during a
+ * generalised tonic-clonic seizure). This detector keeps the same two
+ * pillars without the proprietary classifier:
+ *
+ *   1. **Rhythmic-motion gate.** Per-second power-spectrum check over the
+ *      accelerometer-norm series. A second is "convulsive-like" when at
+ *      least [RHYTHMIC_BAND_RATIO] of its broadband power falls in the
+ *      2–8 Hz band — the canonical clonic-phase frequency range
+ *      (Beniczky 2013, Conradsen 2012). Sustained ≥ [MIN_SUSTAINED_SEC]
+ *      consecutive convulsive-like seconds is the candidate window.
+ *   2. **Ictal-tachycardia corroborator.** Median HR inside the candidate
+ *      window must be ≥ [HR_RISE_FRACTION] above the median of the
+ *      [PRE_EVENT_BASELINE_SEC]-second window immediately preceding the
+ *      candidate. Without HR substrate the detector returns no event
+ *      (rather than firing on accelerometer alone) — specificity, not
+ *      sensitivity, is the priority for an automated path.
+ *
+ * Output is intentionally minimal: one [Detection] per qualifying window,
+ * with `durationSec` carrying the detection window length. The caller
+ * (see [SeizureEvent]) wraps each detection in a SEIZURE_EVENT
+ * MetricReading with `detection_source = "wearable_inferred"` in
+ * event_payloads so the pull-side timeline can distinguish wearable-
+ * inferred events from owner-logged ones.
+ *
+ * ## Honest scope
+ *
+ * - Focal and absence seizures are not wearable-detectable from this
+ *   signal pair — they lack the bilateral rhythmic motor signature.
+ *   Documented in NEUROLOGY_POV §2.12.
+ * - The detector cannot discriminate non-epileptic psychogenic seizures
+ *   (PNES) from convulsive epileptic seizures from autonomic substrate
+ *   alone; per NEUROLOGY_POV §3.3 the peri-event autonomic signature
+ *   stays in the timeline for clinician review but is not surfaced as a
+ *   separate alert.
+ * - Push-side notification stays gated on owner confirmation (manifesto
+ *   guard from #269). Wearable-inferred events default to ADVISORY in the
+ *   timeline; the URGENT escalation path is the existing
+ *   [com.bios.app.alerts.NeurologyUrgentPatterns.statusEpilepticusConvulsive]
+ *   pattern keyed on owner-confirmed SEIZURE_EVENT rows.
+ *
+ * ## References
+ *
+ * - Beniczky S et al. (2013) — Detection of generalized tonic-clonic
+ *   seizures by a wireless wrist accelerometer: a prospective,
+ *   multicenter study. *Epilepsia* 54(4):e58-e61.
+ * - Conradsen I et al. (2012) — Automatic multi-modal intelligent seizure
+ *   acquisition (MISA) system for detection of motor seizures from
+ *   electromyographic data and motion data. *Computer Methods and
+ *   Programs in Biomedicine* 107(1):97-110.
+ * - Onorati F et al. (2017) — Multicenter clinical assessment of
+ *   improved wearable multimodal convulsive seizure detectors.
+ *   *Epilepsia* 58(11):1870-1879. (Embrace2 corroborator design.)
+ * - Empatica EmbracePlus — FDA 510(k) K203626. Convulsive seizure
+ *   detection from wrist accelerometer + EDA + PPG corroboration.
+ */
+object SeizureDetector {
+
+    /**
+     * Single time-stamped HR sample used by the corroborator. Real-time
+     * HR is produced by the camera-PPG path and wearable adapters; the
+     * detector accepts a flat series with epoch-ms timestamps so any
+     * source can feed it without an adapter-specific wrapper.
+     */
+    data class HrSample(val timestampMs: Long, val bpm: Double)
+
+    /**
+     * One qualifying detection. `startTimestampMs` is the epoch-ms of
+     * the first convulsive-like second; `durationSec` is the count of
+     * sustained convulsive-like seconds; `medianHrBpm` and
+     * `baselineHrBpm` are exposed so the caller can record the actual
+     * peri-event substrate (clinician review may want to see the ratio).
+     */
+    data class Detection(
+        val startTimestampMs: Long,
+        val durationSec: Int,
+        val medianHrBpm: Double,
+        val baselineHrBpm: Double,
+    )
+
+    /** Sustained-rhythm gate (seconds). 10 s = Beniczky 2013 minimum window. */
+    const val MIN_SUSTAINED_SEC: Int = 10
+
+    /** Clonic-phase low edge (Hz). Below 2 Hz is non-seizure rhythmic motion (walking, breathing). */
+    const val RHYTHMIC_BAND_LOW_HZ: Double = 2.0
+
+    /** Clonic-phase high edge (Hz). Above 8 Hz is too fast for clonic motor activity. */
+    const val RHYTHMIC_BAND_HIGH_HZ: Double = 8.0
+
+    /** Per-second power ratio in the rhythmic band required to mark a second "convulsive-like". */
+    const val RHYTHMIC_BAND_RATIO: Double = 0.60
+
+    /** Minimum total per-second amplitude before the ratio gate applies — quiet seconds never trigger. */
+    const val MIN_RMS_M_PER_S2: Double = 1.0
+
+    /** Ictal-tachycardia corroborator: median HR rise above pre-event baseline. */
+    const val HR_RISE_FRACTION: Double = 0.20
+
+    /** Pre-event HR baseline window (seconds). 30 s per #269 spec. */
+    const val PRE_EVENT_BASELINE_SEC: Int = 30
+
+    /** Minimum samples per 1-s window. Below this the per-second FFT is undefined. */
+    private const val MIN_SAMPLES_PER_SECOND: Int = 8
+
+    /**
+     * Analyse a contiguous accelerometer-norm series for convulsive-seizure
+     * candidates.
+     *
+     * @param accelNormMagnitudes Per-sample acceleration vector magnitude
+     *   minus gravity (`sqrt(x²+y²+z²) - g`), so the DC component is
+     *   already removed. Same convention as [com.bios.app.ingest.PhoneSensorAdapter].
+     * @param startTimestampMs Epoch-ms of the first sample in
+     *   [accelNormMagnitudes]. Used to time-align HR.
+     * @param sampleRateHz Sampling rate of the accelerometer series. The
+     *   detector chunks the series into 1-second windows of
+     *   `sampleRateHz` samples each.
+     * @param hrSeries Heart-rate samples covering at least the
+     *   [PRE_EVENT_BASELINE_SEC] seconds immediately before
+     *   `startTimestampMs` plus the duration of [accelNormMagnitudes].
+     *   Without HR substrate spanning the baseline window the
+     *   corroborator cannot fire and the detector returns an empty list.
+     */
+    fun analyse(
+        accelNormMagnitudes: List<Double>,
+        startTimestampMs: Long,
+        sampleRateHz: Double,
+        hrSeries: List<HrSample>,
+    ): List<Detection> {
+        val samplesPerSecond = sampleRateHz.toInt()
+        if (samplesPerSecond < MIN_SAMPLES_PER_SECOND) return emptyList()
+        if (accelNormMagnitudes.size < samplesPerSecond * MIN_SUSTAINED_SEC) return emptyList()
+
+        val convulsiveLikeBySecond = markConvulsiveLikeSeconds(
+            accelNormMagnitudes, samplesPerSecond
+        )
+
+        val detections = mutableListOf<Detection>()
+        var runStart = -1
+        var i = 0
+        while (i < convulsiveLikeBySecond.size) {
+            if (convulsiveLikeBySecond[i]) {
+                if (runStart < 0) runStart = i
+            } else {
+                if (runStart >= 0 && i - runStart >= MIN_SUSTAINED_SEC) {
+                    corroborate(runStart, i, startTimestampMs, hrSeries)?.let(detections::add)
+                }
+                runStart = -1
+            }
+            i++
+        }
+        if (runStart >= 0 && convulsiveLikeBySecond.size - runStart >= MIN_SUSTAINED_SEC) {
+            corroborate(runStart, convulsiveLikeBySecond.size, startTimestampMs, hrSeries)
+                ?.let(detections::add)
+        }
+        return detections
+    }
+
+    /**
+     * Per-second pass over the magnitude series: each second is marked
+     * convulsive-like when the share of broadband power inside 2–8 Hz
+     * meets [RHYTHMIC_BAND_RATIO] and the per-second RMS clears the
+     * quiet-second floor.
+     */
+    private fun markConvulsiveLikeSeconds(
+        accelNormMagnitudes: List<Double>,
+        samplesPerSecond: Int,
+    ): BooleanArray {
+        val secondsAvailable = accelNormMagnitudes.size / samplesPerSecond
+        val flags = BooleanArray(secondsAvailable)
+        val nfft = nextPowerOfTwo(samplesPerSecond)
+        val real = DoubleArray(nfft)
+        val imag = DoubleArray(nfft)
+        val df = samplesPerSecond.toDouble() / nfft
+        val halfN = nfft / 2
+
+        for (s in 0 until secondsAvailable) {
+            // Copy this second's samples; the rest of the FFT buffer is
+            // zero-padded (and reset each iteration).
+            var rms2 = 0.0
+            for (k in 0 until samplesPerSecond) {
+                val v = accelNormMagnitudes[s * samplesPerSecond + k]
+                real[k] = v
+                rms2 += v * v
+            }
+            for (k in samplesPerSecond until nfft) real[k] = 0.0
+            for (k in 0 until nfft) imag[k] = 0.0
+            val rms = sqrt(rms2 / samplesPerSecond)
+            if (rms < MIN_RMS_M_PER_S2) continue
+
+            Spectral.fftInPlace(real, imag)
+
+            var bandPower = 0.0
+            var totalPower = 0.0
+            // One-sided power: bin 0 and Nyquist are unique, the rest
+            // double-counted. Magnitude² is enough to compute a ratio —
+            // we don't need PSD-scaled values here.
+            for (kBin in 0..halfN) {
+                val mag2 = real[kBin] * real[kBin] + imag[kBin] * imag[kBin]
+                val oneSided = if (kBin == 0 || kBin == halfN) mag2 else mag2 * 2.0
+                totalPower += oneSided
+                val f = kBin * df
+                if (f >= RHYTHMIC_BAND_LOW_HZ && f <= RHYTHMIC_BAND_HIGH_HZ) {
+                    bandPower += oneSided
+                }
+            }
+            if (totalPower <= 0.0) continue
+            if (bandPower / totalPower >= RHYTHMIC_BAND_RATIO) flags[s] = true
+        }
+        return flags
+    }
+
+    /**
+     * Confirm a candidate window with the ictal-tachycardia corroborator.
+     * Returns the [Detection] when median HR inside the window is at
+     * least [HR_RISE_FRACTION] above the pre-event baseline; null when
+     * baseline coverage is insufficient or the HR rise gate fails.
+     */
+    private fun corroborate(
+        runStartSec: Int,
+        runEndSec: Int,
+        startTimestampMs: Long,
+        hrSeries: List<HrSample>,
+    ): Detection? {
+        val windowStartMs = startTimestampMs + runStartSec * 1_000L
+        val windowEndMs = startTimestampMs + runEndSec * 1_000L
+        val baselineStartMs = windowStartMs - PRE_EVENT_BASELINE_SEC * 1_000L
+
+        val baselineSamples = hrSeries.filter {
+            it.timestampMs in baselineStartMs until windowStartMs
+        }
+        val eventSamples = hrSeries.filter {
+            it.timestampMs in windowStartMs until windowEndMs
+        }
+        // Both windows must carry HR substrate. The baseline floor of 3
+        // samples is a soft guard against firing on a single anomalous
+        // pre-event reading; the event-window floor is 1 because a brief
+        // candidate may legitimately straddle very few HR samples.
+        if (baselineSamples.size < 3 || eventSamples.isEmpty()) return null
+
+        val baselineMedian = medianOf(baselineSamples.map { it.bpm })
+        val eventMedian = medianOf(eventSamples.map { it.bpm })
+        if (baselineMedian <= 0.0) return null
+        val rise = (eventMedian - baselineMedian) / baselineMedian
+        if (rise < HR_RISE_FRACTION) return null
+
+        return Detection(
+            startTimestampMs = windowStartMs,
+            durationSec = runEndSec - runStartSec,
+            medianHrBpm = eventMedian,
+            baselineHrBpm = baselineMedian,
+        )
+    }
+
+    private fun nextPowerOfTwo(n: Int): Int {
+        var p = 1
+        while (p < n) p = p shl 1
+        return p
+    }
+
+    private fun medianOf(values: List<Double>): Double {
+        if (values.isEmpty()) return 0.0
+        val sorted = values.sorted()
+        val n = sorted.size
+        return if (n % 2 == 1) sorted[n / 2] else (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/SeizureEventFactory.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SeizureEventFactory.kt
@@ -1,0 +1,66 @@
+package com.bios.app.engine
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SeizureEvent
+import com.bios.app.model.SeizureEventFields
+import com.bios.contracts.MetricType
+import java.util.UUID
+
+/**
+ * Wraps a [SeizureDetector.Detection] into a writable composite
+ * SEIZURE_EVENT (parent MetricReading + event_payloads sidecar).
+ *
+ * Kept separate from [SeizureDetector] so the detector stays pure
+ * signal-processing (testable without touching the room schema) and
+ * separate from the model package so the data classes stay pure data
+ * (no engine dependency).
+ *
+ * Wearable-inferred events are written with [ConfidenceTier.LOW] —
+ * screening-surrogate confidence, matching the manifesto guard from
+ * #269: the timeline records the detection but the URGENT escalation
+ * path stays gated on owner confirmation.
+ */
+object SeizureEventFactory {
+
+    /**
+     * Build the composite SEIZURE_EVENT row for a wearable-inferred
+     * detection. `now` is injected for tests; production callers can
+     * omit it.
+     */
+    fun fromWearableDetection(
+        detection: SeizureDetector.Detection,
+        sourceId: String,
+        now: Long = System.currentTimeMillis(),
+    ): SeizureEvent {
+        val reading = MetricReading(
+            id = UUID.randomUUID().toString(),
+            metricType = MetricType.SEIZURE_EVENT.key,
+            value = 1.0,
+            timestamp = detection.startTimestampMs,
+            durationSec = detection.durationSec,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.LOW.level,
+            createdAt = now,
+        )
+        val payload = listOf(
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+            ),
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                doubleValue = detection.medianHrBpm,
+            ),
+            EventPayloadField(
+                readingId = reading.id,
+                fieldKey = SeizureEventFields.BASELINE_HR_BPM,
+                doubleValue = detection.baselineHrBpm,
+            ),
+        )
+        return SeizureEvent(reading = reading, payload = payload)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/model/SeizureEvent.kt
+++ b/android/app/src/main/java/com/bios/app/model/SeizureEvent.kt
@@ -1,0 +1,38 @@
+package com.bios.app.model
+
+// Composite SEIZURE_EVENT reading bundled with its event-payload fields.
+// Mirrors the [ExerciseSession] shape: the parent MetricReading carries
+// timestamp and durationSec; the payload carries the per-event structured
+// fields that downstream readers join on event_payloads.reading_id.
+//
+// Owner-logged seizure rows do not need this composite — they are bare
+// MetricReading rows with no payload (or with the
+// [SeizureEventFields.DETECTION_SOURCE] field set to "owner_logged" when
+// the journal entry surface starts populating it). The composite is the
+// shape wearable-inferred detections take so the per-event substrate
+// (median HR, baseline HR) stays attached to the parent row.
+data class SeizureEvent(
+    val reading: MetricReading,
+    val payload: List<EventPayloadField>,
+)
+
+// Field keys for the SEIZURE_EVENT payload. Centralized so adapters,
+// detectors, and pull-side readers can't drift on spelling. New keys
+// belong in docs/DATA_MODEL.md alongside the SEIZURE_EVENT metric.
+object SeizureEventFields {
+    // Distinguishes wearable-inferred detections from owner-logged ones
+    // so the pull-side timeline can render them differently and the
+    // URGENT escalation patterns can require owner confirmation before
+    // firing on automation alone. Allowed values:
+    // [DETECTION_SOURCE_WEARABLE_INFERRED], [DETECTION_SOURCE_OWNER_LOGGED].
+    const val DETECTION_SOURCE = "detection_source"
+
+    // Peri-event HR substrate from the ictal-tachycardia corroborator
+    // (see SeizureDetector). Stored on the parent row so clinician-review
+    // can see the actual ratio behind a wearable_inferred detection.
+    const val MEDIAN_HR_BPM = "median_hr_bpm"
+    const val BASELINE_HR_BPM = "baseline_hr_bpm"
+
+    const val DETECTION_SOURCE_WEARABLE_INFERRED = "wearable_inferred"
+    const val DETECTION_SOURCE_OWNER_LOGGED = "owner_logged"
+}

--- a/android/app/src/test/java/com/bios/app/SeizureDetectorTest.kt
+++ b/android/app/src/test/java/com/bios/app/SeizureDetectorTest.kt
@@ -1,0 +1,236 @@
+package com.bios.app
+
+import com.bios.app.engine.SeizureDetector
+import com.bios.app.engine.SeizureEventFactory
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.SeizureEventFields
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.sin
+
+/**
+ * Pure-state tests for [SeizureDetector] covering the #269 acceptance
+ * cases: a 30 s, 4-Hz rhythmic burst with a concurrent HR spike must
+ * fire a wearable-inferred SEIZURE_EVENT with the right durationSec;
+ * the same rhythmic burst without an HR spike must not fire
+ * (specificity). Additional cases pin down sustain duration, sample-rate
+ * floor, baseline-coverage gate, and the [SeizureEventFactory] payload
+ * shape.
+ */
+class SeizureDetectorTest {
+
+    private val sampleRateHz = 50.0
+    private val samplesPerSecond = sampleRateHz.toInt()
+    private val startMs = 1_000_000_000_000L
+
+    /**
+     * Synthesise a rhythmic accelerometer-norm series at [frequencyHz]
+     * for [durationSec] seconds. Amplitude 4 m/s² mimics the clonic-
+     * phase shake-magnitude range reported in Beniczky 2013.
+     */
+    private fun rhythmicSeries(
+        frequencyHz: Double,
+        durationSec: Int,
+        amplitude: Double = 4.0,
+    ): List<Double> {
+        val total = durationSec * samplesPerSecond
+        return List(total) { i ->
+            val t = i.toDouble() / sampleRateHz
+            amplitude * sin(2.0 * PI * frequencyHz * t)
+        }
+    }
+
+    /** Quiet baseline — low-amplitude broadband noise (resting wrist). */
+    private fun quietSeries(durationSec: Int): List<Double> {
+        val total = durationSec * samplesPerSecond
+        // Deterministic pseudo-noise so the test is reproducible.
+        return List(total) { i -> 0.05 * sin(0.7 * i) + 0.03 * sin(1.3 * i) }
+    }
+
+    /** Build an HR series at [bpm] over a window starting at [fromMs] for [durationSec]. */
+    private fun hrFlat(fromMs: Long, durationSec: Int, bpm: Double, hzSampling: Double = 1.0): List<SeizureDetector.HrSample> {
+        val count = (durationSec * hzSampling).toInt()
+        val intervalMs = (1000.0 / hzSampling).toLong()
+        return List(count) { i ->
+            SeizureDetector.HrSample(fromMs + i * intervalMs, bpm)
+        }
+    }
+
+    @Test
+    fun rhythmic_4hz_30s_with_hr_spike_fires_detection() {
+        val accel = rhythmicSeries(frequencyHz = 4.0, durationSec = 30)
+        val baseline = hrFlat(startMs - 30_000L, durationSec = 30, bpm = 70.0)
+        val event = hrFlat(startMs, durationSec = 30, bpm = 110.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertEquals(1, detections.size)
+        val d = detections.first()
+        assertEquals(startMs, d.startTimestampMs)
+        assertEquals(30, d.durationSec)
+        assertEquals(110.0, d.medianHrBpm, 1e-9)
+        assertEquals(70.0, d.baselineHrBpm, 1e-9)
+    }
+
+    @Test
+    fun rhythmic_4hz_30s_without_hr_spike_does_not_fire() {
+        val accel = rhythmicSeries(frequencyHz = 4.0, durationSec = 30)
+        val baseline = hrFlat(startMs - 30_000L, durationSec = 30, bpm = 70.0)
+        // Teeth-brushing-like rhythmic motion: HR barely budges.
+        val event = hrFlat(startMs, durationSec = 30, bpm = 75.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun short_rhythmic_burst_below_10s_does_not_fire_even_with_hr_spike() {
+        // 6 s of rhythmic motion (below MIN_SUSTAINED_SEC) padded with quiet seconds.
+        val accel = rhythmicSeries(4.0, 6) + quietSeries(20)
+        val baseline = hrFlat(startMs - 30_000L, 30, 70.0)
+        val event = hrFlat(startMs, 26, 120.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun out_of_band_rhythm_at_1hz_does_not_fire() {
+        // Walking-like cadence (≈1 Hz, below the 2 Hz low edge).
+        val accel = rhythmicSeries(frequencyHz = 1.0, durationSec = 30)
+        val baseline = hrFlat(startMs - 30_000L, 30, 70.0)
+        // Even with an HR rise the rhythmic-band gate must reject this.
+        val event = hrFlat(startMs, 30, 120.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun quiet_low_amplitude_signal_does_not_fire() {
+        val accel = quietSeries(durationSec = 30)
+        val baseline = hrFlat(startMs - 30_000L, 30, 70.0)
+        val event = hrFlat(startMs, 30, 120.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun missing_baseline_coverage_returns_empty() {
+        val accel = rhythmicSeries(4.0, 30)
+        // Only the event window has HR; pre-event baseline is missing.
+        val event = hrFlat(startMs, 30, 110.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun sample_rate_below_floor_returns_empty() {
+        val tinyRate = 4.0
+        val accel = List(120) { 0.0 }
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = tinyRate,
+            hrSeries = emptyList(),
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun series_shorter_than_minimum_sustain_returns_empty() {
+        // Only 5 s of samples — below MIN_SUSTAINED_SEC.
+        val accel = rhythmicSeries(4.0, 5)
+        val baseline = hrFlat(startMs - 30_000L, 30, 70.0)
+        val event = hrFlat(startMs, 5, 110.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertTrue(detections.isEmpty())
+    }
+
+    @Test
+    fun factory_writes_seizure_event_with_wearable_inferred_payload() {
+        val detection = SeizureDetector.Detection(
+            startTimestampMs = startMs,
+            durationSec = 30,
+            medianHrBpm = 115.0,
+            baselineHrBpm = 70.0,
+        )
+        val event = SeizureEventFactory.fromWearableDetection(
+            detection = detection,
+            sourceId = "phone_accelerometer",
+            now = startMs + 60_000L,
+        )
+        assertEquals(MetricType.SEIZURE_EVENT.key, event.reading.metricType)
+        assertEquals(1.0, event.reading.value, 1e-9)
+        assertEquals(30, event.reading.durationSec)
+        assertEquals(startMs, event.reading.timestamp)
+        assertEquals(ConfidenceTier.LOW.level, event.reading.confidence)
+        assertEquals("phone_accelerometer", event.reading.sourceId)
+
+        val source = event.payload.first { it.fieldKey == SeizureEventFields.DETECTION_SOURCE }
+        assertEquals(
+            SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+            source.stringValue,
+        )
+        val medianHr = event.payload.first { it.fieldKey == SeizureEventFields.MEDIAN_HR_BPM }
+        assertEquals(115.0, medianHr.doubleValue!!, 1e-9)
+        val baselineHr = event.payload.first { it.fieldKey == SeizureEventFields.BASELINE_HR_BPM }
+        assertEquals(70.0, baselineHr.doubleValue!!, 1e-9)
+        // Every payload row points back at the parent reading.
+        assertTrue(event.payload.all { it.readingId == event.reading.id })
+    }
+
+    @Test
+    fun detection_durationSec_reflects_window_length_not_full_input() {
+        // 12 s rhythmic burst sandwiched between quiet seconds. The
+        // detection should report durationSec = 12, not the full input
+        // length (24 s).
+        val accel = quietSeries(6) + rhythmicSeries(4.0, 12) + quietSeries(6)
+        val baseline = hrFlat(startMs - 30_000L, 30, 70.0)
+        val event = hrFlat(startMs + 6_000L, 12, 110.0)
+        val detections = SeizureDetector.analyse(
+            accelNormMagnitudes = accel,
+            startTimestampMs = startMs,
+            sampleRateHz = sampleRateHz,
+            hrSeries = baseline + event,
+        )
+        assertEquals(1, detections.size)
+        val d = detections.first()
+        assertEquals(12, d.durationSec)
+        assertEquals(startMs + 6_000L, d.startTimestampMs)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a pure-function **`SeizureDetector`** shaped after the FDA-cleared Empatica Embrace2 / EmbracePlus design: a 2–8 Hz per-second rhythmic-motion gate over the accelerometer-norm series, sustained ≥ 10 s, corroborated by an ictal-tachycardia rise (median HR in the candidate window ≥ 20 % above the 30-s pre-event baseline).
- Adds a **`SeizureEvent`** composite (parent MetricReading + event_payloads sidecar) with a `SeizureEventFactory` that writes wearable-inferred detections with `detection_source = "wearable_inferred"` plus `median_hr_bpm` / `baseline_hr_bpm` so the pull-side timeline can distinguish wearable-inferred events from owner-logged ones and a future clinician-share surface can see the peri-event substrate.
- Confidence is `LOW` and there is **no push-side notification**: per the #269 manifesto guard, wearable-inferred events land in the timeline only. URGENT escalation stays gated on the existing owner-confirmed [`statusEpilepticusConvulsive`](android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt) pattern.
- Reuses the [`Spectral.fftInPlace`](android/app/src/main/java/com/bios/app/engine/Spectral.kt) radix-2 FFT primitive per the issue.

## Out of scope (deferred to a follow-up cut)
- Foreground-service wiring of the detector against `PhoneSensorAdapter.accelerometerFlow()` with a battery-budget measurement.
- A settings opt-in toggle (mirroring the PpgCalibrationLogger #266 Cut 1 pattern of opt-in diagnostics).
- Pull-side timeline differentiation between `wearable_inferred` and `owner_logged` rows.
- The `NeurologyUrgentPatterns` change to require `detection_source = "owner_logged"` before firing URGENT on a wearable-inferred long-duration event (currently the URGENT pattern would still fire if a wearable-inferred event were ≥ 5 min; we're avoiding that by not wiring the detector into a continuous capture path yet).

## Manifesto alignment
- Default to the conservative pull-side surface (NEUROLOGY_POV §3.3).
- No claim of "you had a seizure" on detection; the timeline records the candidate.
- Specificity > sensitivity for an automated path — the HR corroborator must clear the 20 % rise gate.
- Focal / absence seizures are not wearable-detectable from this signal pair; documented in the detector KDoc per NEUROLOGY_POV §2.12.
- PNES discrimination is intentionally not surfaced as a separate alert; the autonomic signature stays on the parent row for clinician review.

## Test plan
Acceptance cases from #269 plus edge cases:

- [x] 30 s 4-Hz rhythmic burst + concurrent HR spike (70 → 110 bpm) fires a single detection with `durationSec = 30`.
- [x] Same 30 s 4-Hz burst with HR barely above baseline (70 → 75 bpm) does **not** fire (teeth-brushing specificity).
- [x] 6 s rhythmic burst (below `MIN_SUSTAINED_SEC`) does not fire even with an HR spike.
- [x] 1 Hz walking-cadence rhythm does not fire (out-of-band rejection).
- [x] Quiet low-amplitude signal does not fire.
- [x] Missing pre-event HR baseline returns empty.
- [x] Sample rate below the per-second-FFT floor returns empty.
- [x] `SeizureEventFactory` writes the parent row with `MetricType.SEIZURE_EVENT`, `value = 1.0`, the right `durationSec`, `ConfidenceTier.LOW`, plus `detection_source = "wearable_inferred"`, `median_hr_bpm`, and `baseline_hr_bpm` payload fields all pointing back at the parent reading id.
- [x] A 12 s rhythmic burst sandwiched between quiet seconds reports `durationSec = 12`, not the full input length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)