### PR TITLE
feat(ui): wearable-recommendation banner + tiered hardware list (#245)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -380,7 +380,15 @@ fun BiosApp(viewModel: AppViewModel) {
             composable("sleep_dashboard") {
                 com.bios.app.ui.sleep.SleepDashboardScreen(
                     viewModel = viewModel,
-                    onBack = { navController.popBackStack() }
+                    onBack = { navController.popBackStack() },
+                    onSeeWearableRecommendations = {
+                        navController.navigate("wearable_recommendations")
+                    },
+                )
+            }
+            composable("wearable_recommendations") {
+                com.bios.app.ui.sleep.WearableRecommendationScreen(
+                    onBack = { navController.popBackStack() },
                 )
             }
             composable("active_substances") {

--- a/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt
@@ -68,6 +68,7 @@ import java.util.Locale
 fun SleepDashboardScreen(
     viewModel: AppViewModel,
     onBack: () -> Unit,
+    onSeeWearableRecommendations: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -82,6 +83,10 @@ fun SleepDashboardScreen(
     var longestQuietMs by remember { mutableStateOf(0L) }
     var signalBreakdown by remember {
         mutableStateOf<com.bios.app.engine.PhoneSleepInference.SignalBreakdown?>(null)
+    }
+    // #245 — banner state: gate-derived + persisted dismissed timestamp.
+    var bannerDismissedAtMs by remember {
+        mutableStateOf(WearableRecommendationStore.getDismissedAtMs(context))
     }
 
     LaunchedEffect(windowDays, refreshTick) {
@@ -132,6 +137,32 @@ fun SleepDashboardScreen(
         )
     }
 
+    // #245 — wearable-recommendation banner: pure-function gate over the
+    // last 7 calendar nights, honoring a 30-day cooldown after dismissal.
+    // Both `remember` calls must live at the Composable scope (not
+    // inside the LazyColumn lambda).
+    val recentNights = remember(nights) {
+        WearableRecommendationGate.binByNight(
+            readingsNewestFirst = nights,
+            localDayKey = { ms ->
+                val cal = java.util.Calendar.getInstance().apply {
+                    timeInMillis = ms
+                    set(java.util.Calendar.HOUR_OF_DAY, 0)
+                    set(java.util.Calendar.MINUTE, 0)
+                    set(java.util.Calendar.SECOND, 0)
+                    set(java.util.Calendar.MILLISECOND, 0)
+                }
+                cal.timeInMillis / (24L * 60L * 60L * 1000L)
+            },
+        )
+    }
+    val showWearableBanner = remember(recentNights, bannerDismissedAtMs) {
+        WearableRecommendationGate.shouldShow(
+            recentNights = recentNights,
+            dismissedAtMs = bannerDismissedAtMs,
+        )
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -167,6 +198,18 @@ fun SleepDashboardScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item { WindowSelector(windowDays) { windowDays = it } }
+            if (showWearableBanner) {
+                item {
+                    WearableRecommendationBanner(
+                        onSeeRecommendations = onSeeWearableRecommendations,
+                        onDismiss = {
+                            val now = System.currentTimeMillis()
+                            WearableRecommendationStore.markDismissedNow(context, now)
+                            bannerDismissedAtMs = now
+                        },
+                    )
+                }
+            }
             inferenceMessage?.let { msg ->
                 item { InferenceResultCard(msg) }
             }

--- a/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationBanner.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationBanner.kt
@@ -1,0 +1,99 @@
+package com.bios.app.ui.sleep
+
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * One-time dismissable banner for the sleep dashboard (#245).
+ *
+ * Surface contract — manifesto framing:
+ *   - States a fact (phone-only sleep tracking is unreliable).
+ *   - Offers an option (look at recommended wearables).
+ *   - Does not push the owner toward buying anything.
+ *
+ * Honest expectations carried in copy: even a wearable gives reliable
+ * total sleep time and onset/offset, not reliable stage classification.
+ * That matches Gadgetbridge's own conclusion after a decade of work.
+ */
+@Composable
+internal fun WearableRecommendationBanner(
+    onSeeRecommendations: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Phone-only sleep tracking is unreliable",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Bios's phone-only inference has produced only low-confidence " +
+                    "or missing rows for the past week. A wearable gives reliable " +
+                    "total sleep time and onset/offset (stage classification stays " +
+                    "approximate even on premium hardware).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Dismiss")
+                }
+                Spacer(Modifier.height(0.dp))
+                TextButton(onClick = onSeeRecommendations) {
+                    Text("See recommendations")
+                }
+            }
+        }
+    }
+}
+
+/**
+ * SharedPreferences-backed store for the banner's dismissed-at
+ * timestamp. The Compose call site reads on first render and writes
+ * on dismissal. Lifted out as `object` functions so the test side
+ * doesn't need a fake Context.
+ */
+internal object WearableRecommendationStore {
+
+    private const val PREFS_NAME = "bios_settings"
+    private const val KEY_DISMISSED_AT_MS = "wearable_recommendation_dismissed_at_ms"
+
+    fun getDismissedAtMs(context: Context): Long? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getLong(KEY_DISMISSED_AT_MS, 0L)
+        return if (raw > 0L) raw else null
+    }
+
+    fun markDismissedNow(context: Context, now: Long = System.currentTimeMillis()) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putLong(KEY_DISMISSED_AT_MS, now)
+            .apply()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationGate.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationGate.kt
@@ -1,0 +1,123 @@
+package com.bios.app.ui.sleep
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+
+/**
+ * Pure predicate that decides whether the wearable-recommendation
+ * banner (#245) should appear on the sleep dashboard.
+ *
+ * Even with the lifecycle fix (#241), the sensor-surface expansion
+ * (#243), Cole-Kripke (#244), and per-owner baselining, the phone-only
+ * ceiling is structurally low — Sleep As Android's decade of phone-
+ * only ML caps at ~1/3 awake-period recall, and Gadgetbridge's
+ * 10+-year FOSS effort explicitly chose **not** to attempt phone-side
+ * sleep inference. When Bios's phone-only inference has been
+ * producing only LOW-confidence rows (or nothing) for a sustained
+ * window, the honest escape valve is to surface the option of a
+ * wearable.
+ *
+ * Manifesto framing: this is a **suggestion**, not a nag. The
+ * predicate fires once and the surface is dismissable; a 30-day
+ * cooldown re-evaluates only if the condition still holds.
+ *
+ * ## When the banner shows
+ *
+ * 1. The last [REQUIRED_NIGHTS] calendar nights in the inference
+ *    window each carry either:
+ *    - no SLEEP_DURATION reading at all, **or**
+ *    - only readings at [ConfidenceTier.LOW] (or VENDOR_DERIVED) from
+ *      any source.
+ * 2. AND the owner has not dismissed the banner inside the past
+ *    [REDISPLAY_AFTER_MS].
+ *
+ * Pure-function — takes the night-list and the dismissed-at timestamp
+ * (or null) and returns a Boolean. The Compose-side caller persists
+ * the dismissed timestamp via SharedPreferences; the predicate is
+ * Android-free for JVM unit testing.
+ */
+object WearableRecommendationGate {
+
+    /**
+     * Consecutive-night threshold. 7 nights is the smallest window
+     * that's clearly "a pattern, not a fluke" — a single bad night
+     * (travel, late dinner, sick) won't trip it.
+     */
+    const val REQUIRED_NIGHTS: Int = 7
+
+    /**
+     * Re-display cooldown after the owner dismisses the banner.
+     * 30 days = roughly "ask once a month if the condition still
+     * holds." Anything tighter starts to feel like a nag.
+     */
+    const val REDISPLAY_AFTER_MS: Long = 30L * 24L * 60L * 60L * 1000L
+
+    /**
+     * One night's worth of SLEEP_DURATION rows. The dashboard already
+     * sorts and bins by calendar night; the gate takes the binned list.
+     */
+    data class Night(val readings: List<MetricReading>) {
+        /**
+         * True when this night carries either no reading at all or
+         * only LOW-class confidence rows. VENDOR_DERIVED counts as
+         * LOW for this gate — it's the "vendor said so, no
+         * Bios-side validation" tier and doesn't clear the
+         * unreliable-inference bar.
+         */
+        val isLowOrMissing: Boolean
+            get() = readings.isEmpty() || readings.all {
+                it.confidence <= ConfidenceTier.LOW.level
+            }
+    }
+
+    /**
+     * Evaluate the gate.
+     *
+     * @param recentNights last N calendar nights, newest first. Must
+     *   contain at least [REQUIRED_NIGHTS] entries for the gate to
+     *   fire — fewer entries means the dashboard hasn't had enough
+     *   time to observe the pattern.
+     * @param dismissedAtMs SharedPreferences-persisted timestamp of
+     *   the most recent dismissal (or null if never dismissed).
+     * @param nowMs current wall-clock time. Injected so tests can
+     *   pin the cooldown evaluation.
+     */
+    fun shouldShow(
+        recentNights: List<Night>,
+        dismissedAtMs: Long?,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Boolean {
+        if (recentNights.size < REQUIRED_NIGHTS) return false
+        val lastN = recentNights.take(REQUIRED_NIGHTS)
+        if (!lastN.all { it.isLowOrMissing }) return false
+        if (dismissedAtMs == null) return true
+        return (nowMs - dismissedAtMs) >= REDISPLAY_AFTER_MS
+    }
+
+    /**
+     * Bin a flat MetricReading list (newest first, as the dashboard
+     * already produces) into per-calendar-night [Night] buckets. The
+     * caller passes the result to [shouldShow]. The dashboard uses a
+     * local-time day key; injecting `localDayKey` keeps this pure.
+     */
+    fun binByNight(
+        readingsNewestFirst: List<MetricReading>,
+        localDayKey: (Long) -> Long,
+        nightsBack: Int = REQUIRED_NIGHTS,
+        nowMs: Long = System.currentTimeMillis(),
+    ): List<Night> {
+        val nowDay = localDayKey(nowMs)
+        val buckets = LinkedHashMap<Long, MutableList<MetricReading>>()
+        // Pre-seed the most-recent N days so empty nights still register
+        // as a Night with no readings — that's the missing-row case the
+        // gate needs to see.
+        for (offset in 0 until nightsBack) {
+            buckets[nowDay - offset] = mutableListOf()
+        }
+        for (r in readingsNewestFirst) {
+            val day = localDayKey(r.timestamp)
+            buckets[day]?.add(r)
+        }
+        return buckets.values.map { Night(it.toList()) }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationScreen.kt
@@ -1,0 +1,226 @@
+package com.bios.app.ui.sleep
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Owner-facing tiered list of wearables that the existing
+ * [com.bios.app.ingest.GadgetbridgeAdapter] (and / or the native API
+ * adapters) can ingest from (#245).
+ *
+ * Manifesto framing — same as the banner that brings the owner here:
+ *   - This is a **suggestion**, not a recommendation engine.
+ *   - We surface what's available + the trade-offs; the owner decides.
+ *   - No affiliate links, no telemetry on view, no nudges.
+ *
+ * Each tier lists rough price, the FOSS pipeline the device speaks,
+ * the data quality to expect, and the pairing caveat if any. Honest
+ * about Gadgetbridge's own conclusion — even wrist-worn deep-sleep
+ * detection is "not reliable" on most consumer watches.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WearableRecommendationScreen(onBack: () -> Unit) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Recommended wearables") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                }
+            },
+        )
+        LazyColumn(
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { IntroCard() }
+            items(TIERS, key = { it.title }) { tier -> TierCard(tier) }
+            item { SkipForNowCard() }
+            item { HonestNoteCard() }
+        }
+    }
+}
+
+@Composable
+private fun IntroCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "What a wearable adds over phone-only",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "Total sleep time and onset / offset become reliable. " +
+                    "Stage classification stays approximate even on premium " +
+                    "hardware — Gadgetbridge's own decade of work concluded " +
+                    "wrist-worn deep-sleep detection is not reliable for " +
+                    "most consumer watches.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TierCard(tier: WearableTier) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                tier.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                tier.priceRange,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(tier.description, style = MaterialTheme.typography.bodyMedium)
+            Spacer(Modifier.height(6.dp))
+            Text(
+                "Pipeline: ${tier.pipeline}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "Expected quality: ${tier.qualityNote}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            tier.caveat?.let {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Caveat: $it",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SkipForNowCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Skip for now",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "PineTime — sleep-tracking PR not yet merged.\n" +
+                    "AsteroidOS 2.0 — no sleep tracking.\n" +
+                    "Pebble (revived by Core Devices) — check ship date.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HonestNoteCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "No affiliate links, no telemetry",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "Bios records nothing about whether you opened this screen " +
+                    "or what you tapped on. No vendor sponsors any tier.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private data class WearableTier(
+    val title: String,
+    val priceRange: String,
+    val description: String,
+    val pipeline: String,
+    val qualityNote: String,
+    val caveat: String?,
+)
+
+private val TIERS: List<WearableTier> = listOf(
+    WearableTier(
+        title = "Tier 1 — Best $/signal: Xiaomi Mi Band 7 / 8",
+        priceRange = "~$40-$50",
+        description = "Solid heart rate + motion + decent battery. Mi Band 8 even " +
+            "pushes raw light / deep / REM stages through the xiaomi-protobuf " +
+            "path that Gadgetbridge supports.",
+        pipeline = "Gadgetbridge (xiaomi-protobuf)",
+        qualityNote = "Reliable total sleep time + onset / offset; approximate stages.",
+        caveat = "Token-pairing on newer Huami firmware sometimes needs root or " +
+            "a one-time vendor-app handshake.",
+    ),
+    WearableTier(
+        title = "Tier 2 — Best FOSS philosophy: Bangle.js 2",
+        priceRange = "~$89",
+        description = "Fully open hardware + firmware. MIT-licensed app ecosystem. " +
+            "The on-watch `sleeplog` app runs accel + HR sleep tracking locally.",
+        pipeline = "Gadgetbridge (Bangle.js)",
+        qualityNote = "Honest mid-tier — total sleep time + onset / offset are " +
+            "reliable; staging stays approximate.",
+        caveat = null,
+    ),
+    WearableTier(
+        title = "Tier 3 — Premium: Garmin Instinct 3 / Fenix",
+        priceRange = "~$300-$1000+",
+        description = "Native on-watch sleep staging. Syncs to Gadgetbridge without " +
+            "the proprietary Garmin app. Bios also has a direct GarminApiAdapter.",
+        pipeline = "Gadgetbridge or direct GarminApiAdapter",
+        qualityNote = "Premium total sleep + onset / offset; the closest consumer-" +
+            "tier device to research-grade staging (still approximate).",
+        caveat = null,
+    ),
+)

--- a/android/app/src/test/java/com/bios/app/WearableRecommendationGateTest.kt
+++ b/android/app/src/test/java/com/bios/app/WearableRecommendationGateTest.kt
@@ -1,0 +1,134 @@
+package com.bios.app
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.sleep.WearableRecommendationGate
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for [WearableRecommendationGate.shouldShow]. Covers
+ * the four firing cases the #245 banner UX cares about: too-few-nights,
+ * all-low/missing, mixed (a single HIGH night blocks), and the post-
+ * dismissal cooldown.
+ */
+class WearableRecommendationGateTest {
+
+    private val night = WearableRecommendationGate.Night(emptyList())
+
+    private fun lowNight(): WearableRecommendationGate.Night {
+        return WearableRecommendationGate.Night(
+            listOf(reading(confidence = ConfidenceTier.LOW))
+        )
+    }
+
+    private fun missingNight(): WearableRecommendationGate.Night =
+        WearableRecommendationGate.Night(emptyList())
+
+    private fun mediumNight(): WearableRecommendationGate.Night {
+        return WearableRecommendationGate.Night(
+            listOf(reading(confidence = ConfidenceTier.MEDIUM))
+        )
+    }
+
+    private fun reading(confidence: ConfidenceTier): MetricReading =
+        MetricReading(
+            metricType = "sleep_duration",
+            value = 7.0 * 3600.0,
+            timestamp = 0L,
+            sourceId = "test",
+            confidence = confidence.level,
+        )
+
+    @Test
+    fun fewer_than_seven_nights_never_fires() {
+        val recent = List(6) { lowNight() }
+        assertFalse(
+            WearableRecommendationGate.shouldShow(recent, dismissedAtMs = null)
+        )
+    }
+
+    @Test
+    fun seven_low_or_missing_nights_fires() {
+        val recent = listOf(
+            lowNight(), missingNight(), lowNight(), missingNight(),
+            lowNight(), lowNight(), missingNight(),
+        )
+        assertTrue(
+            WearableRecommendationGate.shouldShow(recent, dismissedAtMs = null)
+        )
+    }
+
+    @Test
+    fun a_single_medium_or_better_night_blocks_the_banner() {
+        val recent = listOf(
+            lowNight(), lowNight(), lowNight(), mediumNight(),
+            lowNight(), lowNight(), lowNight(),
+        )
+        assertFalse(
+            WearableRecommendationGate.shouldShow(recent, dismissedAtMs = null)
+        )
+    }
+
+    @Test
+    fun recent_dismissal_suppresses_re_fire() {
+        val recent = List(7) { lowNight() }
+        val now = 1_716_000_000_000L
+        val dismissed = now - 10L * 24L * 60L * 60L * 1000L // 10 days ago
+        assertFalse(
+            WearableRecommendationGate.shouldShow(
+                recentNights = recent,
+                dismissedAtMs = dismissed,
+                nowMs = now,
+            )
+        )
+    }
+
+    @Test
+    fun dismissal_older_than_thirty_days_re_fires() {
+        val recent = List(7) { lowNight() }
+        val now = 1_716_000_000_000L
+        val dismissed = now - 31L * 24L * 60L * 60L * 1000L // 31 days ago
+        assertTrue(
+            WearableRecommendationGate.shouldShow(
+                recentNights = recent,
+                dismissedAtMs = dismissed,
+                nowMs = now,
+            )
+        )
+    }
+
+    @Test
+    fun bin_by_night_preserves_seven_buckets_even_with_empty_history() {
+        val binned = WearableRecommendationGate.binByNight(
+            readingsNewestFirst = emptyList(),
+            localDayKey = { ms -> ms / (24L * 60L * 60L * 1000L) },
+            nightsBack = 7,
+            nowMs = 7L * 24L * 60L * 60L * 1000L,
+        )
+        // 7 empty Night buckets — all isLowOrMissing == true.
+        assertTrue(binned.size == 7)
+        assertTrue(binned.all { it.isLowOrMissing })
+    }
+
+    @Test
+    fun bin_by_night_routes_readings_to_their_day_bucket() {
+        val day = 24L * 60L * 60L * 1000L
+        val now = 7L * day + day / 2 // halfway through day 7
+        val readings = listOf(
+            // Today (day 7) — a single LOW reading
+            reading(ConfidenceTier.LOW).copy(timestamp = now - 1_000L),
+            // 5 days ago (day 2) — a MEDIUM reading
+            reading(ConfidenceTier.MEDIUM).copy(timestamp = now - 5L * day),
+        )
+        val binned = WearableRecommendationGate.binByNight(
+            readingsNewestFirst = readings,
+            localDayKey = { ms -> ms / day },
+            nightsBack = 7,
+            nowMs = now,
+        )
+        val nonEmpty = binned.filter { it.readings.isNotEmpty() }
+        assertTrue(nonEmpty.size == 2)
+    }
+}


### PR DESCRIPTION
## Summary
After 7 consecutive nights of only LOW-confidence (or missing) sleep rows, the sleep dashboard surfaces a one-time **dismissable** banner inviting the owner to look at a curated hardware list. 30-day cooldown after dismissal so the surface never becomes a nag.

## Manifesto framing
- States a fact (phone-only inference is unreliable for you right now).
- Offers an option (recommended wearables that Bios already ingests from via the existing `GadgetbridgeAdapter` / `GarminApiAdapter`).
- **Never** pushes the owner toward buying anything. No affiliate links, no view telemetry, no vendor sponsorships.
- Honest about what a wearable gives (reliable total sleep + onset/offset) vs. what it doesn't (reliable stage classification — Gadgetbridge's own decade-long conclusion).

## Pieces
- [`WearableRecommendationGate`](android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationGate.kt) — pure-function predicate over the last N nights + dismissed-at timestamp. `binByNight()` turns the dashboard's newest-first `MetricReading` list into per-calendar-night `Night` buckets; `shouldShow()` applies the 7-night and 30-day rules. JVM-testable.
- [`WearableRecommendationBanner`](android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationBanner.kt) — small dismissable `Card`. Hosts the `WearableRecommendationStore` SharedPreferences-backed dismissed-at timestamp.
- [`WearableRecommendationScreen`](android/app/src/main/java/com/bios/app/ui/sleep/WearableRecommendationScreen.kt) — tiered list:
  - **Tier 1** Mi Band 7 / 8 (~$40-50) — best $/signal via Gadgetbridge `xiaomi-protobuf`. Token-pairing caveat surfaced.
  - **Tier 2** Bangle.js 2 (~$89) — best FOSS philosophy. Open hardware + firmware + MIT app ecosystem.
  - **Tier 3** Garmin Instinct 3 / Fenix (~$300-1000+) — premium native staging via either Gadgetbridge or direct `GarminApiAdapter`.
  - Skip-for-now section: PineTime (sleep PR not merged), AsteroidOS 2.0 (no sleep tracking), revived Pebble (check ship date).
- [`MainActivity`](android/app/src/main/java/com/bios/app/ui/MainActivity.kt) — new `composable("wearable_recommendations")` route; `onSeeWearableRecommendations` threaded through `SleepDashboardScreen`.

## Acceptance from #245
- [x] Banner appears after ≥ 7 consecutive nights of LOW-or-missing inferred sleep.
- [x] Dismissable. Re-appears after ≥ 30 days if condition still holds.
- [x] Hardware list reflects the tiered structure called out in the issue.
- [x] Each device documents rough price, FOSS pipeline, data quality, pairing caveat.
- [x] Unit test for the "N LOW nights" predicate (7 tests).
- [x] Pre-commit checks pass.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, both flavours assembleDebug, unit tests).
- [ ] Manual: simulate 7 LOW-confidence sleep nights in the dashboard window; confirm the banner appears.
- [ ] Manual: tap "See recommendations"; confirm the tiered-list screen renders with all three tiers + the skip-for-now + honest-note cards.
- [ ] Manual: tap "Dismiss"; confirm the banner disappears and stays gone on re-entry.

## Out of scope
- `docs/RECOMMENDED_WEARABLES.md` reference doc — the in-app screen carries the full content. Documentation file would duplicate; defer until needed.
- Per-tier deep links to the device's pairing UI — out of scope per the manifesto-clean "we suggest, owner picks" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)