### PR TITLE
feat(ui): seizure timeline screen + provenance chips (#269 Cut 3c)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -313,11 +313,17 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToTreatmentCourses = { navController.navigate("treatment_courses") },
                     onNavigateToAnthropometry = { navController.navigate("anthropometry") },
                     onNavigateToMetricReadingsDebug = { navController.navigate("metric_readings_debug") },
+                    onNavigateToSeizureTimeline = { navController.navigate("seizure_timeline") },
                 )
             }
             composable("metric_readings_debug") {
                 com.bios.app.ui.diagnostics.MetricReadingsDebugScreen(
                     viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
+                )
+            }
+            composable("seizure_timeline") {
+                com.bios.app.ui.seizure.SeizureTimelineScreen(
                     onBack = { navController.popBackStack() },
                 )
             }

--- a/android/app/src/main/java/com/bios/app/ui/seizure/SeizureSourceClassifier.kt
+++ b/android/app/src/main/java/com/bios/app/ui/seizure/SeizureSourceClassifier.kt
@@ -1,0 +1,84 @@
+package com.bios.app.ui.seizure
+
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.SeizureEventFields
+
+/**
+ * Pure classifier for SEIZURE_EVENT provenance (#269 Cut 3c). Reads
+ * the `detection_source` field from a reading's `event_payloads`
+ * sidecar and produces the [DetectionSource] the timeline UI renders.
+ *
+ * Three categories:
+ *  - [DetectionSource.WearableInferred] — payload explicitly carries
+ *    `detection_source = "wearable_inferred"`. Written by
+ *    [com.bios.app.engine.SeizureEventFactory] from
+ *    [com.bios.app.ingest.SeizureDetectionService].
+ *  - [DetectionSource.OwnerLogged] — payload explicitly carries
+ *    `detection_source = "owner_logged"`. Reserved for the future
+ *    owner-logging entry surface.
+ *  - [DetectionSource.OwnerLoggedImplicit] — no `detection_source`
+ *    field at all. Historical owner-logged shape (the journal UI
+ *    predates the payload surface). Treated as owner-logged for
+ *    rendering purposes — same trust profile.
+ *
+ * The wearable-inferred branch also exposes the peri-event HR
+ * substrate ([WearableInferredSubstrate]) so the renderer can show
+ * the actual ratio behind the detection without re-querying.
+ *
+ * Lifted to its own file so JVM tests pin the classification rules
+ * without touching Compose or Room.
+ */
+internal object SeizureSourceClassifier {
+
+    fun classify(payload: List<EventPayloadField>): DetectionSource {
+        val source = payload.firstOrNull {
+            it.fieldKey == SeizureEventFields.DETECTION_SOURCE
+        }?.stringValue
+        return when (source) {
+            SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED ->
+                DetectionSource.WearableInferred(extractSubstrate(payload))
+            SeizureEventFields.DETECTION_SOURCE_OWNER_LOGGED ->
+                DetectionSource.OwnerLogged
+            null -> DetectionSource.OwnerLoggedImplicit
+            else -> DetectionSource.OwnerLoggedImplicit
+        }
+    }
+
+    private fun extractSubstrate(payload: List<EventPayloadField>): WearableInferredSubstrate {
+        val median = payload.firstOrNull {
+            it.fieldKey == SeizureEventFields.MEDIAN_HR_BPM
+        }?.doubleValue
+        val baseline = payload.firstOrNull {
+            it.fieldKey == SeizureEventFields.BASELINE_HR_BPM
+        }?.doubleValue
+        return WearableInferredSubstrate(
+            medianHrBpm = median,
+            baselineHrBpm = baseline,
+        )
+    }
+}
+
+internal sealed interface DetectionSource {
+    data class WearableInferred(val substrate: WearableInferredSubstrate) : DetectionSource
+    data object OwnerLogged : DetectionSource
+    /** No `detection_source` payload field present — historical
+     *  owner-logged shape. Treated identically to [OwnerLogged] by the
+     *  UI; the distinction is preserved so future analytics can see
+     *  which rows pre-dated the explicit payload surface. */
+    data object OwnerLoggedImplicit : DetectionSource
+}
+
+internal data class WearableInferredSubstrate(
+    val medianHrBpm: Double?,
+    val baselineHrBpm: Double?,
+) {
+    /** Percentage rise vs baseline, rounded to whole-percent for the
+     *  pull-side renderer. Null when either value is missing. */
+    val risePercent: Int?
+        get() {
+            val m = medianHrBpm ?: return null
+            val b = baselineHrBpm ?: return null
+            if (b <= 0.0) return null
+            return (((m - b) / b) * 100.0).toInt()
+        }
+}

--- a/android/app/src/main/java/com/bios/app/ui/seizure/SeizureTimelineScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/seizure/SeizureTimelineScreen.kt
@@ -1,0 +1,254 @@
+package com.bios.app.ui.seizure
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.SeizureDetectionPrefs
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Pull-side surface for SEIZURE_EVENT rows (#269 Cut 3c). Lists every
+ * SEIZURE_EVENT in the database, differentiated by `detection_source`:
+ *
+ *  - **Wearable-detected** — written by [com.bios.app.ingest.SeizureDetectionService].
+ *    Carries the peri-event HR substrate (median + baseline + percentage
+ *    rise) so the owner can see the actual ratio behind the detection.
+ *  - **Owner-logged** — bare MetricReading rows or rows with an explicit
+ *    `detection_source = "owner_logged"` payload field. Reserved space
+ *    for the future owner-logging entry surface.
+ *
+ * Read-only this cut. Manual-log entry is a separate UX design
+ * decision (timestamp/duration/character/aura/post-ictal fields per
+ * NEUROLOGY_POV §2.12) and lives in a follow-up. The view-only screen
+ * is enough to close the manifesto gap from #289: the wearable
+ * detector now writes rows the owner can actually see.
+ *
+ * Reached from [com.bios.app.ui.settings.SettingsSeizureDetectionCard].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SeizureTimelineScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val db = remember(context) { BiosDatabase.getInstance(context) }
+    var readings by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
+    var payloadsById by remember { mutableStateOf<Map<String, List<com.bios.app.model.EventPayloadField>>>(emptyMap()) }
+    val detectorOn = remember(context) { SeizureDetectionPrefs.isEnabled(context) }
+
+    LaunchedEffect(Unit) {
+        // Fetch a wide window — SEIZURE_EVENT rows are rare; the cost of
+        // scanning 90 days is negligible and the owner-visible
+        // timeline benefits from showing historical context.
+        val end = System.currentTimeMillis()
+        val start = end - 90L * 24 * 60 * 60 * 1000
+        val readingDao = db.metricReadingDao()
+        val payloadDao = db.eventPayloadFieldDao()
+        val rows = readingDao
+            .fetch(MetricType.SEIZURE_EVENT.key, start, end)
+            .sortedByDescending { it.timestamp }
+        readings = rows
+        payloadsById = payloadDao
+            .fetchForReadings(rows.map { it.id })
+            .groupBy { it.readingId }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Seizure detections") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { SeizureTimelineHeader(detectorOn) }
+            if (readings.isEmpty()) {
+                item { SeizureTimelineEmpty(detectorOn) }
+            } else {
+                items(readings, key = { it.id }) { reading ->
+                    val payload = payloadsById[reading.id] ?: emptyList()
+                    SeizureTimelineRow(
+                        reading = reading,
+                        source = SeizureSourceClassifier.classify(payload),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeizureTimelineHeader(detectorOn: Boolean) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                "What this screen shows",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                "Every SEIZURE_EVENT recorded in Bios — owner-logged entries plus, when the " +
+                    "wearable detector is enabled, candidates flagged by the accelerometer + " +
+                    "heart-rate corroborator. Wearable-detected events are screening-grade " +
+                    "(LOW confidence) and never page emergency services on their own.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                if (detectorOn) "Wearable detector: ON" else "Wearable detector: OFF",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SeizureTimelineEmpty(detectorOn: Boolean) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                if (detectorOn) {
+                    "No detections yet. The detector is watching while charging-independent " +
+                        "background sensing is active."
+                } else {
+                    "No detections yet. Enable the wearable detector from Settings to start " +
+                        "background watching, or log a seizure event manually from a future " +
+                        "owner-entry surface."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SeizureTimelineRow(
+    reading: MetricReading,
+    source: DetectionSource,
+) {
+    val timestampFormat = remember {
+        SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    }
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    timestampFormat.format(Date(reading.timestamp)),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                SourceChip(source)
+            }
+            reading.durationSec?.let { sec ->
+                val mins = sec / 60
+                val secs = sec % 60
+                val durationText = if (mins > 0) "${mins}m ${secs}s" else "${secs}s"
+                Text(
+                    "Duration: $durationText",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            if (source is DetectionSource.WearableInferred) {
+                val sub = source.substrate
+                val median = sub.medianHrBpm
+                val baseline = sub.baselineHrBpm
+                val rise = sub.risePercent
+                if (median != null && baseline != null && rise != null) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        "Peri-event HR: ${median.toInt()} bpm (baseline ${baseline.toInt()}, " +
+                            "+$rise%)",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceChip(source: DetectionSource) {
+    val label = when (source) {
+        is DetectionSource.WearableInferred -> "Wearable-detected"
+        DetectionSource.OwnerLogged -> "Owner-logged"
+        DetectionSource.OwnerLoggedImplicit -> "Owner-logged"
+    }
+    AssistChip(
+        onClick = {},
+        label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ fun SettingsScreen(
     onNavigateToTreatmentCourses: () -> Unit = {},
     onNavigateToAnthropometry: () -> Unit = {},
     onNavigateToMetricReadingsDebug: () -> Unit = {},
+    onNavigateToSeizureTimeline: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
@@ -400,7 +401,7 @@ fun SettingsScreen(
 
         SettingsFeedbackCard()
 
-        SettingsSeizureDetectionCard()
+        SettingsSeizureDetectionCard(onViewDetections = onNavigateToSeizureTimeline)
 
         SettingsDiagnosticsCard()
 

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,7 +38,7 @@ import com.bios.app.ingest.SeizureDetectionService
  * the host file.
  */
 @Composable
-internal fun SettingsSeizureDetectionCard() {
+internal fun SettingsSeizureDetectionCard(onViewDetections: () -> Unit = {}) {
     val context = LocalContext.current
     Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -80,6 +81,10 @@ internal fun SettingsSeizureDetectionCard() {
                         }
                     },
                 )
+            }
+            Spacer(Modifier.height(4.dp))
+            TextButton(onClick = onViewDetections) {
+                Text("View detections")
             }
         }
     }

--- a/android/app/src/test/java/com/bios/app/SeizureSourceClassifierTest.kt
+++ b/android/app/src/test/java/com/bios/app/SeizureSourceClassifierTest.kt
@@ -1,0 +1,148 @@
+package com.bios.app
+
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.SeizureEventFields
+import com.bios.app.ui.seizure.DetectionSource
+import com.bios.app.ui.seizure.SeizureSourceClassifier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [SeizureSourceClassifier] (#269 Cut 3c).
+ * Pins how SEIZURE_EVENT provenance + the peri-event HR substrate
+ * are extracted from the `event_payloads` sidecar so the timeline
+ * renderer can show wearable-detected vs owner-logged rows
+ * differently without re-querying.
+ */
+class SeizureSourceClassifierTest {
+
+    private val readingId = "r1"
+
+    @Test
+    fun empty_payload_is_classified_as_implicit_owner_logged() {
+        val source = SeizureSourceClassifier.classify(emptyList())
+        assertEquals(DetectionSource.OwnerLoggedImplicit, source)
+    }
+
+    @Test
+    fun payload_without_detection_source_field_is_implicit_owner_logged() {
+        // The HR substrate is present (a future owner-log surface might
+        // attach context fields too), but no detection_source — keep the
+        // implicit classification.
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                doubleValue = 95.0,
+            )
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        assertEquals(DetectionSource.OwnerLoggedImplicit, source)
+    }
+
+    @Test
+    fun explicit_owner_logged_payload_is_classified_as_OwnerLogged() {
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = SeizureEventFields.DETECTION_SOURCE_OWNER_LOGGED,
+            )
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        assertEquals(DetectionSource.OwnerLogged, source)
+    }
+
+    @Test
+    fun wearable_inferred_payload_carries_the_hr_substrate() {
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+            ),
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                doubleValue = 120.0,
+            ),
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.BASELINE_HR_BPM,
+                doubleValue = 80.0,
+            ),
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        assertTrue(source is DetectionSource.WearableInferred)
+        val sub = (source as DetectionSource.WearableInferred).substrate
+        assertEquals(120.0, sub.medianHrBpm!!, 1e-9)
+        assertEquals(80.0, sub.baselineHrBpm!!, 1e-9)
+        // (120 - 80) / 80 = 0.5 → 50%
+        assertEquals(50, sub.risePercent)
+    }
+
+    @Test
+    fun wearable_inferred_without_hr_substrate_still_classifies_but_rise_is_null() {
+        // Defensive case: an older wearable-inferred row that pre-dates
+        // the substrate fields should still classify; risePercent is
+        // null when either field is missing.
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+            ),
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        assertTrue(source is DetectionSource.WearableInferred)
+        val sub = (source as DetectionSource.WearableInferred).substrate
+        assertNull(sub.medianHrBpm)
+        assertNull(sub.baselineHrBpm)
+        assertNull(sub.risePercent)
+    }
+
+    @Test
+    fun risePercent_is_null_when_baseline_is_zero_or_negative() {
+        // Math guard — division by zero must not crash the renderer.
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = SeizureEventFields.DETECTION_SOURCE_WEARABLE_INFERRED,
+            ),
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.MEDIAN_HR_BPM,
+                doubleValue = 120.0,
+            ),
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.BASELINE_HR_BPM,
+                doubleValue = 0.0,
+            ),
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        val sub = (source as DetectionSource.WearableInferred).substrate
+        assertNull(sub.risePercent)
+    }
+
+    @Test
+    fun unknown_detection_source_value_falls_through_to_implicit() {
+        // Defensive: a value we don't recognise (mis-spelt, future-key
+        // we don't know about) should not crash and should not falsely
+        // claim wearable-inferred. Implicit owner-logged is the safe
+        // default — the safety gate (#287) only filters on the exact
+        // wearable_inferred string anyway.
+        val payload = listOf(
+            EventPayloadField(
+                readingId = readingId,
+                fieldKey = SeizureEventFields.DETECTION_SOURCE,
+                stringValue = "unrecognised_future_value",
+            )
+        )
+        val source = SeizureSourceClassifier.classify(payload)
+        assertEquals(DetectionSource.OwnerLoggedImplicit, source)
+    }
+}


### PR DESCRIPTION
## Summary
Closes the manifesto gap from [#289](https://github.com/thdelmas/Bios/pull/289): the wearable seizure detector now writes `SEIZURE_EVENT` rows but the owner had no surface to read them on (the only existing view was the [#277](https://github.com/thdelmas/Bios/pull/277) row-count debug screen). "Bios is the instrument; the owner reads it" requires the owner can actually see what the detector flagged — and evaluate it themselves, per the "evaluation belongs to the owner" principle.

This PR ships the pull-side view + provenance differentiation so wearable-detected candidates are clearly distinct from owner-logged events.

## Pieces
- **New: [`SeizureTimelineScreen`](android/app/src/main/java/com/bios/app/ui/seizure/SeizureTimelineScreen.kt)** — lists every `SEIZURE_EVENT` in the last 90 days, newest first. Each row shows the timestamp, duration, and a provenance chip (`Wearable-detected` or `Owner-logged`). Wearable-detected rows additionally render the peri-event HR substrate written by [`SeizureEventFactory`](android/app/src/main/java/com/bios/app/engine/SeizureEventFactory.kt): median bpm, baseline bpm, and percentage rise — so the owner sees the actual ratio behind each detection without re-querying. Header card explains the screen contents + whether the detector is currently on; empty state copy adapts.
- **New: [`SeizureSourceClassifier`](android/app/src/main/java/com/bios/app/ui/seizure/SeizureSourceClassifier.kt)** — pure helper that reads the `detection_source` field from `event_payloads` and produces a sealed `DetectionSource` type. Three branches: `WearableInferred(substrate)`, `OwnerLogged`, `OwnerLoggedImplicit` (no payload at all — historical owner-logged shape from before the payload surface existed). JVM-testable.
- **[`SettingsSeizureDetectionCard`](android/app/src/main/java/com/bios/app/ui/settings/SettingsSeizureDetectionCard.kt)** — gains a "View detections" `TextButton`. Closest discoverability surface since the owner already turned the toggle on there.
- **[`SettingsScreen`](android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt) + [`MainActivity`](android/app/src/main/java/com/bios/app/ui/MainActivity.kt)** — new `onNavigateToSeizureTimeline` callback plumbed through, new `"seizure_timeline"` route registered.

## Read-only this cut (deliberate)
The owner-logging entry surface (timestamp / duration / character / aura / post-ictal per NEUROLOGY_POV §2.12) is a separate UX design decision. Bundling it here would creep scope and force premature schema choices. The view-only screen is enough to close the manifesto gap from #289; the manual-log surface lands in a follow-up.

## Test plan
- [x] **7 unit tests** in [`SeizureSourceClassifierTest`](android/app/src/test/java/com/bios/app/SeizureSourceClassifierTest.kt):
  - `empty_payload_is_classified_as_implicit_owner_logged`
  - `payload_without_detection_source_field_is_implicit_owner_logged` (substrate present, no source key)
  - `explicit_owner_logged_payload_is_classified_as_OwnerLogged`
  - `wearable_inferred_payload_carries_the_hr_substrate` — median 120, baseline 80 → `risePercent = 50`
  - `wearable_inferred_without_hr_substrate_still_classifies_but_rise_is_null` — defensive for rows pre-dating substrate fields
  - `risePercent_is_null_when_baseline_is_zero_or_negative` — division-by-zero guard
  - `unknown_detection_source_value_falls_through_to_implicit` — unrecognised values default to safe (implicit owner-logged); the #287 safety gate only filters the exact `wearable_inferred` string anyway
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: enable the detector (#288), wait for the FG service to land a wearable-inferred row (#289 path), open Settings → Seizure detection → View detections, confirm the row appears with the Wearable-detected chip and the HR substrate line.
- [ ] Manual: with the detector off, confirm the empty-state copy reads "Enable the wearable detector from Settings…" and the header shows "Wearable detector: OFF".

## What this completes
With this cut, [#269](https://github.com/thdelmas/Bios/issues/269) is functionally complete: safety gate (#287), privacy gate (#288), production wiring (#289), and now an owner-readable surface. The remaining nice-to-haves (manual-log entry, per-detection battery telemetry) are explicitly follow-up scope and can be tracked separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)