### PR TITLE
feat(ingest): phone-sleep sensor surface expansion (#243 Cut 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -45,7 +45,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         TreatmentCourse::class,
         GrowthMeasurement::class,
     ],
-    version = 28,
+    version = 29,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -103,7 +103,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged
@@ -480,6 +480,8 @@ abstract class BiosDatabase : RoomDatabase() {
         private val MIGRATION_20_21 = EmergencyContactMigrations.MIGRATION_20_21
         private val MIGRATION_21_22 = EcgStripMigrations.MIGRATION_21_22
         private val MIGRATION_22_23 = PerioperativeMigrations.MIGRATION_22_23
+        private val MIGRATION_28_29 = PhoneSleepSampleMigrations.MIGRATION_28_29
+
         fun buildInMemory(context: Context): BiosDatabase =
             Room.inMemoryDatabaseBuilder(context.applicationContext, BiosDatabase::class.java).build()
     }

--- a/android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt
+++ b/android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt
@@ -1,0 +1,31 @@
+package com.bios.app.data
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Schema migrations for the `phone_sleep_samples` table (#134 base,
+ * #243 Cut 1 expansion). Extracted from [BiosDatabase] to keep the
+ * host file under the 500-line cap; the original `CREATE TABLE` lives
+ * inline as `MIGRATION_10_11` and is left there to preserve the
+ * original chronology.
+ */
+internal object PhoneSleepSampleMigrations {
+
+    // Tier-1 phone-sleep sensor-surface expansion (#243 Cut 1). Three
+    // nullable columns added to phone_sleep_samples: stepDelta
+    // (TYPE_STEP_COUNTER delta since previous sample), dndEnabled
+    // (NotificationManager.currentInterruptionFilter), and
+    // pairedBluetoothConnected (BluetoothManager getConnectedDevices
+    // across HEADSET / A2DP profiles). Nullable so existing rows and
+    // devices missing the underlying signal keep working unchanged;
+    // the inference treats null as "ignore" until the Cut 2 decision-
+    // side weave lands.
+    val MIGRATION_28_29 = object : Migration(28, 29) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN stepDelta INTEGER")
+            db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN dndEnabled INTEGER")
+            db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN pairedBluetoothConnected INTEGER")
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -28,13 +28,34 @@ import kotlin.math.min
  */
 object PhoneSleepInference {
 
-    /** One phone-state observation, typically aggregated over ~1 minute. */
+    /**
+     * One phone-state observation, typically aggregated over ~1 minute.
+     *
+     * Tier-1 nullable additions (#243 Cut 1) are collection-only —
+     * [signalBreakdown] counts them, but [isQuietSample] / [stageAt] /
+     * [confidenceFor] do NOT consume them yet. The decision-side weave
+     * lands in Cut 2 once field data confirms each signal's predictive
+     * value. Until then, a null on any new field means "sensor /
+     * signal absent on this device — ignore" and the inference behaves
+     * exactly as it did before this PR.
+     */
     data class Sample(
         val timestamp: Long,
         val screenOff: Boolean,
         val charging: Boolean,
         val ambientLightLux: Float?,
         val accelMagnitudeVar: Float?,
+        /** Step delta since the previous sample (TYPE_STEP_COUNTER).
+         *  Zero across a sample window is a strong sleep prior. */
+        val stepDelta: Int? = null,
+        /** True when the owner has enabled Do Not Disturb (any non-ALL
+         *  interruption filter). Strong sleep-intent corroborator. */
+        val dndEnabled: Boolean? = null,
+        /** True when at least one paired Bluetooth peripheral (typically
+         *  a wearable / smart speaker / car system) is connected. Lets
+         *  the inference distinguish "phone on nightstand at home" from
+         *  "phone on a bar table at night." */
+        val pairedBluetoothConnected: Boolean? = null,
     )
 
     /**
@@ -225,7 +246,14 @@ object PhoneSleepInference {
     }
 
     /** Per-signal breakdown of the buffer so owners can diagnose which
-     *  signal is keeping the inference from firing. */
+     *  signal is keeping the inference from firing.
+     *
+     *  Tier-1 additions (#243 Cut 1): [zeroStepDelta], [dndOn], and
+     *  [pairedBtConnected] are observability counts of the new optional
+     *  signals; samples where the signal is absent (`null`) are not
+     *  counted. The denominator for each new count is on
+     *  [SignalBreakdown.sampledNewSignals] (samples that carried at
+     *  least one non-null new signal). */
     data class SignalBreakdown(
         val total: Int,
         val screenInactive: Int,
@@ -233,6 +261,16 @@ object PhoneSleepInference {
         val dark: Int,
         val charging: Int,
         val quiet: Int,
+        /** Samples with stepDelta == 0 (owner not walking). */
+        val zeroStepDelta: Int = 0,
+        /** Samples with DND enabled. */
+        val dndOn: Int = 0,
+        /** Samples with at least one paired BT peripheral connected. */
+        val pairedBtConnected: Int = 0,
+        /** Samples that carried at least one non-null Tier-1 new signal.
+         *  Acts as the denominator for the new counts on devices /
+         *  builds where any of the signals weren't recorded. */
+        val sampledNewSignals: Int = 0,
     )
 
     fun signalBreakdown(samples: List<Sample>): SignalBreakdown {
@@ -246,6 +284,12 @@ object PhoneSleepInference {
         }
         val charging = samples.count { it.charging }
         val quiet = samples.count { isQuietSample(it) }
+        val zeroStepDelta = samples.count { it.stepDelta == 0 }
+        val dndOn = samples.count { it.dndEnabled == true }
+        val pairedBtConnected = samples.count { it.pairedBluetoothConnected == true }
+        val sampledNewSignals = samples.count {
+            it.stepDelta != null || it.dndEnabled != null || it.pairedBluetoothConnected != null
+        }
         return SignalBreakdown(
             total = total,
             screenInactive = screenInactive,
@@ -253,6 +297,10 @@ object PhoneSleepInference {
             dark = dark,
             charging = charging,
             quiet = quiet,
+            zeroStepDelta = zeroStepDelta,
+            dndOn = dndOn,
+            pairedBtConnected = pairedBtConnected,
+            sampledNewSignals = sampledNewSignals,
         )
     }
 

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -1,8 +1,13 @@
 package com.bios.app.ingest
 
+import android.app.NotificationManager
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -40,11 +45,22 @@ class PhoneSleepAdapter(private val context: Context) {
         context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
     private val displayManager =
         context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+    // #243 Cut 1: read-only access to the corroborator signals. Each
+    // accessor is null-safe — adapters on devices that lack the
+    // service (rare) or with permissions revoked emit a null on the
+    // matching Sample field and the inference ignores it.
+    private val notificationManager: NotificationManager? =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+    private val bluetoothManager: BluetoothManager? =
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    private val stepDelta = StepCounterDelta(context)
 
     private val accelerometer: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
     private val lightSensor: Sensor? =
         sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
+    private val stepCounter: Sensor? =
+        sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
 
     /**
      * Returns true when the device has the minimum sensor surface needed
@@ -67,7 +83,66 @@ class PhoneSleepAdapter(private val context: Context) {
             charging = isPluggedIn(),
             ambientLightLux = readOnce(lightSensor, AMBIENT_LIGHT_TIMEOUT_MS),
             accelMagnitudeVar = sampleAccelVariance(accelWindowMs),
+            stepDelta = readStepDelta(),
+            dndEnabled = readDndEnabled(),
+            pairedBluetoothConnected = readPairedBluetoothConnected(),
         )
+    }
+
+    /**
+     * Step delta since the previous successful read on this device. Uses
+     * the shared [StepCounterDelta] so the sampler shares its cumulative
+     * checkpoint with [PhoneSensorAdapter] — reading the hardware
+     * counter twice would double-count walking. Returns null when the
+     * sensor is absent (most non-Pixel/-Samsung mid-tier phones) or
+     * when the listener never fires within the timeout.
+     */
+    private suspend fun readStepDelta(): Int? {
+        val sensor = stepCounter ?: return null
+        // Single-shot read of the cumulative counter. The OS treats it
+        // as a wake-up sensor on most devices, so the listener fires
+        // almost immediately; STEP_COUNTER_TIMEOUT_MS is a guard against
+        // silent failures (rare).
+        val cumulative = readOnce(sensor, STEP_COUNTER_TIMEOUT_MS)?.toLong() ?: return null
+        val delta = stepDelta.computeDelta(cumulative, sourceId = STEP_DELTA_SOURCE_ID)
+            ?: return 0
+        return delta.toInt()
+    }
+
+    /**
+     * True when the owner has any non-ALL interruption filter — DND
+     * scheduled, manually enabled, or in alarms-only / priority-only
+     * mode. A strong sleep-intent corroborator that survives the AOD-
+     * display-state ambiguity that confuses [isScreenInactive].
+     */
+    private fun readDndEnabled(): Boolean? {
+        val manager = notificationManager ?: return null
+        return manager.currentInterruptionFilter !=
+            NotificationManager.INTERRUPTION_FILTER_ALL
+    }
+
+    /**
+     * True when at least one paired Bluetooth peripheral is currently
+     * connected on the HEADSET or A2DP profile. The two profiles cover
+     * the home-life signal we care about: wearables, smart speakers,
+     * sleep-headphones, car systems. Returns null when the device
+     * lacks Bluetooth, has BT off, or the BLUETOOTH_CONNECT permission
+     * is missing (the manifest declares it, but the OS may revoke).
+     */
+    private fun readPairedBluetoothConnected(): Boolean? {
+        val manager = bluetoothManager ?: return null
+        val adapter: BluetoothAdapter = manager.adapter ?: return null
+        if (!adapter.isEnabled) return false
+        if (context.checkSelfPermission(android.Manifest.permission.BLUETOOTH_CONNECT)
+            != PackageManager.PERMISSION_GRANTED
+        ) return null
+        return try {
+            val connected = manager.getConnectedDevices(BluetoothProfile.HEADSET) +
+                manager.getConnectedDevices(BluetoothProfile.A2DP)
+            connected.isNotEmpty()
+        } catch (_: SecurityException) {
+            null
+        }
     }
 
     /**
@@ -163,5 +238,14 @@ class PhoneSleepAdapter(private val context: Context) {
         private const val GRAVITY = 9.81f
         private const val DEFAULT_ACCEL_WINDOW_MS = 5_000L
         private const val AMBIENT_LIGHT_TIMEOUT_MS = 1_000L
+        /** Wake-up step-counter listener timeout; matches the ambient-
+         *  light read pattern. Single-shot read of the cumulative
+         *  counter. */
+        private const val STEP_COUNTER_TIMEOUT_MS = 1_500L
+        /** Source id for the shared [StepCounterDelta] checkpoint. Kept
+         *  distinct from PhoneSensorAdapter's so the two readers don't
+         *  cannibalise each other's last-seen cumulative across
+         *  back-to-back fires. */
+        private const val STEP_DELTA_SOURCE_ID = "phone_sleep_step_delta"
     }
 }

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
@@ -125,6 +125,9 @@ class PhoneSleepCollectionService : Service() {
                         charging = sample.charging,
                         ambientLightLux = sample.ambientLightLux,
                         accelMagnitudeVar = sample.accelMagnitudeVar,
+                        stepDelta = sample.stepDelta,
+                        dndEnabled = sample.dndEnabled,
+                        pairedBluetoothConnected = sample.pairedBluetoothConnected,
                     )
                 )
             } catch (t: Throwable) {

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -80,6 +80,9 @@ class PhoneSleepWorker(
                     charging = sample.charging,
                     ambientLightLux = sample.ambientLightLux,
                     accelMagnitudeVar = sample.accelMagnitudeVar,
+                    stepDelta = sample.stepDelta,
+                    dndEnabled = sample.dndEnabled,
+                    pairedBluetoothConnected = sample.pairedBluetoothConnected,
                 )
             )
             // One-line per-firing diagnostic so the failure mode is
@@ -121,6 +124,9 @@ class PhoneSleepWorker(
                         charging = it.charging,
                         ambientLightLux = it.ambientLightLux,
                         accelMagnitudeVar = it.accelMagnitudeVar,
+                        stepDelta = it.stepDelta,
+                        dndEnabled = it.dndEnabled,
+                        pairedBluetoothConnected = it.pairedBluetoothConnected,
                     )
                 }
             val breakdown = PhoneSleepInference.signalBreakdown(samples)
@@ -195,6 +201,9 @@ class PhoneSleepWorker(
                     charging = fresh.charging,
                     ambientLightLux = fresh.ambientLightLux,
                     accelMagnitudeVar = fresh.accelMagnitudeVar,
+                    stepDelta = fresh.stepDelta,
+                    dndEnabled = fresh.dndEnabled,
+                    pairedBluetoothConnected = fresh.pairedBluetoothConnected,
                 )
             )
 
@@ -207,6 +216,9 @@ class PhoneSleepWorker(
                     charging = it.charging,
                     ambientLightLux = it.ambientLightLux,
                     accelMagnitudeVar = it.accelMagnitudeVar,
+                    stepDelta = it.stepDelta,
+                    dndEnabled = it.dndEnabled,
+                    pairedBluetoothConnected = it.pairedBluetoothConnected,
                 )
             }
             if (samples.size < MIN_SAMPLES_FOR_INFERENCE) {

--- a/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
+++ b/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
@@ -15,7 +15,9 @@ import androidx.room.PrimaryKey
  * an overnight window.
  *
  * The schema mirrors [com.bios.app.engine.PhoneSleepInference.Sample]
- * 1:1 so the worker maps row→Sample without translation logic.
+ * 1:1 so the worker maps row→Sample without translation logic. The
+ * Tier-1 expansion fields (#243 Cut 1) are nullable for backward-
+ * compatible reads of rows written before the migration landed.
  */
 @Entity(
     tableName = "phone_sleep_samples",
@@ -28,4 +30,10 @@ data class PhoneSleepSample(
     val charging: Boolean,
     val ambientLightLux: Float?,
     val accelMagnitudeVar: Float?,
+    // #243 Cut 1 — Tier-1 sensor-surface expansion. All nullable so a
+    // sample row from a device missing the underlying signal can still
+    // be persisted; the inference treats null as "ignore."
+    val stepDelta: Int? = null,
+    val dndEnabled: Boolean? = null,
+    val pairedBluetoothConnected: Boolean? = null,
 )

--- a/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
@@ -239,4 +239,89 @@ class PhoneSleepInferenceTest {
         timestamp = t, screenOff = false, charging = false,
         ambientLightLux = 300f, accelMagnitudeVar = 3f
     )
+
+    // ---- #243 Cut 1: Tier-1 sensor-surface expansion ----
+
+    @Test
+    fun signal_breakdown_counts_new_signals_when_present() {
+        // 5 samples: 3 with stepDelta=0 + DND on + paired BT on,
+        // 2 with stepDelta=42 + DND off + no BT.
+        val samples = buildList {
+            repeat(3) { i ->
+                add(
+                    Sample(
+                        timestamp = i.toLong(),
+                        screenOff = true,
+                        charging = true,
+                        ambientLightLux = 0f,
+                        accelMagnitudeVar = 0f,
+                        stepDelta = 0,
+                        dndEnabled = true,
+                        pairedBluetoothConnected = true,
+                    )
+                )
+            }
+            repeat(2) { i ->
+                add(
+                    Sample(
+                        timestamp = (3 + i).toLong(),
+                        screenOff = true,
+                        charging = true,
+                        ambientLightLux = 0f,
+                        accelMagnitudeVar = 0f,
+                        stepDelta = 42,
+                        dndEnabled = false,
+                        pairedBluetoothConnected = false,
+                    )
+                )
+            }
+        }
+        val breakdown = PhoneSleepInference.signalBreakdown(samples)
+        assertEquals(5, breakdown.total)
+        assertEquals(3, breakdown.zeroStepDelta)
+        assertEquals(3, breakdown.dndOn)
+        assertEquals(3, breakdown.pairedBtConnected)
+        assertEquals(5, breakdown.sampledNewSignals)
+    }
+
+    @Test
+    fun signal_breakdown_treats_null_new_signals_as_uncounted() {
+        // No Tier-1 signals recorded — counts stay at 0.
+        val samples = List(4) { i ->
+            Sample(
+                timestamp = i.toLong(),
+                screenOff = true,
+                charging = true,
+                ambientLightLux = 0f,
+                accelMagnitudeVar = 0f,
+                // stepDelta / dndEnabled / pairedBluetoothConnected default null.
+            )
+        }
+        val breakdown = PhoneSleepInference.signalBreakdown(samples)
+        assertEquals(4, breakdown.total)
+        assertEquals(0, breakdown.zeroStepDelta)
+        assertEquals(0, breakdown.dndOn)
+        assertEquals(0, breakdown.pairedBtConnected)
+        assertEquals(0, breakdown.sampledNewSignals)
+    }
+
+    @Test
+    fun new_signal_defaults_do_not_change_inference_behaviour() {
+        // 6 hours of sleepy samples with null Tier-1 fields → inference
+        // still fires. Confirms the new defaults don't suppress the
+        // pre-#243 firing path.
+        val minute = 60_000L
+        val sleepy = List(6 * 60) { i ->
+            Sample(
+                timestamp = i * minute,
+                screenOff = true,
+                charging = true,
+                ambientLightLux = 0f,
+                accelMagnitudeVar = 0f,
+                // stepDelta / dndEnabled / pairedBluetoothConnected default null.
+            )
+        }
+        val readings = PhoneSleepInference.infer(sleepy, sourceId = "test")
+        assertTrue(readings.isNotEmpty())
+    }
 }


### PR DESCRIPTION
## Summary
Adds the first three Tier-1 corroborator signals to `PhoneSleepInference.Sample`:

- **`stepDelta`** — `TYPE_STEP_COUNTER` delta since the previous sample. Zero across a sample window is a strong sleep prior; kills the "fell asleep on the couch with TV on" false negative.
- **`dndEnabled`** — `NotificationManager.currentInterruptionFilter != ALL`. Strong sleep-intent corroborator; survives the AOD-display-state ambiguity that already confuses `isQuietSample`.
- **`pairedBluetoothConnected`** — `BluetoothManager.getConnectedDevices` on HEADSET / A2DP. Distinguishes "phone on nightstand at home with paired watch" from "phone on a bar table at night."

Each new field is nullable. **`null` means "signal absent on this device"** and the inference ignores it — backward-compatible with rows written before the migration and with devices missing the underlying sensor / service.

## Collection-only this cut
`signalBreakdown()` counts the new signals for observability (matches the #240 Step 0 "instrument first, decide later" pattern) but **`isQuietSample` / `stageAt` / `confidenceFor` do NOT consume them yet**. The decision-side weave lands in Cut 2 once field data confirms each signal's predictive value. Until then, the inference behaves exactly as it did before this PR.

## Pieces
- [`PhoneSleepInference.kt`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt) — `Sample` data class gains 3 fields with `= null` defaults; `SignalBreakdown` gains 4 fields (`zeroStepDelta`, `dndOn`, `pairedBtConnected`, `sampledNewSignals` denominator).
- [`PhoneSleepSample.kt`](android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt) — Room entity gains the same 3 nullable columns.
- [`PhoneSleepSampleMigrations.kt`](android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt) — new file holding `MIGRATION_28_29` (DB v28 → v29 with three `ALTER TABLE` statements). Extracted so `BiosDatabase.kt` stays under the 500-line cap.
- [`PhoneSleepAdapter.kt`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt) — adds `readStepDelta()` / `readDndEnabled()` / `readPairedBluetoothConnected()`. Step counter shares the existing `StepCounterDelta` helper with a distinct source-id so two readers don't cannibalise each other's checkpoint. BT path null-safe across missing adapter / off-state / revoked perm.
- [`PhoneSleepWorker.kt`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt) and [`PhoneSleepCollectionService.kt`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt) — pass the new fields through at all four `PhoneSleepSample` mapping sites.
- No new manifest permissions: `ACTIVITY_RECOGNITION` and `BLUETOOTH_CONNECT` were already declared.

## Test plan
- [x] 3 new unit tests in `PhoneSleepInferenceTest`:
  - `signal_breakdown_counts_new_signals_when_present` — mixed-population sample verifies all four new breakdown counts.
  - `signal_breakdown_treats_null_new_signals_as_uncounted` — zero counts and zero `sampledNewSignals` denominator when fields are null.
  - `new_signal_defaults_do_not_change_inference_behaviour` — 6 h sleepy window with null Tier-1 fields still fires (no regression).
- [x] `code-quality-check.sh` green (file length, secrets, lint, both flavours assembleDebug, unit tests).
- [ ] Manual: run an overnight cycle on a Pixel; confirm the new columns are populated in `phone_sleep_samples` via the #253 debug screen.

## Out of scope (Tier 2+ — separate cuts)
- `TYPE_SIGNIFICANT_MOTION` and `TYPE_STATIONARY_DETECT` — trigger-based wake-up sensors need a different listener lifecycle than the periodic-sample model. Highest-value Cut 2 candidate.
- Gyroscope variance (helps cut "phone vibrating on a table" false positives).
- `TYPE_PROXIMITY` (face-down vs face-up nightstand placement).
- `UsageStatsManager` last-unlock signal.
- Tier-3 environmental sensors (ambient temperature, barometric pressure, lux flicker spectral density).

The issue (#243) stays open until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)