### PR TITLE
feat(ingest): charge-triggered phone-sleep service (#241 Cut 1)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,18 @@
     <!-- Background work -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!--
+      Phone-sleep collection foreground service (#241). FOREGROUND_SERVICE
+      is the base permission; FOREGROUND_SERVICE_HEALTH is required on
+      API 34+ for the documented "sleep / vitals" service category that
+      PhoneSleepCollectionService declares. WAKE_LOCK keeps the CPU
+      available so the per-minute sampling cadence does not drift under
+      Doze while the service is running.
+    -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <!-- Step counter. Android 10+ silently delivers zero events to
          Sensor.TYPE_STEP_COUNTER without this permission, even though
          the sensor itself reports `hasStepCounter = true`. Without this
@@ -189,5 +201,21 @@
                 <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- Phone-sleep collection foreground service (#241 Cut 1).
+             Started by PowerConnectionReceiver on ACTION_POWER_CONNECTED
+             during quiet-hours; stopped on ACTION_POWER_DISCONNECTED.
+             Not exported — only Bios itself starts it. The "health"
+             foregroundServiceType is documented for sleep / vitals
+             collection on API 34+; older releases ignore the attribute.
+
+             The PowerConnectionReceiver is registered at runtime in
+             BiosApplication.onCreate — ACTION_POWER_CONNECTED /
+             _DISCONNECTED are NOT on the API 26+ implicit-broadcast
+             allowlist, so manifest-declared receivers never fire. -->
+        <service
+            android:name=".ingest.PhoneSleepCollectionService"
+            android:exported="false"
+            android:foregroundServiceType="health" />
     </application>
 </manifest>

--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.bios.app.alerts.DailyDigestWorker
 import com.bios.app.data.BiosDatabase
 import com.bios.app.ingest.GadgetbridgeReceiver
+import com.bios.app.ingest.PowerConnectionReceiver
 import com.bios.app.ingest.SyncWorker
 import com.bios.app.platform.HealthApiServer
 import com.bios.app.platform.LetheCompat
@@ -29,6 +30,7 @@ class BiosApplication : Application() {
 
     private var healthApiServer: HealthApiServer? = null
     private var gadgetbridgeReceiver: GadgetbridgeReceiver? = null
+    private var powerConnectionReceiver: PowerConnectionReceiver? = null
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     override fun onCreate() {
@@ -70,6 +72,23 @@ class BiosApplication : Application() {
         // self-skips otherwise).
         com.bios.app.ingest.PhoneSleepWorker.enqueuePeriodicWork(this)
 
+        // Register the charge-edge receiver for the new foreground
+        // collection service (#241). ACTION_POWER_CONNECTED /
+        // _DISCONNECTED are not on the API 26+ implicit-broadcast
+        // allowlist, so the receiver must be registered at runtime —
+        // a manifest declaration would never fire. RECEIVER_NOT_EXPORTED
+        // is correct: only the OS sends these broadcasts.
+        powerConnectionReceiver = PowerConnectionReceiver().also {
+            registerReceiver(
+                it,
+                android.content.IntentFilter().apply {
+                    addAction(android.content.Intent.ACTION_POWER_CONNECTED)
+                    addAction(android.content.Intent.ACTION_POWER_DISCONNECTED)
+                },
+                RECEIVER_NOT_EXPORTED,
+            )
+        }
+
         // Schedule daily digest notification (8 AM, user can disable in settings)
         if (DailyDigestWorker.isEnabled(this)) {
             DailyDigestWorker.schedule(this)
@@ -93,6 +112,7 @@ class BiosApplication : Application() {
 
     override fun onTerminate() {
         gadgetbridgeReceiver?.let { unregisterReceiver(it) }
+        powerConnectionReceiver?.let { unregisterReceiver(it) }
         p2pTransport.stop()
         healthApiServer?.stop()
         letheCompat.unregisterWipeReceivers(this)

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
@@ -1,0 +1,231 @@
+package com.bios.app.ingest
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.bios.app.data.BiosDatabase
+import com.bios.app.model.PhoneSleepSample
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Charge-triggered foreground service that collects phone-sleep samples
+ * continuously while the device is plugged in and inside quiet-hours
+ * (#241 Cut 1).
+ *
+ * Replaces — eventually — the WorkManager periodic worker
+ * [PhoneSleepWorker], which on Doze-aggressive OEMs (Samsung, Xiaomi,
+ * OnePlus, Oppo) fires every 30–90 min instead of the requested 15 min
+ * and never accumulates enough samples for the inference's 4 h
+ * minimum-window floor. The worker stays in place this cut as a safety
+ * net; the receiver-triggered service is the new primary path.
+ *
+ * ## Lifecycle
+ *
+ * - **Start.** [PowerConnectionReceiver] fires on
+ *   `ACTION_POWER_CONNECTED`, checks [PhoneSleepQuietHours], and calls
+ *   `ContextCompat.startForegroundService(intent)` when both conditions
+ *   pass.
+ * - **Foreground notification.** Posted in `onCreate` with copy that
+ *   honestly explains what is happening ("Bios is collecting sleep
+ *   signals while charging"). On API 34+ the service type is
+ *   `FOREGROUND_SERVICE_TYPE_HEALTH`.
+ * - **Wake lock.** A `PARTIAL_WAKE_LOCK` keeps the CPU available so the
+ *   sampling cadence doesn't drift under Doze. Released on `onDestroy`.
+ * - **Sampling loop.** [SAMPLE_INTERVAL_MS] cadence, every iteration
+ *   calls [PhoneSleepAdapter.sample] and persists one row to
+ *   `phone_sleep_samples`. Inference itself is left to the existing
+ *   `PhoneSleepWorker` morning trigger (or the dashboard "Infer now"
+ *   path); this service is collection-only.
+ * - **Stop.** [PowerConnectionReceiver] fires on
+ *   `ACTION_POWER_DISCONNECTED` and calls `stopService`.
+ *   Self-protective: if the service is started outside quiet-hours
+ *   (e.g. due to a stale broadcast), `onStartCommand` immediately
+ *   stops itself.
+ *
+ * ## Out of scope for this cut
+ *
+ * - `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` onboarding ask (UI work).
+ * - Removing / downgrading `PhoneSleepWorker`. Both paths coexist; the
+ *   worker's inserts and the service's inserts both land in
+ *   `phone_sleep_samples` and the inference is order-agnostic.
+ * - 1-minute bucket aggregation. This cut samples at the same cadence
+ *   as the worker (one row per sample); the bucketing optimisation
+ *   lands when we measure whether the row volume is a problem.
+ */
+class PhoneSleepCollectionService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var samplingJob: Job? = null
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannelIfNeeded(this)
+        startForegroundWithType()
+        acquireWakeLock()
+        Log.i(TAG, "service onCreate — foreground notification posted")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Self-protective: a stale broadcast or a manual `am startservice`
+        // outside quiet-hours must not turn into an all-day collection
+        // session. The receiver already gates, but we don't trust that
+        // alone — the service double-checks.
+        if (!PhoneSleepQuietHours.isInQuietHoursNow()) {
+            Log.i(TAG, "service started outside quiet-hours; stopping self")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        if (samplingJob == null) samplingJob = launchSamplingLoop()
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        samplingJob?.cancel()
+        samplingJob = null
+        releaseWakeLock()
+        scope.cancel()
+        Log.i(TAG, "service onDestroy — wake lock released")
+        super.onDestroy()
+    }
+
+    private fun launchSamplingLoop(): Job = scope.launch {
+        val adapter = PhoneSleepAdapter(applicationContext)
+        if (!adapter.isAvailable) {
+            Log.i(TAG, "no accelerometer; sampling loop exiting")
+            stopSelf()
+            return@launch
+        }
+        val sampleDao = BiosDatabase.getInstance(applicationContext).phoneSleepSampleDao()
+        while (isActive) {
+            try {
+                val sample = adapter.sample()
+                sampleDao.insert(
+                    PhoneSleepSample(
+                        timestamp = sample.timestamp,
+                        screenOff = sample.screenOff,
+                        charging = sample.charging,
+                        ambientLightLux = sample.ambientLightLux,
+                        accelMagnitudeVar = sample.accelMagnitudeVar,
+                    )
+                )
+            } catch (t: Throwable) {
+                Log.w(TAG, "sample iteration failed: ${t.message}", t)
+            }
+            delay(SAMPLE_INTERVAL_MS)
+        }
+    }
+
+    private fun startForegroundWithType() {
+        val notification = buildNotification(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // API 34+ requires a service-type declaration on every
+            // startForeground call. HEALTH is the documented category
+            // for sleep / vitals collection.
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun acquireWakeLock() {
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        val lock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG).apply {
+            setReferenceCounted(false)
+        }
+        // Cap the lock so a stuck service can't drain the battery
+        // indefinitely; ACTION_POWER_DISCONNECTED normally releases it
+        // well before this.
+        lock.acquire(MAX_WAKE_LOCK_MS)
+        wakeLock = lock
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
+    }
+
+    companion object {
+        private const val TAG = "PhoneSleepCollectionService"
+
+        /** Notification channel id; created lazily on first service start. */
+        const val CHANNEL_ID = "bios_phone_sleep_collection"
+
+        /** Notification id. Stable so the OS keeps replacing it on restart. */
+        private const val NOTIFICATION_ID = 0x515 // arbitrary, stable
+
+        /** Wake-lock tag prefix per AOSP convention `<app>:<purpose>`. */
+        private const val WAKE_LOCK_TAG = "Bios:PhoneSleepCollection"
+
+        /**
+         * Sampling cadence. One row every 60 s gives ~480 samples across
+         * an 8 h window — well above the inference's MIN_SAMPLES floor
+         * even when Doze drops a few — and matches the C4DMH/Sleep
+         * reference implementation cadence.
+         */
+        const val SAMPLE_INTERVAL_MS: Long = 60_000L
+
+        /**
+         * Hard ceiling on the wake-lock hold so a stuck service can't
+         * drain the battery overnight. Bigger than the longest
+         * plausible quiet-hours session so the cap is only hit in a
+         * pathology. */
+        private const val MAX_WAKE_LOCK_MS: Long = 14L * 60L * 60L * 1000L
+
+        /**
+         * Idempotent channel creation. The first service start posts
+         * the foreground notification; on API 26+ the channel must
+         * exist or the notification is silently dropped.
+         */
+        fun createChannelIfNeeded(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val manager = context.getSystemService(NotificationManager::class.java)
+                ?: return
+            if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Sleep signal collection",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description =
+                        "Posted while Bios is collecting sleep signals from the phone " +
+                            "while it is charging overnight."
+                    setShowBadge(false)
+                }
+            )
+        }
+
+        internal fun buildNotification(context: Context): Notification =
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle("Bios is collecting sleep signals")
+                .setContentText("Active while the phone is charging during quiet hours.")
+                .setSmallIcon(context.applicationInfo.icon)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepQuietHours.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepQuietHours.kt
@@ -1,0 +1,65 @@
+package com.bios.app.ingest
+
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Quiet-hours gate for the charge-triggered phone-sleep collection
+ * service (#241 Cut 1).
+ *
+ * Plugging the phone in to charge during the day (commute, desk, café
+ * power bank) is not "going to sleep" and must not trigger a
+ * sleep-collection foreground service. The receiver consults this gate
+ * before starting the service: only `ACTION_POWER_CONNECTED` events that
+ * land inside the quiet-hours window are honoured.
+ *
+ * Defaults are 21:00–08:00 local — the canonical adult sleep band used
+ * by [PhoneSleepInference] internally. The window wraps midnight by
+ * construction.
+ *
+ * Pure helper; lives in `ingest/` only because that's where its callers
+ * sit. No Android dependencies — testable in straight JVM JUnit.
+ */
+object PhoneSleepQuietHours {
+
+    /** Default start of the quiet-hours band (local time). */
+    val DEFAULT_START: LocalTime = LocalTime.of(21, 0)
+
+    /** Default end of the quiet-hours band (local time). */
+    val DEFAULT_END: LocalTime = LocalTime.of(8, 0)
+
+    /**
+     * True when [now] falls inside `[start, end)` interpreted as a
+     * local-time band on `zoneId`. The band wraps midnight: when
+     * `start > end` (the default 21:00 → 08:00 case), `now` is inside
+     * the band iff it is at or after `start` *or* strictly before `end`.
+     */
+    fun isInQuietHours(
+        now: ZonedDateTime,
+        start: LocalTime = DEFAULT_START,
+        end: LocalTime = DEFAULT_END,
+    ): Boolean {
+        val t = now.toLocalTime()
+        return if (start < end) {
+            // Non-wrapping band — e.g. 13:00..15:00 — `now` must sit inside.
+            t >= start && t < end
+        } else {
+            // Wrapping band — e.g. 21:00..08:00 — `now` is inside iff it
+            // is after start OR strictly before end. The two halves never
+            // overlap so OR is safe.
+            t >= start || t < end
+        }
+    }
+
+    /**
+     * Convenience overload that reads system time on the given zone.
+     * Production callers pass `ZoneId.systemDefault()`; tests inject a
+     * fixed [ZonedDateTime] via [isInQuietHours] instead.
+     */
+    fun isInQuietHoursNow(
+        zoneId: ZoneId = ZoneId.systemDefault(),
+        start: LocalTime = DEFAULT_START,
+        end: LocalTime = DEFAULT_END,
+    ): Boolean = isInQuietHours(ZonedDateTime.now(zoneId), start, end)
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PowerConnectionReceiver.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PowerConnectionReceiver.kt
@@ -1,0 +1,56 @@
+package com.bios.app.ingest
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+/**
+ * Charge edge-trigger for [PhoneSleepCollectionService] (#241 Cut 1).
+ *
+ * The receiver listens for the OS-broadcast power events:
+ *
+ * - `ACTION_POWER_CONNECTED` — start collection iff
+ *   [PhoneSleepQuietHours.isInQuietHoursNow] is true. Daytime charging
+ *   (commute, desk, café power bank) is not sleep and never triggers
+ *   the service.
+ * - `ACTION_POWER_DISCONNECTED` — stop collection unconditionally. The
+ *   morning unplug is the canonical end-of-night signal for phone-only
+ *   inference.
+ *
+ * Both power actions are protected broadcasts: the receiver cannot be
+ * targeted by other apps and the system delivers them with at-least-once
+ * semantics. The receiver is declared `android:exported="false"` —
+ * implicit broadcasts from the OS still reach it, but no app can
+ * `am broadcast` it.
+ *
+ * No quiet-hours UI gate yet — the defaults (21:00–08:00 local) are
+ * baked in; a Settings override is a follow-up cut alongside the
+ * battery-optimisation onboarding ask.
+ */
+class PowerConnectionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        val serviceIntent = Intent(context, PhoneSleepCollectionService::class.java)
+        when (action) {
+            Intent.ACTION_POWER_CONNECTED -> {
+                if (!PhoneSleepQuietHours.isInQuietHoursNow()) {
+                    Log.i(TAG, "power connected outside quiet-hours; not starting service")
+                    return
+                }
+                Log.i(TAG, "power connected during quiet-hours; starting collection service")
+                ContextCompat.startForegroundService(context, serviceIntent)
+            }
+            Intent.ACTION_POWER_DISCONNECTED -> {
+                Log.i(TAG, "power disconnected; stopping collection service")
+                context.stopService(serviceIntent)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "PowerConnectionReceiver"
+    }
+}

--- a/android/app/src/test/java/com/bios/app/PhoneSleepQuietHoursTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepQuietHoursTest.kt
@@ -1,0 +1,72 @@
+package com.bios.app
+
+import com.bios.app.ingest.PhoneSleepQuietHours
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Quiet-hours gate covers the daytime / nighttime split that
+ * [PowerConnectionReceiver] keys off — a "phone plugged in" event at
+ * 14:00 must not start the collection service, while one at 23:30 (or
+ * 06:00 the next morning) must. Wrap-around behaviour is the only
+ * non-obvious bit.
+ */
+class PhoneSleepQuietHoursTest {
+
+    private val zone = ZoneId.of("UTC")
+
+    private fun at(hour: Int, minute: Int = 0) =
+        ZonedDateTime.of(LocalDate.of(2026, 5, 23), LocalTime.of(hour, minute), zone)
+
+    @Test
+    fun midnight_is_in_default_quiet_hours() {
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(0, 0)))
+    }
+
+    @Test
+    fun three_am_is_in_default_quiet_hours() {
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(3, 0)))
+    }
+
+    @Test
+    fun seven_am_is_in_default_quiet_hours() {
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(7, 59)))
+    }
+
+    @Test
+    fun eight_am_sharp_is_outside_quiet_hours() {
+        // End is exclusive — 08:00 itself is daytime.
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(8, 0)))
+    }
+
+    @Test
+    fun afternoon_charging_is_outside_quiet_hours() {
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(14, 0)))
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(17, 30)))
+    }
+
+    @Test
+    fun nine_pm_is_in_quiet_hours() {
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(21, 0)))
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(23, 30)))
+    }
+
+    @Test
+    fun just_before_nine_pm_is_outside_quiet_hours() {
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(20, 59)))
+    }
+
+    @Test
+    fun non_wrapping_band_treats_inside_as_in_band() {
+        val start = LocalTime.of(13, 0)
+        val end = LocalTime.of(15, 0)
+        assertTrue(PhoneSleepQuietHours.isInQuietHours(at(14, 0), start, end))
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(12, 59), start, end))
+        assertFalse(PhoneSleepQuietHours.isInQuietHours(at(15, 0), start, end))
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the WorkManager 15-min periodic floor with a **charge edge-triggered foreground service** for the in-quiet-hours window. The octopus investigation flagged Doze-aggressive OEMs (Samsung, Xiaomi, OnePlus, Oppo) firing the periodic worker every 30–90 min as the #1 root cause of the in-production failure tracked in #240 — the sample buffer never accumulates enough rows for the inference's 4 h MIN_SLEEP_WINDOW_MS floor. The new service holds a PARTIAL_WAKE_LOCK and samples at a steady 60 s cadence so the overnight buffer fills reliably.

## Pieces
- [`PhoneSleepQuietHours`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepQuietHours.kt) — pure 21:00–08:00 local-time gate, wrap-aware. No Android deps so it's JVM-testable.
- [`PhoneSleepCollectionService`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt) — foreground service with `FOREGROUND_SERVICE_TYPE_HEALTH` on API 34+. Wake-lock-bounded, self-protective if started outside quiet-hours, persists samples directly to `phone_sleep_samples` via the existing `PhoneSleepAdapter.sample()`.
- [`PowerConnectionReceiver`](android/app/src/main/java/com/bios/app/ingest/PowerConnectionReceiver.kt) — listens for `ACTION_POWER_CONNECTED` / `_DISCONNECTED`. Registered at runtime from `BiosApplication.onCreate` because these actions are **not** on the API 26+ implicit-broadcast allowlist — a manifest receiver would never fire. (Same pattern as the existing `GadgetbridgeReceiver`.)
- Manifest: adds `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_HEALTH`, `WAKE_LOCK` permissions and the service declaration with `foregroundServiceType="health"`.
- [`PhoneSleepQuietHoursTest`](android/app/src/test/java/com/bios/app/PhoneSleepQuietHoursTest.kt) — 8 tests covering daytime / nighttime / wrap-band / non-wrap-band cases.

## Out of scope for this cut (deferred)
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` onboarding ask — needs UI work and copy.
- **Removing or downgrading `PhoneSleepWorker`.** Both paths coexist this cut; the inference is order-agnostic over `phone_sleep_samples` so duplicate inserts just give it more data. Removing the worker waits for field data confirming the service is working.
- 1-minute bucket aggregation (the issue's reference design from C4DMH/Sleep). The current cadence is one row per `adapter.sample()` call — bucketing lands if the row volume measures as a problem.
- Settings override for the 21:00–08:00 quiet-hours band.

## Test plan
- [x] `PhoneSleepQuietHoursTest` covers the gate logic.
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug across both flavours, unit tests).
- [ ] Manual: plug in at 23:30, confirm the foreground notification appears and stays through the night. Unplug at 07:00, confirm notification clears.
- [ ] Manual: plug in at 14:00, confirm no notification (quiet-hours gate working).
- [ ] Manual: after one night, confirm `phone_sleep_samples` row count is well above the 8-sample MIN floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)