### PR TITLE
feat(ui): seizure-detection opt-in toggle (#269 Cut 3a)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SeizureDetectionPrefs.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SeizureDetectionPrefs.kt
@@ -1,0 +1,44 @@
+package com.bios.app.engine
+
+import android.content.Context
+
+/**
+ * Opt-in toggle for the wearable convulsive-seizure detector (#269
+ * Cut 3a). When the owner enables this from `Settings → Seizure
+ * detection`, the continuous accelerometer foreground service that
+ * feeds [SeizureDetector] is allowed to run; when disabled (the
+ * default), the service does not start and no automated detection
+ * happens.
+ *
+ * The toggle is the privacy gate, not the safety gate. The safety
+ * gate (#269 Cut 2, shipped via #287) is in
+ * [com.bios.app.alerts.NeurologyUrgentPatterns]: wearable-inferred
+ * SEIZURE_EVENT rows are excluded from the URGENT and ADVISORY
+ * escalation paths regardless of this toggle. Owner-logged events
+ * always fire those patterns; detector candidates land in the
+ * timeline only and require owner confirmation before any push.
+ *
+ * Defaults to **off**: continuous accelerometer streaming with a
+ * persistent wake-lock has a real (though small) battery cost, and
+ * the manifesto's "owner is final" principle says we don't start
+ * a privacy-relevant background capture without explicit consent.
+ *
+ * Mirrors the [PpgCalibrationLogger.isEnabled] / `setEnabled` shape
+ * so the Settings card pattern is uniform across opt-in detectors.
+ */
+object SeizureDetectionPrefs {
+
+    private const val PREFS_NAME = "bios_seizure_detection"
+    private const val KEY_ENABLED = "enabled"
+
+    fun isEnabled(context: Context): Boolean =
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_ENABLED, false)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -400,6 +400,8 @@ fun SettingsScreen(
 
         SettingsFeedbackCard()
 
+        SettingsSeizureDetectionCard()
+
         SettingsDiagnosticsCard()
 
         // About — long-press Version row opens the metric_readings debug screen (#253).

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
@@ -1,0 +1,77 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.SeizureDetectionPrefs
+
+/**
+ * Settings → Seizure detection card. Single toggle that gates the
+ * continuous accelerometer foreground service feeding
+ * [com.bios.app.engine.SeizureDetector] (#269 Cut 3a). Lives in its
+ * own card (separate from `Diagnostics`) because this is **not**
+ * device-keyed observability — it's an experimental medical detector
+ * the owner opts into, and the copy needs space to be honest about
+ * what enabling it does.
+ *
+ * Off by default. Lives in a separate file because [SettingsScreen]
+ * is at the 500-line limit; new cards land here rather than growing
+ * the host file.
+ */
+@Composable
+internal fun SettingsSeizureDetectionCard() {
+    val context = LocalContext.current
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Seizure detection", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            var enabled by remember {
+                mutableStateOf(SeizureDetectionPrefs.isEnabled(context))
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "Wearable convulsive-seizure detector",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Text(
+                        "Runs a continuous accelerometer + heart-rate watch in the background to " +
+                            "flag candidate convulsive episodes. Detections land in your timeline " +
+                            "for review — they do not page emergency services on their own. " +
+                            "Off by default. Holds a wake lock; expect a measurable battery cost.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = {
+                        enabled = it
+                        SeizureDetectionPrefs.setEnabled(context, it)
+                    },
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds the **privacy gate** the eventual `SeizureDetector` continuous-capture wiring ([#269](https://github.com/thdelmas/Bios/issues/269) Cut 3b) needs before it can be turned on in production. Continuous accelerometer streaming with a persistent wake-lock has a real battery cost; the manifesto's "owner is final" principle says we don't start a privacy-relevant background capture without explicit consent.

This is the second of two gates on the seizure detector. The **safety gate** ([#287](https://github.com/thdelmas/Bios/pull/287), already merged) keeps wearable-inferred SEIZURE_EVENT rows out of the URGENT / ADVISORY escalation paths so automation alone can't page emergency services. The two gates are independent — the safety gate holds even if the privacy gate is toggled off and back on.

## Pieces
- **New: [`SeizureDetectionPrefs`](android/app/src/main/java/com/bios/app/engine/SeizureDetectionPrefs.kt)** — SharedPreferences-backed `isEnabled` / `setEnabled` pair, **off by default**. Mirrors the [`PpgCalibrationLogger`](android/app/src/main/java/com/bios/app/engine/PpgCalibrationLogger.kt) shape so the opt-in detector idiom is uniform across the project.
- **New: [`SettingsSeizureDetectionCard`](android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt)** — Compose card with copy that's honest about what enabling the detector does: timeline-only candidates (no emergency-services page on automation alone, per the #287 safety gate), expect a measurable battery cost.
- **[`SettingsScreen`](android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt)** — mounts the new card above the Diagnostics card.

The card is intentionally separate from `SettingsDiagnosticsCard` — this is an **experimental medical detector** the owner opts into, not a device-keyed observability log. Different cognitive category, deserves its own header.

## Why no toggle test
[`SeizureDetectionPrefs`](android/app/src/main/java/com/bios/app/engine/SeizureDetectionPrefs.kt) is a thin `SharedPreferences` wrapper with no pure-JVM logic. Same exclusion as [`PpgCalibrationLoggerTest`](android/app/src/test/java/com/bios/app/PpgCalibrationLoggerTest.kt) (whose KDoc explicitly says "the Android-side toggle … intentionally not exercised here"). Integration coverage lands with the Cut 3b FG-service wiring that gates on this toggle.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug across both flavours, unit tests).
- [ ] Manual: open Settings, confirm the new "Seizure detection" card appears above "Diagnostics" with the toggle reading "off".
- [ ] Manual: toggle on → kill the app → reopen Settings → toggle still reads "on" (persistence).

## Next
[#269](https://github.com/thdelmas/Bios/issues/269) Cut 3b: wire `SeizureDetector` into a foreground accelerometer service that consults `SeizureDetectionPrefs.isEnabled` before starting. Optional Cut 3c: timeline differentiation between `wearable_inferred` and `owner_logged` rows on the pull-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)