### PR TITLE
feat(ingest): wearable seizure-detection FG service (#269 Cut 3b)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -218,6 +218,16 @@
             android:exported="false"
             android:foregroundServiceType="health" />
 
+        <!-- Wearable convulsive-seizure detector foreground service
+             (#269 Cut 3b). Owner opt-in via SeizureDetectionPrefs;
+             SettingsSeizureDetectionCard starts / stops the service
+             when the toggle flips. Same FOREGROUND_SERVICE_TYPE_HEALTH
+             category as the sleep collector. -->
+        <service
+            android:name=".ingest.SeizureDetectionService"
+            android:exported="false"
+            android:foregroundServiceType="health" />
+
         <!-- Quick Settings tile for owner-asserted bedtime ↔ wake log
              (#242). The tile is exported (the system Settings UI binds
              to it to enumerate available tiles for the picker) and

--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -81,6 +81,15 @@ class BiosApplication : Application() {
         // hub is already tracking when the first sample is taken.
         com.bios.app.ingest.WakeUpMotionTracker.attach(this)
 
+        // Start the wearable seizure-detection foreground service if
+        // the owner has opted in via Settings (#269 Cut 3b). No-op
+        // when the opt-in is off — the service self-stops in
+        // onStartCommand even if start is mis-triggered. The privacy
+        // gate (SeizureDetectionPrefs) and the safety gate (#287
+        // payload-exclusion on URGENT seizure patterns) are both
+        // independent of this start call.
+        com.bios.app.ingest.SeizureDetectionService.startIfOptedIn(this)
+
         // Register the charge-edge receiver for the new foreground
         // collection service (#241). ACTION_POWER_CONNECTED /
         // _DISCONNECTED are not on the API 26+ implicit-broadcast

--- a/android/app/src/main/java/com/bios/app/data/dao/DataSourceDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/DataSourceDao.kt
@@ -15,6 +15,12 @@ interface DataSourceDao {
     @Query("SELECT * FROM data_sources WHERE sourceType = :sourceType LIMIT 1")
     suspend fun findByType(sourceType: String): DataSource?
 
+    @Query(
+        "SELECT * FROM data_sources " +
+            "WHERE sourceType = :sourceType AND deviceName = :deviceName LIMIT 1"
+    )
+    suspend fun findByTypeAndDeviceName(sourceType: String, deviceName: String): DataSource?
+
     @Query("SELECT * FROM data_sources")
     suspend fun getAll(): List<DataSource>
 

--- a/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionBuffer.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionBuffer.kt
@@ -1,0 +1,63 @@
+package com.bios.app.ingest
+
+import kotlin.math.sqrt
+
+/**
+ * Pure-logic rolling buffer for the wearable seizure detector
+ * (#269 Cut 3b). Holds the most-recent [capacitySec] seconds of
+ * accelerometer-norm-minus-gravity values at a fixed [sampleRateHz].
+ * Extracted from [SeizureDetectionService] so the buffer / trim / FFT-
+ * input slicing logic is exercisable on the JVM without an Android
+ * Sensor stack.
+ *
+ * Magnitude convention matches [com.bios.app.engine.SeizureDetector]'s
+ * input contract: `sqrt(x² + y² + z²) - g`, so DC gravity is already
+ * removed and quiet seconds read near zero.
+ */
+internal class SeizureDetectionBuffer(
+    val sampleRateHz: Double,
+    capacitySec: Int,
+) {
+
+    private val capacity: Int = (sampleRateHz * capacitySec).toInt().coerceAtLeast(1)
+    private val magnitudes = ArrayDeque<Double>(capacity)
+
+    /** Epoch-ms of the oldest sample currently in the buffer, or null
+     *  when [isEmpty]. */
+    @Volatile var startTimestampMs: Long? = null
+        private set
+
+    fun isEmpty(): Boolean = magnitudes.isEmpty()
+    fun size(): Int = magnitudes.size
+
+    /**
+     * Append one accelerometer sample. [nowMs] is the epoch-ms of this
+     * sample. The buffer evicts the oldest sample when full; on first
+     * insert it records [startTimestampMs].
+     */
+    @Synchronized
+    fun append(x: Float, y: Float, z: Float, nowMs: Long) {
+        val mag = sqrt((x * x + y * y + z * z).toDouble()) - GRAVITY_M_PER_S2
+        if (magnitudes.isEmpty()) startTimestampMs = nowMs
+        magnitudes.addLast(mag)
+        if (magnitudes.size > capacity) {
+            magnitudes.removeFirst()
+            // Advance the timestamp by one sample period when we evict.
+            startTimestampMs = startTimestampMs?.plus((1_000.0 / sampleRateHz).toLong())
+        }
+    }
+
+    /**
+     * Snapshot the current buffer contents as a defensive copy. The
+     * detector consumes a `List<Double>` and reads it concurrently with
+     * further appends; returning a copy avoids ConcurrentModification
+     * pitfalls without taking a long lock.
+     */
+    @Synchronized
+    fun snapshot(): List<Double> = magnitudes.toList()
+
+    companion object {
+        // Same convention as PhoneSensorAdapter and PhoneSleepAdapter.
+        private const val GRAVITY_M_PER_S2 = 9.81
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionService.kt
@@ -1,0 +1,323 @@
+package com.bios.app.ingest
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.SeizureDetectionPrefs
+import com.bios.app.engine.SeizureDetector
+import com.bios.app.engine.SeizureEventFactory
+import com.bios.app.model.DataSource
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Foreground service that streams the phone accelerometer through
+ * [SeizureDetector] looking for convulsive-pattern candidates while the
+ * owner is opted in (#269 Cut 3b).
+ *
+ * Off by default. The owner enables / disables via
+ * `Settings → Seizure detection` ([SeizureDetectionPrefs]). On enable
+ * the service is started; on disable it is stopped.
+ *
+ * ## Two gates already established
+ *
+ * - **Privacy gate** ([SeizureDetectionPrefs], #269 Cut 3a): the service
+ *   refuses to start when the opt-in is off; if the toggle flips off
+ *   while running it self-stops on the next sampling cycle.
+ * - **Safety gate** (#287, [com.bios.app.alerts.SignalRule.excludePayloadFieldValue]
+ *   on the seizure patterns): wearable-inferred SEIZURE_EVENT rows
+ *   never feed the URGENT / ADVISORY paths regardless of this service's
+ *   output. Detector candidates land in the timeline only.
+ *
+ * ## Lifecycle
+ *
+ * - **Foreground notification.** Posted in `onCreate`; honest copy
+ *   ("Bios is watching for convulsive-pattern movement"). API 34+ uses
+ *   `FOREGROUND_SERVICE_TYPE_HEALTH`.
+ * - **Wake lock.** A `PARTIAL_WAKE_LOCK` keeps the CPU available so the
+ *   sampling cadence doesn't drift under Doze. Released on `onDestroy`.
+ * - **Accelerometer listener.** Registered at `SENSOR_DELAY_GAME`
+ *   (~50 Hz) — comfortably above the 16 Hz Nyquist floor for the 2–8 Hz
+ *   clonic-phase band [SeizureDetector] looks for.
+ * - **Analysis loop.** Every [ANALYSIS_INTERVAL_MS] (= 5 s) the loop
+ *   snapshots the buffer, fetches recent HR readings, and invokes
+ *   [SeizureDetector.analyse]. Detections are persisted via
+ *   [SeizureEventFactory] (LOW confidence, `detection_source =
+ *   "wearable_inferred"`).
+ *
+ * ## What's intentionally out of scope this cut
+ *
+ * - Timeline UI differentiation between `wearable_inferred` and
+ *   `owner_logged` rows — separate Cut 3c.
+ * - Per-detection battery-budget telemetry — separate follow-up.
+ * - Charge-only operation. Seizures can happen any time; we accept the
+ *   continuous wake-lock cost when the owner opts in.
+ */
+class SeizureDetectionService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var analysisJob: Job? = null
+    private var wakeLock: PowerManager.WakeLock? = null
+    private var sensorManager: SensorManager? = null
+    private var accelerometer: Sensor? = null
+    private var buffer: SeizureDetectionBuffer? = null
+
+    private val accelListener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            buffer?.append(
+                event.values[0], event.values[1], event.values[2],
+                System.currentTimeMillis()
+            )
+        }
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannelIfNeeded(this)
+        startForegroundWithType()
+        acquireWakeLock()
+        Log.i(TAG, "service onCreate — foreground notification posted")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!SeizureDetectionPrefs.isEnabled(this)) {
+            Log.i(TAG, "started while opt-in is off; stopping self")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        if (analysisJob == null) {
+            val sm = getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+            val sensor = sm?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+            if (sm == null || sensor == null) {
+                Log.i(TAG, "no accelerometer; stopping self")
+                stopSelf()
+                return START_NOT_STICKY
+            }
+            sensorManager = sm
+            accelerometer = sensor
+            buffer = SeizureDetectionBuffer(SAMPLE_RATE_HZ, BUFFER_CAPACITY_SEC)
+            sm.registerListener(accelListener, sensor, SAMPLE_PERIOD_US)
+            analysisJob = launchAnalysisLoop()
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        sensorManager?.unregisterListener(accelListener)
+        analysisJob?.cancel()
+        analysisJob = null
+        releaseWakeLock()
+        scope.cancel()
+        sensorManager = null
+        accelerometer = null
+        buffer = null
+        Log.i(TAG, "service onDestroy — wake lock released")
+        super.onDestroy()
+    }
+
+    private fun launchAnalysisLoop(): Job = scope.launch {
+        val db = BiosDatabase.getInstance(applicationContext)
+        val readingDao = db.metricReadingDao()
+        val sourceDao = db.dataSourceDao()
+        val payloadDao = db.eventPayloadFieldDao()
+        while (isActive) {
+            delay(ANALYSIS_INTERVAL_MS)
+            if (!SeizureDetectionPrefs.isEnabled(applicationContext)) {
+                Log.i(TAG, "opt-in flipped off during run; stopping self")
+                stopSelf()
+                return@launch
+            }
+            try {
+                val snapshot = buffer?.snapshot().orEmpty()
+                val bufferStart = buffer?.startTimestampMs ?: continue
+                if (snapshot.size < SAMPLE_RATE_HZ.toInt() * SeizureDetector.MIN_SUSTAINED_SEC) {
+                    continue
+                }
+                val analysisEndMs = bufferStart +
+                    ((snapshot.size / SAMPLE_RATE_HZ) * 1_000).toLong()
+                val hrSeries = fetchHrSeries(readingDao, bufferStart, analysisEndMs)
+                val detections = SeizureDetector.analyse(
+                    accelNormMagnitudes = snapshot,
+                    startTimestampMs = bufferStart,
+                    sampleRateHz = SAMPLE_RATE_HZ,
+                    hrSeries = hrSeries,
+                )
+                if (detections.isEmpty()) continue
+                val sourceId = ensureSource(sourceDao)
+                for (d in detections) {
+                    val event = SeizureEventFactory.fromWearableDetection(d, sourceId)
+                    readingDao.insert(event.reading)
+                    payloadDao.insertAll(event.payload)
+                    Log.i(
+                        TAG,
+                        "wearable_inferred seizure event written id=${event.reading.id} " +
+                            "durationSec=${event.reading.durationSec}"
+                    )
+                }
+            } catch (t: Throwable) {
+                Log.w(TAG, "analysis iteration failed: ${t.message}", t)
+            }
+        }
+    }
+
+    private suspend fun fetchHrSeries(
+        readingDao: com.bios.app.data.dao.MetricReadingDao,
+        bufferStartMs: Long,
+        analysisEndMs: Long,
+    ): List<SeizureDetector.HrSample> {
+        // Include the pre-event baseline window the corroborator needs.
+        val baselineStart = bufferStartMs - SeizureDetector.PRE_EVENT_BASELINE_SEC * 1_000L
+        return readingDao
+            .fetch(MetricType.HEART_RATE.key, baselineStart, analysisEndMs)
+            .map { SeizureDetector.HrSample(timestampMs = it.timestamp, bpm = it.value) }
+    }
+
+    private suspend fun ensureSource(dao: com.bios.app.data.dao.DataSourceDao): String {
+        // Reuse the PHONE_SENSOR_DERIVED type but distinguish on deviceName
+        // so provenance reads cleanly alongside the sleep-inference source.
+        val existing = dao.findByTypeAndDeviceName(
+            SourceType.PHONE_SENSOR_DERIVED.key,
+            SOURCE_DEVICE_NAME,
+        )
+        if (existing != null) return existing.id
+        val source = DataSource(
+            sourceType = SourceType.PHONE_SENSOR_DERIVED.key,
+            sensorType = "phone_seizure",
+            deviceName = SOURCE_DEVICE_NAME,
+            readingKind = ReadingKind.DERIVED.name,
+        )
+        dao.insert(source)
+        return source.id
+    }
+
+    private fun startForegroundWithType() {
+        val notification = buildNotification(this)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_HEALTH,
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun acquireWakeLock() {
+        val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+        val lock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKE_LOCK_TAG).apply {
+            setReferenceCounted(false)
+        }
+        lock.acquire(MAX_WAKE_LOCK_MS)
+        wakeLock = lock
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
+    }
+
+    companion object {
+        private const val TAG = "SeizureDetectionService"
+
+        const val CHANNEL_ID = "bios_seizure_detection"
+        private const val NOTIFICATION_ID = 0x5E12 // arbitrary, stable
+
+        private const val WAKE_LOCK_TAG = "Bios:SeizureDetection"
+
+        /** ~50 Hz. SENSOR_DELAY_GAME — comfortably above the 16 Hz
+         *  Nyquist floor for [SeizureDetector]'s 2–8 Hz band, with
+         *  headroom for OS-side sample-rate jitter under Doze. */
+        internal const val SAMPLE_RATE_HZ: Double = 50.0
+        private const val SAMPLE_PERIOD_US: Int = 20_000
+
+        /** Rolling buffer holds 60 s — comfortably longer than
+         *  [SeizureDetector.MIN_SUSTAINED_SEC] (10 s) plus headroom for
+         *  the corroborator's pre-event baseline read window. */
+        internal const val BUFFER_CAPACITY_SEC: Int = 60
+
+        /** Analysis cadence. 5 s gives each detection a fair chance to
+         *  fire within the buffer window without burning CPU per
+         *  sample. */
+        internal const val ANALYSIS_INTERVAL_MS: Long = 5_000L
+
+        /** Wake-lock ceiling. Re-acquired on each app launch; the cap
+         *  protects against a runaway service. 24 h covers a full day
+         *  of opt-in operation; longer than that needs a re-start. */
+        private const val MAX_WAKE_LOCK_MS: Long = 24L * 60L * 60L * 1000L
+
+        /** Stable deviceName for the DataSource row that owns
+         *  wearable-inferred SEIZURE_EVENT rows. */
+        const val SOURCE_DEVICE_NAME = "Wearable seizure detector"
+
+        /** Start the service from app init / the Settings toggle. No-op
+         *  when the opt-in is off. */
+        fun startIfOptedIn(context: Context) {
+            if (!SeizureDetectionPrefs.isEnabled(context)) return
+            val intent = Intent(context, SeizureDetectionService::class.java)
+            ContextCompat.startForegroundService(context.applicationContext, intent)
+        }
+
+        /** Stop the service. Safe to call when already stopped. */
+        fun stop(context: Context) {
+            val intent = Intent(context, SeizureDetectionService::class.java)
+            context.applicationContext.stopService(intent)
+        }
+
+        fun createChannelIfNeeded(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+            val manager = context.getSystemService(NotificationManager::class.java)
+                ?: return
+            if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Seizure detection",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description =
+                        "Posted while Bios is watching for convulsive-pattern movement. " +
+                            "Owner opt-in only."
+                    setShowBadge(false)
+                }
+            )
+        }
+
+        internal fun buildNotification(context: Context): Notification =
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setContentTitle("Bios is watching for convulsive-pattern movement")
+                .setContentText("Detector candidates land in the timeline for your review.")
+                .setSmallIcon(context.applicationInfo.icon)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .build()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.bios.app.engine.SeizureDetectionPrefs
+import com.bios.app.ingest.SeizureDetectionService
 
 /**
  * Settings → Seizure detection card. Single toggle that gates the
@@ -69,6 +70,14 @@ internal fun SettingsSeizureDetectionCard() {
                     onCheckedChange = {
                         enabled = it
                         SeizureDetectionPrefs.setEnabled(context, it)
+                        // Flip the foreground service in real time so the
+                        // owner doesn't need to restart the app for the
+                        // toggle to take effect.
+                        if (it) {
+                            SeizureDetectionService.startIfOptedIn(context)
+                        } else {
+                            SeizureDetectionService.stop(context)
+                        }
                     },
                 )
             }

--- a/android/app/src/test/java/com/bios/app/SeizureDetectionBufferTest.kt
+++ b/android/app/src/test/java/com/bios/app/SeizureDetectionBufferTest.kt
@@ -1,0 +1,93 @@
+package com.bios.app
+
+import com.bios.app.ingest.SeizureDetectionBuffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [SeizureDetectionBuffer] (#269 Cut 3b). The
+ * Android-bound [com.bios.app.ingest.SeizureDetectionService] hosts
+ * the SensorManager listener; the buffer is the only piece of that
+ * hot path that's testable without an emulator.
+ */
+class SeizureDetectionBufferTest {
+
+    @Test
+    fun new_buffer_is_empty_and_has_no_start_timestamp() {
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 60)
+        assertTrue(b.isEmpty())
+        assertEquals(0, b.size())
+        assertNull(b.startTimestampMs)
+    }
+
+    @Test
+    fun append_records_the_first_timestamp_as_buffer_start() {
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 60)
+        b.append(0f, 0f, 9.81f, nowMs = 1_700_000_000_000L)
+        assertEquals(1_700_000_000_000L, b.startTimestampMs)
+        assertEquals(1, b.size())
+    }
+
+    @Test
+    fun magnitude_is_norm_minus_gravity() {
+        // Resting phone with gravity on z should record near-zero magnitude.
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 60)
+        b.append(0f, 0f, 9.81f, nowMs = 0L)
+        val snap = b.snapshot()
+        assertEquals(1, snap.size)
+        // norm = 9.81, minus gravity = ~0
+        assertTrue("expected ~0 for resting sample, got ${snap.single()}", kotlin.math.abs(snap.single()) < 1e-6)
+    }
+
+    @Test
+    fun magnitude_for_strong_motion_is_positive_after_gravity_subtraction() {
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 60)
+        // norm = sqrt(20^2) = 20, minus 9.81 = 10.19
+        b.append(20f, 0f, 0f, nowMs = 0L)
+        val v = b.snapshot().single()
+        assertEquals(10.19, v, 0.01)
+    }
+
+    @Test
+    fun appending_past_capacity_evicts_the_oldest_sample() {
+        // Capacity = 1 s at 50 Hz = 50 samples.
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 1)
+        repeat(60) { i ->
+            b.append(0f, 0f, 9.81f, nowMs = i.toLong())
+        }
+        assertEquals(50, b.size())
+    }
+
+    @Test
+    fun start_timestamp_advances_when_the_buffer_evicts() {
+        // Capacity = 1 s at 50 Hz = 50 samples. Period per sample = 20 ms.
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 1)
+        repeat(50) { i ->
+            b.append(0f, 0f, 9.81f, nowMs = i * 20L) // 50 samples, no eviction
+        }
+        val beforeEvict = b.startTimestampMs
+        assertEquals(0L, beforeEvict)
+
+        b.append(0f, 0f, 9.81f, nowMs = 1_000L) // 51st append triggers one eviction
+        val afterOneEvict = b.startTimestampMs
+        assertNotNull(afterOneEvict)
+        assertEquals(20L, afterOneEvict)
+
+        repeat(10) { b.append(0f, 0f, 9.81f, nowMs = 2_000L) } // 10 more evictions
+        assertEquals(20L + 10L * 20L, b.startTimestampMs)
+    }
+
+    @Test
+    fun snapshot_returns_a_defensive_copy() {
+        val b = SeizureDetectionBuffer(sampleRateHz = 50.0, capacitySec = 60)
+        b.append(1f, 0f, 0f, nowMs = 0L)
+        val s1 = b.snapshot()
+        b.append(2f, 0f, 0f, nowMs = 20L)
+        // s1 must not have grown; the implementation returns a copy.
+        assertEquals(1, s1.size)
+        assertEquals(2, b.snapshot().size)
+    }
+}


### PR DESCRIPTION
## Summary
Wires [`SeizureDetector`](android/app/src/main/java/com/bios/app/engine/SeizureDetector.kt) (shipped pure in [#274](https://github.com/thdelmas/Bios/pull/274)) into a real production caller. This is the third gate-and-then-turn-on cut for the wearable seizure path:

- **Safety gate** ([#287](https://github.com/thdelmas/Bios/pull/287), merged) — `SignalRule.excludePayloadFieldValue` keeps wearable-inferred SEIZURE_EVENT rows out of the URGENT / ADVISORY escalation paths.
- **Privacy gate** ([#288](https://github.com/thdelmas/Bios/pull/288), merged) — `SeizureDetectionPrefs` owner opt-in, off by default.
- **This PR** — actually runs the detector. Detector candidates land in the timeline as `wearable_inferred` SEIZURE_EVENT rows for owner review.

The two existing gates hold regardless of this service's output: a false-positive detection cannot page emergency services, and the service refuses to start when the opt-in is off.

## Pieces
- **New: [`SeizureDetectionService`](android/app/src/main/java/com/bios/app/ingest/SeizureDetectionService.kt)** — `FOREGROUND_SERVICE_TYPE_HEALTH`, `PARTIAL_WAKE_LOCK`, accelerometer listener at `SENSOR_DELAY_GAME` (~50 Hz — comfortably above the 16 Hz Nyquist floor for [`SeizureDetector`](android/app/src/main/java/com/bios/app/engine/SeizureDetector.kt)'s 2–8 Hz clonic band), rolling 60 s buffer, analysis every 5 s. On detection, fetches the HR substrate from `metric_readings` (`HEART_RATE` window covering pre-event baseline + analysis window) and persists detections via [`SeizureEventFactory`](android/app/src/main/java/com/bios/app/engine/SeizureEventFactory.kt) with `confidence = LOW` and `detection_source = "wearable_inferred"`.
- **New: [`SeizureDetectionBuffer`](android/app/src/main/java/com/bios/app/ingest/SeizureDetectionBuffer.kt)** — pure-logic rolling buffer. Extracted so the magnitude conversion (`sqrt(x²+y²+z²) − g`), eviction, and timestamp-advancement logic are JVM-testable without an Android sensor stack.
- **[`DataSourceDao.findByTypeAndDeviceName`](android/app/src/main/java/com/bios/app/data/dao/DataSourceDao.kt)** — added. The seizure source and the phone-sleep source share `SourceType.PHONE_SENSOR_DERIVED` but must register as distinct `data_sources` rows for clean provenance (`deviceName = "Wearable seizure detector"` vs `"Phone sleep inference"`).
- **[`BiosApplication.onCreate`](android/app/src/main/java/com/bios/app/BiosApplication.kt)** — calls `SeizureDetectionService.startIfOptedIn(this)` so the service comes back online after an app restart when the toggle is on. The service self-stops if the opt-in is somehow off when `onStartCommand` runs.
- **[`SettingsSeizureDetectionCard`](android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt)** — toggle now starts / stops the service in real time so the owner doesn't need to restart the app.
- **Manifest** — service declaration mirrors `PhoneSleepCollectionService`.

## What this does NOT do (deferred to Cut 3c)
- **Timeline differentiation** between `wearable_inferred` and `owner_logged` SEIZURE_EVENT rows on the pull-side UI. Today both render identically; the wearable-inferred ones carry the `detection_source` payload field so the renderer change is plumbing-ready when it lands.
- **Per-detection battery-budget telemetry** so the opt-in copy's "expect a measurable battery cost" claim can be quantified from real field data.

## Battery realism
Continuous 50 Hz accelerometer + a persistent wake-lock has a real drain. Order-of-magnitude estimate: a few mA at the sensor hub plus the CPU cost of one FFT per second (extracted via [`Spectral.fftInPlace`](android/app/src/main/java/com/bios/app/engine/Spectral.kt) — already optimised). The opt-in copy in #288's card already says "expect a measurable battery cost." Per-detection telemetry follow-up will replace the estimate with measurement.

## Test plan
- [x] **6 unit tests** in new [`SeizureDetectionBufferTest`](android/app/src/test/java/com/bios/app/SeizureDetectionBufferTest.kt):
  - `new_buffer_is_empty_and_has_no_start_timestamp`
  - `append_records_the_first_timestamp_as_buffer_start`
  - `magnitude_is_norm_minus_gravity` — resting phone reads ~0
  - `magnitude_for_strong_motion_is_positive_after_gravity_subtraction`
  - `appending_past_capacity_evicts_the_oldest_sample`
  - `start_timestamp_advances_when_the_buffer_evicts` — the corroborator depends on a correct timestamp for the pre-event HR baseline window
  - `snapshot_returns_a_defensive_copy` — no `ConcurrentModification` when the listener appends while analysis is reading
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug across both flavours, unit tests).
- [ ] Manual: enable the toggle, confirm the foreground notification appears and persists across screen-off.
- [ ] Manual: simulate convulsive motion + HR rise on a test device, confirm a SEIZURE_EVENT row lands in the metric_readings debug screen (#277) with `confidence = 1` (LOW) and a `detection_source = "wearable_inferred"` payload field.
- [ ] Manual: disable the toggle, confirm the notification clears within a few seconds (next analysis tick).

## Next
[#269](https://github.com/thdelmas/Bios/issues/269) Cut 3c (timeline UI differentiation) + per-detection battery telemetry are the natural follow-ups. After those land, the issue can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)