### PR TITLE
feat(alerts): URGENT seizure-pattern safety gate (#269 Cut 2 prep)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt
@@ -2,6 +2,7 @@ package com.bios.app.alerts
 
 import com.bios.app.model.AlertTier
 import com.bios.app.model.ConditionCategory
+import com.bios.app.model.SeizureEventFields
 import com.bios.contracts.MetricType
 
 /**
@@ -24,8 +25,13 @@ import com.bios.contracts.MetricType
  *
  * The wearable convulsive-pattern detector (band-pass 2–8 Hz
  * accelerometer + ictal-tachycardia corroborator, Empatica Embrace2
- * shape, #269) is deferred — the substrate exists but a calibrated
- * detector needs its own design pass.
+ * shape, #269 Cut 1) ships at [com.bios.app.model.ConfidenceTier.LOW]
+ * and writes `detection_source = "wearable_inferred"` on the payload.
+ * Both seizure patterns here apply [SignalRule.excludePayloadFieldValue]
+ * to keep those rows out of the URGENT / ADVISORY paths — automation
+ * alone must not page the owner for emergency services. Wearable-
+ * inferred events stay visible in the timeline; escalation waits for
+ * owner confirmation (#269 Cut 2).
  *
  * ## References
  *
@@ -71,6 +77,16 @@ object NeurologyUrgentPatterns {
                 absoluteWindowHours = 1,
                 absoluteMinReadings = 1,
                 durationAtLeastSec = 300,
+                // #269 Cut 2 safety gate: URGENT escalation must require
+                // owner confirmation. The wearable convulsive-pattern
+                // detector (SeizureDetector) writes LOW-confidence rows
+                // with detection_source = "wearable_inferred"; those
+                // rows are kept in the timeline but excluded here so
+                // automation alone cannot trigger an emergency-services
+                // prompt. Bare owner-logged rows (no payload) pass
+                // through unchanged.
+                excludePayloadFieldValue = SeizureEventFields.DETECTION_SOURCE to
+                    SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
             ),
         ),
         minActiveSignals = 1,
@@ -104,6 +120,14 @@ object NeurologyUrgentPatterns {
                 absoluteAbove = 0.0,
                 absoluteWindowHours = 24,
                 absoluteMinReadings = 3,
+                // #269 Cut 2 safety gate: a "cluster" of wearable-inferred
+                // LOW-confidence detections is detector noise, not a
+                // clinical signal. The cluster pattern's ADVISORY action
+                // ("contact treating neurologist within 24 h") is owner-
+                // facing and demands confirmation that the events
+                // happened — same reasoning as the URGENT gate above.
+                excludePayloadFieldValue = SeizureEventFields.DETECTION_SOURCE to
+                    SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
             ),
         ),
         minActiveSignals = 1,

--- a/android/app/src/main/java/com/bios/app/alerts/SignalRule.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/SignalRule.kt
@@ -95,6 +95,22 @@ data class SignalRule(
      * column. Default null = no duration filter.
      */
     val durationAtLeastSec: Int? = null,
+    /**
+     * #269 Cut 2 safety gate: when set, the rule drops any reading whose
+     * `event_payloads` sidecar contains a row with `fieldKey == first` and
+     * `stringValue == second`. Used by [com.bios.app.alerts.NeurologyUrgentPatterns]
+     * to exclude wearable-inferred SEIZURE_EVENT rows (`detection_source =
+     * "wearable_inferred"`) from the URGENT path — automated convulsive-
+     * pattern detection ships at LOW confidence and must not escalate
+     * without owner confirmation. Bare rows with no payload pass through
+     * unchanged (the historical owner-logged shape predates the payload
+     * surface).
+     *
+     * Only meaningful for absolute-rule rows ([absoluteWindowHours] > 0);
+     * the detector consults [com.bios.app.data.dao.EventPayloadFieldDao]
+     * for the matching readings when this field is non-null.
+     */
+    val excludePayloadFieldValue: Pair<String, String>? = null,
 ) {
     /** True when this rule is evaluated as an absolute clinical threshold. */
     val isAbsolute: Boolean get() = absoluteAbove != null || absoluteBelow != null

--- a/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt
@@ -400,20 +400,6 @@ class AnomalyDetector(
         )
     }
 
-    private fun classifySeverity(
-        activeSignals: Int,
-        combinedScore: Double,
-        totalRules: Int
-    ): AlertTier {
-        val signalRatio = activeSignals.toDouble() / totalRules.toDouble()
-
-        return when {
-            combinedScore > 3.0 || signalRatio > 0.8 -> AlertTier.ADVISORY
-            combinedScore > 2.0 || signalRatio > 0.5 -> AlertTier.NOTICE
-            else -> AlertTier.OBSERVATION
-        }
-    }
-
     private fun buildExplanation(
         pattern: ConditionPattern,
         deviations: Map<MetricType, Double>
@@ -444,18 +430,28 @@ class AnomalyDetector(
         )
     }
 
-    // Window-mode values for the absolute-rule path; row-fetch + duration
-    // filter when SignalRule.durationAtLeastSec is set (#268), otherwise
-    // the value-only fast path.
+    // Absolute-rule window values. Fast value-only path unless the
+    // rule needs row-level columns: durationAtLeastSec (#268) requires
+    // durationSec; excludePayloadFieldValue (#269 Cut 2 safety gate)
+    // requires a payload lookup to drop wearable_inferred SEIZURE_EVENT
+    // rows from the URGENT path.
     private suspend fun fetchAbsoluteWindowValues(rule: com.bios.app.alerts.SignalRule): List<Double> {
         val minDuration = rule.durationAtLeastSec
-            ?: return fetchRecentValues(rule.metricType, rule.absoluteWindowHours)
+        val excludePayload = rule.excludePayloadFieldValue
+        if (minDuration == null && excludePayload == null) {
+            return fetchRecentValues(rule.metricType, rule.absoluteWindowHours)
+        }
         val endMillis = System.currentTimeMillis()
         val startMillis = endMillis - rule.absoluteWindowHours.toLong() * 3600 * 1000
-        return daoFor(rule.metricType)
-            .fetch(rule.metricType.key, startMillis, endMillis)
-            .filter { (it.durationSec ?: 0) >= minDuration }
-            .map { it.value }
+        var rows = daoFor(rule.metricType).fetch(rule.metricType.key, startMillis, endMillis)
+        if (minDuration != null) rows = rows.filter { (it.durationSec ?: 0) >= minDuration }
+        if (excludePayload != null) {
+            val payloads = db.eventPayloadFieldDao()
+                .fetchForReadings(rows.map { it.id })
+                .groupBy { it.readingId }
+            rows = applyPayloadExclusion(rows, payloads, excludePayload)
+        }
+        return rows.map { it.value }
     }
 
     private fun daoFor(metricType: MetricType): MetricReadingDao =

--- a/android/app/src/main/java/com/bios/app/engine/AnomalySeverity.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalySeverity.kt
@@ -1,0 +1,27 @@
+package com.bios.app.engine
+
+import com.bios.app.model.AlertTier
+
+/**
+ * Pure severity classifier for [AnomalyDetector]. Extracted to a top-
+ * level function so [AnomalyDetector] stays under the 500-line cap and
+ * so unit tests can pin the cutoffs without spinning up the full
+ * detector.
+ *
+ * Cutoffs are deliberately conservative: ADVISORY requires either a
+ * very high combined score (> 3.0) or near-full signal agreement
+ * (> 0.8). NOTICE catches moderately-high scores or majority-active
+ * patterns; everything else stays at OBSERVATION.
+ */
+internal fun classifySeverity(
+    activeSignals: Int,
+    combinedScore: Double,
+    totalRules: Int,
+): AlertTier {
+    val signalRatio = activeSignals.toDouble() / totalRules.toDouble()
+    return when {
+        combinedScore > 3.0 || signalRatio > 0.8 -> AlertTier.ADVISORY
+        combinedScore > 2.0 || signalRatio > 0.5 -> AlertTier.NOTICE
+        else -> AlertTier.OBSERVATION
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/PayloadExclusion.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PayloadExclusion.kt
@@ -1,0 +1,27 @@
+package com.bios.app.engine
+
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+
+/**
+ * Pure helper for [com.bios.app.alerts.SignalRule.excludePayloadFieldValue]
+ * (#269 Cut 2 safety gate). Drops any row whose [payloadsByReading] entry
+ * contains a field matching `(fieldKey, stringValue) == excludePayload`.
+ * Rows missing from [payloadsByReading] pass through unchanged — that
+ * matches the historical "bare owner-logged row, no payload" shape.
+ *
+ * Lifted out so unit tests can exercise the filtering rule without
+ * touching Room, and so [AnomalyDetector] stays under the 500-line cap.
+ */
+internal fun applyPayloadExclusion(
+    rows: List<MetricReading>,
+    payloadsByReading: Map<String, List<EventPayloadField>>,
+    excludePayload: Pair<String, String>,
+): List<MetricReading> {
+    val (fieldKey, excludedValue) = excludePayload
+    return rows.filterNot { row ->
+        payloadsByReading[row.id]?.any {
+            it.fieldKey == fieldKey && it.stringValue == excludedValue
+        } == true
+    }
+}

--- a/android/app/src/test/java/com/bios/app/NeurologyUrgentPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/NeurologyUrgentPatternsTest.kt
@@ -6,6 +6,7 @@ import com.bios.app.alerts.DeviationDirection
 import com.bios.app.alerts.NeurologyUrgentPatterns
 import com.bios.app.alerts.ThresholdSource
 import com.bios.app.model.AlertTier
+import com.bios.app.model.SeizureEventFields
 import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -103,6 +104,46 @@ class NeurologyUrgentPatternsTest {
         assertEquals(3, rule.absoluteMinReadings)
         // No duration filter — Haut 2007 cluster definition is count-based.
         assertNull(rule.durationAtLeastSec)
+    }
+
+    // -- #269 Cut 2 safety gate: both seizure patterns exclude
+    // wearable-inferred rows from the escalation paths --
+
+    @Test
+    fun status_epilepticus_excludes_wearable_inferred_detection_source() {
+        val rule = NeurologyUrgentPatterns.statusEpilepticusConvulsive.signalRules.single()
+        val gate = rule.excludePayloadFieldValue
+        assertNotNull(
+            "URGENT seizure pattern must drop wearable-inferred rows",
+            gate,
+        )
+        assertEquals(SeizureEventFields.DETECTION_SOURCE, gate!!.first)
+        assertEquals(SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED, gate.second)
+    }
+
+    @Test
+    fun seizure_cluster_excludes_wearable_inferred_detection_source() {
+        val rule = NeurologyUrgentPatterns.seizureCluster.signalRules.single()
+        val gate = rule.excludePayloadFieldValue
+        assertNotNull(
+            "Cluster pattern must drop wearable-inferred rows",
+            gate,
+        )
+        assertEquals(SeizureEventFields.DETECTION_SOURCE, gate!!.first)
+        assertEquals(SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED, gate.second)
+    }
+
+    @Test
+    fun non_seizure_neurology_patterns_do_not_apply_the_payload_gate() {
+        // The payload gate is seizure-specific. GCS / thunderclap have no
+        // wearable-inferred equivalent (yet) and adding the field on them
+        // would silently lock out future detectors that haven't shipped.
+        val gcsRule = NeurologyUrgentPatterns.acuteAlteredConsciousnessLowGcs
+            .signalRules.single()
+        val thunderclapRule = NeurologyUrgentPatterns.thunderclapHeadache
+            .signalRules.single()
+        assertNull(gcsRule.excludePayloadFieldValue)
+        assertNull(thunderclapRule.excludePayloadFieldValue)
     }
 
     // -- acute_altered_consciousness_gcs_le_8 --

--- a/android/app/src/test/java/com/bios/app/PayloadExclusionTest.kt
+++ b/android/app/src/test/java/com/bios/app/PayloadExclusionTest.kt
@@ -1,0 +1,133 @@
+package com.bios.app
+
+import com.bios.app.engine.applyPayloadExclusion
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SeizureEventFields
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-function coverage for the #269 Cut 2 safety gate: wearable-inferred
+ * SEIZURE_EVENT rows must not feed the URGENT / ADVISORY seizure patterns
+ * in [com.bios.app.alerts.NeurologyUrgentPatterns]. The full evaluator
+ * path (`AnomalyDetector.fetchAbsoluteWindowValues`) builds the
+ * `payloadsByReading` map from the DAO; this file pins the filtering
+ * decision over fake inputs so the safety semantics are nailed down
+ * independently of Room.
+ */
+class PayloadExclusionTest {
+
+    private val sourceId = "test-source"
+    private fun row(id: String): MetricReading = MetricReading(
+        id = id,
+        metricType = MetricType.SEIZURE_EVENT.key,
+        value = 1.0,
+        timestamp = 0L,
+        durationSec = 360,
+        sourceId = sourceId,
+        confidence = 50,
+    )
+
+    private val detectionSourceGate =
+        SeizureEventFields.DETECTION_SOURCE to
+            SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED
+
+    @Test
+    fun bare_owner_logged_rows_pass_through() {
+        // Historical owner-logged seizure entries have no event_payloads
+        // sidecar at all. The safety gate must not silently drop them.
+        val rows = listOf(row("a"), row("b"))
+        val filtered = applyPayloadExclusion(rows, emptyMap(), detectionSourceGate)
+        assertEquals(rows, filtered)
+    }
+
+    @Test
+    fun explicit_owner_logged_rows_pass_through() {
+        val rows = listOf(row("a"))
+        val payloads = mapOf(
+            "a" to listOf(
+                EventPayloadField(
+                    readingId = "a",
+                    fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                    stringValue = SeizureEventFields.DETECTION_SOURCE_OWNER_LOGGED,
+                )
+            )
+        )
+        val filtered = applyPayloadExclusion(rows, payloads, detectionSourceGate)
+        assertEquals(rows, filtered)
+    }
+
+    @Test
+    fun wearable_inferred_rows_are_dropped() {
+        val rows = listOf(row("a"))
+        val payloads = mapOf(
+            "a" to listOf(
+                EventPayloadField(
+                    readingId = "a",
+                    fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                    stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+                )
+            )
+        )
+        val filtered = applyPayloadExclusion(rows, payloads, detectionSourceGate)
+        assertTrue("wearable-inferred row must not escalate", filtered.isEmpty())
+    }
+
+    @Test
+    fun mixed_population_drops_only_wearable_inferred() {
+        // A realistic 24h cluster window: one bare owner-logged event,
+        // one explicit owner_logged, one wearable_inferred. The cluster
+        // pattern's absoluteMinReadings is 3 — after the safety gate the
+        // surviving count must be 2 so the cluster fails to fire from
+        // detector noise alone.
+        val rows = listOf(row("bare"), row("owner"), row("wear"))
+        val payloads = mapOf(
+            "owner" to listOf(
+                EventPayloadField(
+                    readingId = "owner",
+                    fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                    stringValue = SeizureEventFields.DETECTION_SOURCE_OWNER_LOGGED,
+                )
+            ),
+            "wear" to listOf(
+                EventPayloadField(
+                    readingId = "wear",
+                    fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                    stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+                ),
+                EventPayloadField(
+                    readingId = "wear",
+                    fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                    doubleValue = 112.0,
+                ),
+            ),
+        )
+        val filtered = applyPayloadExclusion(rows, payloads, detectionSourceGate)
+        assertEquals(2, filtered.size)
+        assertEquals(setOf("bare", "owner"), filtered.map { it.id }.toSet())
+    }
+
+    @Test
+    fun unrelated_payload_fields_do_not_drop_the_row() {
+        // A wearable-inferred row carries median_hr_bpm and baseline_hr_bpm
+        // alongside the detection_source field. The filter must key on
+        // (fieldKey, stringValue) — a row that only carries the HR
+        // substrate (no detection_source row) is treated as bare and
+        // passes through.
+        val rows = listOf(row("a"))
+        val payloads = mapOf(
+            "a" to listOf(
+                EventPayloadField(
+                    readingId = "a",
+                    fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                    doubleValue = 95.0,
+                )
+            )
+        )
+        val filtered = applyPayloadExclusion(rows, payloads, detectionSourceGate)
+        assertEquals(rows, filtered)
+    }
+}


### PR DESCRIPTION
## Summary
The [#269 Cut 1 PR](https://github.com/thdelmas/Bios/pull/274) shipped `SeizureDetector` as a pure function but **explicitly deferred wiring it into a continuous accelerometer-capture path** because the existing URGENT [`statusEpilepticusConvulsive`](android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt) and ADVISORY [`seizureCluster`](android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt) patterns would fire on **any** SEIZURE_EVENT row — including the LOW-confidence wearable-inferred detections the detector produces. Per the manifesto guard from the issue: automation alone must not page the owner for emergency services.

This PR adds the safety gate the eventual FG-service wiring depends on. After this lands, a follow-up cut can safely wire `SeizureDetector` to a continuous accelerometer flow knowing wearable-inferred rows can't escalate without owner confirmation.

## Pieces
- **New: `SignalRule.excludePayloadFieldValue: Pair<String, String>?`** ([SignalRule.kt](android/app/src/main/java/com/bios/app/alerts/SignalRule.kt)). When set, the evaluator drops any reading whose `event_payloads` sidecar contains a row with `fieldKey == first && stringValue == second`. Generic on purpose — the seizure case is the first user, but other future detectors (PPG-derived a-fib, accelerometer-derived fall events) will want the same gate.
- **[`AnomalyDetector.fetchAbsoluteWindowValues`](android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt)** consults [`EventPayloadFieldDao.fetchForReadings`](android/app/src/main/java/com/bios/app/data/dao/EventPayloadFieldDao.kt) for the matching rows when the rule sets the gate, then routes the filter through a small pure helper.
- **New: [`applyPayloadExclusion`](android/app/src/main/java/com/bios/app/engine/PayloadExclusion.kt)** — top-level pure function so unit tests pin the filter semantics without Room.
- **[`statusEpilepticusConvulsive`](android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt)** and **[`seizureCluster`](android/app/src/main/java/com/bios/app/alerts/NeurologyUrgentPatterns.kt)** both ship the gate pinned to `detection_source = "wearable_inferred"`. The cluster pattern is ADVISORY but its suggested action (\"contact treating neurologist within 24 h\") is still owner-facing and demands confirmation that the events happened — same reasoning as the URGENT gate. **Bare owner-logged rows (no payload) pass through unchanged**, preserving the historical journal-entry shape.

## What this does NOT do
- The wearable-inferred path's existing **timeline visibility** is unaffected. Owners still see detector candidates; only the URGENT / ADVISORY escalation surfaces are gated.
- The eventual continuous-capture wiring of `SeizureDetector` into a foreground accelerometer service is still deferred — but unblocked.

## File-length housekeeping
[`AnomalyDetector.kt`](android/app/src/main/java/com/bios/app/engine/AnomalyDetector.kt) was at the 500-line cap. Extracted the pure `classifySeverity` helper to [`AnomalySeverity.kt`](android/app/src/main/java/com/bios/app/engine/AnomalySeverity.kt) — note this matches what [`AnomalyDetectorTest`](android/app/src/test/java/com/bios/app/AnomalyDetectorTest.kt) was already mirror-testing, so test discoverability improves too.

## Test plan
- [x] **3 new pattern-config tests** in [`NeurologyUrgentPatternsTest`](android/app/src/test/java/com/bios/app/NeurologyUrgentPatternsTest.kt):
  - `status_epilepticus_excludes_wearable_inferred_detection_source`
  - `seizure_cluster_excludes_wearable_inferred_detection_source`
  - `non_seizure_neurology_patterns_do_not_apply_the_payload_gate` — narrowness guard (GCS / thunderclap have no wearable-inferred equivalent, must not silently inherit the gate)
- [x] **5 filter-logic tests** in new [`PayloadExclusionTest`](android/app/src/test/java/com/bios/app/PayloadExclusionTest.kt):
  - `bare_owner_logged_rows_pass_through` — no payload at all (historical shape)
  - `explicit_owner_logged_rows_pass_through` — payload present but value != excluded
  - `wearable_inferred_rows_are_dropped`
  - `mixed_population_drops_only_wearable_inferred` — realistic 24h cluster window
  - `unrelated_payload_fields_do_not_drop_the_row` — gate keys on `(fieldKey, stringValue)`, not just fieldKey presence
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug across both flavours, unit tests).

## Out of scope (next cut)
- Wiring `SeizureDetector` into a foreground accelerometer service against `PhoneSensorAdapter.accelerometerFlow()`.
- Settings opt-in toggle (per #269 Cut 1's deferred list).
- Pull-side timeline differentiation between `wearable_inferred` and `owner_logged` rows (UX cut).

[#269](https://github.com/thdelmas/Bios/issues/269) stays open until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)