### PR TITLE
feat(worker): MOH screening worker fires diary-triggered alerts (#276)

### DIFF
--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -2,6 +2,7 @@ package com.bios.app
 
 import android.app.Application
 import com.bios.app.alerts.DailyDigestWorker
+import com.bios.app.alerts.MohScreeningWorker
 import com.bios.app.data.BiosDatabase
 import com.bios.app.ingest.GadgetbridgeReceiver
 import com.bios.app.ingest.PowerConnectionReceiver
@@ -93,6 +94,11 @@ class BiosApplication : Application() {
         if (DailyDigestWorker.isEnabled(this)) {
             DailyDigestWorker.schedule(this)
         }
+
+        // Schedule the daily MOH screening worker (#276). Idempotent via
+        // WorkManager's unique-work policy. The worker is a no-op when
+        // the diary is empty, so it's safe to enqueue unconditionally.
+        MohScreeningWorker.schedule(this)
 
         // Schedule daily paediatric-band recompute (#198). Idempotent and
         // a no-op when no birth date is on file — safe to enqueue on every

--- a/android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt
@@ -1,0 +1,212 @@
+package com.bios.app.alerts
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.HeadacheLogRepo
+import com.bios.app.data.MigraineAttackRepo
+import com.bios.app.model.Anomaly
+import com.bios.app.model.AlertTier
+import java.util.concurrent.TimeUnit
+
+/**
+ * Daily worker that runs the MOH screening evaluator over the rolling
+ * diary window (#276 / #207).
+ *
+ * The MOH `ConditionPattern` ([HeadachePatterns.medicationOveruseHeadacheScreen])
+ * is intentionally not in the standard signal-rule pipeline — its
+ * inputs are diary rows, not metric streams ([HeadachePatterns.kt:99-119]).
+ * Until this worker, the pattern was registered for text + content-policy
+ * compliance but never fired in production. The worker is the missing
+ * wiring: fetch → [MedicationOveruseHeadacheEvaluator.evaluate] →
+ * insert an [Anomaly] only on a true-verdict transition or post-ack
+ * re-fire.
+ *
+ * ## Dedup
+ *
+ * Verdict state is persisted to SharedPreferences across worker
+ * invocations. The worker fires (writes an Anomaly) only when:
+ *
+ *   1. The verdict is `meetsScreeningThreshold = true`, **and**
+ *   2. Either:
+ *      - the previously-stored verdict was `false` (false→true
+ *        transition), **or**
+ *      - the previously-stored verdict was `true` and the previously-
+ *        written Anomaly has been acknowledged by the owner (re-surface
+ *        after ack).
+ *
+ * The verdict-state flip and the last-Anomaly-id pointer are updated
+ * on every tick. A false verdict resets the stored state so the next
+ * true verdict counts as a fresh transition.
+ *
+ * ## Cadence
+ *
+ * Daily. The IHS ICHD-3 §8.2 screen is a chronic-pattern metric — a
+ * day's worth of diary entries won't change the 3-month verdict in any
+ * clinically interesting way, and a more frequent cadence would burn
+ * battery without earning information. Mirrors [DailyDigestWorker]
+ * scheduling shape.
+ */
+class MohScreeningWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        val db = BiosDatabase.getInstance(context)
+        val migraineRepo = MigraineAttackRepo(db)
+        val headacheRepo = HeadacheLogRepo(db)
+
+        val now = System.currentTimeMillis()
+        val windowStart = now - HeadachePatterns.MOH_WINDOW_DAYS * MS_PER_DAY
+        val attacks = migraineRepo.fetchInRange(windowStart, now)
+        val logs = headacheRepo.fetchInRange(windowStart, now)
+
+        val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
+            migraineAttacks = attacks,
+            headacheLogs = logs,
+            nowMillis = now,
+        )
+
+        val decision = decideFireOrSkip(
+            verdict = verdict,
+            previousState = readPreviousState(context),
+            previouslyAcked = wasPreviouslyAcked(context, db),
+        )
+        when (decision) {
+            FireDecision.SuppressVerdictFalse -> {
+                writePreviousState(context, verdictTrue = false, lastAnomalyId = null)
+            }
+            FireDecision.SuppressVerdictUnchanged -> {
+                // Keep the existing state intact — the previously-fired
+                // Anomaly is still the active surface.
+            }
+            FireDecision.Fire -> {
+                val anomaly = buildAnomaly(verdict, now)
+                db.anomalyDao().insert(anomaly)
+                writePreviousState(context, verdictTrue = true, lastAnomalyId = anomaly.id)
+            }
+        }
+        return Result.success()
+    }
+
+    companion object {
+        const val WORK_NAME = "bios_moh_screening"
+        private const val MS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+
+        // SharedPreferences keys.
+        private const val PREFS_NAME = "bios_moh_state"
+        private const val KEY_LAST_VERDICT_TRUE = "last_verdict_true"
+        private const val KEY_LAST_ANOMALY_ID = "last_anomaly_id"
+
+        /** Daily cadence. Idempotent via WorkManager unique-work policy. */
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<MohScreeningWorker>(
+                24, TimeUnit.HOURS,
+            ).build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        internal data class PreviousState(
+            val verdictTrue: Boolean,
+            val lastAnomalyId: String?,
+        )
+
+        internal sealed interface FireDecision {
+            object Fire : FireDecision
+            object SuppressVerdictFalse : FireDecision
+            object SuppressVerdictUnchanged : FireDecision
+        }
+
+        /**
+         * Pure dedup logic, extracted from [doWork] so the firing
+         * transitions are directly unit-testable without a worker
+         * scaffold.
+         */
+        internal fun decideFireOrSkip(
+            verdict: MedicationOveruseHeadacheEvaluator.Verdict,
+            previousState: PreviousState,
+            previouslyAcked: Boolean,
+        ): FireDecision {
+            if (!verdict.meetsScreeningThreshold) return FireDecision.SuppressVerdictFalse
+            // Verdict is true. Fire only on a transition or after the
+            // previous Anomaly has been acknowledged by the owner.
+            if (!previousState.verdictTrue) return FireDecision.Fire
+            if (previouslyAcked) return FireDecision.Fire
+            return FireDecision.SuppressVerdictUnchanged
+        }
+
+        /**
+         * Build the [Anomaly] row carried by a fired MOH screen. The
+         * pattern text comes straight from
+         * [HeadachePatterns.medicationOveruseHeadacheScreen]; the per-
+         * month substrate from [MedicationOveruseHeadacheEvaluator.describeVerdict]
+         * lands appended to [Anomaly.explanation] so the timeline /
+         * detail surface can render both the static pattern text and
+         * the actual per-month counts that triggered the fire.
+         */
+        internal fun buildAnomaly(
+            verdict: MedicationOveruseHeadacheEvaluator.Verdict,
+            nowMillis: Long,
+        ): Anomaly {
+            val pattern = HeadachePatterns.medicationOveruseHeadacheScreen
+            val substrate = MedicationOveruseHeadacheEvaluator.describeVerdict(verdict)
+            return Anomaly(
+                detectedAt = nowMillis,
+                metricTypes = "[]",
+                deviationScores = "{}",
+                // Threshold-met is a binary verdict — no probability score
+                // to surface. 1.0 keeps the column populated without
+                // implying a calibrated certainty.
+                combinedScore = 1.0,
+                patternId = pattern.id,
+                severity = AlertTier.ADVISORY.level,
+                title = pattern.title,
+                explanation = "${pattern.explanation}\n\n$substrate",
+                suggestedAction = pattern.suggestedAction,
+            )
+        }
+
+        private fun readPreviousState(context: Context): PreviousState {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            return PreviousState(
+                verdictTrue = prefs.getBoolean(KEY_LAST_VERDICT_TRUE, false),
+                lastAnomalyId = prefs.getString(KEY_LAST_ANOMALY_ID, null),
+            )
+        }
+
+        private fun writePreviousState(
+            context: Context,
+            verdictTrue: Boolean,
+            lastAnomalyId: String?,
+        ) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean(KEY_LAST_VERDICT_TRUE, verdictTrue)
+                .apply {
+                    if (lastAnomalyId == null) remove(KEY_LAST_ANOMALY_ID)
+                    else putString(KEY_LAST_ANOMALY_ID, lastAnomalyId)
+                }
+                .apply()
+        }
+
+        private suspend fun wasPreviouslyAcked(context: Context, db: BiosDatabase): Boolean {
+            val state = readPreviousState(context)
+            val id = state.lastAnomalyId ?: return false
+            // No direct fetch-by-id on AnomalyDao; scan the recent window.
+            // 50 is well above the per-day fire ceiling, so even an
+            // owner with a dense alert history will still see their
+            // last MOH fire here.
+            return db.anomalyDao().fetchRecent(50).firstOrNull { it.id == id }?.acknowledged == true
+        }
+    }
+}

--- a/android/app/src/test/java/com/bios/app/MohScreeningWorkerTest.kt
+++ b/android/app/src/test/java/com/bios/app/MohScreeningWorkerTest.kt
@@ -1,0 +1,117 @@
+package com.bios.app
+
+import com.bios.app.alerts.HeadachePatterns
+import com.bios.app.alerts.MedicationOveruseHeadacheEvaluator
+import com.bios.app.alerts.MohScreeningWorker
+import com.bios.app.alerts.MohScreeningWorker.Companion.FireDecision
+import com.bios.app.alerts.MohScreeningWorker.Companion.PreviousState
+import com.bios.app.model.AlertTier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the [MohScreeningWorker] dedup decision and Anomaly-shape
+ * helpers. Covers the four transitions called out in #276:
+ *
+ *   - verdict false → no fire (state reset)
+ *   - verdict false→true → fire
+ *   - verdict true→true without ack → no fire (already surfaced)
+ *   - verdict true→true after ack → fire (re-surface)
+ *
+ * Plus the [MohScreeningWorker.buildAnomaly] shape so the alert text
+ * surface stays anchored to the pattern declaration.
+ */
+class MohScreeningWorkerTest {
+
+    private val verdictTrue = MedicationOveruseHeadacheEvaluator.Verdict(
+        meetsScreeningThreshold = true,
+        perMonthCounts = listOf(
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 5, 14),
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 4, 12),
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 3, 11),
+        ),
+    )
+
+    private val verdictFalse = MedicationOveruseHeadacheEvaluator.Verdict(
+        meetsScreeningThreshold = false,
+        perMonthCounts = listOf(
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 5, 5),
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 4, 8),
+            MedicationOveruseHeadacheEvaluator.MonthCount(2026, 3, 4),
+        ),
+    )
+
+    @Test
+    fun false_verdict_suppresses_fire_and_signals_state_reset() {
+        val decision = MohScreeningWorker.decideFireOrSkip(
+            verdict = verdictFalse,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "prev"),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.SuppressVerdictFalse, decision)
+    }
+
+    @Test
+    fun first_true_verdict_fires() {
+        val decision = MohScreeningWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = false, lastAnomalyId = null),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.Fire, decision)
+    }
+
+    @Test
+    fun continued_true_verdict_does_not_refire_without_ack() {
+        val decision = MohScreeningWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "prev"),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.SuppressVerdictUnchanged, decision)
+    }
+
+    @Test
+    fun continued_true_verdict_refires_after_ack() {
+        val decision = MohScreeningWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "prev"),
+            previouslyAcked = true,
+        )
+        assertEquals(FireDecision.Fire, decision)
+    }
+
+    @Test
+    fun false_to_true_transition_fires_after_state_reset() {
+        // Mimics the lifecycle: verdict went true, then false (state
+        // reset), then back to true on a later tick.
+        val decision = MohScreeningWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = false, lastAnomalyId = null),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.Fire, decision)
+    }
+
+    @Test
+    fun built_anomaly_matches_pattern_declaration() {
+        val now = 1_716_000_000_000L
+        val anomaly = MohScreeningWorker.buildAnomaly(verdictTrue, now)
+        val pattern = HeadachePatterns.medicationOveruseHeadacheScreen
+        assertEquals(pattern.id, anomaly.patternId)
+        assertEquals(pattern.title, anomaly.title)
+        assertEquals(pattern.suggestedAction, anomaly.suggestedAction)
+        assertEquals(AlertTier.ADVISORY.level, anomaly.severity)
+        assertEquals(now, anomaly.detectedAt)
+        // The verdict substrate (per-month counts + IHS threshold) lands
+        // appended to the static pattern explanation so the alert detail
+        // surface can render both.
+        assertTrue(anomaly.explanation.startsWith(pattern.explanation))
+        assertTrue(anomaly.explanation.contains("May 2026: 14 acute-treatment days"))
+        assertTrue(anomaly.explanation.contains("IHS ICHD-3 §8.2 screening threshold"))
+        // No metric streams; the JSON columns stay empty.
+        assertEquals("[]", anomaly.metricTypes)
+        assertEquals("{}", anomaly.deviationScores)
+    }
+}


### PR DESCRIPTION
## Summary
`MedicationOveruseHeadacheEvaluator` and the `medication_overuse_headache_screen` `ConditionPattern` have shipped in `main`, but no production code calls `evaluate()` — the IHS ICHD-3 §8.2 screen never actually fires for the owner. This PR is the missing wiring.

Daily `WorkManager` periodic, scheduled idempotently from `BiosApplication.onCreate`. Each tick:

1. Pulls the rolling **100-day window** of [`MigraineAttack`](android/app/src/main/java/com/bios/app/model/MigraineAttack.kt) + [`HeadacheLog`](android/app/src/main/java/com/bios/app/model/HeadacheLog.kt) rows via the existing repos.
2. Calls `MedicationOveruseHeadacheEvaluator.evaluate`.
3. Inserts an **ADVISORY** [`Anomaly`](android/app/src/main/java/com/bios/app/model/Anomaly.kt) against the `medication_overuse_headache_screen` pattern when **(a)** `verdict.meetsScreeningThreshold` is true **and (b)** the previously-stored verdict was false **or** the previously-fired Anomaly has been acknowledged.

Pattern text is anchored to the declaration in [`HeadachePatterns.kt`](android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt); the [`describeVerdict`](android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt#L245) per-month substrate is appended so the alert detail surface can render both the static pattern text and the per-month counts that triggered the fire.

## Dedup
Verdict state is persisted to `SharedPreferences` ("bios_moh_state"). A false verdict resets the stored state so the next true verdict counts as a fresh transition. The pure decision logic is extracted as `MohScreeningWorker.decideFireOrSkip` so the firing transitions are directly unit-testable.

## Acceptance from #276
- [x] The MOH screen fires as an `AlertCard` when the diary actually crosses the threshold (and only then).
- [x] Tapping "Learn more" lands on `ConditionDetailScreen` for the empty-`signalRules` pattern — the static pattern text is the substrate the owner reads (#278 already filtered the misleading "0% match" surface).
- [x] Dedup behaves so the alert doesn't refire on every worker tick while the verdict stays true.

## Test plan
- [x] `MohScreeningWorkerTest` — six tests covering all four dedup transitions + `buildAnomaly()` shape (severity ADVISORY, pattern text anchored, per-month substrate appended).
- [x] `code-quality-check.sh` green (file length, secrets, lint, both flavours assembleDebug, unit tests).
- [ ] Manual: log diary entries that cross the threshold across the most-recent 3 calendar months, wait for the worker to fire (or force-run), confirm an ADVISORY appears in "Needs attention".
- [ ] Manual: acknowledge the alert, force-run the worker again, confirm it re-fires.

## Out of scope (#276 explicitly):
Renderer surfacing of `describeVerdict` output inside the detail screen (per-month breakdown table). The verdict substrate currently lands appended to `Anomaly.explanation`, which the existing renderer shows; a richer per-month UX is its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)