### PR TITLE
feat(debug): per-MetricType row count screen (#253)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
@@ -139,6 +139,53 @@ interface MetricReadingDao {
     @Query("SELECT * FROM metric_readings WHERE createdAt > :sinceMillis ORDER BY createdAt ASC")
     suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading>
 
+    /**
+     * Per-metric-type row count + most-recent timestamp, count-descending.
+     * Powers the debug screen in #253 ("what's actually in my DB right now").
+     * `lastTimestamp` is nullable because empty buckets (no surviving rows
+     * for a metric after a pruning sweep) report MAX(...) = NULL.
+     */
+    data class MetricTypeCountRow(
+        val metricType: String,
+        val count: Int,
+        val lastTimestamp: Long?,
+    )
+
+    @Query("""
+        SELECT metricType AS metricType,
+               COUNT(*) AS count,
+               MAX(timestamp) AS lastTimestamp
+        FROM metric_readings
+        GROUP BY metricType
+        ORDER BY count DESC
+    """)
+    suspend fun metricTypeCounts(): List<MetricTypeCountRow>
+
+    /**
+     * Per-sourceId row count for a single metric type, count-descending.
+     * Used by the debug screen to surface vendor-specific drift on the
+     * top metrics (e.g. HR coming half from Health Connect and half from
+     * a paired wearable). Joins the data_sources table for the human-
+     * readable label.
+     */
+    data class SourceCountRow(
+        val sourceId: String,
+        val sourceLabel: String?,
+        val count: Int,
+    )
+
+    @Query("""
+        SELECT mr.sourceId AS sourceId,
+               ds.deviceName AS sourceLabel,
+               COUNT(*) AS count
+        FROM metric_readings mr
+        LEFT JOIN data_sources ds ON mr.sourceId = ds.id
+        WHERE mr.metricType = :metricType
+        GROUP BY mr.sourceId
+        ORDER BY count DESC
+    """)
+    suspend fun sourceCountsForMetric(metricType: String): List<SourceCountRow>
+
     @Query("DELETE FROM metric_readings WHERE timestamp < :beforeMillis")
     suspend fun deleteBefore(beforeMillis: Long): Int
 

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -312,6 +312,13 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToInterventionEvents = { navController.navigate("intervention_events") },
                     onNavigateToTreatmentCourses = { navController.navigate("treatment_courses") },
                     onNavigateToAnthropometry = { navController.navigate("anthropometry") },
+                    onNavigateToMetricReadingsDebug = { navController.navigate("metric_readings_debug") },
+                )
+            }
+            composable("metric_readings_debug") {
+                com.bios.app.ui.diagnostics.MetricReadingsDebugScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
                 )
             }
             // Self-surface routes — extracted to IdentityRoutes.kt to keep this file

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/MetricReadingsDebugScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/MetricReadingsDebugScreen.kt
@@ -1,0 +1,188 @@
+package com.bios.app.ui.diagnostics
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.ui.AppViewModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Debug screen for the metric_readings table (#253).
+ *
+ * Lists every MetricType with at least one row, count-descending, and
+ * expands the top [TOP_METRICS_FOR_SOURCE_BREAKDOWN] to a per-DataSource
+ * breakdown so the owner can see which adapter is producing the volume
+ * dominating the encrypted DB.
+ *
+ * Read-only: no mutations from this screen. Reachable via a long-press
+ * easter egg on the Version row in Settings — kept off the main nav so
+ * release-build owners don't stumble into it, but accessible when an
+ * adapter is silently failing and the row count for that source has
+ * dropped to zero.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MetricReadingsDebugScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+) {
+    var rows by remember { mutableStateOf<List<MetricReadingDao.MetricTypeCountRow>>(emptyList()) }
+    var totalReadings by remember { mutableIntStateOf(0) }
+    var sourceBreakdowns by remember {
+        mutableStateOf<Map<String, List<MetricReadingDao.SourceCountRow>>>(emptyMap())
+    }
+
+    LaunchedEffect(Unit) {
+        val dao = viewModel.db.metricReadingDao()
+        totalReadings = dao.countAll()
+        val counts = dao.metricTypeCounts()
+        rows = counts
+        // Pre-fetch the per-source breakdown for the top metric types so
+        // expansion doesn't latency-spike when the owner scrolls.
+        sourceBreakdowns = counts.take(TOP_METRICS_FOR_SOURCE_BREAKDOWN)
+            .associate { it.metricType to dao.sourceCountsForMetric(it.metricType) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("metric_readings") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+        )
+
+        LazyColumn(
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            item {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Total rows", style = MaterialTheme.typography.titleSmall)
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            "%,d".format(totalReadings),
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Text(
+                            "${rows.size} distinct metric types",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            items(rows, key = { it.metricType }) { row ->
+                MetricRowCard(row, sourceBreakdowns[row.metricType])
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricRowCard(
+    row: MetricReadingDao.MetricTypeCountRow,
+    sources: List<MetricReadingDao.SourceCountRow>?,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    row.metricType,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "%,d".format(row.count),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            row.lastTimestamp?.let {
+                Text(
+                    "last: ${formatTimestamp(it)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (!sources.isNullOrEmpty()) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                Text(
+                    "by source",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(4.dp))
+                sources.forEach { source ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Text(
+                            source.sourceLabel?.takeIf { it.isNotBlank() } ?: source.sourceId,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        Text(
+                            "%,d".format(source.count),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatTimestamp(millis: Long): String =
+    SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(Date(millis))
+
+/**
+ * How many of the top-volume metric types get an expanded per-DataSource
+ * breakdown. The issue calls out "HR / steps / sleep" — three is enough
+ * to expose the canonical vendor-drift case (HR coming half from HC and
+ * half from a paired wearable) without overwhelming the screen.
+ */
+private const val TOP_METRICS_FOR_SOURCE_BREAKDOWN: Int = 3

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsAboutCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsAboutCard.kt
@@ -1,0 +1,58 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Settings → About card. Shows the app version and hosts the
+ * release-build-safe easter egg for the metric_readings debug screen
+ * (#253): long-press the Version row to navigate to it.
+ *
+ * Extracted from [SettingsScreen] to keep the host file under the
+ * 500-line cap and centralise the long-press handler (release-build
+ * surface, but discoverable for owners who need to confirm what is in
+ * their encrypted DB without an `adb` workaround).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun SettingsAboutCard(
+    onLongPressVersion: () -> Unit = {},
+) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("About", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = onLongPressVersion,
+                    )
+                    .padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text("Version", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    "0.2.0",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -54,6 +54,7 @@ fun SettingsScreen(
     onNavigateToInterventionEvents: () -> Unit = {},
     onNavigateToTreatmentCourses: () -> Unit = {},
     onNavigateToAnthropometry: () -> Unit = {},
+    onNavigateToMetricReadingsDebug: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -401,14 +402,8 @@ fun SettingsScreen(
 
         SettingsDiagnosticsCard()
 
-        // About
-        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text("About", style = MaterialTheme.typography.titleSmall)
-                Spacer(Modifier.height(8.dp))
-                SettingsRow("Version", "0.2.0")
-            }
-        }
+        // About — long-press Version row opens the metric_readings debug screen (#253).
+        SettingsAboutCard(onLongPressVersion = onNavigateToMetricReadingsDebug)
     }
 
     if (showDeleteDialog) {

--- a/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
@@ -221,6 +221,8 @@ private class FakeMetricReadingDao(
     override suspend fun oldestTimestamp(): Long? = notUsed()
     override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
     override suspend fun sourceFreshness(): List<MetricReadingDao.SourceFreshnessRow> = notUsed()
+    override suspend fun metricTypeCounts(): List<MetricReadingDao.MetricTypeCountRow> = notUsed()
+    override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()

--- a/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
@@ -166,6 +166,8 @@ private class FakeReadingDao(
     override suspend fun oldestTimestamp(): Long? = notUsed()
     override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
     override suspend fun sourceFreshness(): List<MetricReadingDao.SourceFreshnessRow> = notUsed()
+    override suspend fun metricTypeCounts(): List<MetricReadingDao.MetricTypeCountRow> = notUsed()
+    override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()


### PR DESCRIPTION
## Summary
In-app debug surface for the `metric_readings` table reachable via a **long-press easter egg** on the Settings → About → Version row. The 106 MB encrypted DB cannot be queried with `adb` (SQLCipher is locked outside the app), so until now there was no way to confirm which adapter is producing the volume that dominates the file. This turns SUBJECT_PROFILE.md's inference into confirmation.

## Pieces
- [`MetricReadingDao.metricTypeCounts()`](android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt) — `GROUP BY metricType`, count-descending, with most-recent timestamp per row.
- [`MetricReadingDao.sourceCountsForMetric(metricType)`](android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt) — per-`DataSource` breakdown joined to `data_sources.deviceName` for the human-readable label.
- [`MetricReadingsDebugScreen`](android/app/src/main/java/com/bios/app/ui/diagnostics/MetricReadingsDebugScreen.kt) — LazyColumn with a total-rows header card and one card per metric type. The top 3 metric types pre-fetch their per-source breakdown so vendor-specific drift (e.g. HR coming half from Health Connect and half from a paired wearable) is immediately visible.
- [`SettingsAboutCard`](android/app/src/main/java/com/bios/app/ui/settings/SettingsAboutCard.kt) — extracted from `SettingsScreen.kt` (which was at 496/500 lines). The long-press handler on the Version row is the release-build-safe easter egg called out in the #253 acceptance.
- `MainActivity`: adds `composable("metric_readings_debug")` route.
- `FakeMetricReadingDao` stubs in `CircadianEngineTest` + `HrRecoveryPersisterTest` updated so they keep compiling against the expanded DAO.

## Acceptance from #253
- [x] Debug screen reachable from Settings — long-press the Version row.
- [x] Lists every MetricType with non-zero row count, plus total row count of the table.
- [x] Includes DataSource-level breakdown for the top 3 metric types so vendor-specific drift is visible.
- [x] Read-only — no mutations.

## Out of scope this cut
- `event_payloads`, `computed_aggregate`, `personal_baseline` tables — the issue mentions these as "if the screen real estate allows"; deferred until field use confirms the metric-table screen is the right shape.
- Date-range filter, export of the count table.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: open Settings, long-press Version row, confirm the debug screen opens with the total-rows header, per-metric list, and source breakdown on the top 3.
- [ ] Manual: confirm a short tap on the Version row does nothing (only long-press triggers the easter egg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)