### PR TITLE
feat(alerts): chronic-migraine threshold pattern + worker (#283 Cut 3)

### DIFF
--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -117,6 +117,11 @@ class BiosApplication : Application() {
         // the diary is empty, so it's safe to enqueue unconditionally.
         MohScreeningWorker.schedule(this)
 
+        // Schedule the daily chronic-migraine screening worker (#283 Cut 3,
+        // IHS ICHD-3 §1.3). Same idempotent shape as MOH; reads from the
+        // headache-event metric_readings rows the #293 writer mirrors.
+        com.bios.app.alerts.ChronicMigraineWorker.schedule(this)
+
         // Schedule daily paediatric-band recompute (#198). Idempotent and
         // a no-op when no birth date is on file — safe to enqueue on every
         // launch.

--- a/android/app/src/main/java/com/bios/app/alerts/ChronicMigraineEvaluator.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ChronicMigraineEvaluator.kt
@@ -1,0 +1,158 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Pure-Kotlin chronic migraine evaluator (#283 Cut 3, IHS ICHD-3 §1.3).
+ *
+ * Reads from the cross-cutting `metric_readings` view written by
+ * [com.bios.app.data.HeadacheEventWriter] (#283 Cut 2). Each entry
+ * the owner records via the migraine / headache diary lands as one
+ * of three MetricType rows:
+ *  - [MetricType.MIGRAINE_ATTACK_EVENT]
+ *  - [MetricType.HEADACHE_ATTACK_EVENT]
+ *  - [MetricType.CLUSTER_HEADACHE_ATTACK_EVENT]
+ *
+ * The evaluator counts, per calendar month in the supplied timezone:
+ *  - **headache_days** — distinct calendar dates with **any** of the
+ *    three event types. Cluster headache counts as a headache for the
+ *    chronic-migraine threshold even though it's a distinct entity —
+ *    the IHS criterion is "headache days," not "migraine-class
+ *    headache days."
+ *  - **migraine_days** — distinct calendar dates with at least one
+ *    [MetricType.MIGRAINE_ATTACK_EVENT]. Tension and cluster rows do
+ *    not contribute to this count even if they occurred on the same
+ *    date.
+ *
+ * The verdict ([Verdict.meetsScreeningThreshold]) is `true` iff
+ * **every** one of the most-recent
+ * [HeadachePatterns.MOH_CONSECUTIVE_MONTHS_REQUIRED] calendar months
+ * (3) has `headache_days ≥ 15` AND `migraine_days ≥ 8`.
+ *
+ * Same shape as [MedicationOveruseHeadacheEvaluator] so the
+ * [ChronicMigraineWorker] dedup logic mirrors [MohScreeningWorker]
+ * one-to-one.
+ */
+object ChronicMigraineEvaluator {
+
+    data class Verdict(
+        val meetsScreeningThreshold: Boolean,
+        /** Per-calendar-month breakdown, newest first. */
+        val perMonthCounts: List<MonthCount>,
+    )
+
+    /** Per-calendar-month day counts. [headacheDays] is the distinct-date
+     *  count for any headache event type; [migraineDays] is the subset
+     *  with at least one MIGRAINE_ATTACK_EVENT. */
+    data class MonthCount(
+        val year: Int,
+        val month: Int,
+        val headacheDays: Int,
+        val migraineDays: Int,
+    )
+
+    /**
+     * Evaluate the chronic-migraine screen across the supplied
+     * headache-event readings.
+     *
+     * @param readings the headache-event rows from the rolling window;
+     *   the evaluator filters to the three relevant MetricTypes
+     *   internally so callers can pass an unfiltered window without
+     *   pre-classifying
+     * @param nowMillis "now" for picking the most-recent 3 calendar months
+     * @param zoneId timezone for calendar-month boundaries
+     */
+    fun evaluate(
+        readings: List<MetricReading>,
+        nowMillis: Long = System.currentTimeMillis(),
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): Verdict {
+        val migraineKey = MetricType.MIGRAINE_ATTACK_EVENT.key
+        val headacheKey = MetricType.HEADACHE_ATTACK_EVENT.key
+        val clusterKey = MetricType.CLUSTER_HEADACHE_ATTACK_EVENT.key
+
+        val anyHeadacheDates = mutableSetOf<EventDate>()
+        val migraineDates = mutableSetOf<EventDate>()
+
+        for (reading in readings) {
+            val key = reading.metricType
+            if (key != migraineKey && key != headacheKey && key != clusterKey) continue
+            val date = eventDate(reading.timestamp, zoneId)
+            anyHeadacheDates += date
+            if (key == migraineKey) migraineDates += date
+        }
+
+        val targetMonths = recentCalendarMonths(
+            nowMillis = nowMillis,
+            zoneId = zoneId,
+            count = HeadachePatterns.MOH_CONSECUTIVE_MONTHS_REQUIRED,
+        )
+
+        val perMonthCounts = targetMonths.map { (year, month) ->
+            MonthCount(
+                year = year,
+                month = month,
+                headacheDays = anyHeadacheDates.count { it.year == year && it.month == month },
+                migraineDays = migraineDates.count { it.year == year && it.month == month },
+            )
+        }
+
+        val headacheThreshold = HeadachePatterns.CHRONIC_MIGRAINE_HEADACHE_DAYS_PER_MONTH_THRESHOLD
+        val migraineThreshold = HeadachePatterns.CHRONIC_MIGRAINE_MIGRAINE_DAYS_PER_MONTH_THRESHOLD
+        val meets = perMonthCounts.size == HeadachePatterns.MOH_CONSECUTIVE_MONTHS_REQUIRED &&
+            perMonthCounts.all {
+                it.headacheDays >= headacheThreshold && it.migraineDays >= migraineThreshold
+            }
+
+        return Verdict(meetsScreeningThreshold = meets, perMonthCounts = perMonthCounts)
+    }
+
+    /**
+     * Build a manifesto-clean alert message body summarising the per-
+     * month headache + migraine day counts. Returned text obeys
+     * [AlertContentPolicy] — data statements only, no second-person
+     * judgments.
+     */
+    fun describeVerdict(verdict: Verdict): String {
+        if (verdict.perMonthCounts.isEmpty()) return ""
+        val monthLine = verdict.perMonthCounts.joinToString("; ") { mc ->
+            "${monthLabel(mc.year, mc.month)}: ${mc.headacheDays} headache days (${mc.migraineDays} migraine)"
+        }
+        return "Per-month headache + migraine day counts (most recent first): $monthLine. " +
+            "IHS ICHD-3 §1.3 chronic-migraine threshold is " +
+            "${HeadachePatterns.CHRONIC_MIGRAINE_HEADACHE_DAYS_PER_MONTH_THRESHOLD} headache days/month " +
+            "with ${HeadachePatterns.CHRONIC_MIGRAINE_MIGRAINE_DAYS_PER_MONTH_THRESHOLD}+ migraine, " +
+            "across ${HeadachePatterns.MOH_CONSECUTIVE_MONTHS_REQUIRED} consecutive months."
+    }
+
+    private data class EventDate(val year: Int, val month: Int, val day: Int)
+
+    private fun eventDate(epochMillis: Long, zoneId: ZoneId): EventDate {
+        val zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), zoneId)
+        return EventDate(zdt.year, zdt.monthValue, zdt.dayOfMonth)
+    }
+
+    private fun recentCalendarMonths(
+        nowMillis: Long,
+        zoneId: ZoneId,
+        count: Int,
+    ): List<Pair<Int, Int>> {
+        val now = ZonedDateTime.ofInstant(Instant.ofEpochMilli(nowMillis), zoneId)
+        return (0 until count).map { offset ->
+            val month = now.minusMonths(offset.toLong())
+            month.year to month.monthValue
+        }
+    }
+
+    private fun monthLabel(year: Int, month: Int): String {
+        val mm = java.time.Month.of(month).getDisplayName(
+            java.time.format.TextStyle.SHORT,
+            java.util.Locale.US,
+        )
+        return "$mm $year"
+    }
+}

--- a/android/app/src/main/java/com/bios/app/alerts/ChronicMigraineWorker.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/ChronicMigraineWorker.kt
@@ -1,0 +1,172 @@
+package com.bios.app.alerts
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.bios.app.data.BiosDatabase
+import com.bios.app.model.AlertTier
+import com.bios.app.model.Anomaly
+import com.bios.contracts.MetricType
+import java.util.concurrent.TimeUnit
+
+/**
+ * Daily worker that runs the chronic-migraine screen (#283 Cut 3 /
+ * IHS ICHD-3 §1.3) over the rolling diary window.
+ *
+ * Mirrors [MohScreeningWorker] one-to-one — the chronic-migraine
+ * pattern shares the same registration shape (empty `signalRules`,
+ * ADVISORY severity, evaluated by a dedicated pure-Kotlin scorer)
+ * and benefits from the same fetch → evaluate → dedup → insert
+ * pipeline.
+ *
+ * Reads from the `metric_readings` view written by
+ * [com.bios.app.data.HeadacheEventWriter]. The split between this
+ * worker and [MohScreeningWorker] is deliberate: the MOH worker
+ * reads `MigraineAttack` / `HeadacheLog` entity rows (which carry
+ * the freetext `medicationTaken` field the existing evaluator
+ * counts) while this worker reads the cross-cutting structured
+ * headache-event rows the chronic-migraine evaluator's day-counting
+ * logic needs.
+ *
+ * Dedup, cadence, and Anomaly construction all mirror MOH —
+ * deliberate, so the two chronic-pattern alerts surface uniformly.
+ */
+class ChronicMigraineWorker(
+    context: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        val db = BiosDatabase.getInstance(context)
+        val readingDao = db.metricReadingDao()
+
+        val now = System.currentTimeMillis()
+        val windowStart = now - HeadachePatterns.MOH_WINDOW_DAYS * MS_PER_DAY
+        // Three event types feed this evaluator; one fetch per metric is
+        // cheaper than a JOIN-on-IN-clause for the volumes we see.
+        val rows = buildList {
+            addAll(readingDao.fetch(MetricType.MIGRAINE_ATTACK_EVENT.key, windowStart, now))
+            addAll(readingDao.fetch(MetricType.HEADACHE_ATTACK_EVENT.key, windowStart, now))
+            addAll(readingDao.fetch(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT.key, windowStart, now))
+        }
+
+        val verdict = ChronicMigraineEvaluator.evaluate(rows, nowMillis = now)
+
+        val decision = decideFireOrSkip(
+            verdict = verdict,
+            previousState = readPreviousState(context),
+            previouslyAcked = wasPreviouslyAcked(context, db),
+        )
+        when (decision) {
+            FireDecision.SuppressVerdictFalse -> {
+                writePreviousState(context, verdictTrue = false, lastAnomalyId = null)
+            }
+            FireDecision.SuppressVerdictUnchanged -> {
+                // Keep the existing state intact — the previously-fired
+                // Anomaly is still the active surface.
+            }
+            FireDecision.Fire -> {
+                val anomaly = buildAnomaly(verdict, now)
+                db.anomalyDao().insert(anomaly)
+                writePreviousState(context, verdictTrue = true, lastAnomalyId = anomaly.id)
+            }
+        }
+        return Result.success()
+    }
+
+    companion object {
+        const val WORK_NAME = "bios_chronic_migraine_screening"
+        private const val MS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+
+        private const val PREFS_NAME = "bios_chronic_migraine_state"
+        private const val KEY_LAST_VERDICT_TRUE = "last_verdict_true"
+        private const val KEY_LAST_ANOMALY_ID = "last_anomaly_id"
+
+        /** Daily cadence. Idempotent via WorkManager unique-work policy.
+         *  Mirrors [MohScreeningWorker.schedule]. */
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<ChronicMigraineWorker>(
+                24, TimeUnit.HOURS,
+            ).build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        internal data class PreviousState(
+            val verdictTrue: Boolean,
+            val lastAnomalyId: String?,
+        )
+
+        internal sealed interface FireDecision {
+            object Fire : FireDecision
+            object SuppressVerdictFalse : FireDecision
+            object SuppressVerdictUnchanged : FireDecision
+        }
+
+        internal fun decideFireOrSkip(
+            verdict: ChronicMigraineEvaluator.Verdict,
+            previousState: PreviousState,
+            previouslyAcked: Boolean,
+        ): FireDecision {
+            if (!verdict.meetsScreeningThreshold) return FireDecision.SuppressVerdictFalse
+            if (!previousState.verdictTrue) return FireDecision.Fire
+            if (previouslyAcked) return FireDecision.Fire
+            return FireDecision.SuppressVerdictUnchanged
+        }
+
+        internal fun buildAnomaly(
+            verdict: ChronicMigraineEvaluator.Verdict,
+            nowMillis: Long,
+        ): Anomaly {
+            val pattern = HeadachePatterns.chronicMigraineThreshold
+            val substrate = ChronicMigraineEvaluator.describeVerdict(verdict)
+            return Anomaly(
+                detectedAt = nowMillis,
+                metricTypes = "[]",
+                deviationScores = "{}",
+                combinedScore = 1.0,
+                patternId = pattern.id,
+                severity = AlertTier.ADVISORY.level,
+                title = pattern.title,
+                explanation = "${pattern.explanation}\n\n$substrate",
+                suggestedAction = pattern.suggestedAction,
+            )
+        }
+
+        private fun readPreviousState(context: Context): PreviousState {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            return PreviousState(
+                verdictTrue = prefs.getBoolean(KEY_LAST_VERDICT_TRUE, false),
+                lastAnomalyId = prefs.getString(KEY_LAST_ANOMALY_ID, null),
+            )
+        }
+
+        private fun writePreviousState(
+            context: Context,
+            verdictTrue: Boolean,
+            lastAnomalyId: String?,
+        ) {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean(KEY_LAST_VERDICT_TRUE, verdictTrue)
+                .apply {
+                    if (lastAnomalyId == null) remove(KEY_LAST_ANOMALY_ID)
+                    else putString(KEY_LAST_ANOMALY_ID, lastAnomalyId)
+                }
+                .apply()
+        }
+
+        private suspend fun wasPreviouslyAcked(context: Context, db: BiosDatabase): Boolean {
+            val state = readPreviousState(context)
+            val id = state.lastAnomalyId ?: return false
+            return db.anomalyDao().fetchRecent(50).firstOrNull { it.id == id }?.acknowledged == true
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
@@ -62,7 +62,7 @@ import java.time.ZonedDateTime
  */
 object HeadachePatterns {
 
-    val all by lazy { listOf(medicationOveruseHeadacheScreen) }
+    val all by lazy { listOf(medicationOveruseHeadacheScreen, chronicMigraineThreshold) }
 
     /**
      * IHS ICHD-3 §8.2 MOH screening threshold: acute-headache-medication
@@ -86,6 +86,45 @@ object HeadachePatterns {
      * even when the current date is on the first of the month.
      */
     const val MOH_WINDOW_DAYS: Int = 100
+
+    /**
+     * Chronic migraine threshold (IHS ICHD-3 §1.3): headache on ≥15
+     * days per month for >3 months, of which at least 8 days per month
+     * meet criteria for migraine (with or without aura) or respond to
+     * migraine-specific acute treatment.
+     */
+    const val CHRONIC_MIGRAINE_HEADACHE_DAYS_PER_MONTH_THRESHOLD: Int = 15
+    const val CHRONIC_MIGRAINE_MIGRAINE_DAYS_PER_MONTH_THRESHOLD: Int = 8
+
+    /**
+     * Chronic migraine pattern (IHS ICHD-3 §1.3). Same registration
+     * shape as [medicationOveruseHeadacheScreen]: empty signalRules,
+     * evaluated by the dedicated [ChronicMigraineEvaluator] on a daily
+     * worker, ADVISORY severity (chronic-pattern condition, not acute
+     * event), manifesto-clean text — data statement, no diagnostic
+     * claim.
+     */
+    val chronicMigraineThreshold = ConditionPattern(
+        id = "chronic_migraine_threshold",
+        title = "Headache + migraine days meet chronic-migraine threshold",
+        category = ConditionCategory.MENTAL_HEALTH,
+        signalRules = emptyList(),
+        minActiveSignals = 0,
+        severityFloor = AlertTier.ADVISORY,
+        explanation = "Diary entries show 15 or more headache days per month, of which 8 or more were logged as migraine attacks, across the most recent 3 calendar months.\n\n" +
+            "That pattern is the published IHS ICHD-3 §1.3 chronic-migraine threshold. Chronic migraine is the diagnostic term the headache-medicine literature uses for migraine that has crossed from episodic into a near-constant background headache state, with the migraine-specific features (aura, autonomic disturbance, photophobia / phonophobia, response to triptans) persisting on a subset of days. Crossing the threshold matters because the preventive-therapy options — and the urgency of starting one — change with the diagnostic class.\n\n" +
+            "This is a data observation against the published clinical screen — not a chronic-migraine diagnosis. The owner decides whether to discuss the pattern with a neurologist or primary-care clinician.",
+        suggestedAction = "If headache frequency has been climbing into the 15+ days/month range, a neurology or primary-care visit can review the diary pattern and discuss whether a preventive medication is indicated (CGRP-class monoclonal antibodies, topiramate, beta-blockers, botulinum toxin per the relevant guideline). Bring the diary — the full record of dates, intensities, migraine vs non-migraine classification, and acute-treatment use is the substrate the clinical conversation needs.",
+        references = listOf(
+            "IHS International Classification of Headache Disorders, 3rd edition (ICHD-3) §1.3 — Chronic migraine",
+            "Goadsby PJ et al. (2017) — Pathophysiology of migraine: a disorder of sensory processing. Physiological Reviews 97(2):553-622",
+            "Lipton RB et al. (2007) — Migraine in the United States: a review of epidemiology and patient care from the AMPP study. Headache 47(3):353-365",
+        ),
+        earlyDetection = "Chronic migraine develops gradually from episodic migraine — typically over months to a few years — as headache frequency climbs through the 5-9 / 10-14 days-per-month bands before crossing into the 15+ range that meets the IHS ICHD-3 §1.3 threshold. The structured headache diary records every attack the owner logs, with the type (migraine vs non-migraine) and acute treatment captured per entry. The screen runs over a 90-day window and surfaces only when the threshold holds across every one of the most-recent 3 calendar months.",
+        prevention = "Episodic migraine progressing to chronic migraine is associated in the headache-medicine literature with: frequent acute-medication use (the medication-overuse-headache pathway — see the separate MOH screen), untreated comorbid conditions (anxiety, depression, obstructive sleep apnea), sustained stress, poor sleep, and undiagnosed primary-headache disorder going untreated. Each of these is owner-modifiable upstream of the chronic-migraine threshold. The diary plus the MOH screen plus the regular cardiovascular / sleep instrumentation Bios already collects gives the owner the full picture to take to a clinician.",
+        healing = "Preventive medication is the literature's first-line response — CGRP-class monoclonal antibodies, topiramate, beta-blockers, candesartan, and (for chronic migraine specifically) botulinum toxin per the PREEMPT trials. Lifestyle modification of identified triggers, treatment of comorbid sleep / mood disorders, and managed withdrawal of overused acute medication if MOH is also present all contribute. The diary continues to be useful through any preventive trial — clinicians read the headache-day count trajectory across weeks as the primary efficacy signal.",
+        risks = "Chronic migraine carries a higher risk of progressing to medication-overuse headache (the two often coexist), more frequent disability from individual attacks, and reduced response to acute treatment as the central pain pathways become more sensitised. Chronic migraine is also associated with elevated rates of depression and anxiety in the headache-medicine literature. The reversibility of chronic migraine on adequate preventive treatment is the main reason the threshold matters — early surfacing of the pattern lets the owner and clinician intervene before sensitisation deepens.",
+    )
 
     /**
      * MOH screen pattern. Severity ADVISORY (chronic pattern, not acute

--- a/android/app/src/test/java/com/bios/app/ChronicMigraineEvaluatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/ChronicMigraineEvaluatorTest.kt
@@ -1,0 +1,190 @@
+package com.bios.app
+
+import com.bios.app.alerts.ChronicMigraineEvaluator
+import com.bios.app.alerts.HeadachePatterns
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [ChronicMigraineEvaluator] (#283 Cut 3,
+ * IHS ICHD-3 §1.3). Pins:
+ *  - The "any headache" + "migraine-only" day-counting semantics
+ *    (distinct dates per month, cluster + tension contribute to
+ *    headache-days but not to migraine-days)
+ *  - The all-three-months-must-meet rule
+ *  - The boundary cases the headache-medicine literature cares about
+ *    (exact threshold = meets, one short = fails)
+ */
+class ChronicMigraineEvaluatorTest {
+
+    private val zone = ZoneId.of("America/New_York")
+    private val sourceId = "self-reported"
+
+    /** Build "now" at a deterministic instant inside a known month so
+     *  the "recent 3 calendar months" window is stable across test
+     *  runs. February 15 sits comfortably inside a month so the day-15
+     *  threshold can be hit without wrapping. */
+    private val now: Long = ZonedDateTime.of(
+        2026, 2, 15, 12, 0, 0, 0, zone,
+    ).toInstant().toEpochMilli()
+
+    private fun reading(
+        metricType: MetricType,
+        year: Int,
+        month: Int,
+        day: Int,
+    ): MetricReading {
+        val ts = ZonedDateTime.of(year, month, day, 10, 0, 0, 0, zone)
+            .toInstant().toEpochMilli()
+        return MetricReading(
+            metricType = metricType.key,
+            value = 5.0,
+            timestamp = ts,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+        )
+    }
+
+    @Test
+    fun no_readings_yields_empty_per_month_counts_at_threshold_false() {
+        val verdict = ChronicMigraineEvaluator.evaluate(emptyList(), now, zone)
+        assertFalse(verdict.meetsScreeningThreshold)
+        // Three months reported with zero counts so the renderer has
+        // substrate to show.
+        assertEquals(3, verdict.perMonthCounts.size)
+        assertTrue(verdict.perMonthCounts.all { it.headacheDays == 0 && it.migraineDays == 0 })
+    }
+
+    @Test
+    fun multiple_events_on_the_same_day_count_as_one_day() {
+        // Two migraine entries + one tension on Feb 10 → one headache
+        // day + one migraine day for February.
+        val rows = listOf(
+            reading(MetricType.MIGRAINE_ATTACK_EVENT, 2026, 2, 10),
+            reading(MetricType.MIGRAINE_ATTACK_EVENT, 2026, 2, 10),
+            reading(MetricType.HEADACHE_ATTACK_EVENT, 2026, 2, 10),
+        )
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        val feb = v.perMonthCounts.first { it.year == 2026 && it.month == 2 }
+        assertEquals(1, feb.headacheDays)
+        assertEquals(1, feb.migraineDays)
+    }
+
+    @Test
+    fun cluster_and_tension_count_as_headache_but_not_as_migraine() {
+        val rows = listOf(
+            reading(MetricType.HEADACHE_ATTACK_EVENT, 2026, 2, 1),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 2, 2),
+        )
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        val feb = v.perMonthCounts.first { it.year == 2026 && it.month == 2 }
+        assertEquals(2, feb.headacheDays)
+        assertEquals(0, feb.migraineDays)
+    }
+
+    @Test
+    fun unrelated_metric_types_are_ignored() {
+        // A noise row (SLEEP_DURATION etc.) inside the window must not
+        // poison either count.
+        val rows = listOf(
+            reading(MetricType.MIGRAINE_ATTACK_EVENT, 2026, 2, 5),
+            reading(MetricType.SLEEP_DURATION, 2026, 2, 5),
+            reading(MetricType.HEART_RATE, 2026, 2, 6),
+        )
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        val feb = v.perMonthCounts.first { it.year == 2026 && it.month == 2 }
+        assertEquals(1, feb.headacheDays)
+        assertEquals(1, feb.migraineDays)
+    }
+
+    @Test
+    fun verdict_is_true_when_all_three_months_clear_both_thresholds() {
+        // Build a synthetic 3-month diary that's exactly at threshold:
+        // 15 headache days/month, 8 of which are migraine. Pattern must
+        // fire.
+        val rows = mutableListOf<MetricReading>()
+        for (monthsBack in 0..2) {
+            val zdtTarget = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(now), zone)
+                .minusMonths(monthsBack.toLong())
+            val y = zdtTarget.year
+            val m = zdtTarget.monthValue
+            // 8 migraine days on days 1-8, 7 headache days on days 9-15.
+            for (d in 1..8) rows += reading(MetricType.MIGRAINE_ATTACK_EVENT, y, m, d)
+            for (d in 9..15) rows += reading(MetricType.HEADACHE_ATTACK_EVENT, y, m, d)
+        }
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        assertTrue("expected threshold met, got $v", v.meetsScreeningThreshold)
+        assertTrue(v.perMonthCounts.all { it.headacheDays == 15 && it.migraineDays == 8 })
+    }
+
+    @Test
+    fun verdict_is_false_when_one_month_falls_short_on_headache_days() {
+        // Two months at threshold, one month with only 14 headache days
+        // → fail. The chronic-migraine pattern requires ALL three.
+        val rows = mutableListOf<MetricReading>()
+        for (monthsBack in 0..2) {
+            val zdtTarget = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(now), zone)
+                .minusMonths(monthsBack.toLong())
+            val y = zdtTarget.year
+            val m = zdtTarget.monthValue
+            val headacheTarget = if (monthsBack == 1) 14 else 15
+            for (d in 1..8) rows += reading(MetricType.MIGRAINE_ATTACK_EVENT, y, m, d)
+            for (d in 9..(headacheTarget)) {
+                rows += reading(MetricType.HEADACHE_ATTACK_EVENT, y, m, d)
+            }
+        }
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        assertFalse("expected threshold not met, got $v", v.meetsScreeningThreshold)
+    }
+
+    @Test
+    fun verdict_is_false_when_one_month_falls_short_on_migraine_days() {
+        // Each month has 15 headache days but only 7 migraine days in
+        // one of them → fail (need 8 migraine days/month).
+        val rows = mutableListOf<MetricReading>()
+        for (monthsBack in 0..2) {
+            val zdtTarget = ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(now), zone)
+                .minusMonths(monthsBack.toLong())
+            val y = zdtTarget.year
+            val m = zdtTarget.monthValue
+            val migraineTarget = if (monthsBack == 2) 7 else 8
+            for (d in 1..migraineTarget) {
+                rows += reading(MetricType.MIGRAINE_ATTACK_EVENT, y, m, d)
+            }
+            for (d in (migraineTarget + 1)..15) {
+                rows += reading(MetricType.HEADACHE_ATTACK_EVENT, y, m, d)
+            }
+        }
+        val v = ChronicMigraineEvaluator.evaluate(rows, now, zone)
+        assertFalse(v.meetsScreeningThreshold)
+    }
+
+    @Test
+    fun describeVerdict_surfaces_each_month_with_both_counts() {
+        val verdict = ChronicMigraineEvaluator.Verdict(
+            meetsScreeningThreshold = true,
+            perMonthCounts = listOf(
+                ChronicMigraineEvaluator.MonthCount(2026, 2, 17, 9),
+                ChronicMigraineEvaluator.MonthCount(2026, 1, 18, 10),
+                ChronicMigraineEvaluator.MonthCount(2025, 12, 20, 12),
+            ),
+        )
+        val text = ChronicMigraineEvaluator.describeVerdict(verdict)
+        assertTrue("Feb count missing: $text", text.contains("17 headache days (9 migraine)"))
+        assertTrue(text.contains("Jan"))
+        assertTrue(text.contains("Dec"))
+        assertTrue(
+            "threshold reference missing: $text",
+            text.contains(
+                "${HeadachePatterns.CHRONIC_MIGRAINE_HEADACHE_DAYS_PER_MONTH_THRESHOLD} headache days/month"
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/com/bios/app/ChronicMigraineWorkerDedupTest.kt
+++ b/android/app/src/test/java/com/bios/app/ChronicMigraineWorkerDedupTest.kt
@@ -1,0 +1,93 @@
+package com.bios.app
+
+import com.bios.app.alerts.ChronicMigraineEvaluator
+import com.bios.app.alerts.ChronicMigraineWorker
+import com.bios.app.alerts.ChronicMigraineWorker.Companion.FireDecision
+import com.bios.app.alerts.ChronicMigraineWorker.Companion.PreviousState
+import com.bios.app.alerts.HeadachePatterns
+import com.bios.app.model.AlertTier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of the chronic-migraine worker's dedup logic and
+ * Anomaly construction (#283 Cut 3). Mirrors the MOH worker dedup
+ * tests one-to-one; the chronic-migraine pattern shares the same
+ * fire-on-transition / re-fire-after-ack semantics.
+ */
+class ChronicMigraineWorkerDedupTest {
+
+    private val verdictTrue = ChronicMigraineEvaluator.Verdict(
+        meetsScreeningThreshold = true,
+        perMonthCounts = emptyList(),
+    )
+    private val verdictFalse = ChronicMigraineEvaluator.Verdict(
+        meetsScreeningThreshold = false,
+        perMonthCounts = emptyList(),
+    )
+
+    @Test
+    fun verdict_false_always_suppresses_and_clears_state() {
+        val decision = ChronicMigraineWorker.decideFireOrSkip(
+            verdict = verdictFalse,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "a1"),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.SuppressVerdictFalse, decision)
+    }
+
+    @Test
+    fun verdict_true_after_false_state_fires() {
+        // The canonical false→true transition. Fire.
+        val decision = ChronicMigraineWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = false, lastAnomalyId = null),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.Fire, decision)
+    }
+
+    @Test
+    fun verdict_true_with_unacked_existing_alert_suppresses() {
+        // The previously-fired alert is still on the dashboard waiting
+        // for the owner to ack it. Don't double-fire.
+        val decision = ChronicMigraineWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "a1"),
+            previouslyAcked = false,
+        )
+        assertEquals(FireDecision.SuppressVerdictUnchanged, decision)
+    }
+
+    @Test
+    fun verdict_true_after_ack_re_fires() {
+        // Owner acked the previous alert and the pattern still holds —
+        // re-surface so it doesn't silently disappear.
+        val decision = ChronicMigraineWorker.decideFireOrSkip(
+            verdict = verdictTrue,
+            previousState = PreviousState(verdictTrue = true, lastAnomalyId = "a1"),
+            previouslyAcked = true,
+        )
+        assertEquals(FireDecision.Fire, decision)
+    }
+
+    @Test
+    fun buildAnomaly_emits_ADVISORY_severity_and_anchored_pattern_text() {
+        val verdict = ChronicMigraineEvaluator.Verdict(
+            meetsScreeningThreshold = true,
+            perMonthCounts = listOf(
+                ChronicMigraineEvaluator.MonthCount(2026, 2, 16, 9),
+                ChronicMigraineEvaluator.MonthCount(2026, 1, 18, 10),
+                ChronicMigraineEvaluator.MonthCount(2025, 12, 20, 12),
+            ),
+        )
+        val anomaly = ChronicMigraineWorker.buildAnomaly(verdict, nowMillis = 1_700_000_000_000L)
+        assertEquals(AlertTier.ADVISORY.level, anomaly.severity)
+        assertEquals(HeadachePatterns.chronicMigraineThreshold.id, anomaly.patternId)
+        assertEquals(HeadachePatterns.chronicMigraineThreshold.title, anomaly.title)
+        // Per-month substrate appended so the detail surface can render
+        // the actual counts that triggered the fire.
+        assertTrue(anomaly.explanation.contains("16 headache days (9 migraine)"))
+    }
+}


### PR DESCRIPTION
## Summary
Builds on [#292](https://github.com/thdelmas/Bios/pull/292) (event MetricTypes + payload keys) and [#293](https://github.com/thdelmas/Bios/pull/293) ([`HeadacheEventWriter`](android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt) mirroring entity rows into `metric_readings`). With the structured event stream in place, the IHS ICHD-3 §1.3 chronic-migraine threshold is now evaluable on a daily cadence without joining across entity tables.

## Pieces
- **[`HeadachePatterns.chronicMigraineThreshold`](android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt)** — new `ConditionPattern` alongside the existing MOH screen. Empty `signalRules` + ADVISORY severity + manifesto-clean text (data observation, no diagnostic claim). Registered in `HeadachePatterns.all`.
- **New: [`ChronicMigraineEvaluator`](android/app/src/main/java/com/bios/app/alerts/ChronicMigraineEvaluator.kt)** — pure-Kotlin scorer that counts per-calendar-month **headache days** (any of `HEADACHE_ATTACK_EVENT` / `MIGRAINE_ATTACK_EVENT` / `CLUSTER_HEADACHE_ATTACK_EVENT`) + **migraine days** (only `MIGRAINE_ATTACK_EVENT`) from `metric_readings`, then verdicts true iff every one of the most-recent 3 months has ≥15 headache days AND ≥8 migraine days. Same `Verdict` / `MonthCount` / `describeVerdict` shape as `MedicationOveruseHeadacheEvaluator` so the alert detail renderer stays uniform.
- **New: [`ChronicMigraineWorker`](android/app/src/main/java/com/bios/app/alerts/ChronicMigraineWorker.kt)** — daily `WorkManager` periodic, mirrors [`MohScreeningWorker`](android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt) one-to-one (fetch → evaluate → `decideFireOrSkip` → insert `Anomaly`). Pure dedup logic extracted so it's unit-testable without a worker scaffold. Persisted state lives in its own `SharedPreferences` file so MOH and chronic-migraine dedup states don't collide.
- **[`BiosApplication.onCreate`](android/app/src/main/java/com/bios/app/BiosApplication.kt)** now schedules the worker alongside the existing MOH worker.

## Day-counting semantics
The headache-medicine literature counts **calendar days**, not events. Multiple entries on the same date count as one day; tension and cluster contribute to the **headache-day** count but not to the **migraine-day** subset. The verdict requires ALL three of the most-recent calendar months to clear both thresholds — one month short on either count fails the screen. The 100-day fetch window comfortably covers 3 consecutive months in any timezone even on the first of the month.

## Test plan
- [x] **7 evaluator tests** in [`ChronicMigraineEvaluatorTest`](android/app/src/test/java/com/bios/app/ChronicMigraineEvaluatorTest.kt):
  - `no_readings_yields_empty_per_month_counts_at_threshold_false`
  - `multiple_events_on_the_same_day_count_as_one_day` — distinct-date semantics
  - `cluster_and_tension_count_as_headache_but_not_as_migraine` — classification split
  - `unrelated_metric_types_are_ignored` — noise robustness
  - `verdict_is_true_when_all_three_months_clear_both_thresholds` — canonical fire case
  - `verdict_is_false_when_one_month_falls_short_on_headache_days`
  - `verdict_is_false_when_one_month_falls_short_on_migraine_days`
  - `describeVerdict_surfaces_each_month_with_both_counts`
- [x] **5 worker dedup tests** in [`ChronicMigraineWorkerDedupTest`](android/app/src/test/java/com/bios/app/ChronicMigraineWorkerDedupTest.kt) — every `FireDecision` branch + Anomaly construction shape.
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: open Settings → Identity → Headache & migraine diary, log a synthetic 3-month diary that crosses the threshold (15 headache days/month, 8 migraine), force-run the worker, confirm an ADVISORY card lands in "Needs attention" with the per-month substrate appended.

## What's left for #283
The issue body's third acceptance item — "**MOH evaluator updated to consume the structured `MEDICATION_INTAKE` rows where they exist (keeping freetext as fallback)**" — is intentionally **out of scope for this PR**. The existing MOH evaluator already works against the entity rows the diary populates, and the structured `MEDICATION_INTAKE` rows [#293](https://github.com/thdelmas/Bios/pull/293) writes ride alongside the same entity fields. The update is forward-looking (future entry surfaces that write only the structured row would otherwise miss MOH counting) but doesn't gate any existing functionality. I'd suggest landing it as a small follow-up PR once this Cut 3 is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)