### PR TITLE
feat(engine): per-owner baselined activity threshold (#244 Cut 2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/BaselinedActivityThreshold.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselinedActivityThreshold.kt
@@ -1,0 +1,169 @@
+package com.bios.app.engine
+
+import android.content.Context
+
+/**
+ * Per-owner-learned activity threshold for
+ * [PhoneSleepInference.isQuietSample] (#244 Cut 2).
+ *
+ * The prior hardcoded `ACTIVITY_THRESHOLD = 0.5f (m/s²)²` has no
+ * published basis — the actigraphy literature explicitly warns that
+ * thresholds are device- and population-dependent. Modern Android
+ * phones span at least an order of magnitude in accelerometer noise
+ * floor (sensor-hub class on flagships vs commodity sensors on
+ * sub-$200 mid-tier), so a single global cutoff over-fires on quiet
+ * devices and under-fires on noisy ones.
+ *
+ * The learned threshold is **3× the 25th percentile of
+ * accelMagnitudeVar measured during the owner's nominal quiet hours
+ * over a rolling 7-day window**. The 3× factor pulls the threshold
+ * above the owner's own quiet-night noise floor; the P25 baseline is
+ * robust to occasional outliers (a single restless night doesn't
+ * shift the threshold).
+ *
+ * **Fallback.** Until at least [MIN_SAMPLES_FOR_BASELINE] quiet-hour
+ * samples have accumulated, [currentThreshold] returns the
+ * conservative pre-Cut-2 constant
+ * [PhoneSleepInference.ACTIVITY_THRESHOLD]. Same shape as
+ * [SeizureDetectionPrefs] and [PpgCalibrationLogger] — owner-facing
+ * features fall back to a documented default when the learned signal
+ * isn't ready.
+ *
+ * **Storage.** Rolling sample buffer as a comma-separated `Float`
+ * string in [PREFS_NAME]; pruning happens lazily on the next
+ * [recordSample] call. Sample count stays small (typically ~660
+ * samples at the FG-service 60s cadence × 11 quiet hours × 7 days),
+ * so the CSV serialization is well under 50 KB even in the worst
+ * case.
+ *
+ * Mirrors the per-owner-calibration spirit of Bios's "instrument,
+ * not coach" principle: Bios learns *this* owner's quiet baseline,
+ * not a population average.
+ */
+object BaselinedActivityThreshold {
+
+    /** Multiplier applied to the P25 baseline. Pulls the threshold
+     *  comfortably above the owner's quiet-night noise floor while
+     *  staying low enough to catch genuine movement. */
+    const val P25_MULTIPLIER: Float = 3.0f
+
+    /** Minimum quiet-hour samples before a learned threshold is
+     *  trusted. Below this, [currentThreshold] returns the fallback.
+     *  Picked so the buffer covers at least ~6 hours of one quiet
+     *  night at the 60s FG-service cadence. */
+    const val MIN_SAMPLES_FOR_BASELINE: Int = 360
+
+    /** Rolling window the baseline reads from. 7 days per #244's
+     *  spec — long enough that one anomalous night doesn't shift the
+     *  threshold, short enough that the owner's actual current
+     *  device / movement regime dominates. */
+    private const val WINDOW_MS: Long = 7L * 24 * 60 * 60 * 1000
+
+    /** SharedPreferences file + keys. */
+    private const val PREFS_NAME = "bios_baselined_activity_threshold"
+    private const val KEY_SAMPLES = "samples"
+    private const val KEY_TIMESTAMPS = "timestamps"
+
+    // -- pure compute (JVM-testable) --
+
+    /**
+     * Compute the learned threshold from a list of quiet-hour
+     * variance samples. Returns null when there aren't enough
+     * samples; callers should fall back to the documented default.
+     *
+     * The result is `[P25_MULTIPLIER] * P25(samples)` with a sanity
+     * floor at 0.05 — a degenerate phone (perfectly still on a
+     * laboratory bench) could produce a near-zero P25; multiplying
+     * by 3 still leaves an unusably small threshold. The floor keeps
+     * the threshold above plausible sensor-hub quantization noise.
+     */
+    fun compute(samples: List<Float>): Float? {
+        if (samples.size < MIN_SAMPLES_FOR_BASELINE) return null
+        val sorted = samples.sorted()
+        val p25Index = (sorted.size * 25 / 100).coerceIn(0, sorted.size - 1)
+        val p25 = sorted[p25Index]
+        val raw = P25_MULTIPLIER * p25
+        return raw.coerceAtLeast(MIN_LEARNED_THRESHOLD)
+    }
+
+    /** Sanity floor for the learned threshold. See [compute]. */
+    private const val MIN_LEARNED_THRESHOLD: Float = 0.05f
+
+    /**
+     * Prune samples older than [WINDOW_MS] from the supplied parallel
+     * sample / timestamp arrays. Returns the surviving subset (both
+     * lists in lockstep). Pure logic for JVM testing.
+     */
+    fun pruneOldSamples(
+        samples: List<Float>,
+        timestamps: List<Long>,
+        nowMs: Long,
+    ): Pair<List<Float>, List<Long>> {
+        require(samples.size == timestamps.size) {
+            "samples (${samples.size}) and timestamps (${timestamps.size}) must be parallel"
+        }
+        val cutoff = nowMs - WINDOW_MS
+        val keptSamples = mutableListOf<Float>()
+        val keptTimestamps = mutableListOf<Long>()
+        for (i in samples.indices) {
+            if (timestamps[i] >= cutoff) {
+                keptSamples += samples[i]
+                keptTimestamps += timestamps[i]
+            }
+        }
+        return keptSamples to keptTimestamps
+    }
+
+    // -- Android-bound storage --
+
+    /**
+     * Record a quiet-hour variance sample into the rolling buffer.
+     * Callers are responsible for the quiet-hour gate (typically via
+     * [com.bios.app.ingest.PhoneSleepQuietHours]); this method does
+     * not check. Triggers a prune of >7-day-old samples.
+     */
+    fun recordSample(context: Context, variance: Float, nowMs: Long = System.currentTimeMillis()) {
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val existingSamples = parseFloatCsv(prefs.getString(KEY_SAMPLES, "").orEmpty())
+        val existingTimestamps = parseLongCsv(prefs.getString(KEY_TIMESTAMPS, "").orEmpty())
+        val (prunedSamples, prunedTimestamps) =
+            pruneOldSamples(existingSamples, existingTimestamps, nowMs)
+        val newSamples = prunedSamples + variance
+        val newTimestamps = prunedTimestamps + nowMs
+        prefs.edit()
+            .putString(KEY_SAMPLES, newSamples.joinToString(",") { it.toString() })
+            .putString(KEY_TIMESTAMPS, newTimestamps.joinToString(",") { it.toString() })
+            .apply()
+    }
+
+    /**
+     * Return the current threshold for [PhoneSleepInference.isQuietSample]
+     * — either the learned value if the buffer has crossed
+     * [MIN_SAMPLES_FOR_BASELINE], or the documented pre-Cut-2 fallback
+     * otherwise. Safe to call from any thread.
+     */
+    fun currentThreshold(context: Context): Float {
+        val prefs = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val samples = parseFloatCsv(prefs.getString(KEY_SAMPLES, "").orEmpty())
+        return compute(samples) ?: PhoneSleepInference.ACTIVITY_THRESHOLD
+    }
+
+    /** Test-only reset hook. */
+    internal fun clearForTest(context: Context) {
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().clear().apply()
+    }
+
+    private fun parseFloatCsv(csv: String): List<Float> {
+        if (csv.isBlank()) return emptyList()
+        return csv.split(",").mapNotNull { it.toFloatOrNull() }
+    }
+
+    private fun parseLongCsv(csv: String): List<Long> {
+        if (csv.isBlank()) return emptyList()
+        return csv.split(",").mapNotNull { it.toLongOrNull() }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt
@@ -75,10 +75,14 @@ object PhoneSleepInference {
      * reading plus optional [MetricType.SLEEP_STAGE] rows for LIGHT / AWAKE
      * segments inside the sleep window. Empty when no viable window is found.
      */
-    fun infer(samples: List<Sample>, sourceId: String): List<MetricReading> {
+    fun infer(
+        samples: List<Sample>,
+        sourceId: String,
+        activityThreshold: Float = ACTIVITY_THRESHOLD,
+    ): List<MetricReading> {
         if (samples.size < 2) return emptyList()
         val sorted = samples.sortedBy { it.timestamp }
-        val window = longestScreenOffStretch(sorted) ?: return emptyList()
+        val window = longestScreenOffStretch(sorted, activityThreshold) ?: return emptyList()
         val (startIdx, endIdx) = window
         val windowMs = sorted[endIdx].timestamp - sorted[startIdx].timestamp
         if (windowMs < MIN_SLEEP_WINDOW_MS) return emptyList()
@@ -203,7 +207,10 @@ object PhoneSleepInference {
      * fails the stationary check the moment the owner adjusts position.
      * "Phone on nightstand showing AOD" passes all three.
      */
-    internal fun isQuietSample(s: Sample): Boolean {
+    internal fun isQuietSample(
+        s: Sample,
+        activityThreshold: Float = ACTIVITY_THRESHOLD,
+    ): Boolean {
         if (s.screenOff) return true
         // #243 Cut 2: hardware-confirmed stillness + charging is the
         // AOD-on-nightstand signature with the strongest primary signal
@@ -212,7 +219,7 @@ object PhoneSleepInference {
         // bypasses the lux check (streetlight through a window must
         // not disqualify a clearly-stationary plugged-in device).
         if (s.stationary == true && s.charging) return true
-        val lowMotion = (s.accelMagnitudeVar ?: Float.MAX_VALUE) < ACTIVITY_THRESHOLD
+        val lowMotion = (s.accelMagnitudeVar ?: Float.MAX_VALUE) < activityThreshold
         val dark = (s.ambientLightLux ?: Float.MAX_VALUE) < DARK_LUX_THRESHOLD
         return s.charging && lowMotion && dark
     }
@@ -227,13 +234,16 @@ object PhoneSleepInference {
      *
      * Returns null when no quiet stretch exists at all.
      */
-    private fun longestScreenOffStretch(samples: List<Sample>): Pair<Int, Int>? {
+    private fun longestScreenOffStretch(
+        samples: List<Sample>,
+        activityThreshold: Float = ACTIVITY_THRESHOLD,
+    ): Pair<Int, Int>? {
         var best: Pair<Int, Int>? = null
         var bestLen = 0L
         var runStart = -1
         var i = 0
         while (i < samples.size) {
-            if (isQuietSample(samples[i])) {
+            if (isQuietSample(samples[i], activityThreshold)) {
                 if (runStart == -1) runStart = i
                 if (i == samples.lastIndex) {
                     val len = samples[i].timestamp - samples[runStart].timestamp
@@ -245,7 +255,7 @@ object PhoneSleepInference {
                 // quiet stretch resume after? If the gap is brief, treat it
                 // as a flicker and keep the run going.
                 val gapStart = i
-                while (i < samples.size && !isQuietSample(samples[i])) i++
+                while (i < samples.size && !isQuietSample(samples[i], activityThreshold)) i++
                 val gapEndExclusive = i
                 val gapDurMs = if (gapEndExclusive < samples.size) {
                     samples[gapEndExclusive].timestamp - samples[gapStart].timestamp
@@ -275,10 +285,13 @@ object PhoneSleepInference {
      * no stretch exists. Used by the dashboard diagnostic so the owner can
      * see how close the buffer is to crossing the 4h floor.
      */
-    fun longestScreenOffMs(samples: List<Sample>): Long {
+    fun longestScreenOffMs(
+        samples: List<Sample>,
+        activityThreshold: Float = ACTIVITY_THRESHOLD,
+    ): Long {
         if (samples.size < 2) return 0L
         val sorted = samples.sortedBy { it.timestamp }
-        val range = longestScreenOffStretch(sorted) ?: return 0L
+        val range = longestScreenOffStretch(sorted, activityThreshold) ?: return 0L
         return sorted[range.second].timestamp - sorted[range.first].timestamp
     }
 
@@ -316,17 +329,20 @@ object PhoneSleepInference {
         val sampledNewSignals: Int = 0,
     )
 
-    fun signalBreakdown(samples: List<Sample>): SignalBreakdown {
+    fun signalBreakdown(
+        samples: List<Sample>,
+        activityThreshold: Float = ACTIVITY_THRESHOLD,
+    ): SignalBreakdown {
         val total = samples.size
         val screenInactive = samples.count { it.screenOff }
         val lowMotion = samples.count {
-            (it.accelMagnitudeVar ?: Float.MAX_VALUE) < ACTIVITY_THRESHOLD
+            (it.accelMagnitudeVar ?: Float.MAX_VALUE) < activityThreshold
         }
         val dark = samples.count {
             (it.ambientLightLux ?: Float.MAX_VALUE) < DARK_LUX_THRESHOLD
         }
         val charging = samples.count { it.charging }
-        val quiet = samples.count { isQuietSample(it) }
+        val quiet = samples.count { isQuietSample(it, activityThreshold) }
         val zeroStepDelta = samples.count { it.stepDelta == 0 }
         val dndOn = samples.count { it.dndEnabled == true }
         val pairedBtConnected = samples.count { it.pairedBluetoothConnected == true }

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt
@@ -15,6 +15,7 @@ import android.hardware.SensorManager
 import android.hardware.display.DisplayManager
 import android.os.BatteryManager
 import android.view.Display
+import com.bios.app.engine.BaselinedActivityThreshold
 import com.bios.app.engine.PhoneSleepInference
 import com.bios.app.model.MetricReading
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -193,10 +194,17 @@ class PhoneSleepAdapter(private val context: Context) {
 
     /**
      * Hand the collected samples to the pure inference layer and emit
-     * `SLEEP_DURATION` (+ optional `SLEEP_STAGE`) readings.
+     * `SLEEP_DURATION` (+ optional `SLEEP_STAGE`) readings. Uses the
+     * per-owner-learned activity threshold (#244 Cut 2) when the
+     * baseline has accumulated enough quiet-hour samples, falling
+     * back to [PhoneSleepInference.ACTIVITY_THRESHOLD] otherwise.
      */
     fun infer(samples: List<PhoneSleepInference.Sample>, sourceId: String): List<MetricReading> =
-        PhoneSleepInference.infer(samples, sourceId)
+        PhoneSleepInference.infer(
+            samples,
+            sourceId,
+            BaselinedActivityThreshold.currentThreshold(context),
+        )
 
     private suspend fun sampleAccelVariance(durationMs: Long): Float? {
         val sensor = accelerometer ?: return null

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt
@@ -13,6 +13,7 @@ import android.os.PowerManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.BaselinedActivityThreshold
 import com.bios.app.model.PhoneSleepSample
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -132,6 +133,15 @@ class PhoneSleepCollectionService : Service() {
                         stationary = sample.stationary,
                     )
                 )
+                // #244 Cut 2: feed the variance sample into the per-owner
+                // baseline. The service only runs during quiet hours (the
+                // PhoneSleepQuietHours gate runs in onStartCommand), so
+                // every sample here qualifies as a quiet-hour observation.
+                sample.accelMagnitudeVar?.let {
+                    BaselinedActivityThreshold.recordSample(
+                        applicationContext, it, sample.timestamp,
+                    )
+                }
             } catch (t: Throwable) {
                 Log.w(TAG, "sample iteration failed: ${t.message}", t)
             }

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
 import com.bios.app.data.BiosDatabase
+import com.bios.app.engine.BaselinedActivityThreshold
 import com.bios.app.engine.PhoneSleepInference
 import com.bios.app.model.DataSource
 import com.bios.app.model.PhoneSleepSample
@@ -87,10 +88,23 @@ class PhoneSleepWorker(
                     stationary = sample.stationary,
                 )
             )
+            // #244 Cut 2: feed the variance sample into the per-owner
+            // baseline when we're inside quiet hours. The 15-min
+            // worker cadence is lower-volume than the FG service but
+            // still adds samples on devices where the service hasn't
+            // started (no charging trigger today, etc.).
+            if (PhoneSleepQuietHours.isInQuietHoursNow()) {
+                sample.accelMagnitudeVar?.let {
+                    BaselinedActivityThreshold.recordSample(context, it, sample.timestamp)
+                }
+            }
+            // Use the learned threshold for diagnostic logging so the
+            // "quiet=" log line reflects what the inference will see.
+            val threshold = BaselinedActivityThreshold.currentThreshold(context)
             // One-line per-firing diagnostic so the failure mode is
             // observable from `adb logcat -s PhoneSleepWorker` without
             // having to decrypt SQLCipher rows. See #240.
-            val quiet = PhoneSleepInference.isQuietSample(sample)
+            val quiet = PhoneSleepInference.isQuietSample(sample, threshold)
             Log.i(
                 TAG,
                 "diag: sample screenOff=${sample.screenOff} " +
@@ -133,8 +147,9 @@ class PhoneSleepWorker(
                         stationary = it.stationary,
                     )
                 }
-            val breakdown = PhoneSleepInference.signalBreakdown(samples)
-            val longestQuietMin = PhoneSleepInference.longestScreenOffMs(samples) / 60_000L
+            val breakdown = PhoneSleepInference.signalBreakdown(samples, threshold)
+            val longestQuietMin =
+                PhoneSleepInference.longestScreenOffMs(samples, threshold) / 60_000L
             Log.i(
                 TAG,
                 "diag: decision=Fire window=${decision.windowStartMs}..${decision.windowEndMs} " +

--- a/android/app/src/test/java/com/bios/app/BaselinedActivityThresholdTest.kt
+++ b/android/app/src/test/java/com/bios/app/BaselinedActivityThresholdTest.kt
@@ -1,0 +1,128 @@
+package com.bios.app
+
+import com.bios.app.engine.BaselinedActivityThreshold
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [BaselinedActivityThreshold]'s compute +
+ * pruneOldSamples helpers (#244 Cut 2). The Android-bound storage
+ * wrapper (`recordSample` / `currentThreshold`) is a thin
+ * SharedPreferences shim — same exclusion documented in
+ * `PpgCalibrationLoggerTest`: the unit-test source set has no
+ * Android Context.
+ */
+class BaselinedActivityThresholdTest {
+
+    private val minSamples = BaselinedActivityThreshold.MIN_SAMPLES_FOR_BASELINE
+
+    @Test
+    fun compute_returns_null_below_min_sample_count() {
+        val tooFew = List(minSamples - 1) { 0.1f }
+        assertNull(BaselinedActivityThreshold.compute(tooFew))
+    }
+
+    @Test
+    fun compute_returns_3x_P25_at_or_above_min_sample_count() {
+        // Samples: 1..400 ranks evenly distributed. P25 by rank-index
+        // floor(400 * 25 / 100) = 100 sits at the 101st value (1-indexed)
+        // = 101. Expected threshold = 3 * 101 = 303.
+        val samples = (1..400).map { it.toFloat() }
+        val result = BaselinedActivityThreshold.compute(samples)
+        assertNotNull(result)
+        assertEquals(303f, result!!, 1f)
+    }
+
+    @Test
+    fun compute_applies_a_sanity_floor_for_degenerate_inputs() {
+        // A perfectly still phone (variance ≈ 0 for every sample) would
+        // produce a near-zero P25 and an unusably small 3*P25. The
+        // sanity floor keeps the threshold above sensor-hub quantization
+        // noise so isQuietSample stays meaningful even on lab benches.
+        val allZero = List(minSamples) { 0f }
+        val result = BaselinedActivityThreshold.compute(allZero)
+        assertNotNull(result)
+        assertEquals(0.05f, result!!, 1e-6f)
+    }
+
+    @Test
+    fun compute_uses_the_25th_percentile_not_the_mean() {
+        // 90% of samples at variance = 0.05 (quiet), 10% at variance = 5
+        // (a few high-motion outliers). The MEAN would be skewed by the
+        // outliers (~0.55); the P25 stays at 0.05 → threshold = 0.15.
+        val quiet = List((minSamples * 0.9).toInt()) { 0.05f }
+        val outliers = List(minSamples - quiet.size) { 5f }
+        val samples = quiet + outliers
+        val result = BaselinedActivityThreshold.compute(samples)
+        assertNotNull(result)
+        assertEquals(0.15f, result!!, 1e-3f)
+    }
+
+    @Test
+    fun compute_is_resilient_to_unsorted_input() {
+        // The implementation sorts internally; the caller doesn't need
+        // to pre-sort.
+        val ascending = (1..400).map { it.toFloat() }
+        val shuffled = ascending.shuffled(java.util.Random(42L))
+        assertEquals(
+            BaselinedActivityThreshold.compute(ascending),
+            BaselinedActivityThreshold.compute(shuffled),
+        )
+    }
+
+    // -- pruneOldSamples --
+
+    @Test
+    fun pruneOldSamples_keeps_samples_inside_the_7_day_window() {
+        val now = 1_700_000_000_000L
+        val day = 24L * 60 * 60 * 1000
+        val samples = listOf(0.1f, 0.2f, 0.3f, 0.4f)
+        val timestamps = listOf(
+            now - 8 * day, // outside — drops
+            now - 6 * day, // inside
+            now - 3 * day, // inside
+            now,           // inside
+        )
+        val (keptSamples, keptTimestamps) =
+            BaselinedActivityThreshold.pruneOldSamples(samples, timestamps, now)
+        assertEquals(listOf(0.2f, 0.3f, 0.4f), keptSamples)
+        assertEquals(listOf(now - 6 * day, now - 3 * day, now), keptTimestamps)
+    }
+
+    @Test
+    fun pruneOldSamples_keeps_sample_exactly_at_the_cutoff() {
+        val now = 1_700_000_000_000L
+        val sevenDays = 7L * 24 * 60 * 60 * 1000
+        val cutoff = now - sevenDays
+        val (kept, _) = BaselinedActivityThreshold.pruneOldSamples(
+            samples = listOf(1.0f, 2.0f),
+            timestamps = listOf(cutoff, cutoff - 1),
+            nowMs = now,
+        )
+        // Sample at exactly the cutoff is "≥ cutoff" → kept. The one
+        // 1 ms older drops.
+        assertEquals(listOf(1.0f), kept)
+    }
+
+    @Test
+    fun pruneOldSamples_empty_input_yields_empty_output() {
+        val (kept, keptTs) = BaselinedActivityThreshold.pruneOldSamples(
+            emptyList(), emptyList(), nowMs = 1_700_000_000_000L,
+        )
+        assertEquals(emptyList<Float>(), kept)
+        assertEquals(emptyList<Long>(), keptTs)
+    }
+
+    @Test
+    fun pruneOldSamples_throws_on_misaligned_lists() {
+        runCatching {
+            BaselinedActivityThreshold.pruneOldSamples(
+                samples = listOf(1f, 2f, 3f),
+                timestamps = listOf(100L, 200L),
+                nowMs = 300L,
+            )
+        }.let { assertEquals(true, it.isFailure) }
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the hardcoded `ACTIVITY_THRESHOLD = 0.5f (m/s²)²` constant used by [`PhoneSleepInference.isQuietSample`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt) with a **per-owner-learned value**: 3× the 25th percentile of `accelMagnitudeVar` across quiet hours over a rolling 7-day window. The prior global cutoff over-fires on quiet devices (flagship sensor hubs) and under-fires on noisy ones (commodity mid-tier sensors); the actigraphy literature explicitly warns thresholds are device- and population-dependent.

This is Cut 2 of three from [#244](https://github.com/thdelmas/Bios/issues/244). Cut 1 (Cole-Kripke FIR, [#297](https://github.com/thdelmas/Bios/pull/297)) and Cut 1b (Webster rescoring, [#298](https://github.com/thdelmas/Bios/pull/298)) shipped the algorithm; this PR makes it self-calibrating. Cut 3 (PhysioNet validation harness) is the natural follow-up to measure the resulting accuracy lift.

## Pieces
- **New: [`BaselinedActivityThreshold`](android/app/src/main/java/com/bios/app/engine/BaselinedActivityThreshold.kt)** — pure-Kotlin compute helpers (`compute` for the 3*P25 threshold over a sample list, `pruneOldSamples` for the 7-day window) plus an Android-side `SharedPreferences`-backed wrapper that appends each quiet-hour sample and prunes lazily. Falls back to the pre-Cut-2 constant until at least `MIN_SAMPLES_FOR_BASELINE = 360` quiet-hour samples have accumulated (~6 hours of one good night at the FG-service 60s cadence).
- **[`PhoneSleepInference.infer`](android/app/src/main/java/com/bios/app/engine/PhoneSleepInference.kt) / `isQuietSample` / `signalBreakdown` / `longestScreenOffMs` / `longestScreenOffStretch`** — all accept an optional `activityThreshold` parameter (default = the pre-Cut-2 constant for backward compatibility with any external callers).
- **[`PhoneSleepAdapter.infer`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepAdapter.kt)** reads `BaselinedActivityThreshold.currentThreshold` and passes it through.
- **[`PhoneSleepCollectionService`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepCollectionService.kt)** feeds every collected sample into the baseline. The service is already gated by [`PhoneSleepQuietHours`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepQuietHours.kt) (21:00–08:00), so every sample qualifies as a quiet-hour observation by definition.
- **[`PhoneSleepWorker`](android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt)** feeds samples too when its 15-min firing lands inside quiet hours, and uses the learned threshold for its diagnostic `signalBreakdown` / `longestScreenOffMs` log line so the `"quiet="` output reflects what `infer` will actually see.

## Sanity floor
When the learned 3*P25 drops below 0.05 (degenerate lab-bench cases where the phone is essentially motionless), the floor keeps the threshold above plausible sensor-hub quantization noise so `isQuietSample` doesn't degenerate.

## What this PR does NOT do
- **No baselining of `ACTIVITY_COUNT_PER_VARIANCE`** (the Cole-Kripke FIR's activity-count multiplier). The issue's "open question" recommended bundling these but #244 Cut 2's spec explicitly targets the `ACTIVITY_THRESHOLD` constant. The Cole-Kripke side benefits from per-owner learning too and can land in a future follow-up; not required for #244 to close.
- **No UI surface** showing the learned threshold to the owner — it's an internal calibration concern. The debug screen ([#277](https://github.com/thdelmas/Bios/pull/277)) could surface it later if useful.

## Test plan
- [x] **9 pure-JVM tests** in [`BaselinedActivityThresholdTest`](android/app/src/test/java/com/bios/app/BaselinedActivityThresholdTest.kt):
  - `compute_returns_null_below_min_sample_count` — fallback gate
  - `compute_returns_3x_P25_at_or_above_min_sample_count` — canonical case (400 samples, P25 rank-index = 100 → value 101 → threshold 303)
  - `compute_applies_a_sanity_floor_for_degenerate_inputs` — all-zero input → floor at 0.05
  - `compute_uses_the_25th_percentile_not_the_mean` — outlier robustness (90% quiet + 10% outliers → P25 = quiet floor)
  - `compute_is_resilient_to_unsorted_input` — caller doesn't need to pre-sort
  - `pruneOldSamples_keeps_samples_inside_the_7_day_window`
  - `pruneOldSamples_keeps_sample_exactly_at_the_cutoff` — boundary is inclusive
  - `pruneOldSamples_empty_input_yields_empty_output`
  - `pruneOldSamples_throws_on_misaligned_lists` — defensive precondition
- [x] All existing `PhoneSleepInferenceTest` cases pass unchanged (default-param backward compat preserves the constant).
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: run an overnight cycle on a Pixel, confirm `BaselinedActivityThreshold` SharedPreferences accumulates samples. After ~7 days of data, confirm `currentThreshold` returns a learned value (not the constant), and the worker's `"quiet="` diagnostic log line reflects the learned threshold.

## Next
**Cut 3** — PhysioNet `sleep-accel` validation harness (Walch 2019 dataset, 31 subjects). Measures the actual accuracy lift from Cuts 1/1b/2 against PSG-labeled ground truth and becomes a regression substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)