### PR TITLE
feat(ui): cluster-headache periodicity histogram (#284)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/IdentityRoutes.kt
+++ b/android/app/src/main/java/com/bios/app/ui/IdentityRoutes.kt
@@ -33,7 +33,15 @@ internal fun NavGraphBuilder.identityRoutes(navController: NavController) {
         com.bios.app.ui.goals.GoalsOfCareScreen(onBack = { navController.popBackStack() })
     }
     composable("headache_diary") {
-        com.bios.app.ui.headache.HeadacheDiaryScreen(onBack = { navController.popBackStack() })
+        com.bios.app.ui.headache.HeadacheDiaryScreen(
+            onBack = { navController.popBackStack() },
+            onNavigateToClusterPeriodicity = { navController.navigate("cluster_periodicity") },
+        )
+    }
+    composable("cluster_periodicity") {
+        com.bios.app.ui.headache.ClusterPeriodicityScreen(
+            onBack = { navController.popBackStack() },
+        )
     }
     composable("fast_stroke") {
         com.bios.app.ui.stroke.FastStrokeScreen(onBack = { navController.popBackStack() })

--- a/android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityHistogram.kt
+++ b/android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityHistogram.kt
@@ -1,0 +1,72 @@
+package com.bios.app.ui.headache
+
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Pure-Kotlin binning helper for the cluster-headache periodicity
+ * histogram (#284, NEUROLOGY_POV §2.5 / IHS ICHD-3 §3.1).
+ *
+ * Cluster headache is one of the few neurological conditions whose
+ * **time-of-day distribution is itself diagnostic**: nocturnal-onset
+ * clusters firing within a 1–2 h window of the same clock time night
+ * after night are the canonical "clockwork" presentation. The
+ * pull-side histogram surfaces the substrate directly — no judgment,
+ * no alert, no pattern. The owner reads the periodicity themselves
+ * (or shares it with a neurologist).
+ *
+ * Counts onset-hour of every
+ * [MetricType.CLUSTER_HEADACHE_ATTACK_EVENT] row in the supplied
+ * list, mapping each row's `timestamp` to the local hour-of-day
+ * (0–23) in the supplied timezone. The result is a stable 24-bin
+ * array — bins with no events still appear (with count 0) so the
+ * renderer can show the canonical "clockwork" gaps that distinguish
+ * cluster from non-cluster headache.
+ *
+ * Other MetricType rows passed in are silently ignored so the
+ * caller can hand over a generic windowed fetch without
+ * pre-classifying.
+ */
+internal object ClusterPeriodicityHistogram {
+
+    /** One bin of the histogram. [hourOfDay] is 0..23, [count] is the
+     *  number of cluster-event onsets that fell in that hour. */
+    data class HourBin(val hourOfDay: Int, val count: Int)
+
+    /**
+     * Bin the cluster-event onsets by hour-of-day in the supplied
+     * timezone. Returns a 24-element list ordered 0..23 (midnight
+     * first), suitable for direct rendering as a horizontal bar
+     * chart.
+     */
+    fun bin(
+        readings: List<MetricReading>,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+    ): List<HourBin> {
+        val counts = IntArray(HOURS_IN_DAY)
+        val clusterKey = MetricType.CLUSTER_HEADACHE_ATTACK_EVENT.key
+        for (reading in readings) {
+            if (reading.metricType != clusterKey) continue
+            val hour = ZonedDateTime
+                .ofInstant(Instant.ofEpochMilli(reading.timestamp), zoneId)
+                .hour
+            counts[hour] += 1
+        }
+        return (0 until HOURS_IN_DAY).map { HourBin(hourOfDay = it, count = counts[it]) }
+    }
+
+    /** Total cluster-event count across the binned rows (i.e. the
+     *  histogram's sum). Convenient for the screen header. */
+    fun totalEvents(bins: List<HourBin>): Int = bins.sumOf { it.count }
+
+    /** The peak hour-of-day and its count, or null when the histogram
+     *  is empty. Surfaced separately so the renderer can highlight
+     *  the clockwork-onset hour the diagnostic literature describes. */
+    fun peakHour(bins: List<HourBin>): HourBin? =
+        bins.maxByOrNull { it.count }?.takeIf { it.count > 0 }
+
+    private const val HOURS_IN_DAY: Int = 24
+}

--- a/android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityScreen.kt
@@ -1,0 +1,233 @@
+package com.bios.app.ui.headache
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.BiosDatabase
+import com.bios.contracts.MetricType
+
+/**
+ * Cluster-headache periodicity histogram (#284).
+ *
+ * Renders a 24-bar horizontal histogram of cluster-event onsets
+ * over the last 90 days, hour-of-day on the y-axis (00–23 top to
+ * bottom). The pull-side diagnostic substrate the headache-medicine
+ * literature describes — the canonical "clockwork" nocturnal-onset
+ * pattern is visible as a single tall bar in the small-hours range.
+ *
+ * Manifesto: no judgment, no alert, no pattern. The owner reads
+ * the periodicity; the owner decides what (if anything) to do.
+ * Bios is the instrument.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClusterPeriodicityScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val db = remember(context) { BiosDatabase.getInstance(context) }
+    var bins by remember { mutableStateOf<List<ClusterPeriodicityHistogram.HourBin>>(emptyList()) }
+    var totalEvents by remember { mutableStateOf(0) }
+    var peakHour by remember { mutableStateOf<ClusterPeriodicityHistogram.HourBin?>(null) }
+
+    LaunchedEffect(Unit) {
+        val end = System.currentTimeMillis()
+        val start = end - WINDOW_DAYS * 24L * 60L * 60L * 1000L
+        val rows = db.metricReadingDao()
+            .fetch(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT.key, start, end)
+        bins = ClusterPeriodicityHistogram.bin(rows)
+        totalEvents = ClusterPeriodicityHistogram.totalEvents(bins)
+        peakHour = ClusterPeriodicityHistogram.peakHour(bins)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Cluster periodicity") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { PeriodicityHeader(totalEvents = totalEvents, peakHour = peakHour) }
+            if (totalEvents == 0) {
+                item { PeriodicityEmpty() }
+            } else {
+                item { PeriodicityHistogram(bins = bins) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodicityHeader(
+    totalEvents: Int,
+    peakHour: ClusterPeriodicityHistogram.HourBin?,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                "What this view shows",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                "Onset hour of every cluster-headache event logged in the last $WINDOW_DAYS days, " +
+                    "binned by hour-of-day in your local timezone. Cluster headache is " +
+                    "characterised in the headache-medicine literature by clockwork onset within " +
+                    "a narrow window night after night — visible here as a tall bar in a single " +
+                    "hour.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                "Total cluster events in window: $totalEvents",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (peakHour != null) {
+                Text(
+                    "Peak hour: ${formatHour(peakHour.hourOfDay)} (${peakHour.count} events)",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodicityEmpty() {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "No cluster-headache events logged in the last $WINDOW_DAYS days. " +
+                    "Log a cluster headache from the diary screen to populate the histogram.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PeriodicityHistogram(bins: List<ClusterPeriodicityHistogram.HourBin>) {
+    val maxCount = bins.maxOf { it.count }.coerceAtLeast(1)
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            for (bin in bins) {
+                PeriodicityRow(bin = bin, maxCount = maxCount)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeriodicityRow(
+    bin: ClusterPeriodicityHistogram.HourBin,
+    maxCount: Int,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = formatHour(bin.hourOfDay),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.width(48.dp),
+            fontWeight = FontWeight.Bold,
+        )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(16.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            val fraction = bin.count.toFloat() / maxCount.toFloat()
+            if (fraction > 0f) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction.coerceAtLeast(0.04f))
+                        .height(16.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(MaterialTheme.colorScheme.primary),
+                )
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = bin.count.toString(),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.width(32.dp),
+        )
+    }
+}
+
+/** Pads single-digit hours and appends `:00` so the y-axis labels
+ *  read as wall-clock times rather than bare integers. */
+private fun formatHour(hour: Int): String = "%02d:00".format(hour)
+
+private const val WINDOW_DAYS: Int = 90

--- a/android/app/src/main/java/com/bios/app/ui/headache/HeadacheDiaryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/headache/HeadacheDiaryScreen.kt
@@ -61,7 +61,10 @@ import java.util.Locale
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HeadacheDiaryScreen(onBack: () -> Unit) {
+fun HeadacheDiaryScreen(
+    onBack: () -> Unit,
+    onNavigateToClusterPeriodicity: () -> Unit = {},
+) {
     val context = LocalContext.current
     val db = remember(context) { BiosDatabase.getInstance(context) }
     val migraineRepo = remember(db) { MigraineAttackRepo(db) }
@@ -122,6 +125,10 @@ fun HeadacheDiaryScreen(onBack: () -> Unit) {
                                 modifier = Modifier.weight(1f),
                             ) { Text("Log headache") }
                         }
+                        OutlinedButton(
+                            onClick = onNavigateToClusterPeriodicity,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) { Text("View cluster periodicity") }
                     }
                 }
             }

--- a/android/app/src/test/java/com/bios/app/ClusterPeriodicityHistogramTest.kt
+++ b/android/app/src/test/java/com/bios/app/ClusterPeriodicityHistogramTest.kt
@@ -1,0 +1,128 @@
+package com.bios.app
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.ui.headache.ClusterPeriodicityHistogram
+import com.bios.contracts.MetricType
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [ClusterPeriodicityHistogram] (#284). Pins the
+ * binning semantics that drive the cluster-periodicity diagnostic
+ * view: 24 stable bins (one per hour-of-day in the supplied
+ * timezone), non-cluster MetricTypes silently ignored, and the
+ * peak-hour helper used by the screen header.
+ */
+class ClusterPeriodicityHistogramTest {
+
+    private val ny = ZoneId.of("America/New_York")
+    private val sourceId = "self-reported"
+
+    private fun reading(
+        metricType: MetricType,
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        zone: ZoneId = ny,
+    ): MetricReading {
+        val ts = ZonedDateTime.of(year, month, day, hour, 0, 0, 0, zone)
+            .toInstant().toEpochMilli()
+        return MetricReading(
+            metricType = metricType.key,
+            value = 1.0,
+            timestamp = ts,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.HIGH.level,
+        )
+    }
+
+    @Test
+    fun empty_input_yields_24_zero_bins() {
+        val bins = ClusterPeriodicityHistogram.bin(emptyList(), ny)
+        assertEquals(24, bins.size)
+        assertEquals((0..23).toList(), bins.map { it.hourOfDay })
+        assertTrue(bins.all { it.count == 0 })
+    }
+
+    @Test
+    fun cluster_events_bin_to_the_correct_local_hour() {
+        // Two events at 02:00 local, one at 14:00 local.
+        val rows = listOf(
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 2, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 14),
+        )
+        val bins = ClusterPeriodicityHistogram.bin(rows, ny)
+        assertEquals(2, bins[2].count)
+        assertEquals(1, bins[14].count)
+        // Every other bin stays at zero.
+        bins.filter { it.hourOfDay !in setOf(2, 14) }.forEach { assertEquals(0, it.count) }
+    }
+
+    @Test
+    fun non_cluster_metric_types_are_silently_ignored() {
+        // The caller can hand over an unfiltered windowed fetch — the
+        // helper only counts cluster events. A migraine row at 02:00
+        // and a heart-rate noise row must not bump the 02:00 bin.
+        val rows = listOf(
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 2),
+            reading(MetricType.MIGRAINE_ATTACK_EVENT, 2026, 5, 2, 2),
+            reading(MetricType.HEART_RATE, 2026, 5, 3, 2),
+        )
+        val bins = ClusterPeriodicityHistogram.bin(rows, ny)
+        assertEquals(1, bins[2].count)
+    }
+
+    @Test
+    fun timezone_is_applied_at_binning_time() {
+        // Same UTC instant lands in different hour-of-day bins depending
+        // on the supplied zone. A 06:00 UTC event reads as 02:00 EDT
+        // (UTC-4) — pin that semantic so the diagnostic timeline reads
+        // the owner's wall clock, not server time.
+        val utcRow = reading(
+            MetricType.CLUSTER_HEADACHE_ATTACK_EVENT,
+            2026, 5, 1, 6,
+            zone = ZoneId.of("UTC"),
+        )
+        val binsNy = ClusterPeriodicityHistogram.bin(listOf(utcRow), ny)
+        // EDT = UTC-4 in May → 06:00 UTC = 02:00 EDT.
+        assertEquals(1, binsNy[2].count)
+        assertEquals(0, binsNy[6].count)
+    }
+
+    @Test
+    fun totalEvents_sums_every_bin() {
+        val rows = listOf(
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 2, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 3, 14),
+        )
+        val bins = ClusterPeriodicityHistogram.bin(rows, ny)
+        assertEquals(3, ClusterPeriodicityHistogram.totalEvents(bins))
+    }
+
+    @Test
+    fun peakHour_returns_the_most_populated_bin() {
+        val rows = listOf(
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 2, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 3, 2),
+            reading(MetricType.CLUSTER_HEADACHE_ATTACK_EVENT, 2026, 5, 1, 14),
+        )
+        val bins = ClusterPeriodicityHistogram.bin(rows, ny)
+        val peak = ClusterPeriodicityHistogram.peakHour(bins)
+        assertEquals(ClusterPeriodicityHistogram.HourBin(2, 3), peak)
+    }
+
+    @Test
+    fun peakHour_returns_null_on_empty_histogram() {
+        val bins = ClusterPeriodicityHistogram.bin(emptyList(), ny)
+        assertNull(ClusterPeriodicityHistogram.peakHour(bins))
+    }
+}


### PR DESCRIPTION
## Summary
Pull-side diagnostic substrate that the headache-medicine literature treats as itself diagnostic for cluster headache: time-of-day onset distribution. Nocturnal-onset clusters firing within a 1–2h window of the same clock time night after night are the canonical "clockwork" presentation. The screen surfaces the substrate directly — no alert, no pattern, no judgment. The owner reads the periodicity (or shares it with a neurologist).

Unblocked by [#292](https://github.com/thdelmas/Bios/pull/292)'s `CLUSTER_HEADACHE_ATTACK_EVENT` MetricType + [#293](https://github.com/thdelmas/Bios/pull/293)'s [`HeadacheEventWriter`](android/app/src/main/java/com/bios/app/data/HeadacheEventWriter.kt) which mirrors `HeadacheLog(type=CLUSTER)` rows as structured `MetricReading` rows the helper can scan.

## Pieces
- **New: [`ClusterPeriodicityHistogram`](android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityHistogram.kt)** — pure helper that bins cluster-event onsets by hour-of-day in the owner's local timezone. Returns 24 stable bins (missing hours stay at zero so the "clockwork" gaps that distinguish cluster from non-cluster headache stay visible). Non-cluster MetricTypes silently ignored so callers can hand over an unfiltered windowed fetch. Plus `totalEvents` and `peakHour` helpers for the screen header.
- **New: [`ClusterPeriodicityScreen`](android/app/src/main/java/com/bios/app/ui/headache/ClusterPeriodicityScreen.kt)** — Compose: 24-row horizontal bar histogram (00:00 to 23:00 top to bottom), header card explaining the diagnostic context + total events + peak hour. Empty-state copy when no cluster events are logged.
- **[`IdentityRoutes`](android/app/src/main/java/com/bios/app/ui/IdentityRoutes.kt)** registers the `cluster_periodicity` route; **[`HeadacheDiaryScreen`](android/app/src/main/java/com/bios/app/ui/headache/HeadacheDiaryScreen.kt)** gains a "View cluster periodicity" button alongside the existing entry buttons.

## Manifesto alignment
The screen ships ZERO judgments and ZERO alerts. Cluster periodicity is the diagnostic evidence — the owner reads it themselves. Aligns with the principle that "Bios is the instrument; the owner reads it" and the explicit "evaluation belongs to the owner" stance.

## Test plan
- [x] **7 unit tests** in [`ClusterPeriodicityHistogramTest`](android/app/src/test/java/com/bios/app/ClusterPeriodicityHistogramTest.kt):
  - `empty_input_yields_24_zero_bins` — stable 24-bin output (gaps visible)
  - `cluster_events_bin_to_the_correct_local_hour`
  - `non_cluster_metric_types_are_silently_ignored` — robust to unfiltered input
  - `timezone_is_applied_at_binning_time` — wall-clock semantic, not server time
  - `totalEvents_sums_every_bin`
  - `peakHour_returns_the_most_populated_bin`
  - `peakHour_returns_null_on_empty_histogram`
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: open Settings → Identity → Headache & migraine diary, log 3 cluster headaches around 02:00 local, tap "View cluster periodicity", confirm the 02:00 bar is the tallest and "Peak hour: 02:00 (3 events)" appears in the header.

## Out of scope (per the original issue)
- No cross-correlation with sleep / autonomic / other signals — explicit out-of-scope in the issue body.
- No "cluster bout in progress" alert pattern — explicit out-of-scope; the periodicity surface is the substrate the owner reads, not a trigger for automated alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)