### PR TITLE
feat(data): headache event MetricReading mirror + intake (#283 Cut 2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt
+++ b/android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt
@@ -1,0 +1,207 @@
+package com.bios.app.data
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.EventPayloadField
+import com.bios.app.model.HeadacheEventFields
+import com.bios.app.model.HeadacheLog
+import com.bios.app.model.HeadacheType
+import com.bios.app.model.MetricReading
+import com.bios.app.model.MigraineAttack
+import com.bios.contracts.MetricType
+import java.util.UUID
+
+/**
+ * Pure helper that turns a [MigraineAttack] or [HeadacheLog] entity
+ * into the cross-cutting `metric_readings` + `event_payloads` writeset
+ * the chronic-migraine and MOH evaluators read (#283 Cut 2).
+ *
+ * The entity tables stay the primary store — the diary screen reads
+ * them, and they carry richer structured fields than fit in a generic
+ * payload sidecar. This helper produces a denormalised view of the
+ * same event so engines can scan a single `metric_readings` window
+ * for headache-days / migraine-days / treatment-days, without
+ * cross-table joins.
+ *
+ * The parent reading uses the entity's own UUID as its `id` so an
+ * entity-table delete can clear the matching `MetricReading` by id
+ * without an indirect lookup (see
+ * [com.bios.app.data.dao.MetricReadingDao.deleteById]).
+ *
+ * `value` carries the 0–10 intensity. `durationSec` carries the event
+ * duration when known. Confidence is [ConfidenceTier.HIGH] — owner
+ * assertion is the highest-grade signal we get for headache events.
+ *
+ * When the entity records an abortive medication, the writeset also
+ * includes a child [MetricType.MEDICATION_INTAKE] [MetricReading] +
+ * a reciprocal payload link on the parent
+ * ([HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID]). The
+ * `value` of the child intake is `1.0` (presence marker) — the
+ * free-text dose lives in a `medication_name` payload field on the
+ * child, and Cut 3 / future work can parse the mg out when the
+ * pharmacokinetic-engine path needs it.
+ */
+internal object HeadacheEventWriter {
+
+    /** Field key on the child MEDICATION_INTAKE row that carries the
+     *  owner's free-text medication name (e.g. "sumatriptan 50 mg").
+     *  Lives here, not in [HeadacheEventFields], because it's a key
+     *  on the **child** row, not on the parent headache event. */
+    const val MEDICATION_NAME_FIELD = "medication_name"
+
+    /** Field key on the child MEDICATION_INTAKE row that links back to
+     *  the parent headache event reading id. Reciprocal of
+     *  [HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID]; lets a
+     *  scan-from-the-medication-side path (e.g. future MS DMT
+     *  adherence) walk back to the triggering attack. */
+    const val PARENT_HEADACHE_EVENT_FIELD = "parent_headache_event_id"
+
+    data class WriteSet(
+        val parent: MetricReading,
+        val payload: List<EventPayloadField>,
+        /** Child MEDICATION_INTAKE row when the entity recorded an
+         *  abortive medication; null otherwise. */
+        val abortiveIntake: MetricReading?,
+        /** Payload rows for the child intake (medication name +
+         *  back-link to the parent). Empty when [abortiveIntake] is
+         *  null. */
+        val abortivePayload: List<EventPayloadField>,
+    )
+
+    fun fromMigraineAttack(
+        attack: MigraineAttack,
+        sourceId: String,
+        now: Long = System.currentTimeMillis(),
+    ): WriteSet {
+        val parent = MetricReading(
+            id = attack.id,
+            metricType = MetricType.MIGRAINE_ATTACK_EVENT.key,
+            value = attack.peakIntensity.toDouble(),
+            timestamp = attack.onsetTimestamp,
+            durationSec = attack.endTimestamp?.let {
+                ((it - attack.onsetTimestamp) / 1_000L).toInt().coerceAtLeast(0)
+            },
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            createdAt = now,
+        )
+        val payload = buildList {
+            if (attack.aura) add(boolField(parent.id, HeadacheEventFields.AURA, true))
+            attack.triggers.takeIf { it.isNotEmpty() }?.let { triggers ->
+                add(
+                    EventPayloadField(
+                        readingId = parent.id,
+                        fieldKey = HeadacheEventFields.TRIGGERS,
+                        stringValue = triggers.joinToString(",") { it.name },
+                    )
+                )
+            }
+            attack.medicationTaken?.let { med ->
+                add(
+                    EventPayloadField(
+                        readingId = parent.id,
+                        fieldKey = HeadacheEventFields.ABORTIVE_MEDICATION,
+                        stringValue = med,
+                    )
+                )
+            }
+            attack.notes?.let { add(stringField(parent.id, HeadacheEventFields.NOTES, it)) }
+        }
+        return wrapWithAbortiveIntake(parent, payload, attack.medicationTaken, sourceId, now)
+    }
+
+    fun fromHeadacheLog(
+        log: HeadacheLog,
+        sourceId: String,
+        now: Long = System.currentTimeMillis(),
+    ): WriteSet {
+        val parent = MetricReading(
+            id = log.id,
+            metricType = metricTypeForHeadache(log.type).key,
+            value = log.intensity.toDouble(),
+            timestamp = log.timestamp,
+            durationSec = log.durationMinutes?.let { (it.toLong() * 60L).toInt().coerceAtLeast(0) },
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            createdAt = now,
+        )
+        val payload = buildList {
+            log.medicationTaken?.let { med ->
+                add(
+                    EventPayloadField(
+                        readingId = parent.id,
+                        fieldKey = HeadacheEventFields.ABORTIVE_MEDICATION,
+                        stringValue = med,
+                    )
+                )
+            }
+            log.notes?.let { add(stringField(parent.id, HeadacheEventFields.NOTES, it)) }
+        }
+        return wrapWithAbortiveIntake(parent, payload, log.medicationTaken, sourceId, now)
+    }
+
+    /** [HeadacheType.MIGRAINE] gets routed to [MetricType.MIGRAINE_ATTACK_EVENT]
+     *  so the chronic-migraine evaluator's migraine-day count picks it up
+     *  alongside [MigraineAttack] rows. CLUSTER routes to the dedicated
+     *  cluster event so #284's periodicity histogram has a clean stream.
+     *  Everything else (TENSION / OTHER) is generic HEADACHE_ATTACK_EVENT. */
+    private fun metricTypeForHeadache(type: HeadacheType): MetricType = when (type) {
+        HeadacheType.MIGRAINE -> MetricType.MIGRAINE_ATTACK_EVENT
+        HeadacheType.CLUSTER -> MetricType.CLUSTER_HEADACHE_ATTACK_EVENT
+        HeadacheType.TENSION, HeadacheType.OTHER -> MetricType.HEADACHE_ATTACK_EVENT
+    }
+
+    private fun wrapWithAbortiveIntake(
+        parent: MetricReading,
+        parentPayload: List<EventPayloadField>,
+        medicationTaken: String?,
+        sourceId: String,
+        now: Long,
+    ): WriteSet {
+        if (medicationTaken.isNullOrBlank()) {
+            return WriteSet(parent, parentPayload, abortiveIntake = null, abortivePayload = emptyList())
+        }
+        val intakeId = UUID.randomUUID().toString()
+        val intake = MetricReading(
+            id = intakeId,
+            metricType = MetricType.MEDICATION_INTAKE.key,
+            value = 1.0, // presence marker; dose parsing is future work
+            timestamp = parent.timestamp,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+            createdAt = now,
+        )
+        val intakePayload = listOf(
+            EventPayloadField(
+                readingId = intakeId,
+                fieldKey = MEDICATION_NAME_FIELD,
+                stringValue = medicationTaken,
+            ),
+            EventPayloadField(
+                readingId = intakeId,
+                fieldKey = PARENT_HEADACHE_EVENT_FIELD,
+                stringValue = parent.id,
+            ),
+        )
+        // Add the parent-side back-link payload field.
+        val parentWithLink = parentPayload + EventPayloadField(
+            readingId = parent.id,
+            fieldKey = HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID,
+            stringValue = intakeId,
+        )
+        return WriteSet(parent, parentWithLink, intake, intakePayload)
+    }
+
+    private fun boolField(readingId: String, key: String, value: Boolean): EventPayloadField =
+        EventPayloadField(
+            readingId = readingId,
+            fieldKey = key,
+            longValue = if (value) 1L else 0L,
+        )
+
+    private fun stringField(readingId: String, key: String, value: String): EventPayloadField =
+        EventPayloadField(
+            readingId = readingId,
+            fieldKey = key,
+            stringValue = value,
+        )
+}

--- a/android/app/src/main/java/com/bios/app/data/HeadacheLogRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/HeadacheLogRepo.kt
@@ -1,5 +1,6 @@
 package com.bios.app.data
 
+import com.bios.app.model.HeadacheEventFields
 import com.bios.app.model.HeadacheLog
 import com.bios.app.model.HeadacheType
 
@@ -44,10 +45,41 @@ class HeadacheLogRepo(private val db: BiosDatabase) {
             notes = notes?.trim()?.takeIf { it.isNotBlank() },
         )
         dao.insert(log)
+        writeMetricReadingMirror(log)
         return log.id
     }
 
-    suspend fun remove(id: String) = dao.deleteById(id)
+    suspend fun remove(id: String) {
+        val existing = dao.fetchById(id)
+        dao.deleteById(id)
+        existing?.let { clearMetricReadingMirror(it) }
+    }
+
+    private suspend fun writeMetricReadingMirror(log: HeadacheLog) {
+        val sourceId = resolveSelfReportedSource(db)
+        val writeSet = HeadacheEventWriter.fromHeadacheLog(log, sourceId)
+        db.metricReadingDao().insert(writeSet.parent)
+        db.eventPayloadFieldDao().insertAll(writeSet.payload)
+        writeSet.abortiveIntake?.let {
+            db.metricReadingDao().insert(it)
+            db.eventPayloadFieldDao().insertAll(writeSet.abortivePayload)
+        }
+    }
+
+    private suspend fun clearMetricReadingMirror(log: HeadacheLog) {
+        val payloadDao = db.eventPayloadFieldDao()
+        val readingDao = db.metricReadingDao()
+        val parentPayload = payloadDao.fetchForReading(log.id)
+        val intakeId = parentPayload
+            .firstOrNull { it.fieldKey == HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID }
+            ?.stringValue
+        payloadDao.deleteForReading(log.id)
+        readingDao.deleteById(log.id)
+        if (intakeId != null) {
+            payloadDao.deleteForReading(intakeId)
+            readingDao.deleteById(intakeId)
+        }
+    }
 
     suspend fun fetchAll(): List<HeadacheLog> = dao.fetchAll()
 

--- a/android/app/src/main/java/com/bios/app/data/MigraineAttackRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/MigraineAttackRepo.kt
@@ -1,5 +1,6 @@
 package com.bios.app.data
 
+import com.bios.app.model.HeadacheEventFields
 import com.bios.app.model.MigraineAttack
 import com.bios.app.model.MigraineTrigger
 
@@ -48,16 +49,56 @@ class MigraineAttackRepo(private val db: BiosDatabase) {
             notes = notes?.trim()?.takeIf { it.isNotBlank() },
         )
         dao.insert(attack)
+        writeMetricReadingMirror(attack)
         return attack.id
     }
 
     /** Mark an in-progress attack as resolved at the given [endTimestamp]. */
     suspend fun close(id: String, endTimestamp: Long = System.currentTimeMillis()) {
         val existing = dao.fetchById(id) ?: return
-        dao.update(existing.copy(endTimestamp = endTimestamp))
+        val updated = existing.copy(endTimestamp = endTimestamp)
+        dao.update(updated)
+        // Refresh the metric_readings mirror so the parent row's
+        // durationSec is up to date for the chronic-migraine evaluator
+        // (Cut 3). Cheapest path: delete-then-rewrite.
+        clearMetricReadingMirror(existing)
+        writeMetricReadingMirror(updated)
     }
 
-    suspend fun remove(id: String) = dao.deleteById(id)
+    suspend fun remove(id: String) {
+        val existing = dao.fetchById(id)
+        dao.deleteById(id)
+        existing?.let { clearMetricReadingMirror(it) }
+    }
+
+    private suspend fun writeMetricReadingMirror(attack: MigraineAttack) {
+        val sourceId = resolveSelfReportedSource(db)
+        val writeSet = HeadacheEventWriter.fromMigraineAttack(attack, sourceId)
+        db.metricReadingDao().insert(writeSet.parent)
+        db.eventPayloadFieldDao().insertAll(writeSet.payload)
+        writeSet.abortiveIntake?.let {
+            db.metricReadingDao().insert(it)
+            db.eventPayloadFieldDao().insertAll(writeSet.abortivePayload)
+        }
+    }
+
+    private suspend fun clearMetricReadingMirror(attack: MigraineAttack) {
+        // Walk the parent payload to find any linked MEDICATION_INTAKE
+        // child id, then cascade. Two DAO calls — the payload table is
+        // small per reading so the round-trips are cheap.
+        val payloadDao = db.eventPayloadFieldDao()
+        val readingDao = db.metricReadingDao()
+        val parentPayload = payloadDao.fetchForReading(attack.id)
+        val intakeId = parentPayload
+            .firstOrNull { it.fieldKey == HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID }
+            ?.stringValue
+        payloadDao.deleteForReading(attack.id)
+        readingDao.deleteById(attack.id)
+        if (intakeId != null) {
+            payloadDao.deleteForReading(intakeId)
+            readingDao.deleteById(intakeId)
+        }
+    }
 
     suspend fun fetchAll(): List<MigraineAttack> = dao.fetchAll()
 

--- a/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
@@ -189,6 +189,19 @@ interface MetricReadingDao {
     @Query("DELETE FROM metric_readings WHERE timestamp < :beforeMillis")
     suspend fun deleteBefore(beforeMillis: Long): Int
 
+    /**
+     * Delete a single reading by id. Used by the headache / migraine
+     * entry repos (#283 Cut 2) so an entity-table delete also clears
+     * the parent HEADACHE/CLUSTER/MIGRAINE_ATTACK_EVENT row written
+     * alongside it. Callers are responsible for cascading to any
+     * linked MEDICATION_INTAKE child (via the
+     * [com.bios.app.model.HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID]
+     * payload field) and for clearing `event_payloads` via
+     * [EventPayloadFieldDao.deleteForReading].
+     */
+    @Query("DELETE FROM metric_readings WHERE id = :readingId")
+    suspend fun deleteById(readingId: String): Int
+
     @Query("DELETE FROM metric_readings")
     suspend fun deleteAll()
 }

--- a/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
@@ -225,6 +225,7 @@ private class FakeMetricReadingDao(
     override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteById(readingId: String): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()
 
     private fun <T> notUsed(): T = error("FakeMetricReadingDao: method not exercised by CircadianEngineTest")

--- a/android/app/src/test/java/com/bios/app/HeadacheEventWriterTest.kt
+++ b/android/app/src/test/java/com/bios/app/HeadacheEventWriterTest.kt
@@ -1,0 +1,241 @@
+package com.bios.app
+
+import com.bios.app.data.HeadacheEventWriter
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.HeadacheEventFields
+import com.bios.app.model.HeadacheLog
+import com.bios.app.model.HeadacheType
+import com.bios.app.model.MigraineAttack
+import com.bios.app.model.MigraineTrigger
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [HeadacheEventWriter] (#283 Cut 2). Pins the
+ * shape of the cross-cutting `metric_readings` + `event_payloads`
+ * writeset the chronic-migraine (#283 Cut 3), MOH (existing), and
+ * future clinician-share exporters read.
+ *
+ * The entity tables stay the primary store; this writer produces the
+ * denormalised view so engines can scan a single `metric_readings`
+ * window for headache-days / migraine-days / treatment-days.
+ */
+class HeadacheEventWriterTest {
+
+    private val sourceId = "self-reported"
+    private val now = 1_700_000_000_000L
+
+    // -- MigraineAttack →
+
+    @Test
+    fun migraine_attack_writes_parent_with_entity_id_and_intensity() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            endTimestamp = 5_000L,
+            peakIntensity = 7,
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertEquals(attack.id, ws.parent.id)
+        assertEquals(MetricType.MIGRAINE_ATTACK_EVENT.key, ws.parent.metricType)
+        assertEquals(7.0, ws.parent.value, 1e-9)
+        assertEquals(1_000L, ws.parent.timestamp)
+        // (5_000 - 1_000) ms = 4 s
+        assertEquals(4, ws.parent.durationSec)
+        assertEquals(ConfidenceTier.HIGH.level, ws.parent.confidence)
+    }
+
+    @Test
+    fun migraine_attack_in_progress_has_null_durationSec() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            endTimestamp = null,
+            peakIntensity = 4,
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertNull(ws.parent.durationSec)
+    }
+
+    @Test
+    fun migraine_aura_writes_a_boolean_payload_field() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 5,
+            aura = true,
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        val auraField = ws.payload.firstOrNull { it.fieldKey == HeadacheEventFields.AURA }
+        assertNotNull(auraField)
+        assertEquals(1L, auraField!!.longValue)
+    }
+
+    @Test
+    fun migraine_without_aura_does_not_emit_an_aura_payload_field() {
+        // We don't write "owner answered no" rows — the absence of the
+        // field encodes "owner did not record it." Saves storage and
+        // matches the renderer's "missing = unknown" convention.
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 5,
+            aura = false,
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertTrue(ws.payload.none { it.fieldKey == HeadacheEventFields.AURA })
+    }
+
+    @Test
+    fun migraine_triggers_are_joined_into_one_string_field() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 5,
+            triggers = setOf(MigraineTrigger.STRESS, MigraineTrigger.SLEEP_DEPRIVATION),
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        val triggersField = ws.payload.first { it.fieldKey == HeadacheEventFields.TRIGGERS }
+        // Storage format is the enum names; the parser side splits on comma.
+        val stored = triggersField.stringValue!!.split(",").toSet()
+        assertEquals(setOf("STRESS", "SLEEP_DEPRIVATION"), stored)
+    }
+
+    @Test
+    fun empty_triggers_set_does_not_emit_a_payload_field() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 5,
+            triggers = emptySet(),
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertTrue(ws.payload.none { it.fieldKey == HeadacheEventFields.TRIGGERS })
+    }
+
+    // -- Abortive medication →
+
+    @Test
+    fun abortive_medication_creates_a_linked_intake_child_row() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 6,
+            medicationTaken = "sumatriptan 50 mg",
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+
+        // Parent carries the abortive_medication freetext + the back-link
+        // to the child intake row.
+        val medField = ws.payload.first { it.fieldKey == HeadacheEventFields.ABORTIVE_MEDICATION }
+        assertEquals("sumatriptan 50 mg", medField.stringValue)
+        val linkField = ws.payload.first {
+            it.fieldKey == HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID
+        }
+
+        // Child intake row.
+        assertNotNull(ws.abortiveIntake)
+        val intake = ws.abortiveIntake!!
+        assertEquals(MetricType.MEDICATION_INTAKE.key, intake.metricType)
+        assertEquals(1.0, intake.value, 1e-9) // presence marker for Cut 2
+        assertEquals(attack.onsetTimestamp, intake.timestamp)
+        assertEquals(ConfidenceTier.HIGH.level, intake.confidence)
+        assertEquals(intake.id, linkField.stringValue)
+
+        // Child carries the medication name and a back-link to the parent.
+        val nameField = ws.abortivePayload.first {
+            it.fieldKey == HeadacheEventWriter.MEDICATION_NAME_FIELD
+        }
+        assertEquals("sumatriptan 50 mg", nameField.stringValue)
+        val parentLink = ws.abortivePayload.first {
+            it.fieldKey == HeadacheEventWriter.PARENT_HEADACHE_EVENT_FIELD
+        }
+        assertEquals(attack.id, parentLink.stringValue)
+    }
+
+    @Test
+    fun no_medication_leaves_abortive_intake_null() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 4,
+            medicationTaken = null,
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertNull(ws.abortiveIntake)
+        assertTrue(ws.abortivePayload.isEmpty())
+        assertTrue(ws.payload.none {
+            it.fieldKey == HeadacheEventFields.ABORTIVE_MEDICATION_INTAKE_ID
+        })
+    }
+
+    @Test
+    fun blank_medication_string_is_treated_as_none() {
+        val attack = MigraineAttack(
+            onsetTimestamp = 1_000L,
+            peakIntensity = 4,
+            medicationTaken = "   ",
+        )
+        val ws = HeadacheEventWriter.fromMigraineAttack(attack, sourceId, now)
+        assertNull(ws.abortiveIntake)
+    }
+
+    // -- HeadacheLog routing →
+
+    @Test
+    fun headache_log_with_type_TENSION_routes_to_generic_HEADACHE_ATTACK_EVENT() {
+        val log = HeadacheLog(
+            timestamp = 1_000L,
+            intensity = 4,
+            type = HeadacheType.TENSION,
+        )
+        val ws = HeadacheEventWriter.fromHeadacheLog(log, sourceId, now)
+        assertEquals(MetricType.HEADACHE_ATTACK_EVENT.key, ws.parent.metricType)
+    }
+
+    @Test
+    fun headache_log_with_type_OTHER_routes_to_generic_HEADACHE_ATTACK_EVENT() {
+        val log = HeadacheLog(
+            timestamp = 1_000L,
+            intensity = 3,
+            type = HeadacheType.OTHER,
+        )
+        val ws = HeadacheEventWriter.fromHeadacheLog(log, sourceId, now)
+        assertEquals(MetricType.HEADACHE_ATTACK_EVENT.key, ws.parent.metricType)
+    }
+
+    @Test
+    fun headache_log_with_type_MIGRAINE_routes_to_MIGRAINE_ATTACK_EVENT() {
+        // The chronic-migraine evaluator counts migraine-days from both
+        // MigraineAttack rows and HeadacheLog(type=MIGRAINE) rows — they
+        // must converge on the same MetricType key.
+        val log = HeadacheLog(
+            timestamp = 1_000L,
+            intensity = 6,
+            type = HeadacheType.MIGRAINE,
+        )
+        val ws = HeadacheEventWriter.fromHeadacheLog(log, sourceId, now)
+        assertEquals(MetricType.MIGRAINE_ATTACK_EVENT.key, ws.parent.metricType)
+    }
+
+    @Test
+    fun headache_log_with_type_CLUSTER_routes_to_CLUSTER_HEADACHE_ATTACK_EVENT() {
+        // The #284 cluster periodicity histogram reads from the cluster
+        // event MetricType — tension rows must not leak in.
+        val log = HeadacheLog(
+            timestamp = 1_000L,
+            intensity = 8,
+            type = HeadacheType.CLUSTER,
+        )
+        val ws = HeadacheEventWriter.fromHeadacheLog(log, sourceId, now)
+        assertEquals(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT.key, ws.parent.metricType)
+    }
+
+    @Test
+    fun headache_log_durationMinutes_converts_to_durationSec() {
+        val log = HeadacheLog(
+            timestamp = 1_000L,
+            intensity = 4,
+            type = HeadacheType.TENSION,
+            durationMinutes = 90,
+        )
+        val ws = HeadacheEventWriter.fromHeadacheLog(log, sourceId, now)
+        assertEquals(90 * 60, ws.parent.durationSec)
+    }
+}

--- a/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
@@ -170,6 +170,7 @@ private class FakeReadingDao(
     override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteById(readingId: String): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()
 
     private fun <T> notUsed(): T = error("FakeReadingDao: method not exercised by HrRecoveryPersisterTest")


### PR DESCRIPTION
## Summary
Builds on [#292](https://github.com/thdelmas/Bios/pull/292)'s MetricType + payload-key foundation. The headache / migraine diary entities ([`MigraineAttack`](android/app/src/main/java/com/bios/app/model/MigraineAttack.kt), [`HeadacheLog`](android/app/src/main/java/com/bios/app/model/HeadacheLog.kt)) stay the primary store; this PR adds a cross-cutting `metric_readings` + `event_payloads` view of every entry so the chronic-migraine threshold pattern (Cut 3) and the existing MOH evaluator can scan a single window for headache-days, migraine-days, and treatment-days without joining across entity tables.

## Pieces
- **New: [`HeadacheEventWriter`](android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt)** — pure helper that turns a `MigraineAttack` or `HeadacheLog` into a `(parent, payload, optional intake child, child payload)` writeset. The parent reading uses the entity's own UUID as its `id` so an entity-table delete clears the matching `MetricReading` by id without indirect lookup. `HeadacheType` routes:
  - `MIGRAINE` → `MIGRAINE_ATTACK_EVENT` (chronic-migraine evaluator counts both `MigraineAttack` rows and `HeadacheLog(MIGRAINE)` rows here)
  - `CLUSTER` → `CLUSTER_HEADACHE_ATTACK_EVENT` (clean stream for [#284](https://github.com/thdelmas/Bios/issues/284)'s periodicity histogram)
  - `TENSION` / `OTHER` → generic `HEADACHE_ATTACK_EVENT`
- **[`MigraineAttackRepo`](android/app/src/main/java/com/bios/app/data/MigraineAttackRepo.kt) / [`HeadacheLogRepo`](android/app/src/main/java/com/bios/app/data/HeadacheLogRepo.kt)** — `add` / `remove` (and `close` for in-progress migraines) now mirror writes to `metric_readings`. `close()` refreshes the mirror so the parent `durationSec` is current once the owner closes an in-progress attack.
- **[`MetricReadingDao.deleteById`](android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt)** — needed for the remove cascade. The child intake cascade walks the parent payload to find the linked id (no schema change — the [`ABORTIVE_MEDICATION_INTAKE_ID`](android/app/src/main/java/com/bios/app/model/HeadacheEventFields.kt) payload field is the back-pointer).
- **`FakeMetricReadingDao` / `FakeReadingDao`** in two existing test fixtures gain the new `deleteById` override.

## Medication intake design notes
When the entity records an abortive medication, the writer emits a child `MetricType.MEDICATION_INTAKE` reading + payload fields on both sides:
- Parent carries `ABORTIVE_MEDICATION` (freetext) + `ABORTIVE_MEDICATION_INTAKE_ID` (link to the child).
- Child carries `medication_name` (freetext, mirrors parent) + `parent_headache_event_id` (back-link).

Child intake `value = 1.0` is a **presence marker** for Cut 2. The MOH evaluator only needs presence (treatment-day count); dose parsing out of `"sumatriptan 50 mg"` style strings is future work tied to the MS DMT adherence path. The freetext name lives on the payload sidecar so a parser can land later without re-writing existing rows.

## Test plan
- [x] **13 unit tests** in [`HeadacheEventWriterTest`](android/app/src/test/java/com/bios/app/HeadacheEventWriterTest.kt) covering id reuse, intensity → value, duration → durationSec, aura / triggers / abortive-medication payload emission, all four `HeadacheType` routing branches, in-progress migraine = null duration, and the full linked-intake-child shape (parent + child + reciprocal back-link).
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: open Settings → Identity → Headache & migraine diary, log a migraine with aura + a trigger + abortive med; confirm a `MIGRAINE_ATTACK_EVENT` row appears in the [#277](https://github.com/thdelmas/Bios/pull/277) debug screen alongside the `MEDICATION_INTAKE` row.
- [ ] Manual: delete the entry, confirm both rows are gone from the debug screen.

## Next
**Cut 3** ships the `chronic_migraine_threshold` `ConditionPattern` + worker on the [`MohScreeningWorker`](android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt) shape, and updates the MOH evaluator to consume the structured `MEDICATION_INTAKE` rows where they exist (keeping the legacy freetext path as fallback). After that, #283 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)