### PR TITLE
feat(engine): Webster post-FIR rescoring rules (#244 Cut 1b)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -122,10 +122,19 @@ object PhoneSleepInference {
     /**
      * Walk the [startIdx, endIdx] index range and merge consecutive samples
      * that share the same coarse activity label into contiguous segments.
-     * The per-sample label comes from the 7-tap Cole-Kripke classifier
-     * (#244 Cut 1) which reads a centered 7-wide window of accelerometer
-     * variances — meaningfully smoother than the prior 1-tap threshold
-     * and matched to the published actigraphy baseline since 1992.
+     *
+     * The per-sample label is the result of a two-phase classification
+     * (#244 Cuts 1 + 1b):
+     *  1. **Cole-Kripke 7-tap FIR** scores each sample's centered window
+     *     of accelerometer variances — the published 1992 baseline.
+     *  2. **Webster rescoring rules a-e** clean up the canonical
+     *     post-FIR misclassifications: wake-bout forward extension
+     *     (rules a/b/c) + brief-sleep absorption between long wake
+     *     runs (rules d/e).
+     *
+     * Webster looks at the WHOLE sample range (not just [startIdx,
+     * endIdx]) so its preceding-wake-run lookbacks aren't truncated at
+     * the window boundary.
      */
     private fun segmentByActivity(
         samples: List<Sample>,
@@ -133,11 +142,16 @@ object PhoneSleepInference {
         endIdx: Int
     ): List<Segment> {
         val variances: List<Float?> = samples.map { it.accelMagnitudeVar }
+        val rawAwake = BooleanArray(samples.size) { i ->
+            ColeKripkeClassifier.isAwake(ColeKripkeClassifier.centeredWindow(variances, i))
+        }
+        val rescoredAwake = WebsterRescoring.rescore(rawAwake)
+
         val out = mutableListOf<Segment>()
         var segStart = samples[startIdx].timestamp
-        var currentStage = stageAt(variances, startIdx)
+        var currentStage = stageFor(rescoredAwake[startIdx])
         for (i in (startIdx + 1)..endIdx) {
-            val stage = stageAt(variances, i)
+            val stage = stageFor(rescoredAwake[i])
             if (stage != currentStage) {
                 out += Segment(currentStage, segStart, samples[i].timestamp - segStart)
                 segStart = samples[i].timestamp
@@ -147,9 +161,13 @@ object PhoneSleepInference {
         out += Segment(currentStage, segStart, samples[endIdx].timestamp - segStart)
         // Collapse very brief AWAKE flickers (< AWAKE_BOUT_MIN_MS) back into
         // the surrounding sleep — single-minute movement bouts during sleep
-        // are normal posture shifts, not wake events.
+        // are normal posture shifts, not wake events. Complementary to
+        // Webster's d/e rules which absorb in the opposite direction.
         return mergeBriefAwake(out)
     }
+
+    private fun stageFor(awake: Boolean): SleepStage =
+        if (awake) SleepStage.AWAKE else SleepStage.LIGHT
 
     private fun mergeBriefAwake(segments: List<Segment>): List<Segment> {
         if (segments.size <= 1) return segments
@@ -168,23 +186,6 @@ object PhoneSleepInference {
         return out
     }
 
-    /**
-     * Score sample `index` against the Cole-Kripke 7-tap FIR filter
-     * over a centered window of accelerometer variances. `LIGHT` when
-     * the windowed sleep index is below the wake threshold; `AWAKE`
-     * otherwise. Boundary samples reuse the edge value (see
-     * [ColeKripkeClassifier.centeredWindow]).
-     *
-     * Replaces the prior 1-tap variance threshold (`variance > 0.5 →
-     * AWAKE`) with the published 1992 baseline. Single isolated
-     * variance spikes no longer fire AWAKE on their own — Cole-Kripke
-     * requires the surrounding context to corroborate, which matches
-     * the actigraphy literature's "sustained motion = wake" stance.
-     */
-    private fun stageAt(variances: List<Float?>, index: Int): SleepStage {
-        val window = ColeKripkeClassifier.centeredWindow(variances, index)
-        return if (ColeKripkeClassifier.isAwake(window)) SleepStage.AWAKE else SleepStage.LIGHT
-    }
 
     /**
      * Per-sample "owner is likely quiet / not actively using the device"

--- a/android/app/src/main/java/com/bios/app/engine/WebsterRescoring.kt
+++ b/android/app/src/main/java/com/bios/app/engine/WebsterRescoring.kt
@@ -1,0 +1,172 @@
+package com.bios.app.engine
+
+/**
+ * Webster's post-FIR rescoring rules (Webster et al. 1982; carried
+ * forward in Cole-Kripke 1992). Applied to the boolean wake/sleep
+ * array produced by [ColeKripkeClassifier] to fix two well-documented
+ * misclassification patterns the bare FIR cannot:
+ *
+ *  - Wake bouts naturally **persist** — once an owner has been awake
+ *    for several minutes, even quiet sub-minutes during the wake
+ *    period (browsing in stillness, reading) are wake from the
+ *    actigraphy perspective. Rules **a / b / c** extend wake forward
+ *    by 1 / 3 / 4 minutes after sustained wake runs.
+ *  - **Brief sleep epochs sandwiched between long wake** are usually
+ *    drowsy minutes the FIR caught, not real sleep. Rules **d / e**
+ *    absorb short sleep runs surrounded by long wake runs back into
+ *    wake.
+ *
+ * Both halves operate on the FIR output as the "original" — they
+ * read the original to decide where rules fire, but write
+ * exclusively to the rescored copy. This is deterministic in a
+ * single pass (no fixed-point iteration), matching the canonical
+ * `ghammad/pyActigraphy` / `dipetkov/actigraph.sleepr` reference
+ * implementations.
+ *
+ * Rules deliberately do **not** address the opposite problem (brief
+ * wake bouts during long sleep — posture shifts that the FIR
+ * smoothing footprint extends to several minutes). That stays the
+ * responsibility of
+ * [com.bios.app.engine.PhoneSleepInference.mergeBriefAwake] +
+ * `AWAKE_BOUT_MIN_MS`, which operates at the segment level after
+ * Webster's rescoring lands.
+ *
+ * ## Rule reference
+ *
+ *  - **Rule a**: after at least 4 minutes of wake, the next 1 minute
+ *    is wake regardless of FIR score.
+ *  - **Rule b**: after at least 10 minutes of wake, the next 3
+ *    minutes are wake regardless of FIR score.
+ *  - **Rule c**: after at least 15 minutes of wake, the next 4
+ *    minutes are wake regardless of FIR score.
+ *  - **Rule d**: a sleep run of length ≤ 6 minutes flanked by wake
+ *    runs of length ≥ 10 minutes on **both** sides is recoded as
+ *    wake.
+ *  - **Rule e**: a sleep run of length ≤ 10 minutes flanked by wake
+ *    runs of length ≥ 20 minutes on **both** sides is recoded as
+ *    wake.
+ *
+ * Each rule is more aggressive than the prior one in some
+ * dimension (longer extension / longer absorbed run) but requires
+ * a stronger context (longer preceding wake run / stronger
+ * flanking).
+ *
+ * ## References
+ *  - Webster JB, Kripke DF, Messin S, Mullaney DJ, Wyborney G
+ *    (1982) — An activity-based sleep monitor system for ambulatory
+ *    use. *Sleep* 5(4):389–399.
+ *  - Cole RJ, Kripke DF, Gruen W, Mullaney DJ, Gillin JC (1992) —
+ *    Automatic sleep/wake identification from wrist activity.
+ *    *Sleep* 15(5):461–469.
+ */
+internal object WebsterRescoring {
+
+    /** Rule a: extend wake by 1 sample after a ≥ 4-sample wake run. */
+    const val RULE_A_PREV_WAKE_MIN: Int = 4
+    const val RULE_A_EXTEND: Int = 1
+
+    /** Rule b: extend wake by 3 samples after a ≥ 10-sample wake run. */
+    const val RULE_B_PREV_WAKE_MIN: Int = 10
+    const val RULE_B_EXTEND: Int = 3
+
+    /** Rule c: extend wake by 4 samples after a ≥ 15-sample wake run. */
+    const val RULE_C_PREV_WAKE_MIN: Int = 15
+    const val RULE_C_EXTEND: Int = 4
+
+    /** Rule d: absorb sleep runs of ≤ 6 surrounded by wake ≥ 10. */
+    const val RULE_D_SLEEP_RUN_MAX: Int = 6
+    const val RULE_D_FLANKING_WAKE_MIN: Int = 10
+
+    /** Rule e: absorb sleep runs of ≤ 10 surrounded by wake ≥ 20. */
+    const val RULE_E_SLEEP_RUN_MAX: Int = 10
+    const val RULE_E_FLANKING_WAKE_MIN: Int = 20
+
+    /**
+     * Apply Webster's rules a–e to a boolean wake array (`true` =
+     * wake). Returns a new array; the input is not modified.
+     */
+    fun rescore(awake: BooleanArray): BooleanArray {
+        if (awake.isEmpty()) return BooleanArray(0)
+        val rescored = awake.copyOf()
+        applyForwardExtensionRules(awake, rescored)
+        absorbBriefSleepRuns(awake, rescored)
+        return rescored
+    }
+
+    /**
+     * Rules a / b / c: forward-extend wake after sustained wake runs.
+     * Read the preceding wake-run length from the **original** FIR
+     * output so each rule fires at most once per wake → sleep
+     * transition (the rescored array drifts ahead of the original but
+     * doesn't loop the rule on its own writes).
+     */
+    private fun applyForwardExtensionRules(original: BooleanArray, rescored: BooleanArray) {
+        // Pre-compute, for each index i, the count of consecutive
+        // wake samples ending at i-1 (i.e. immediately before i) in
+        // the ORIGINAL array.
+        val precedingWakeRun = IntArray(original.size)
+        var runLength = 0
+        for (i in original.indices) {
+            precedingWakeRun[i] = runLength
+            runLength = if (original[i]) runLength + 1 else 0
+        }
+        for (i in original.indices) {
+            if (original[i]) continue // current is wake → no extension needed
+            val prev = precedingWakeRun[i]
+            val extendBy = when {
+                prev >= RULE_C_PREV_WAKE_MIN -> RULE_C_EXTEND
+                prev >= RULE_B_PREV_WAKE_MIN -> RULE_B_EXTEND
+                prev >= RULE_A_PREV_WAKE_MIN -> RULE_A_EXTEND
+                else -> 0
+            }
+            for (k in 0 until extendBy) {
+                val j = i + k
+                if (j < rescored.size) rescored[j] = true
+            }
+        }
+    }
+
+    /**
+     * Rules d / e: absorb brief sleep runs sandwiched between
+     * sufficiently-long wake runs. Read run lengths from the
+     * **original** FIR output (so Webster's own forward-extension
+     * writes don't change which sleep runs qualify).
+     */
+    private fun absorbBriefSleepRuns(original: BooleanArray, rescored: BooleanArray) {
+        var i = 0
+        while (i < original.size) {
+            if (original[i]) { i++; continue }
+            val runStart = i
+            while (i < original.size && !original[i]) i++
+            val runEnd = i - 1 // inclusive
+            val sleepRunLength = runEnd - runStart + 1
+
+            val prevWake = countWakeBackward(original, runStart - 1)
+            val nextWake = countWakeForward(original, runEnd + 1)
+
+            val absorb = (sleepRunLength <= RULE_D_SLEEP_RUN_MAX &&
+                prevWake >= RULE_D_FLANKING_WAKE_MIN &&
+                nextWake >= RULE_D_FLANKING_WAKE_MIN) ||
+                (sleepRunLength <= RULE_E_SLEEP_RUN_MAX &&
+                    prevWake >= RULE_E_FLANKING_WAKE_MIN &&
+                    nextWake >= RULE_E_FLANKING_WAKE_MIN)
+            if (absorb) {
+                for (j in runStart..runEnd) rescored[j] = true
+            }
+        }
+    }
+
+    private fun countWakeBackward(arr: BooleanArray, fromInclusive: Int): Int {
+        var count = 0
+        var i = fromInclusive
+        while (i >= 0 && arr[i]) { count++; i-- }
+        return count
+    }
+
+    private fun countWakeForward(arr: BooleanArray, fromInclusive: Int): Int {
+        var count = 0
+        var i = fromInclusive
+        while (i < arr.size && arr[i]) { count++; i++ }
+        return count
+    }
+}

--- a/android/app/src/test/java/com/bios/app/WebsterRescoringTest.kt
+++ b/android/app/src/test/java/com/bios/app/WebsterRescoringTest.kt
@@ -1,0 +1,226 @@
+package com.bios.app
+
+import com.bios.app.engine.WebsterRescoring
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [WebsterRescoring] (#244 Cut 1b). Pins each
+ * of Webster's rescoring rules a-e individually plus several
+ * integration scenarios that exercise the published behavior.
+ *
+ * Convention: `true` = wake, `false` = sleep. Helpers below produce
+ * BooleanArrays from compact W/S strings to keep the per-rule
+ * fixtures readable.
+ */
+class WebsterRescoringTest {
+
+    @Test
+    fun rescore_returns_a_new_array_and_does_not_mutate_the_input() {
+        val input = pattern("WWWWS")
+        val output = WebsterRescoring.rescore(input)
+        assertNotSame(input, output)
+        // Original input still has S at index 4.
+        assertFalse(input[4])
+    }
+
+    @Test
+    fun empty_input_returns_empty_array() {
+        val output = WebsterRescoring.rescore(BooleanArray(0))
+        assertEquals(0, output.size)
+    }
+
+    @Test
+    fun all_sleep_input_stays_all_sleep() {
+        // No wake bouts → no rules fire.
+        val output = WebsterRescoring.rescore(pattern("SSSSSSSSSSSSSSSS"))
+        assertTrue(output.none { it })
+    }
+
+    @Test
+    fun all_wake_input_stays_all_wake() {
+        val output = WebsterRescoring.rescore(pattern("WWWWWWWWWWWWWWWW"))
+        assertTrue(output.all { it })
+    }
+
+    // -- Rule a: ≥4 wake → next 1 sleep becomes wake --
+
+    @Test
+    fun rule_a_fires_after_exactly_4_wake() {
+        // 4W then 1S → S flips to W per rule a.
+        // After the flip we expect WWWWW (the 5th sample is wake).
+        val output = WebsterRescoring.rescore(pattern("WWWWS"))
+        assertPatternEquals("WWWWW", output)
+    }
+
+    @Test
+    fun rule_a_does_not_fire_after_only_3_wake() {
+        // 3 wake samples is below the rule-a threshold.
+        val output = WebsterRescoring.rescore(pattern("WWWS"))
+        assertPatternEquals("WWWS", output)
+    }
+
+    @Test
+    fun rule_a_only_extends_one_sample() {
+        // 4W then 2S → only the first S flips (rule a says "next 1").
+        // The second S remains S because Webster reads the ORIGINAL
+        // preceding-wake-run (which is interrupted by the first S),
+        // not the rescored array.
+        val output = WebsterRescoring.rescore(pattern("WWWWSS"))
+        assertPatternEquals("WWWWWS", output)
+    }
+
+    // -- Rule b: ≥10 wake → next 3 sleep become wake --
+
+    @Test
+    fun rule_b_fires_after_exactly_10_wake() {
+        val output = WebsterRescoring.rescore(pattern("WWWWWWWWWWSSSS"))
+        // 10W + 3 flipped W + final S = 13W then S.
+        assertPatternEquals("WWWWWWWWWWWWWS", output)
+    }
+
+    @Test
+    fun rule_b_chooses_3_sample_extension_over_rule_a_single() {
+        // Both rule a (≥4) and rule b (≥10) qualify; rule b's longer
+        // extension wins.
+        val output = WebsterRescoring.rescore(pattern("WWWWWWWWWWS"))
+        assertPatternEquals("WWWWWWWWWWW", output)
+    }
+
+    // -- Rule c: ≥15 wake → next 4 sleep become wake --
+
+    @Test
+    fun rule_c_fires_after_exactly_15_wake() {
+        val input = pattern("WWWWWWWWWWWWWWW" + "SSSSS")
+        val output = WebsterRescoring.rescore(input)
+        // 15W + 4 flipped W + final S.
+        assertPatternEquals("WWWWWWWWWWWWWWW" + "WWWWS", output)
+    }
+
+    @Test
+    fun rule_c_chooses_4_sample_extension_over_rules_a_and_b() {
+        val input = pattern("WWWWWWWWWWWWWWW" + "S")
+        val output = WebsterRescoring.rescore(input)
+        assertPatternEquals("WWWWWWWWWWWWWWWW", output)
+    }
+
+    // -- Rule d: sleep run ≤6 flanked by wake ≥10 → recoded as wake --
+
+    @Test
+    fun rule_d_absorbs_5_sleep_between_two_long_wake_runs() {
+        val input = pattern(
+            "WWWWWWWWWW" +  // 10 wake
+            "SSSSS" +       // 5 sleep (≤6) — should be absorbed
+            "WWWWWWWWWW"    // 10 wake
+        )
+        val output = WebsterRescoring.rescore(input)
+        assertTrue("brief sleep should absorb to wake", output.all { it })
+    }
+
+    @Test
+    fun rule_d_does_not_fire_when_sleep_run_exceeds_6() {
+        // 7 sleep samples > rule d's ≤6 max. The wake-run extension
+        // rules a-c still apply at the boundary.
+        val input = pattern(
+            "WWWWWWWWWW" +  // 10 wake
+            "SSSSSSS" +     // 7 sleep
+            "WWWWWWWWWW"
+        )
+        val output = WebsterRescoring.rescore(input)
+        // 10W (rule b extends 3 on the first S since preceding wake = 10),
+        // then 4 surviving S, then 10W. Total wake = 10 + 3 + 10 = 23.
+        // (Rule b doesn't re-fire on subsequent sleeps because the
+        // preceding-wake-run is read from the ORIGINAL — interrupted
+        // by the first sleep.)
+        assertEquals(23, output.count { it })
+    }
+
+    @Test
+    fun rule_d_does_not_fire_when_one_flank_is_too_short() {
+        // Only 9 wake on the right → rule d's ≥10 flanking threshold
+        // fails on that side.
+        val input = pattern(
+            "WWWWWWWWWW" +  // 10 wake
+            "SSS" +         // 3 sleep
+            "WWWWWWWWW"     // 9 wake (short)
+        )
+        val output = WebsterRescoring.rescore(input)
+        // Rule d fails. Rule a-c forward extension still fires on first S.
+        // 10W + rule b extends 3 → 13W + 9W = 22W, total 22.
+        assertEquals(22, output.count { it })
+    }
+
+    // -- Rule e: sleep run ≤10 flanked by wake ≥20 --
+
+    @Test
+    fun rule_e_absorbs_10_sleep_between_two_20_wake_runs() {
+        val input = pattern(
+            "W".repeat(20) +
+            "S".repeat(10) +
+            "W".repeat(20)
+        )
+        val output = WebsterRescoring.rescore(input)
+        assertTrue("rule-e absorption should produce all wake", output.all { it })
+    }
+
+    @Test
+    fun rule_e_does_not_fire_when_sleep_run_exceeds_10() {
+        // 11 sleep samples — above rule e's ≤10 ceiling.
+        val input = pattern(
+            "W".repeat(20) +
+            "S".repeat(11) +
+            "W".repeat(20)
+        )
+        val output = WebsterRescoring.rescore(input)
+        // Rule e fails. Rules a-c still fire on the first sleep.
+        // 20W + rule c extends 4 = 24W, then 7S, then 20W. Total 44 wake.
+        assertEquals(44, output.count { it })
+    }
+
+    // -- Integration --
+
+    @Test
+    fun forward_extension_and_brief_sleep_absorption_compose_cleanly() {
+        // Long wake → brief sleep → long wake → moderate sleep → long wake
+        // Brief sleep gets absorbed; moderate gets the forward extension
+        // but not full absorption.
+        val input = pattern(
+            "W".repeat(20) +    // long wake
+            "S".repeat(4) +     // brief sleep — absorbed by rule d
+            "W".repeat(15) +    // long wake
+            "S".repeat(8) +     // moderate sleep — rule c extends 4
+            "W".repeat(15)      // long wake
+        )
+        val output = WebsterRescoring.rescore(input)
+        // Expected: 20W + 4W (absorbed) + 15W + 4W (rule c extension) + 4S + 15W
+        assertEquals(58, output.count { it })
+        // Confirm the 4-sleep gap survives in the right place.
+        val expectedSleepCount = 4
+        assertEquals(expectedSleepCount, output.count { !it })
+    }
+
+    @Test
+    fun rules_do_not_fire_at_array_start_or_end_when_run_context_is_missing() {
+        // Array starts with sleep — no preceding wake at all.
+        val startSleep = WebsterRescoring.rescore(pattern("SSSWWWWWW"))
+        assertPatternEquals("SSSWWWWWW", startSleep)
+
+        // Array ends with sleep after a long wake — rule c fires, but
+        // only as many samples as remain.
+        val endShort = WebsterRescoring.rescore(pattern("W".repeat(15) + "SS"))
+        // Rule c wants to extend 4 but only 2 samples remain. Both flip.
+        assertPatternEquals("W".repeat(15) + "WW", endShort)
+    }
+
+    // -- helpers --
+
+    private fun pattern(s: String): BooleanArray = BooleanArray(s.length) { s[it] == 'W' }
+
+    private fun assertPatternEquals(expected: String, actual: BooleanArray) {
+        val actualStr = actual.joinToString("") { if (it) "W" else "S" }
+        assertEquals(expected, actualStr)
+    }
+}


### PR DESCRIPTION
## Summary
Completes the canonical Cole-Kripke actigraphy algorithm landed in [#297](https://github.com/thdelmas/Bios/pull/297): the bare 7-tap FIR alone is the published baseline, but Webster (1982) added 5 post-FIR rescoring rules that the actigraphy literature treats as part of the same algorithm. Rules a/b/c forward-extend wake after sustained wake runs ("wake persists"); rules d/e absorb brief sleep epochs sandwiched between long wake runs ("brief sleep during long wake is drowsy minutes, not real sleep").

## Pieces
- **New: [`WebsterRescoring`](android/app/src/main/java/com/bios/app/engine/WebsterRescoring.kt)** — pure boolean-array transform. Takes the post-FIR awake mask and returns a rescored copy. Rules a/b/c read the preceding-wake-run from the **ORIGINAL** FIR output (deterministic single pass, no fixed-point iteration — matches `pyActigraphy` / `actigraph.sleepr` reference ports). Rules d/e walk sleep runs once, absorbing those that meet the brief-run / long-flank criteria.
- **[`PhoneSleepInference.segmentByActivity`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt)** computes the per-sample FIR awake mask once for the whole sample array, applies Webster, then walks `[startIdx, endIdx]` over the rescored mask. Webster sees the full array so its lookbacks aren't truncated at the sleep-window boundary.
- **`stageAt(variances, index)` retired** — `segmentByActivity` now uses a small inline `stageFor(awake)` mapper since the per-sample classification needs the whole-array Webster pass.

## Rule reference (Webster 1982 / Cole-Kripke 1992)

| Rule | Trigger | Action |
|---|---|---|
| a | ≥ 4 min wake preceding | Next 1 min sleep → wake |
| b | ≥ 10 min wake preceding | Next 3 min sleep → wake |
| c | ≥ 15 min wake preceding | Next 4 min sleep → wake |
| d | Sleep run ≤ 6 flanked by wake ≥ 10 on both sides | Run → wake |
| e | Sleep run ≤ 10 flanked by wake ≥ 20 on both sides | Run → wake |

## Complementarity with `mergeBriefAwake`
Webster's d/e rules absorb brief sleep into surrounding wake. The pre-existing [`mergeBriefAwake`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt) policy (controlled by `AWAKE_BOUT_MIN_MS`) goes the **opposite** direction: brief AWAKE during long sleep gets recoded back to sleep (posture shifts). Both kept — they address complementary misclassifications at opposite poles. Documented inline.

## Test plan
- [x] **13 new unit tests** in [`WebsterRescoringTest`](android/app/src/test/java/com/bios/app/WebsterRescoringTest.kt):
  - Pure-transform invariants (returns new array, doesn't mutate input, empty input → empty output, all-sleep / all-wake unchanged)
  - Rule a: fires after exactly 4 wake, doesn't after 3, extends only 1 sample (reads original, not rescored)
  - Rule b: fires after exactly 10 wake, chooses 3-sample extension over rule a's single
  - Rule c: fires after exactly 15 wake, chooses 4-sample over rules a + b
  - Rule d: absorbs 5 sleep flanked by 10 wake on both sides; doesn't fire on 7 sleep or one-flank-short
  - Rule e: absorbs 10 sleep flanked by 20 wake; doesn't fire on 11 sleep
  - Integration: forward-extension + brief-sleep absorption compose cleanly
  - Edge: rules don't fire at array start when context is missing; truncate to available samples at array end
- [x] All existing `PhoneSleepInferenceTest` cases pass unchanged.
- [x] `code-quality-check.sh` green.

## What's left in #244
- **Cut 2** — per-owner baselined threshold. Replaces the hardcoded `ACTIVITY_COUNT_PER_VARIANCE = 9.0f` with a 7-day quiet-hour rolling baseline. Real per-owner accuracy lift.
- **Cut 3** — PhysioNet `sleep-accel` validation harness. Honest accuracy number against PSG-labeled ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)