### PR TITLE
feat(ingest): wake-up motion sensors + stationary weave (#243 Cut 2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -73,6 +73,14 @@ class BiosApplication : Application() {
         // self-skips otherwise).
         com.bios.app.ingest.PhoneSleepWorker.enqueuePeriodicWork(this)
 
+        // Arm the wake-up motion tracker so SIGNIFICANT_MOTION /
+        // STATIONARY_DETECT listeners are live before the periodic
+        // worker fires (#243 Cut 2). The short-lived adapter the worker
+        // builds per firing wouldn't otherwise give the sensors time to
+        // observe a state transition; attaching here means the sensor-
+        // hub is already tracking when the first sample is taken.
+        com.bios.app.ingest.WakeUpMotionTracker.attach(this)
+
         // Register the charge-edge receiver for the new foreground
         // collection service (#241). ACTION_POWER_CONNECTED /
         // _DISCONNECTED are not on the API 26+ implicit-broadcast

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -45,7 +45,7 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         TreatmentCourse::class,
         GrowthMeasurement::class,
     ],
-    version = 29,
+    version = 30,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -103,7 +103,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged
@@ -481,6 +481,7 @@ abstract class BiosDatabase : RoomDatabase() {
         private val MIGRATION_21_22 = EcgStripMigrations.MIGRATION_21_22
         private val MIGRATION_22_23 = PerioperativeMigrations.MIGRATION_22_23
         private val MIGRATION_28_29 = PhoneSleepSampleMigrations.MIGRATION_28_29
+        private val MIGRATION_29_30 = PhoneSleepSampleMigrations.MIGRATION_29_30
 
         fun buildInMemory(context: Context): BiosDatabase =
             Room.inMemoryDatabaseBuilder(context.applicationContext, BiosDatabase::class.java).build()

--- a/android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt
+++ b/android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt
@@ -28,4 +28,19 @@ internal object PhoneSleepSampleMigrations {
             db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN pairedBluetoothConnected INTEGER")
         }
     }
+
+    // Tier-1 phone-sleep wake-up motion sensors (#243 Cut 2). Two more
+    // nullable columns: significantMotionFired (TYPE_SIGNIFICANT_MOTION
+    // recency flag) and stationary (TYPE_STATIONARY_DETECT current
+    // state). Nullable so devices missing either wake-up sensor keep
+    // recording other signals unchanged; the inference treats null as
+    // "ignore." The stationary field is consumed by isQuietSample
+    // because hardware-confirmed multi-second stillness bypasses the
+    // AOD-display-state ambiguity that the variance proxy can't.
+    val MIGRATION_29_30 = object : Migration(29, 30) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN significantMotionFired INTEGER")
+            db.execSQL("ALTER TABLE phone_sleep_samples ADD COLUMN stationary INTEGER")
+        }
+    }
 }

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -31,13 +31,15 @@ object PhoneSleepInference {
     /**
      * One phone-state observation, typically aggregated over ~1 minute.
      *
-     * Tier-1 nullable additions (#243 Cut 1) are collection-only —
-     * [signalBreakdown] counts them, but [isQuietSample] / [stageAt] /
-     * [confidenceFor] do NOT consume them yet. The decision-side weave
-     * lands in Cut 2 once field data confirms each signal's predictive
-     * value. Until then, a null on any new field means "sensor /
-     * signal absent on this device — ignore" and the inference behaves
-     * exactly as it did before this PR.
+     * Tier-1 nullable additions (#243 Cut 1) are collection-only with
+     * one exception: [stationary] is consumed by [isQuietSample] (#243
+     * Cut 2) because hardware-confirmed multi-second stillness is much
+     * stronger than the accelerometer-variance proxy and crucially
+     * bypasses the AOD-display-state ambiguity. The remaining new
+     * fields stay observability-only until field data confirms their
+     * predictive value; a null on any new field means "sensor / signal
+     * absent on this device — ignore" and the inference behaves
+     * exactly as before for that field.
      */
     data class Sample(
         val timestamp: Long,
@@ -56,6 +58,16 @@ object PhoneSleepInference {
          *  the inference distinguish "phone on nightstand at home" from
          *  "phone on a bar table at night." */
         val pairedBluetoothConnected: Boolean? = null,
+        /** True when SIGNIFICANT_MOTION fired within the recency window
+         *  before this sample (#243 Cut 2). Collection-only for now;
+         *  observability via [signalBreakdown]. */
+        val significantMotionFired: Boolean? = null,
+        /** Hardware-confirmed stillness from TYPE_STATIONARY_DETECT
+         *  (#243 Cut 2). When `true` AND charging, [isQuietSample]
+         *  accepts the sample regardless of screen / lux state — this
+         *  is the AOD-on-nightstand signature with the strongest
+         *  primary sensor we have. */
+        val stationary: Boolean? = null,
     )
 
     /**
@@ -175,6 +187,13 @@ object PhoneSleepInference {
      */
     internal fun isQuietSample(s: Sample): Boolean {
         if (s.screenOff) return true
+        // #243 Cut 2: hardware-confirmed stillness + charging is the
+        // AOD-on-nightstand signature with the strongest primary signal
+        // we have. STATIONARY_DETECT requires multi-second stillness in
+        // the sensor hub — much stronger than the variance proxy, and
+        // bypasses the lux check (streetlight through a window must
+        // not disqualify a clearly-stationary plugged-in device).
+        if (s.stationary == true && s.charging) return true
         val lowMotion = (s.accelMagnitudeVar ?: Float.MAX_VALUE) < ACTIVITY_THRESHOLD
         val dark = (s.ambientLightLux ?: Float.MAX_VALUE) < DARK_LUX_THRESHOLD
         return s.charging && lowMotion && dark
@@ -248,12 +267,12 @@ object PhoneSleepInference {
     /** Per-signal breakdown of the buffer so owners can diagnose which
      *  signal is keeping the inference from firing.
      *
-     *  Tier-1 additions (#243 Cut 1): [zeroStepDelta], [dndOn], and
-     *  [pairedBtConnected] are observability counts of the new optional
-     *  signals; samples where the signal is absent (`null`) are not
-     *  counted. The denominator for each new count is on
-     *  [SignalBreakdown.sampledNewSignals] (samples that carried at
-     *  least one non-null new signal). */
+     *  Tier-1 additions (#243 Cut 1 + Cut 2): [zeroStepDelta], [dndOn],
+     *  [pairedBtConnected], [sigMotionFired], and [stationaryDetected]
+     *  are observability counts of the new optional signals; samples
+     *  where the signal is absent (`null`) are not counted. The
+     *  denominator for each new count is on [sampledNewSignals]
+     *  (samples that carried at least one non-null new signal). */
     data class SignalBreakdown(
         val total: Int,
         val screenInactive: Int,
@@ -267,6 +286,12 @@ object PhoneSleepInference {
         val dndOn: Int = 0,
         /** Samples with at least one paired BT peripheral connected. */
         val pairedBtConnected: Int = 0,
+        /** Samples where SIGNIFICANT_MOTION fired in the recency
+         *  window (#243 Cut 2). */
+        val sigMotionFired: Int = 0,
+        /** Samples where STATIONARY_DETECT confirms the device is
+         *  currently still (#243 Cut 2). */
+        val stationaryDetected: Int = 0,
         /** Samples that carried at least one non-null Tier-1 new signal.
          *  Acts as the denominator for the new counts on devices /
          *  builds where any of the signals weren't recorded. */
@@ -287,8 +312,12 @@ object PhoneSleepInference {
         val zeroStepDelta = samples.count { it.stepDelta == 0 }
         val dndOn = samples.count { it.dndEnabled == true }
         val pairedBtConnected = samples.count { it.pairedBluetoothConnected == true }
+        val sigMotionFired = samples.count { it.significantMotionFired == true }
+        val stationaryDetected = samples.count { it.stationary == true }
         val sampledNewSignals = samples.count {
-            it.stepDelta != null || it.dndEnabled != null || it.pairedBluetoothConnected != null
+            it.stepDelta != null || it.dndEnabled != null ||
+                it.pairedBluetoothConnected != null ||
+                it.significantMotionFired != null || it.stationary != null
         }
         return SignalBreakdown(
             total = total,
@@ -300,6 +329,8 @@ object PhoneSleepInference {
             zeroStepDelta = zeroStepDelta,
             dndOn = dndOn,
             pairedBtConnected = pairedBtConnected,
+            sigMotionFired = sigMotionFired,
+            stationaryDetected = stationaryDetected,
             sampledNewSignals = sampledNewSignals,
         )
     }

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -77,6 +77,11 @@ class PhoneSleepAdapter(private val context: Context) {
      */
     suspend fun sample(accelWindowMs: Long = DEFAULT_ACCEL_WINDOW_MS): PhoneSleepInference.Sample {
         val now = System.currentTimeMillis()
+        // #243 Cut 2: defensive attach so test contexts and any future
+        // entry path that bypasses BiosApplication still get a live
+        // tracker. The attach is idempotent.
+        WakeUpMotionTracker.attach(context)
+        val motion = WakeUpMotionTracker.snapshot(now)
         return PhoneSleepInference.Sample(
             timestamp = now,
             screenOff = isScreenInactive(),
@@ -86,6 +91,8 @@ class PhoneSleepAdapter(private val context: Context) {
             stepDelta = readStepDelta(),
             dndEnabled = readDndEnabled(),
             pairedBluetoothConnected = readPairedBluetoothConnected(),
+            significantMotionFired = motion.significantMotionFired,
+            stationary = motion.stationary,
         )
     }
 

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
@@ -128,6 +128,8 @@ class PhoneSleepCollectionService : Service() {
                         stepDelta = sample.stepDelta,
                         dndEnabled = sample.dndEnabled,
                         pairedBluetoothConnected = sample.pairedBluetoothConnected,
+                        significantMotionFired = sample.significantMotionFired,
+                        stationary = sample.stationary,
                     )
                 )
             } catch (t: Throwable) {

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -83,6 +83,8 @@ class PhoneSleepWorker(
                     stepDelta = sample.stepDelta,
                     dndEnabled = sample.dndEnabled,
                     pairedBluetoothConnected = sample.pairedBluetoothConnected,
+                    significantMotionFired = sample.significantMotionFired,
+                    stationary = sample.stationary,
                 )
             )
             // One-line per-firing diagnostic so the failure mode is
@@ -127,6 +129,8 @@ class PhoneSleepWorker(
                         stepDelta = it.stepDelta,
                         dndEnabled = it.dndEnabled,
                         pairedBluetoothConnected = it.pairedBluetoothConnected,
+                        significantMotionFired = it.significantMotionFired,
+                        stationary = it.stationary,
                     )
                 }
             val breakdown = PhoneSleepInference.signalBreakdown(samples)
@@ -204,6 +208,8 @@ class PhoneSleepWorker(
                     stepDelta = fresh.stepDelta,
                     dndEnabled = fresh.dndEnabled,
                     pairedBluetoothConnected = fresh.pairedBluetoothConnected,
+                    significantMotionFired = fresh.significantMotionFired,
+                    stationary = fresh.stationary,
                 )
             )
 
@@ -219,6 +225,8 @@ class PhoneSleepWorker(
                     stepDelta = it.stepDelta,
                     dndEnabled = it.dndEnabled,
                     pairedBluetoothConnected = it.pairedBluetoothConnected,
+                    significantMotionFired = it.significantMotionFired,
+                    stationary = it.stationary,
                 )
             }
             if (samples.size < MIN_SAMPLES_FOR_INFERENCE) {

--- a/android/app/src/main/java/com/bios/app/ingest/WakeUpMotionTracker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/WakeUpMotionTracker.kt
@@ -1,0 +1,187 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.hardware.TriggerEvent
+import android.hardware.TriggerEventListener
+import android.util.Log
+
+/**
+ * Process-scoped tracker for the two Tier-1 wake-up motion sensors used
+ * by the phone-only sleep inference (#243 Cut 2):
+ *
+ * - [Sensor.TYPE_SIGNIFICANT_MOTION] — fires once when the device has
+ *   moved significantly. The strongest single onset/offset hint we are
+ *   not yet using; near-zero standby cost because it runs in the sensor
+ *   hub.
+ * - [Sensor.TYPE_STATIONARY_DETECT] — fires once when the device has
+ *   been still for a few seconds. Hardware-confirmed stillness — much
+ *   stronger than the accelerometer-variance proxy, and crucially
+ *   bypasses the AOD-display-state ambiguity that confuses the existing
+ *   `isQuietSample` fallback on always-on-display phones.
+ *
+ * Both sensors are documented one-shot trigger sensors: each fire
+ * automatically unregisters the listener, and the tracker re-registers
+ * to keep the next state-transition observable. Sensor-hub batching
+ * means the standing wattage of holding these listeners overnight is
+ * effectively zero on modern Android hardware.
+ *
+ * ## Lifecycle
+ *
+ * `attach(context)` is idempotent and meant to be called from
+ * [com.bios.app.BiosApplication.onCreate] so listeners arm at app start
+ * — the periodic worker creates short-lived adapters that wouldn't
+ * otherwise give the sensors time to fire. Once attached, the tracker
+ * lives for the process lifetime.
+ *
+ * `snapshot()` reads the most-recently-recorded fire timestamps and
+ * returns the current state. Both fields are null when the sensor is
+ * absent on the device or when neither has fired since attach.
+ */
+object WakeUpMotionTracker {
+
+    private const val TAG = "WakeUpMotionTracker"
+
+    @Volatile private var attached: Boolean = false
+    @Volatile private var sensorManager: SensorManager? = null
+    @Volatile private var sigMotionSensor: Sensor? = null
+    @Volatile private var stationarySensor: Sensor? = null
+
+    // System-clock millis of the most recent fire of each sensor.
+    // 0L means the sensor has never fired since attach (or is absent).
+    @Volatile private var lastSigMotionMs: Long = 0L
+    @Volatile private var lastStationaryMs: Long = 0L
+
+    private val sigMotionListener = object : TriggerEventListener() {
+        override fun onTrigger(event: TriggerEvent) {
+            lastSigMotionMs = System.currentTimeMillis()
+            // Re-arm: TriggerEvent sensors auto-unregister on each fire.
+            val sm = sensorManager
+            val sensor = sigMotionSensor
+            if (sm != null && sensor != null) sm.requestTriggerSensor(this, sensor)
+        }
+    }
+
+    private val stationaryListener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            lastStationaryMs = System.currentTimeMillis()
+            // Re-arm: stationary-detect is documented one-shot; the OS
+            // unregisters on fire and we must re-register to catch the
+            // next stationary-onset transition.
+            val sm = sensorManager
+            val sensor = stationarySensor
+            if (sm != null && sensor != null) {
+                sm.unregisterListener(this)
+                sm.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+            }
+        }
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+    }
+
+    /**
+     * Bind the tracker to the process-global [SensorManager] and arm
+     * both wake-up listeners. Idempotent — subsequent calls no-op so
+     * worker / service paths can call defensively. Safe on devices
+     * missing either sensor: missing-sensor fields stay null and the
+     * corresponding [snapshot] field remains null forever.
+     */
+    fun attach(context: Context) {
+        if (attached) return
+        synchronized(this) {
+            if (attached) return
+            val sm = context.applicationContext
+                .getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+            if (sm == null) {
+                Log.i(TAG, "no SensorManager — wake-up motion tracking disabled")
+                attached = true
+                return
+            }
+            sensorManager = sm
+            sigMotionSensor = sm.getDefaultSensor(Sensor.TYPE_SIGNIFICANT_MOTION)
+            stationarySensor = sm.getDefaultSensor(Sensor.TYPE_STATIONARY_DETECT)
+            sigMotionSensor?.let { sm.requestTriggerSensor(sigMotionListener, it) }
+            stationarySensor?.let {
+                sm.registerListener(stationaryListener, it, SensorManager.SENSOR_DELAY_NORMAL)
+            }
+            Log.i(
+                TAG,
+                "attached — sigMotion=${sigMotionSensor != null} " +
+                    "stationary=${stationarySensor != null}"
+            )
+            attached = true
+        }
+    }
+
+    /** Result of [snapshot]. Both fields are null when the underlying
+     *  sensor is absent on this device or when the tracker hasn't yet
+     *  observed any fire (typical immediately after [attach]). */
+    data class Snapshot(
+        val significantMotionFired: Boolean?,
+        val stationary: Boolean?,
+    )
+
+    /**
+     * Read the current motion state. Semantics:
+     *
+     * - [Snapshot.significantMotionFired] is `true` when SIGNIFICANT_MOTION
+     *   fired within [RECENT_FIRE_WINDOW_MS]; `false` when the sensor is
+     *   present (and has fired at least once historically) but did not
+     *   fire recently; `null` when the sensor is absent.
+     * - [Snapshot.stationary] reflects the most-recent transition we
+     *   captured: `true` when STATIONARY_DETECT fired more recently
+     *   than SIGNIFICANT_MOTION; `false` when SIGNIFICANT_MOTION is
+     *   the more recent of the two; `null` when neither has ever
+     *   fired or the sensor is absent.
+     */
+    fun snapshot(nowMs: Long = System.currentTimeMillis()): Snapshot {
+        val sm = sensorManager
+        if (sm == null) return Snapshot(null, null)
+        val sigPresent = sigMotionSensor != null
+        val stationaryPresent = stationarySensor != null
+
+        val sigFired = if (!sigPresent) {
+            null
+        } else if (lastSigMotionMs == 0L) {
+            // Sensor armed but no historical fire — best we can say is
+            // "no recent significant motion observed."
+            false
+        } else {
+            (nowMs - lastSigMotionMs) < RECENT_FIRE_WINDOW_MS
+        }
+
+        val stationary: Boolean? = when {
+            !stationaryPresent && !sigPresent -> null
+            lastSigMotionMs == 0L && lastStationaryMs == 0L -> null
+            else -> lastStationaryMs > lastSigMotionMs
+        }
+
+        return Snapshot(sigFired, stationary)
+    }
+
+    /** Testing-only reset. Lets unit tests recycle the singleton between
+     *  cases. NOT for production callers. */
+    internal fun resetForTest() {
+        synchronized(this) {
+            sensorManager?.let { sm ->
+                sigMotionSensor?.let { sm.cancelTriggerSensor(sigMotionListener, it) }
+                stationarySensor?.let { sm.unregisterListener(stationaryListener, it) }
+            }
+            sensorManager = null
+            sigMotionSensor = null
+            stationarySensor = null
+            lastSigMotionMs = 0L
+            lastStationaryMs = 0L
+            attached = false
+        }
+    }
+
+    /** Recency window for [Snapshot.significantMotionFired]. A
+     *  significant-motion fire within the last 10 minutes is "recent"
+     *  enough to mark the current sample as motion-positive; older
+     *  fires read as "no recent motion." The stationary signal carries
+     *  the longer-horizon stillness information separately. */
+    internal const val RECENT_FIRE_WINDOW_MS: Long = 10L * 60L * 1000L
+}

--- a/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
+++ b/android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt
@@ -36,4 +36,9 @@ data class PhoneSleepSample(
     val stepDelta: Int? = null,
     val dndEnabled: Boolean? = null,
     val pairedBluetoothConnected: Boolean? = null,
+    // #243 Cut 2 — wake-up motion sensors (SIGNIFICANT_MOTION +
+    // STATIONARY_DETECT). Read from the process-scoped
+    // WakeUpMotionTracker; null on devices missing either sensor.
+    val significantMotionFired: Boolean? = null,
+    val stationary: Boolean? = null,
 )

--- a/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt
@@ -305,6 +305,144 @@ class PhoneSleepInferenceTest {
         assertEquals(0, breakdown.sampledNewSignals)
     }
 
+    // ---- #243 Cut 2: wake-up motion sensors + stationary weave ----
+
+    @Test
+    fun signal_breakdown_counts_wake_up_motion_signals() {
+        // 4 samples: 2 with sigMotion fired + stationary false, 2 with
+        // sigMotion not fired + stationary true. Counts must split.
+        val samples = buildList {
+            repeat(2) { i ->
+                add(
+                    Sample(
+                        timestamp = i.toLong(),
+                        screenOff = true,
+                        charging = true,
+                        ambientLightLux = 0f,
+                        accelMagnitudeVar = 0f,
+                        significantMotionFired = true,
+                        stationary = false,
+                    )
+                )
+            }
+            repeat(2) { i ->
+                add(
+                    Sample(
+                        timestamp = (2 + i).toLong(),
+                        screenOff = true,
+                        charging = true,
+                        ambientLightLux = 0f,
+                        accelMagnitudeVar = 0f,
+                        significantMotionFired = false,
+                        stationary = true,
+                    )
+                )
+            }
+        }
+        val breakdown = PhoneSleepInference.signalBreakdown(samples)
+        assertEquals(4, breakdown.total)
+        assertEquals(2, breakdown.sigMotionFired)
+        assertEquals(2, breakdown.stationaryDetected)
+        assertEquals(4, breakdown.sampledNewSignals)
+    }
+
+    @Test
+    fun signal_breakdown_treats_null_wake_up_signals_as_uncounted() {
+        // No wake-up sensors recorded — counts stay at 0 and the
+        // denominator excludes these samples too.
+        val samples = List(3) { i ->
+            Sample(
+                timestamp = i.toLong(),
+                screenOff = true,
+                charging = true,
+                ambientLightLux = 0f,
+                accelMagnitudeVar = 0f,
+                // significantMotionFired / stationary default null.
+            )
+        }
+        val breakdown = PhoneSleepInference.signalBreakdown(samples)
+        assertEquals(3, breakdown.total)
+        assertEquals(0, breakdown.sigMotionFired)
+        assertEquals(0, breakdown.stationaryDetected)
+        assertEquals(0, breakdown.sampledNewSignals)
+    }
+
+    @Test
+    fun stationary_plus_charging_passes_isQuietSample_even_when_screen_on_and_lit() {
+        // The AOD-on-nightstand failure mode the Cut 2 weave specifically
+        // targets: screen reads on (AOD), room is lit (streetlight,
+        // partner's lamp), accel-variance proxy might disagree — but
+        // hardware-confirmed stillness + charging is strong enough.
+        val s = Sample(
+            timestamp = 0L,
+            screenOff = false,
+            charging = true,
+            ambientLightLux = 80f, // lit room
+            accelMagnitudeVar = 1.0f, // high enough to fail lowMotion proxy
+            stationary = true,
+        )
+        assertTrue(PhoneSleepInference.isQuietSample(s))
+    }
+
+    @Test
+    fun stationary_without_charging_does_not_pass_isQuietSample() {
+        // Without the plugged-in confirmation we won't accept the
+        // single stationary signal — a phone left still on a meeting
+        // table for an hour must not read as sleep.
+        val s = Sample(
+            timestamp = 0L,
+            screenOff = false,
+            charging = false,
+            ambientLightLux = 80f,
+            accelMagnitudeVar = 1.0f,
+            stationary = true,
+        )
+        assertFalse(PhoneSleepInference.isQuietSample(s))
+    }
+
+    @Test
+    fun stationary_null_falls_back_to_the_three_way_fallback() {
+        // Devices missing TYPE_STATIONARY_DETECT must keep using the
+        // pre-Cut-2 charging + lowMotion + dark fallback — the stationary
+        // shortcut is a strict additive path, never a regression.
+        val sampleQuietByFallback = Sample(
+            timestamp = 0L,
+            screenOff = false,
+            charging = true,
+            ambientLightLux = 0f, // dark
+            accelMagnitudeVar = 0f, // low motion
+            stationary = null,
+        )
+        assertTrue(PhoneSleepInference.isQuietSample(sampleQuietByFallback))
+
+        val sampleNotQuiet = Sample(
+            timestamp = 0L,
+            screenOff = false,
+            charging = true,
+            ambientLightLux = 200f, // lit — fails dark
+            accelMagnitudeVar = 0f,
+            stationary = null,
+        )
+        assertFalse(PhoneSleepInference.isQuietSample(sampleNotQuiet))
+    }
+
+    @Test
+    fun stationary_false_does_not_force_quiet_when_fallback_would_pass() {
+        // stationary = false (device is actively moving) shouldn't poison
+        // an otherwise-clean dark-charging-still window. The Cut 2 weave
+        // is purely additive (stationary == true opens a path); a false
+        // here lets the existing fallback decide.
+        val s = Sample(
+            timestamp = 0L,
+            screenOff = true, // screenOff short-circuit
+            charging = false,
+            ambientLightLux = 0f,
+            accelMagnitudeVar = 0f,
+            stationary = false,
+        )
+        assertTrue(PhoneSleepInference.isQuietSample(s))
+    }
+
     @Test
     fun new_signal_defaults_do_not_change_inference_behaviour() {
         // 6 hours of sleepy samples with null Tier-1 fields → inference


### PR DESCRIPTION
## Summary
Adds the two Tier-1 trigger-based wake-up sensors that [#281](https://github.com/thdelmas/Bios/pull/281) flagged as the explicit highest-value Cut 2 candidate:

- **`TYPE_SIGNIFICANT_MOTION`** — collection-only observability. The strongest single onset/offset hint Bios was not yet using. Near-zero standby cost because the sensor hub runs it.
- **`TYPE_STATIONARY_DETECT`** — **decision-side weave into [`isQuietSample`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt)**. Hardware-confirmed multi-second stillness + charging accepts a sample regardless of screen / lux state. Directly targets the AOD-display-state ambiguity the octopus investigation flagged as the most-likely root cause of the in-production sleep-detection failure ([#240](https://github.com/thdelmas/Bios/issues/240)).

Both are documented one-shot wake-up sensors — they auto-unregister on each fire and must be re-armed.

## Pieces
- **New: [`WakeUpMotionTracker`](android/app/src/main/java/com/bios/app/ingest/WakeUpMotionTracker.kt)** — process-scoped singleton that holds a `TriggerEventListener` (significant motion) + `SensorEventListener` (stationary detect), auto-re-arms both on each fire, and exposes `snapshot(now)` returning the current motion state. Both fields are null when the underlying sensor is absent on the device.
- **`BiosApplication.onCreate`** calls `WakeUpMotionTracker.attach(this)` so listeners arm at app start. The short-lived per-firing adapter the [`PhoneSleepWorker`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt) builds wouldn't otherwise give the sensors time to observe a state transition.
- **[`PhoneSleepInference.Sample`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt)** gains `significantMotionFired: Boolean?` + `stationary: Boolean?` with the same `null = absent = ignore` semantics as Cut 1.
- **[`PhoneSleepInference.isQuietSample`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt)** — new early-return: `if (s.stationary == true && s.charging) return true`. Bypasses the lux check (streetlight through a window must not disqualify a clearly-stationary plugged-in device). Strict additive — `stationary = null` and `stationary = false` both fall through to the existing fallback.
- **`SignalBreakdown`** gains `sigMotionFired` + `stationaryDetected` counts plus the expanded `sampledNewSignals` denominator. Matches the Cut 1 observability shape.
- **[`PhoneSleepSample`](android/app/src/main/java/com/bios/app/model/PhoneSleepSample.kt)** Room entity gains the two nullable columns. **[`MIGRATION_29_30`](android/app/src/main/java/com/bios/app/data/PhoneSleepSampleMigrations.kt)** adds them; DB version bumped to 30.
- All four existing mapping sites in [`PhoneSleepWorker`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt) (insert + read-back, in both periodic and force-now paths) and the one site in [`PhoneSleepCollectionService`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt) plumb the new fields through.

## Why `stationary` is decision-side-ready (sigMotion isn't)
Cut 1's PR explicitly deferred decision-side consumption pending field data. `STATIONARY_DETECT` is a different shape from the other Tier-1 signals — it's hardware-confirmed (multi-second stillness in the sensor hub, not a software heuristic over a single accel sample), and the failure mode it fixes (AOD on-display reporting `STATE_ON` through the night) is the single most-likely root cause of the production failure. `SIGNIFICANT_MOTION` stays collection-only this cut — the signal is useful but its predictive value for the inverse case (when *not* fired) needs measurement before we trust it in `isQuietSample`.

## Test plan
- [x] **5 new unit tests** in [`PhoneSleepInferenceTest`](android/app/src/test/java/com/bios/app/PhoneSleepInferenceTest.kt):
  - `signal_breakdown_counts_wake_up_motion_signals` — split-population coverage of both new counts.
  - `signal_breakdown_treats_null_wake_up_signals_as_uncounted` — null safety + denominator behaviour.
  - `stationary_plus_charging_passes_isQuietSample_even_when_screen_on_and_lit` — the AOD-on-nightstand path explicitly.
  - `stationary_without_charging_does_not_pass_isQuietSample` — single signal alone is not enough.
  - `stationary_null_falls_back_to_the_three_way_fallback` — devices missing the sensor keep working unchanged (no regression).
  - `stationary_false_does_not_force_quiet_when_fallback_would_pass` — additive-only weave.
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug across both flavours, unit tests).
- [ ] Manual: run an overnight cycle on a Pixel; confirm `significantMotionFired` / `stationary` columns are populated in `phone_sleep_samples` via the #277 debug screen.
- [ ] Manual: on an AOD-on device (most modern Samsung / Pixel flagships), confirm the previously-failing overnight window now produces a `SLEEP_DURATION` reading thanks to the stationary weave.

## Out of scope for this cut (deferred)
- Gyroscope variance (helps cut "phone vibrating on a table" false positives — separate Tier-1 item).
- `TYPE_PROXIMITY` (face-down vs face-up nightstand placement).
- `UsageStatsManager` last-unlock signal.
- Tier-3 environmental sensors (ambient temperature, barometer, lux flicker spectral density).
- Decision-side weave for `significantMotionFired` — collection-only until field data confirms predictive value.

[#243](https://github.com/thdelmas/Bios/issues/243) stays open until the remaining Tier-1 items land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)