### PR TITLE
fix(engine): skip empty-signalRules patterns in slow engine (#207)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -46,13 +46,16 @@ class AnomalyDetector(
     private val baselineDao = db.personalBaselineDao()
     private val anomalyDao = db.anomalyDao()
 
-    // Acute-window patterns (#190) fire on their own detector (rate-of-change
-    // semantics the slow engine cannot express); skip here. appliesIn honors
-    // excludedStates + requiredStates (#200) + region (#196) + owner-conditions (#196).
+    // Acute-window patterns (#190) and signalRules-less patterns (e.g. MOH #207,
+    // scored by a dedicated diary evaluator) bypass this pipeline; surfacing
+    // them here would render a misleading "Current Match Score: 0%" in the
+    // detail screen. appliesIn honors excludedStates + requiredStates (#200) +
+    // region (#196) + owner-conditions (#196).
     private fun applicablePatterns(): List<ConditionPattern> {
         val acuteIds = com.bios.app.alerts.AcuteWindowPatterns.all.map { it.id }.toSet()
         return ConditionPatterns.all.filter {
-            it.appliesIn(physiologyState, regionConfig, ownerConditions, drugClass) && it.id !in acuteIds
+            it.appliesIn(physiologyState, regionConfig, ownerConditions, drugClass) &&
+                it.id !in acuteIds && it.signalRules.isNotEmpty()
         }
     }
 


### PR DESCRIPTION
## Summary
[`ConditionPattern`](android/app/src/main/java/com/bios/app/alerts/ConditionPattern.kt)s with `signalRules = emptyList()` are scored by a dedicated evaluator outside the `AnomalyDetector` pipeline (currently the MOH pattern in [`HeadachePatterns.kt:103`](android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt#L103), which is scored by the `MigraineAttack` / `HeadacheLog` diary evaluator). Letting them through `applicablePatterns()` means the detail screen renders a misleading **"Current Match Score: 0%"** — the slow engine has nothing to score against because there are no signals to evaluate.

Filter them out alongside the acute-window patterns ([#190](https://github.com/thdelmas/Bios/issues/190)), which already bypass this pipeline for the same reason: their scoring lives in a dedicated detector. Comment updated to call out both classes.

Prep for [#276](https://github.com/thdelmas/Bios/issues/276) (wiring `MedicationOveruseHeadacheEvaluator` into a diary-triggered alert worker) — the worker takes over from the slow engine for the empty-signalRules case, and this change keeps the detail screen honest in the interim.

## Test plan
- [x] `code-quality-check.sh` green.
- [ ] Manual: open the MOH pattern detail screen, confirm it no longer shows "Current Match Score: 0%" from the slow engine (the diary evaluator's score remains the source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)