### PR TITLE
feat(alerts): MOH evaluator consumes structured intakes (closes #283)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt
@@ -3,6 +3,7 @@ package com.bios.app.alerts
 import com.bios.app.model.AlertTier
 import com.bios.app.model.ConditionCategory
 import com.bios.app.model.HeadacheLog
+import com.bios.app.model.MetricReading
 import com.bios.app.model.MigraineAttack
 import java.time.Instant
 import java.time.ZoneId
@@ -206,14 +207,40 @@ object MedicationOveruseHeadacheEvaluator {
     /**
      * Evaluate the MOH screen across the given diary records.
      *
-     * @param migraineAttacks records to count
-     * @param headacheLogs records to count
+     * Two parallel sources feed the per-day treatment count:
+     *  - The legacy path reads the freetext `medicationTaken` field
+     *    on each [MigraineAttack] / [HeadacheLog]. This was the only
+     *    surface available before #283 Cut 2; it remains the source
+     *    of truth for any row written by an entry path that doesn't
+     *    yet write the structured intake row.
+     *  - The structured path reads
+     *    [com.bios.contracts.MetricType.MEDICATION_INTAKE] rows
+     *    written by [com.bios.app.data.HeadacheEventWriter] (#293).
+     *    Caller pre-filters these to rows that carry the
+     *    `parent_headache_event_id` payload back-link so non-headache
+     *    intake rows (supplements, caffeine, etc.) don't poison the
+     *    count.
+     *
+     * Both paths converge on the distinct-date set per month, so a
+     * row that lands via both surfaces (the Cut 2 writer populates
+     * both simultaneously) counts as exactly one treatment day for
+     * that date. Forward-looking: an entry path that drops the
+     * legacy freetext field but keeps the structured intake row
+     * still feeds MOH correctly.
+     *
+     * @param migraineAttacks legacy-path records
+     * @param headacheLogs legacy-path records
+     * @param headacheLinkedIntakes structured-path MEDICATION_INTAKE
+     *   rows pre-filtered by the caller to those linked to a headache
+     *   event. Defaults to empty for backward compatibility with
+     *   pre-#283 Cut 3 callers.
      * @param nowMillis "now" for picking the most-recent 3 calendar months
      * @param zoneId timezone for calendar-month boundaries (defaults to system default)
      */
     fun evaluate(
         migraineAttacks: List<MigraineAttack>,
         headacheLogs: List<HeadacheLog>,
+        headacheLinkedIntakes: List<MetricReading> = emptyList(),
         nowMillis: Long = System.currentTimeMillis(),
         zoneId: ZoneId = ZoneId.systemDefault(),
     ): Verdict {
@@ -230,6 +257,9 @@ object MedicationOveruseHeadacheEvaluator {
             if (!log.medicationTaken.isNullOrBlank()) {
                 treatmentDates += treatmentDate(log.timestamp, zoneId)
             }
+        }
+        for (intake in headacheLinkedIntakes) {
+            treatmentDates += treatmentDate(intake.timestamp, zoneId)
         }
 
         val targetMonths = recentCalendarMonths(

--- a/android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt
@@ -7,10 +7,13 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.bios.app.data.BiosDatabase
+import com.bios.app.data.HeadacheEventWriter
 import com.bios.app.data.HeadacheLogRepo
 import com.bios.app.data.MigraineAttackRepo
-import com.bios.app.model.Anomaly
 import com.bios.app.model.AlertTier
+import com.bios.app.model.Anomaly
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
 import java.util.concurrent.TimeUnit
 
 /**
@@ -66,10 +69,16 @@ class MohScreeningWorker(
         val windowStart = now - HeadachePatterns.MOH_WINDOW_DAYS * MS_PER_DAY
         val attacks = migraineRepo.fetchInRange(windowStart, now)
         val logs = headacheRepo.fetchInRange(windowStart, now)
+        // #283 Cut 3 follow-up: structured MEDICATION_INTAKE rows the
+        // HeadacheEventWriter mirror produces. Filter to rows linked
+        // to a parent headache event so non-headache intake (future
+        // supplements / caffeine / etc.) doesn't count toward MOH.
+        val headacheLinkedIntakes = fetchHeadacheLinkedIntakes(db, windowStart, now)
 
         val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
             migraineAttacks = attacks,
             headacheLogs = logs,
+            headacheLinkedIntakes = headacheLinkedIntakes,
             nowMillis = now,
         )
 
@@ -93,6 +102,31 @@ class MohScreeningWorker(
             }
         }
         return Result.success()
+    }
+
+    /**
+     * Read MEDICATION_INTAKE rows in the window that carry the
+     * [HeadacheEventWriter.PARENT_HEADACHE_EVENT_FIELD] payload
+     * back-link. The back-link is the unambiguous "this intake was
+     * for a headache event" signal that lets us count toward MOH
+     * without sweeping up unrelated dosed-intake rows.
+     */
+    private suspend fun fetchHeadacheLinkedIntakes(
+        db: BiosDatabase,
+        startMs: Long,
+        endMs: Long,
+    ): List<MetricReading> {
+        val intakeRows = db.metricReadingDao()
+            .fetch(MetricType.MEDICATION_INTAKE.key, startMs, endMs)
+        if (intakeRows.isEmpty()) return emptyList()
+        val payloads = db.eventPayloadFieldDao()
+            .fetchForReadings(intakeRows.map { it.id })
+            .groupBy { it.readingId }
+        return intakeRows.filter { row ->
+            payloads[row.id]?.any {
+                it.fieldKey == HeadacheEventWriter.PARENT_HEADACHE_EVENT_FIELD
+            } == true
+        }
     }
 
     companion object {

--- a/android/app/src/test/java/com/bios/app/MedicationOveruseHeadacheEvaluatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/MedicationOveruseHeadacheEvaluatorTest.kt
@@ -2,9 +2,12 @@ package com.bios.app
 
 import com.bios.app.alerts.HeadachePatterns
 import com.bios.app.alerts.MedicationOveruseHeadacheEvaluator
+import com.bios.app.model.ConfidenceTier
 import com.bios.app.model.HeadacheLog
 import com.bios.app.model.HeadacheType
+import com.bios.app.model.MetricReading
 import com.bios.app.model.MigraineAttack
+import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -225,4 +228,119 @@ class MedicationOveruseHeadacheEvaluatorTest {
 
     private fun millisAt(year: Int, month: Int, day: Int, hour: Int = 12): Long =
         ZonedDateTime.of(year, month, day, hour, 0, 0, 0, UTC).toInstant().toEpochMilli()
+
+    // -- #283 Cut 3 follow-up: structured MEDICATION_INTAKE path --
+
+    private fun intake(year: Int, month: Int, day: Int): MetricReading = MetricReading(
+        metricType = MetricType.MEDICATION_INTAKE.key,
+        value = 1.0,
+        timestamp = millisAt(year, month, day),
+        sourceId = "self-reported",
+        confidence = ConfidenceTier.HIGH.level,
+    )
+
+    @Test
+    fun `evaluator fires from structured intakes alone when freetext path is empty`() {
+        // Forward-looking case: a future entry surface writes only the
+        // structured MEDICATION_INTAKE row (no entity freetext). MOH
+        // must still count those days.
+        val intakes = buildList {
+            for (month in listOf(3, 4, 5)) {
+                for (day in 1..10) add(intake(2026, month, day))
+            }
+        }
+        val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
+            migraineAttacks = emptyList(),
+            headacheLogs = emptyList(),
+            headacheLinkedIntakes = intakes,
+            nowMillis = millisAt(2026, 5, 15),
+            zoneId = UTC,
+        )
+        assertTrue("expected threshold met from intakes alone", verdict.meetsScreeningThreshold)
+    }
+
+    @Test
+    fun `same-day entity row and structured intake count as one day not two`() {
+        // The #293 writer populates both surfaces simultaneously. The
+        // distinct-date set guarantees no double counting.
+        val attacks = buildList {
+            for (month in listOf(3, 4, 5)) {
+                for (day in 1..10) add(
+                    MigraineAttack(
+                        onsetTimestamp = millisAt(2026, month, day),
+                        peakIntensity = 5,
+                        medicationTaken = "sumatriptan",
+                    )
+                )
+            }
+        }
+        // Mirror intakes on the same dates — what #293 actually writes.
+        val intakes = buildList {
+            for (month in listOf(3, 4, 5)) {
+                for (day in 1..10) add(intake(2026, month, day))
+            }
+        }
+        val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
+            migraineAttacks = attacks,
+            headacheLogs = emptyList(),
+            headacheLinkedIntakes = intakes,
+            nowMillis = millisAt(2026, 5, 15),
+            zoneId = UTC,
+        )
+        assertTrue(verdict.meetsScreeningThreshold)
+        // Each month should report exactly 10 days — not 20 from double counting.
+        verdict.perMonthCounts.forEach { assertEquals(10, it.treatmentDays) }
+    }
+
+    @Test
+    fun `structured intake on a day with no entity row still counts that day`() {
+        // Mixed case: entity rows cover 9 days/month, intakes cover one
+        // additional day/month. Combined distinct-date count = 10 → fires.
+        val attacks = buildList {
+            for (month in listOf(3, 4, 5)) {
+                for (day in 1..9) add(
+                    MigraineAttack(
+                        onsetTimestamp = millisAt(2026, month, day),
+                        peakIntensity = 5,
+                        medicationTaken = "ibuprofen",
+                    )
+                )
+            }
+        }
+        val intakes = listOf(intake(2026, 3, 10), intake(2026, 4, 10), intake(2026, 5, 10))
+        val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
+            migraineAttacks = attacks,
+            headacheLogs = emptyList(),
+            headacheLinkedIntakes = intakes,
+            nowMillis = millisAt(2026, 5, 15),
+            zoneId = UTC,
+        )
+        assertTrue(verdict.meetsScreeningThreshold)
+        verdict.perMonthCounts.forEach { assertEquals(10, it.treatmentDays) }
+    }
+
+    @Test
+    fun `default empty intakes list keeps legacy-only call sites unchanged`() {
+        // Backward-compat: the pre-follow-up signature still resolves
+        // (no headacheLinkedIntakes argument) and produces the same
+        // verdict as before.
+        val attacks = buildList {
+            for (month in listOf(3, 4, 5)) {
+                for (day in 1..10) add(
+                    MigraineAttack(
+                        onsetTimestamp = millisAt(2026, month, day),
+                        peakIntensity = 5,
+                        medicationTaken = "triptan",
+                    )
+                )
+            }
+        }
+        val verdict = MedicationOveruseHeadacheEvaluator.evaluate(
+            migraineAttacks = attacks,
+            headacheLogs = emptyList(),
+            nowMillis = millisAt(2026, 5, 15),
+            zoneId = UTC,
+        )
+        assertTrue(verdict.meetsScreeningThreshold)
+    }
 }


### PR DESCRIPTION
## Summary
Final acceptance item from [#283](https://github.com/thdelmas/Bios/issues/283): the MOH evaluator now consumes the structured `MEDICATION_INTAKE` rows the [#293](https://github.com/thdelmas/Bios/pull/293) writer mirrors alongside the legacy freetext path. Both feed the distinct-date set per month, so a row that lands via both surfaces (the writer populates both simultaneously) counts as exactly one treatment day. Forward-looking: an entry surface that drops the legacy freetext but keeps the structured intake still feeds MOH correctly.

## Pieces
- **[`MedicationOveruseHeadacheEvaluator.evaluate`](android/app/src/main/java/com/bios/app/alerts/HeadachePatterns.kt)** gains an optional `headacheLinkedIntakes: List<MetricReading> = emptyList()` parameter. Default empty preserves backward compatibility with any pre-follow-up call sites (none exist today besides the worker, but the contract is open).
- **[`MohScreeningWorker`](android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt)** fetches `MEDICATION_INTAKE` rows in the window, filters to those carrying the [`HeadacheEventWriter.PARENT_HEADACHE_EVENT_FIELD`](android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt) payload back-link (the unambiguous "this intake was for a headache event" signal that excludes future non-headache dosed-intake — supplements, caffeine, etc.), and passes them to the evaluator.

## Why the back-link filter
`MEDICATION_INTAKE` is a shared `MetricType` — the pharmacokinetic engine, MS DMT adherence path, and any future medication-companion will all write to it. The MOH evaluator only cares about headache-related treatment days. The `parent_headache_event_id` payload field is set by [`HeadacheEventWriter`](android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt) on every intake row it creates, so filtering on its presence is the exact "this was for a headache" semantic without an explicit metadata tag.

## Test plan
- [x] **4 new evaluator tests** in [`MedicationOveruseHeadacheEvaluatorTest`](android/app/src/test/java/com/bios/app/MedicationOveruseHeadacheEvaluatorTest.kt):
  - `evaluator fires from structured intakes alone when freetext path is empty` — the forward-looking case
  - `same-day entity row and structured intake count as one day not two` — no double counting via the distinct-date set
  - `structured intake on a day with no entity row still counts that day` — mixed case
  - `default empty intakes list keeps legacy-only call sites unchanged` — backward compat
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: with the structured intake mirror populated from real diary writes (via #293), force-run the MOH worker, confirm the verdict's per-month counts now reflect both sources.

## Closes #283
With this PR, all three acceptance items from [#283](https://github.com/thdelmas/Bios/issues/283) are shipped:
1. ✅ `HEADACHE_ATTACK_EVENT` + `CLUSTER_HEADACHE_ATTACK_EVENT` MetricTypes + `HeadacheEventFields` ([#292](https://github.com/thdelmas/Bios/pull/292))
2. ✅ Per-event `MEDICATION_INTAKE` writer + entry-surface mirror ([#293](https://github.com/thdelmas/Bios/pull/293))
3. ✅ `chronic_migraine_threshold` pattern + worker ([#294](https://github.com/thdelmas/Bios/pull/294))
4. ✅ MOH evaluator updated to consume structured rows (this PR)

I'll close #283 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)