### PR TITLE
feat(contracts): headache event MetricTypes + payload keys (#283 Cut 1)

### DIFF
--- a/android/app/src/main/java/com/bios/app/model/HeadacheEventFields.kt
+++ b/android/app/src/main/java/com/bios/app/model/HeadacheEventFields.kt
@@ -1,0 +1,104 @@
+package com.bios.app.model
+
+/**
+ * `event_payloads` field-key namespace for the ICHD-3-shaped headache
+ * event types added in #283 Cut 1:
+ *
+ *  - [com.bios.contracts.MetricType.MIGRAINE_ATTACK_EVENT]
+ *  - [com.bios.contracts.MetricType.HEADACHE_ATTACK_EVENT]
+ *  - [com.bios.contracts.MetricType.CLUSTER_HEADACHE_ATTACK_EVENT]
+ *
+ * Centralised so the entry surface ([MigraineAttack] / [HeadacheLog] →
+ * MetricReading-row writer, Cut 2), the chronic-migraine evaluator
+ * (Cut 3), the MOH evaluator (already shipping, will be updated to
+ * consume the structured rows), and any future clinician-share
+ * exporter can't drift on spelling. Same shape and rationale as
+ * [SeizureEventFields].
+ *
+ * The IHS ICHD-3 (International Classification of Headache Disorders,
+ * 3rd ed.) field set is the documented contract. Onset and end are
+ * carried on the parent [MetricReading.timestamp] +
+ * [MetricReading.durationSec] respectively — they don't need payload
+ * fields. Severity is carried on the parent [MetricReading.value]
+ * (0–10 numeric rating scale, the same scale [HeadacheLog.intensity]
+ * and [MigraineAttack.peakIntensity] already use).
+ *
+ * The remaining ICHD-3 fields live here as nullable payload keys —
+ * a payload row exists when the owner recorded that field at entry
+ * time, doesn't when they didn't. Renderers must treat absence as
+ * "owner did not record" not "owner answered no."
+ */
+object HeadacheEventFields {
+
+    /**
+     * Headache side. ICHD-3 §1.1.C.1 (migraine criterion: unilateral
+     * location, often pulsating).
+     * Allowed values: [SIDE_UNILATERAL_LEFT], [SIDE_UNILATERAL_RIGHT],
+     * [SIDE_BILATERAL], [SIDE_HOLOCRANIAL].
+     */
+    const val SIDE = "side"
+    const val SIDE_UNILATERAL_LEFT = "unilateral_left"
+    const val SIDE_UNILATERAL_RIGHT = "unilateral_right"
+    const val SIDE_BILATERAL = "bilateral"
+    const val SIDE_HOLOCRANIAL = "holocranial"
+
+    /**
+     * Headache character. ICHD-3 §1.1.C.3 (migraine criterion: pulsating
+     * quality). Allowed values: [CHARACTER_PULSATING],
+     * [CHARACTER_PRESSING], [CHARACTER_STABBING],
+     * [CHARACTER_BURNING], [CHARACTER_OTHER].
+     */
+    const val CHARACTER = "character"
+    const val CHARACTER_PULSATING = "pulsating"
+    const val CHARACTER_PRESSING = "pressing"
+    const val CHARACTER_STABBING = "stabbing"
+    const val CHARACTER_BURNING = "burning"
+    const val CHARACTER_OTHER = "other"
+
+    /** ICHD-3 §1.1.D.2 — photophobia. `longValue` 1 = true, 0 = false. */
+    const val PHOTOPHOBIA = "photophobia"
+
+    /** ICHD-3 §1.1.D.2 — phonophobia. `longValue` 1 = true, 0 = false. */
+    const val PHONOPHOBIA = "phonophobia"
+
+    /** ICHD-3 §1.1.D.1 — nausea (with or without vomiting). `longValue`
+     *  1 = true, 0 = false. */
+    const val NAUSEA = "nausea"
+
+    /** ICHD-3 §1.2 — aura (visual / sensory / speech / motor symptoms
+     *  preceding or accompanying the attack). `longValue` 1 = true,
+     *  0 = false. */
+    const val AURA = "aura"
+
+    /** ICHD-3 §1.1.C.4 — aggravation by routine physical activity (e.g.
+     *  walking, climbing stairs). `longValue` 1 = true, 0 = false. */
+    const val AGGRAVATED_BY_ACTIVITY = "aggravated_by_activity"
+
+    /** ICHD-3 §3.1.B.3 — cranial autonomic features ipsilateral to the
+     *  pain (conjunctival injection, lacrimation, nasal congestion,
+     *  ptosis, etc.). Diagnostic of cluster headache and other TACs.
+     *  `longValue` 1 = true, 0 = false. */
+    const val AUTONOMIC_FEATURES = "autonomic_features"
+
+    /** Free-text owner-recorded triggers (comma-separated, mirrors the
+     *  [MigraineTrigger] enum names where they apply). Stored on
+     *  `stringValue`. */
+    const val TRIGGERS = "triggers"
+
+    /** Free-text name of the abortive medication taken (e.g.
+     *  "sumatriptan 50 mg", "ibuprofen 400 mg"). Mirrors the existing
+     *  [MigraineAttack.medicationTaken] / [HeadacheLog.medicationTaken]
+     *  free-text fields so legacy rows can be carried forward. */
+    const val ABORTIVE_MEDICATION = "abortive_medication"
+
+    /** `MetricReading.id` of the linked
+     *  [com.bios.contracts.MetricType.MEDICATION_INTAKE] row written by
+     *  the per-event writer (Cut 2). Lets the MOH evaluator (and any
+     *  future MS DMT adherence path) walk back from the structured
+     *  medication-intake row to the parent headache event. Stored on
+     *  `stringValue`. */
+    const val ABORTIVE_MEDICATION_INTAKE_ID = "abortive_medication_intake_id"
+
+    /** Owner free-text note. */
+    const val NOTES = "notes"
+}

--- a/android/app/src/test/java/com/bios/app/HeadacheEventFieldsTest.kt
+++ b/android/app/src/test/java/com/bios/app/HeadacheEventFieldsTest.kt
@@ -1,0 +1,94 @@
+package com.bios.app
+
+import com.bios.app.model.HeadacheEventFields
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Frozen snapshot of the [HeadacheEventFields] payload-field-key set
+ * (#283 Cut 1). These strings land in the `event_payloads` sidecar of
+ * every HEADACHE_ATTACK_EVENT / CLUSTER_HEADACHE_ATTACK_EVENT /
+ * MIGRAINE_ATTACK_EVENT row written by the entry surface (#283 Cut 2)
+ * and read by the chronic-migraine evaluator (#283 Cut 3), the MOH
+ * evaluator update (also Cut 3), and any future clinician-share
+ * exporter.
+ *
+ * **How to update this file.**
+ *  - Adding a key: append the new constant + add it to the snapshot.
+ *  - Renaming a key: don't. Keep the old constant + add the new one,
+ *    or migrate readers first. Renaming silently invalidates every
+ *    pre-rename row on disk.
+ *  - Same trust-the-wire-format reasoning as
+ *    `MetricTypeKeysSnapshotTest`.
+ */
+class HeadacheEventFieldsTest {
+
+    private val shippedKeys: Map<String, String> = mapOf(
+        "SIDE" to HeadacheEventFields.SIDE,
+        "SIDE_UNILATERAL_LEFT" to HeadacheEventFields.SIDE_UNILATERAL_LEFT,
+        "SIDE_UNILATERAL_RIGHT" to HeadacheEventFields.SIDE_UNILATERAL_RIGHT,
+        "SIDE_BILATERAL" to HeadacheEventFields.SIDE_BILATERAL,
+        "SIDE_HOLOCRANIAL" to HeadacheEventFields.SIDE_HOLOCRANIAL,
+        "CHARACTER" to HeadacheEventFields.CHARACTER,
+        "CHARACTER_PULSATING" to HeadacheEventFields.CHARACTER_PULSATING,
+        "CHARACTER_PRESSING" to HeadacheEventFields.CHARACTER_PRESSING,
+        "CHARACTER_STABBING" to HeadacheEventFields.CHARACTER_STABBING,
+        "CHARACTER_BURNING" to HeadacheEventFields.CHARACTER_BURNING,
+        "CHARACTER_OTHER" to HeadacheEventFields.CHARACTER_OTHER,
+        "PHOTOPHOBIA" to HeadacheEventFields.PHOTOPHOBIA,
+        "PHONOPHOBIA" to HeadacheEventFields.PHONOPHOBIA,
+        "NAUSEA" to HeadacheEventFields.NAUSEA,
+        "AURA" to HeadacheEventFields.AURA,
+        "AGGRAVATED_BY_ACTIVITY" to HeadacheEventFields.AGGRAVATED_BY_ACTIVITY,
+        "AUTONOMIC_FEATURES" to HeadacheEventFields.AUTONOMIC_FEATURES,
+        "TRIGGERS" to HeadacheEventFields.TRIGGERS,
+        "ABORTIVE_MEDICATION" to HeadacheEventFields.ABORTIVE_MEDICATION,
+        "ABORTIVE_MEDICATION_INTAKE_ID" to HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID,
+        "NOTES" to HeadacheEventFields.NOTES,
+    )
+
+    @Test
+    fun every_field_key_value_is_frozen() {
+        // Pinning each constant to its shipped string. Renaming a value
+        // here invalidates every row written under the old name — the
+        // diary substrate the chronic-migraine and MOH evaluators read
+        // depends on these names staying put.
+        assertEquals("side", shippedKeys["SIDE"])
+        assertEquals("unilateral_left", shippedKeys["SIDE_UNILATERAL_LEFT"])
+        assertEquals("unilateral_right", shippedKeys["SIDE_UNILATERAL_RIGHT"])
+        assertEquals("bilateral", shippedKeys["SIDE_BILATERAL"])
+        assertEquals("holocranial", shippedKeys["SIDE_HOLOCRANIAL"])
+        assertEquals("character", shippedKeys["CHARACTER"])
+        assertEquals("pulsating", shippedKeys["CHARACTER_PULSATING"])
+        assertEquals("pressing", shippedKeys["CHARACTER_PRESSING"])
+        assertEquals("stabbing", shippedKeys["CHARACTER_STABBING"])
+        assertEquals("burning", shippedKeys["CHARACTER_BURNING"])
+        assertEquals("other", shippedKeys["CHARACTER_OTHER"])
+        assertEquals("photophobia", shippedKeys["PHOTOPHOBIA"])
+        assertEquals("phonophobia", shippedKeys["PHONOPHOBIA"])
+        assertEquals("nausea", shippedKeys["NAUSEA"])
+        assertEquals("aura", shippedKeys["AURA"])
+        assertEquals("aggravated_by_activity", shippedKeys["AGGRAVATED_BY_ACTIVITY"])
+        assertEquals("autonomic_features", shippedKeys["AUTONOMIC_FEATURES"])
+        assertEquals("triggers", shippedKeys["TRIGGERS"])
+        assertEquals("abortive_medication", shippedKeys["ABORTIVE_MEDICATION"])
+        assertEquals(
+            "abortive_medication_intake_id",
+            shippedKeys["ABORTIVE_MEDICATION_INTAKE_ID"],
+        )
+        assertEquals("notes", shippedKeys["NOTES"])
+    }
+
+    @Test
+    fun no_field_keys_collide() {
+        // Each constant must be a unique string so a payload row keyed
+        // by one field can't be misread as another. Catches accidental
+        // copy-paste collisions when adding new fields.
+        val values = shippedKeys.values.toList()
+        assertEquals(
+            "Duplicate values in HeadacheEventFields: ${values.groupBy { it }.filter { it.value.size > 1 }.keys}",
+            values.size,
+            values.toSet().size,
+        )
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -137,14 +137,15 @@ enum class MetricType(
     PAIN_SCORE("pain_score", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
     CONSCIOUSNESS_LEVEL("consciousness_level", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
-    // Neurology owner-symptom logging (#207, NEUROLOGY_POV §2.6 / §2.5 /
-    // §2.15). Owner-input only — manifesto §3.3 prohibits automated voice /
-    // face stroke detection. HEADACHE_INTENSITY_NRS is the flat-metric
-    // shadow of the structured HeadacheLog / MigraineAttack entities;
-    // sidecar fields (aura, triggers, treatment, FAST item) live on the
-    // structured row, not in event_payloads.
+    // Neurology owner-symptom logging (#207 + #283 Cut 1, NEUROLOGY_POV §2.5+§2.6+§2.15).
+    // Owner-input only — manifesto §3.3 prohibits automated voice / face stroke detection.
+    // HEADACHE_INTENSITY_NRS is the flat-metric shadow of the structured HeadacheLog /
+    // MigraineAttack entities. Headache / cluster / migraine event payload fields land
+    // on event_payloads via com.bios.app.model.HeadacheEventFields.
     HEADACHE_INTENSITY_NRS("headache_intensity_nrs", MetricUnit.SCORE, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
     MIGRAINE_ATTACK_EVENT("migraine_attack_event", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+    HEADACHE_ATTACK_EVENT("headache_attack_event", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
+    CLUSTER_HEADACHE_ATTACK_EVENT("cluster_headache_attack_event", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
     FAST_STROKE_SUSPECTED("fast_stroke_suspected", MetricUnit.EVENT, MetricDomain.NEUROLOGICAL, allowsManualEntry = true),
 
     // Neurology URGENT primitives (audit §3.2 #24 / NEUROLOGY_POV §2.1+§2.3).

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -230,6 +230,12 @@ class MetricTypeKeysSnapshotTest {
         // Neurology owner-PRO (#207)
         "headache_intensity_nrs",
         "migraine_attack_event",
+        // ICHD-3 structured event surface (#283 Cut 1) — generic headache +
+        // cluster split from migraine so the chronic-migraine pattern
+        // (#283 Cut 3, IHS ICHD-3 §1.3) can count migraine-days separately
+        // and #284's cluster periodicity histogram has its own row stream.
+        "headache_attack_event",
+        "cluster_headache_attack_event",
         "fast_stroke_suspected",
         // Neurology URGENT primitives (#216, audit §3.2 #24)
         "seizure_event",

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/NeurologyAttackEventInvariantsTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/NeurologyAttackEventInvariantsTest.kt
@@ -1,0 +1,38 @@
+package com.bios.contracts
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the shape of the three owner-PRO neurology attack event types
+ * added across #207 + #283 Cut 1. All three must share
+ * (EVENT, NEUROLOGICAL, allowsManualEntry=true) so:
+ *
+ *  - the #283 Cut 2 entry-payload writer treats them uniformly,
+ *  - the #283 Cut 3 chronic-migraine evaluator can count
+ *    migraine-days separately from headache-days from a single
+ *    `metric_readings` scan,
+ *  - the #284 cluster periodicity histogram has its own row stream
+ *    independent of generic headache rows.
+ *
+ * Lifted out of [MetricTypeTest] to keep that file under the 500-line cap.
+ */
+class NeurologyAttackEventInvariantsTest {
+
+    @Test
+    fun attack_events_share_the_owner_pro_shape() {
+        for (t in setOf(
+            MetricType.MIGRAINE_ATTACK_EVENT,
+            MetricType.HEADACHE_ATTACK_EVENT,
+            MetricType.CLUSTER_HEADACHE_ATTACK_EVENT,
+        )) {
+            assertEquals(MetricDomain.NEUROLOGICAL, t.domain)
+            assertEquals(MetricUnit.EVENT, t.unit)
+            assertTrue(
+                "${t.key} must allow manual entry — owner is the only source",
+                t.allowsManualEntry,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Foundational additions for the headache / migraine / cluster structured-event surface. Cuts 2 (per-event `MEDICATION_INTAKE` writer + entry surface migration) and 3 (chronic-migraine threshold pattern + worker + MOH evaluator update consuming structured rows) depend on this.

## Pieces
- **[`MetricType`](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt)** — adds `HEADACHE_ATTACK_EVENT` + `CLUSTER_HEADACHE_ATTACK_EVENT` alongside `MIGRAINE_ATTACK_EVENT`. The split is load-bearing:
  - The chronic-migraine threshold pattern (IHS ICHD-3 §1.3: ≥15 headache days/month with ≥8 migraine-like for 3 months) counts **migraine-days separately from headache-days**. A single combined MetricType would force a payload-field discriminator the slow engine can't read efficiently.
  - [#284](https://github.com/thdelmas/Bios/issues/284)'s cluster periodicity histogram needs its own row stream — cluster's diagnostic signal is **time-of-day periodicity**, and mixing tension rows would dilute it.
- **New: [`HeadacheEventFields`](android/app/src/main/java/com/bios/app/model/HeadacheEventFields.kt)** — centralised payload-field-key namespace for every ICHD-3 field that lands on `event_payloads`: `side` (with constants for unilateral L/R / bilateral / holocranial), `character` (pulsating / pressing / etc.), boolean flags for photophobia / phonophobia / nausea / aura / aggravation by activity / autonomic features (cluster TAC), `triggers`, `abortive_medication`, `abortive_medication_intake_id` (will be set by Cut 2's per-event `MEDICATION_INTAKE` writer), `notes`. Same shape and rationale as [`SeizureEventFields`](android/app/src/main/java/com/bios/app/model/SeizureEvent.kt).

## Tests
- **[`MetricTypeKeysSnapshotTest`](android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt)** — appended the two new keys so the contracts forward-compat guard catches future accidental removals.
- **New: [`HeadacheEventFieldsTest`](android/app/src/test/java/com/bios/app/HeadacheEventFieldsTest.kt)** — frozen snapshot of every payload-field-key value, plus a collision guard. Same trust-the-wire-format reasoning as `MetricTypeKeysSnapshotTest`: a rename silently invalidates rows on disk that downstream evaluators read.
- **New: [`NeurologyAttackEventInvariantsTest`](android/bios-contracts/src/test/kotlin/com/bios/contracts/NeurologyAttackEventInvariantsTest.kt)** — pins `(EVENT, NEUROLOGICAL, allowsManualEntry=true)` for all three attack event types. Drift on any of these would silently break Cuts 2 and 3. Extracted to its own file to keep [`MetricTypeTest`](android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt) under the 500-line cap.

## What this PR does NOT do
- **No production writer** — Cut 2 wires the entry surface ([`MigraineAttack`](android/app/src/main/java/com/bios/app/model/MigraineAttack.kt) / [`HeadacheLog`](android/app/src/main/java/com/bios/app/model/HeadacheLog.kt) → `MetricReading` + payload sidecar) plus the per-event `MEDICATION_INTAKE` writer.
- **No new pattern** — Cut 3 ships the `chronic_migraine_threshold` `ConditionPattern` + worker on the [`MohScreeningWorker`](android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt) shape.
- **No DB schema change** — these are enum additions to a contract module and a constants file. No migration needed (event_payloads rows for the new keys land in the existing `event_payloads` table).

## File-length housekeeping
[`MetricType.kt`](android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt) was already at the 500-line cap. Trimmed the pre-existing neurology owner-PRO comment block to keep the file at exactly 500 lines after the additions.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- No manual verification needed — pure additive contract change with no UX surface this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)