### PR TITLE
feat(ui): owner-asserted sleep Quick Settings tile (#242 Cut 1)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -217,5 +217,21 @@
             android:name=".ingest.PhoneSleepCollectionService"
             android:exported="false"
             android:foregroundServiceType="health" />
+
+        <!-- Quick Settings tile for owner-asserted bedtime ↔ wake log
+             (#242). The tile is exported (the system Settings UI binds
+             to it to enumerate available tiles for the picker) and
+             gated by the BIND_QUICK_SETTINGS_TILE permission, which is
+             only granted to the SystemUI process. -->
+        <service
+            android:name=".ingest.SleepTileService"
+            android:exported="true"
+            android:icon="@android:drawable/ic_lock_idle_alarm"
+            android:label="Going to bed"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/java/com/bios/app/ingest/SleepTileService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SleepTileService.kt
@@ -1,0 +1,155 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.SleepEntryRepo
+import com.bios.app.ui.sleep.ManualSleepEntry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+/**
+ * Owner-asserted bedtime ↔ wake-time tile (#242 / #134).
+ *
+ * The most-starred FOSS sleep app on F-Droid is purely manual: owners
+ * prefer a reliable manual log over an unreliable inference. This tile
+ * is the same idea anchored to a one-tap surface — the owner taps once
+ * at bedtime (tile flips to "Sleeping"), taps again at wake (tile
+ * flips back to "Going to bed" and a `SLEEP_DURATION`
+ * `MetricReading` lands with `ConfidenceTier.HIGH` via
+ * [SleepEntryRepo]).
+ *
+ * "Owner is final" applies: the tile-written rows ride the same
+ * SELF_REPORTED source as the existing dashboard duration entry, so
+ * the baseline engine ignores them while they still surface in the
+ * sleep dashboard, regularity calculator, and FHIR export.
+ *
+ * ## State
+ *
+ * The bedtime timestamp is persisted to SharedPreferences ("bios_sleep_tile")
+ * so the tile survives system restarts of the host process. A
+ * non-positive stored value means "not started"; on first tap we store
+ * `System.currentTimeMillis()`, on second tap we read it, validate via
+ * [ManualSleepEntry.validate], and clear it.
+ *
+ * Invalid sessions (e.g. accidental double-tap, wake-before-bedtime
+ * clock skew) are dropped with a Log.i and a tile subtitle update —
+ * never written, never poison the baseline.
+ */
+class SleepTileService : TileService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onStartListening() {
+        super.onStartListening()
+        renderTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val now = System.currentTimeMillis()
+        val storedBedtime = readBedtime(applicationContext)
+        if (storedBedtime <= 0L) {
+            writeBedtime(applicationContext, now)
+            Log.i(TAG, "tile started at $now")
+            renderTile(activeBedtime = now)
+            return
+        }
+        when (val result = ManualSleepEntry.validate(storedBedtime, now)) {
+            is ManualSleepEntry.Result.Valid -> {
+                clearBedtime(applicationContext)
+                writeReading(result.range)
+                Log.i(
+                    TAG,
+                    "tile stopped at $now; logged ${result.range.durationSeconds}s",
+                )
+                renderTile(subtitle = "Logged ${formatHours(result.range.durationSeconds)}")
+            }
+            is ManualSleepEntry.Result.Invalid -> {
+                clearBedtime(applicationContext)
+                Log.i(TAG, "tile stopped at $now; dropped: ${result.reason}")
+                renderTile(subtitle = result.reason)
+            }
+            ManualSleepEntry.Result.NotStarted -> {
+                // Unreachable given the early-return above, but the
+                // sealed exhaustiveness keeps the contract honest.
+                renderTile()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun writeReading(range: ManualSleepEntry.Range) {
+        val context = applicationContext
+        scope.launch {
+            try {
+                val repo = SleepEntryRepo(BiosDatabase.getInstance(context))
+                repo.add(
+                    durationSeconds = range.durationSeconds,
+                    timestamp = range.wakeMs,
+                )
+            } catch (t: Throwable) {
+                Log.w(TAG, "failed to persist owner-asserted sleep: ${t.message}", t)
+            }
+        }
+    }
+
+    private fun renderTile(
+        activeBedtime: Long = readBedtime(applicationContext),
+        subtitle: String? = null,
+    ) {
+        val tile = qsTile ?: return
+        val active = activeBedtime > 0L
+        tile.state = if (active) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        tile.label = if (active) "Sleeping" else "Going to bed"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            tile.subtitle = subtitle ?: if (active) "Tap on wake" else "Tap to start"
+        }
+        tile.contentDescription =
+            if (active) "Stop the manual sleep log" else "Start a manual sleep log"
+        tile.updateTile()
+    }
+
+    private fun formatHours(seconds: Long): String {
+        val h = seconds / 3600L
+        val m = (seconds % 3600L) / 60L
+        return when {
+            h > 0L -> "${h}h ${m}m"
+            else -> "${m}m"
+        }
+    }
+
+    companion object {
+        private const val TAG = "SleepTileService"
+        private const val PREFS_NAME = "bios_sleep_tile"
+        private const val KEY_BEDTIME_MS = "bedtime_ms"
+
+        internal fun readBedtime(context: Context): Long =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getLong(KEY_BEDTIME_MS, 0L)
+
+        internal fun writeBedtime(context: Context, bedtimeMs: Long) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putLong(KEY_BEDTIME_MS, bedtimeMs)
+                .apply()
+        }
+
+        internal fun clearBedtime(context: Context) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .remove(KEY_BEDTIME_MS)
+                .apply()
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/sleep/ManualSleepEntry.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/ManualSleepEntry.kt
@@ -1,0 +1,77 @@
+package com.bios.app.ui.sleep
+
+/**
+ * Pure-logic helper for owner-asserted sleep windows (#242).
+ *
+ * Validates a (bedtime, wake-time) pair before any side effects hit the
+ * DB. Used by both the Quick Settings tile ([com.bios.app.ingest.SleepTileService])
+ * and any future Compose-side editable surface so the two paths share
+ * one source of truth on what counts as a usable manual sleep log.
+ *
+ * Owner-asserted always beats heuristic; per the project manifesto
+ * "the owner is final." But a tile that lands a 12-second-long
+ * "sleep" row (the owner tapping it twice by accident) would poison
+ * the baseline engine, so the validator enforces a minimum session
+ * length plus a physiological 24 h cap (mirrors [SleepEntryRepo]).
+ */
+object ManualSleepEntry {
+
+    /**
+     * Minimum session length the tile / dialog will accept. 15 min is
+     * the threshold below which an accidental double-tap is far more
+     * likely than a real sleep window; the cutoff matches the
+     * [com.bios.app.engine.PhoneSleepInference] AWAKE-bout floor so
+     * inferred and manual windows speak the same language.
+     */
+    const val MIN_DURATION_SECONDS: Long = 15L * 60L
+
+    /** Physiological ceiling. Mirrors [com.bios.app.data.SleepEntryRepo]. */
+    const val MAX_DURATION_SECONDS: Long = 24L * 60L * 60L
+
+    /** Validated owner-asserted sleep window. */
+    data class Range(
+        val bedtimeMs: Long,
+        val wakeMs: Long,
+    ) {
+        val durationSeconds: Long get() = (wakeMs - bedtimeMs) / 1000L
+    }
+
+    sealed interface Result {
+        /** Tile has never been tapped, or the stored bedtime was cleared. */
+        object NotStarted : Result
+
+        /**
+         * Pair is unusable. [reason] is plain English suitable for a
+         * Toast / tile subtitle — no second-person judgment per the
+         * manifesto framing.
+         */
+        data class Invalid(val reason: String) : Result
+
+        /** Pair is good; caller can hand [range] to [SleepEntryRepo.add]. */
+        data class Valid(val range: Range) : Result
+    }
+
+    /**
+     * Validate a (bedtime, wake-time) pair from a tile double-tap or a
+     * dialog submission. A `bedtimeMs <= 0` argument signals "the tile
+     * hasn't been started yet" — distinct from "invalid pair."
+     */
+    fun validate(bedtimeMs: Long, wakeMs: Long): Result {
+        if (bedtimeMs <= 0L) return Result.NotStarted
+        if (wakeMs <= bedtimeMs) {
+            return Result.Invalid("Wake time must be after bedtime.")
+        }
+        val durationSec = (wakeMs - bedtimeMs) / 1000L
+        if (durationSec < MIN_DURATION_SECONDS) {
+            return Result.Invalid(
+                "Session is shorter than ${MIN_DURATION_SECONDS / 60} minutes; not logged."
+            )
+        }
+        if (durationSec > MAX_DURATION_SECONDS) {
+            return Result.Invalid(
+                "Session is longer than ${MAX_DURATION_SECONDS / 3600} hours; not logged."
+            )
+        }
+        return Result.Valid(Range(bedtimeMs = bedtimeMs, wakeMs = wakeMs))
+    }
+}

--- a/android/app/src/test/java/com/bios/app/ManualSleepEntryTest.kt
+++ b/android/app/src/test/java/com/bios/app/ManualSleepEntryTest.kt
@@ -1,0 +1,81 @@
+package com.bios.app
+
+import com.bios.app.ui.sleep.ManualSleepEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-state tests for [ManualSleepEntry.validate]. Covers the four
+ * outcomes the tile and any future Compose surface need to render:
+ * NotStarted, Valid, Invalid (wake-before-bedtime), Invalid (too short
+ * — accidental double-tap), Invalid (over 24 h).
+ */
+class ManualSleepEntryTest {
+
+    private val midnight = 1_716_500_000_000L
+
+    @Test
+    fun zero_bedtime_signals_not_started() {
+        val result = ManualSleepEntry.validate(bedtimeMs = 0L, wakeMs = midnight)
+        assertEquals(ManualSleepEntry.Result.NotStarted, result)
+    }
+
+    @Test
+    fun negative_bedtime_signals_not_started() {
+        val result = ManualSleepEntry.validate(bedtimeMs = -1L, wakeMs = midnight)
+        assertEquals(ManualSleepEntry.Result.NotStarted, result)
+    }
+
+    @Test
+    fun seven_hour_window_is_valid() {
+        val bedtime = midnight
+        val wake = bedtime + 7L * 3600L * 1000L
+        val result = ManualSleepEntry.validate(bedtime, wake)
+        assertTrue(result is ManualSleepEntry.Result.Valid)
+        val range = (result as ManualSleepEntry.Result.Valid).range
+        assertEquals(bedtime, range.bedtimeMs)
+        assertEquals(wake, range.wakeMs)
+        assertEquals(7L * 3600L, range.durationSeconds)
+    }
+
+    @Test
+    fun fifteen_minute_window_is_at_the_minimum_floor() {
+        val bedtime = midnight
+        val wake = bedtime + 15L * 60L * 1000L
+        assertTrue(ManualSleepEntry.validate(bedtime, wake) is ManualSleepEntry.Result.Valid)
+    }
+
+    @Test
+    fun fourteen_minute_window_is_rejected_as_too_short() {
+        val bedtime = midnight
+        val wake = bedtime + 14L * 60L * 1000L
+        val result = ManualSleepEntry.validate(bedtime, wake)
+        assertTrue(result is ManualSleepEntry.Result.Invalid)
+        assertTrue((result as ManualSleepEntry.Result.Invalid).reason.contains("15 minutes"))
+    }
+
+    @Test
+    fun wake_before_bedtime_is_rejected() {
+        val bedtime = midnight
+        val wake = bedtime - 3600L * 1000L
+        val result = ManualSleepEntry.validate(bedtime, wake)
+        assertTrue(result is ManualSleepEntry.Result.Invalid)
+        assertTrue((result as ManualSleepEntry.Result.Invalid).reason.contains("after bedtime"))
+    }
+
+    @Test
+    fun wake_equal_to_bedtime_is_rejected() {
+        val result = ManualSleepEntry.validate(midnight, midnight)
+        assertTrue(result is ManualSleepEntry.Result.Invalid)
+    }
+
+    @Test
+    fun over_24_hour_window_is_rejected_as_too_long() {
+        val bedtime = midnight
+        val wake = bedtime + 25L * 3600L * 1000L
+        val result = ManualSleepEntry.validate(bedtime, wake)
+        assertTrue(result is ManualSleepEntry.Result.Invalid)
+        assertTrue((result as ManualSleepEntry.Result.Invalid).reason.contains("24 hours"))
+    }
+}


### PR DESCRIPTION
## Summary
The most-starred FOSS sleep app on F-Droid ([`vmiklos/plees-tracker`](https://github.com/vmiklos/plees-tracker)) is **purely manual** — the signal: owners prefer a reliable manual log over an unreliable automatic detector. Bios needs the same owner-asserted escape valve so that on nights the phone-only inference fails, sleep duration still reaches the dashboard at HIGH confidence. Aligned with the manifesto's "owner is final" principle.

## Pieces
- [`ManualSleepEntry`](android/app/src/main/java/com/bios/app/ui/sleep/ManualSleepEntry.kt) — pure-logic validator for the (bedtime, wake-time) pair. `NotStarted` / `Valid` / `Invalid` sealed result; **15-minute minimum** (matches `PhoneSleepInference`'s AWAKE-bout floor so manual and inferred windows speak the same language); 24-hour physiological ceiling. No Android deps — JVM-testable.
- [`SleepTileService`](android/app/src/main/java/com/bios/app/ingest/SleepTileService.kt) — `TileService` that flips between "Going to bed" (INACTIVE) and "Sleeping" (ACTIVE) on each tap. Stores bedtime in SharedPreferences so the tile survives system restarts of its host. On wake-tap, validates via `ManualSleepEntry` and writes via the existing [`SleepEntryRepo`](android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt) — SELF_REPORTED source, `ConfidenceTier.HIGH`. Invalid sessions (accidental double-tap, clock skew) drop with a tile-subtitle update and never poison the baseline.
- Manifest: tile service exported with `BIND_QUICK_SETTINGS_TILE` so the SystemUI add-tile picker can find it.
- 8 unit tests in [`ManualSleepEntryTest`](android/app/src/test/java/com/bios/app/ManualSleepEntryTest.kt).

## Reuses existing infra
- `SleepEntryRepo` already writes `SLEEP_DURATION` with SELF_REPORTED + HIGH confidence (the dashboard duration entry uses the same path).
- `BaselineEngine` already ignores SELF_REPORTED rows; the dashboard surfaces them through the **Recent nights** list.
- No new `SourceType` needed — the issue mentioned `OWNER_ASSERTED` "if not already present", but `SELF_REPORTED` + the existing `resolveSelfReportedSource` helper covers the semantics.

## Acceptance from #242
- [x] Tile appears in Android's add-tile picker (manifest service with `BIND_QUICK_SETTINGS_TILE` + `QS_TILE` intent filter).
- [x] Tapping tile twice (start/stop) produces a `SLEEP_DURATION` row with `ConfidenceTier.HIGH`.
- [x] Unit tests for the entry-to-MetricReading conversion (the validator path).
- [x] Pre-commit checks pass.
- [ ] Manual entry visible on dashboard alongside inferred rows — the existing **Recent nights** list already surfaces SLEEP_DURATION rows regardless of source; should "just work" but worth a manual verification post-merge.

## Out of scope for this cut (deferred)
- The Compose "I went to bed at X, woke up at Y" editable-times button on `SleepDashboardScreen`. The existing `SleepEntryScreen` already handles duration-based manual entry; a bedtime/waketime UX is a follow-up.
- Labelling on the dashboard distinguishing tile-written rows from dashboard-written rows. Both ride SELF_REPORTED; the existing renderer doesn't differentiate sub-source today.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, both flavours assembleDebug, unit tests).
- [ ] Manual: add the tile from the Quick Settings picker; tap to start, confirm "Sleeping" + subtitle update.
- [ ] Manual: tap again after 30 min; confirm "Logged 0h 30m" subtitle and a new SLEEP_DURATION row appears in the dashboard.
- [ ] Manual: tap twice in quick succession (under 15 min); confirm the invalid-session subtitle and no DB row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)