### PR TITLE
feat(engine): per-device PPG motion-rejection profile (#266 Cut 2)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt
+++ b/android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt
@@ -52,14 +52,20 @@ enum class CaptureQuality(val message: String, val isGood: Boolean) {
         const val FINGER_OFF_MIN_VARIANCE = 0.5
 
         /**
-         * Motion threshold on the *median* frame-to-frame Y jump over the
-         * recent window. Heart-beats produce a few large diffs per second
-         * (systolic peaks) on top of mostly small diffs, so a single max
-         * value is a poor discriminator — devices with strong PPG amplitude
-         * would always classify as MOTION. Median-of-diffs is robust to
-         * those spikes: sustained motion lifts the whole distribution.
+         * Default motion threshold on the *median* frame-to-frame Y
+         * jump over the recent window. Heart-beats produce a few
+         * large diffs per second (systolic peaks) on top of mostly
+         * small diffs, so a single max value is a poor discriminator
+         * — devices with strong PPG amplitude would always classify
+         * as MOTION. Median-of-diffs is robust to those spikes:
+         * sustained motion lifts the whole distribution.
+         *
+         * Per-device overrides ([PpgDeviceProfile.motionMedianJumpY])
+         * land once the [PpgCalibrationLogger] distribution data is
+         * in (#266 Cut 2). The default preserves pre-Cut-2
+         * behaviour for devices not yet in [PpgDeviceProfiles.PROFILES].
          */
-        const val MOTION_MEDIAN_JUMP_Y = 6.0
+        const val MOTION_MEDIAN_JUMP_Y_DEFAULT = 6.0
 
         /** Window for the motion check (seconds). */
         const val MOTION_WINDOW_SEC = 1.0
@@ -67,8 +73,17 @@ enum class CaptureQuality(val message: String, val isGood: Boolean) {
         /**
          * Classify the most recent frames. [window] is mean-Y values oldest
          * first; [samplingRateHz] is the analyzer's current frame rate.
+         *
+         * @param profile per-device thresholds (#266 Cut 2). Default
+         *   = [PpgDeviceProfiles.DEFAULT] so any caller that hasn't
+         *   yet plumbed a device profile through gets the pre-Cut-2
+         *   behaviour.
          */
-        fun classify(window: List<Double>, samplingRateHz: Double): CaptureQuality {
+        fun classify(
+            window: List<Double>,
+            samplingRateHz: Double,
+            profile: PpgDeviceProfile = PpgDeviceProfiles.DEFAULT,
+        ): CaptureQuality {
             if (window.size < MIN_FRAMES_FOR_CLASSIFICATION) return WAITING
 
             val mean = window.average()
@@ -85,7 +100,7 @@ enum class CaptureQuality(val message: String, val isGood: Boolean) {
                 .sorted()
             if (recentDiffs.isEmpty()) return STEADY
             val median = recentDiffs[recentDiffs.size / 2]
-            if (median > MOTION_MEDIAN_JUMP_Y) return MOTION
+            if (median > profile.motionMedianJumpY) return MOTION
 
             return STEADY
         }
@@ -95,7 +110,7 @@ enum class CaptureQuality(val message: String, val isGood: Boolean) {
          * full capture, sampled in non-overlapping 1-second windows. Returned
          * percentiles (p50 = typical session-wide steadiness; p90 = the worst
          * sustained second the owner held through) let the calibration logger
-         * characterise the distribution that [MOTION_MEDIAN_JUMP_Y] is being
+         * characterise the distribution that [MOTION_MEDIAN_JUMP_Y_DEFAULT] is being
          * thresholded against, on each device. Returns `null` when the
          * recording is too short to produce a single window.
          */

--- a/android/app/src/main/java/com/bios/app/engine/PpgDeviceProfile.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PpgDeviceProfile.kt
@@ -1,0 +1,97 @@
+package com.bios.app.engine
+
+/**
+ * Device-specific motion-rejection thresholds for the camera-PPG
+ * capture path (#266 Cut 2).
+ *
+ * The eyeball-tuned defaults in [CaptureQuality] and
+ * [PpgSignalProcessor] over-reject on hardware whose LED-to-lens
+ * geometry puts more frame-to-frame variability into the live
+ * luminance trace than the constants expect (Pixel 9a is the known
+ * regression). The actigraphy / PPG literature is consistent that
+ * motion thresholds are device-dependent — what reads as "still"
+ * on a Pixel 6 is "moving" on a 9a and vice versa.
+ *
+ * This profile decouples the rejection logic from a global cutoff,
+ * letting [PpgDeviceProfiles.forDevice] return per-device values
+ * derived from the [PpgCalibrationLogger] (#266 Cut 1) distribution
+ * data as it accumulates. Unknown devices fall back to the
+ * [PpgDeviceProfiles.DEFAULT] which preserves pre-Cut-2 behavior —
+ * no regression risk for the device set that currently works.
+ *
+ * Both thresholds are tuned together. The real-time check
+ * ([motionMedianJumpY]) and the offline check ([maxPeakAmplitudeCov])
+ * exist to catch the same kind of motion artifact at two layers;
+ * setting them independently for a device produces confusing
+ * inconsistency (real-time says STEADY, offline rejects after 60 s).
+ * Per-device profiles must keep them coupled.
+ */
+data class PpgDeviceProfile(
+    /**
+     * Median frame-to-frame Y jump (8-bit luminance) the real-time
+     * classifier accepts before flipping to MOTION. Higher = more
+     * tolerant; per-device tuning lets noisier hardware stay below
+     * the line without genuine motion slipping through.
+     *
+     * See [CaptureQuality.MOTION_MEDIAN_JUMP_Y_DEFAULT] for the
+     * eyeball-tuned baseline and the rationale.
+     */
+    val motionMedianJumpY: Double,
+    /**
+     * Coefficient-of-variation cap on detected peak amplitudes the
+     * offline processor accepts before rejecting as
+     * MOTION_ARTIFACT. Same scale as
+     * [PpgSignalProcessor.MAX_PEAK_AMPLITUDE_COV_DEFAULT] (0.80 is
+     * the documented baseline tolerating clean fingertip PPG's
+     * respiratory + vasomotor modulation).
+     */
+    val maxPeakAmplitudeCov: Double,
+)
+
+/**
+ * Per-device registry of [PpgDeviceProfile]s.
+ *
+ * **PROFILES is intentionally empty at Cut 2 landing.** The issue
+ * (#266) spec is explicit: thresholds belong in this table only
+ * once derived from real distribution data (via the [PpgCalibrationLogger]
+ * the Cut 1 owner-debug toggle records). Adding a Pixel 9a /
+ * Pixel 6 / Samsung S24 / etc. entry is a one-line edit once at
+ * least 5–10 captures of accepted-quality data have been analyzed
+ * for that model.
+ *
+ * `forDevice(model)` is null-safe and case-insensitive on
+ * `Build.MODEL` so device-marketing-name capitalization variations
+ * resolve to the same profile.
+ */
+object PpgDeviceProfiles {
+
+    /** Eyeball-tuned defaults — preserved here as the fallback so
+     *  the Cut 2 refactor is behaviour-preserving for the device
+     *  set that currently works. */
+    val DEFAULT: PpgDeviceProfile = PpgDeviceProfile(
+        motionMedianJumpY = CaptureQuality.MOTION_MEDIAN_JUMP_Y_DEFAULT,
+        maxPeakAmplitudeCov = PpgSignalProcessor.MAX_PEAK_AMPLITUDE_COV_DEFAULT,
+    )
+
+    /**
+     * Per-device overrides. Empty at Cut 2 landing; populated as
+     * the calibration-log distribution data accumulates. See
+     * scripts/analyze-ppg-calibration-log.md (TBD) for the
+     * threshold-derivation procedure once enough captures are in.
+     */
+    internal val PROFILES: Map<String, PpgDeviceProfile> = emptyMap()
+
+    /**
+     * Resolve the [PpgDeviceProfile] for the supplied device model
+     * string (typically `Build.MODEL`). Null or unknown → [DEFAULT].
+     * Case-insensitive lookup so "pixel 9a" and "Pixel 9a" resolve
+     * identically.
+     */
+    fun forDevice(model: String?): PpgDeviceProfile {
+        if (model == null) return DEFAULT
+        return PROFILES[model]
+            ?: PROFILES[model.lowercase()]
+            ?: PROFILES.entries.firstOrNull { it.key.equals(model, ignoreCase = true) }?.value
+            ?: DEFAULT
+    }
+}

--- a/android/app/src/main/java/com/bios/app/engine/PpgResult.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PpgResult.kt
@@ -29,7 +29,7 @@ data class PpgResult(
     val waveformFeatures: PulseWaveformFeatures? = null,
     /**
      * Trimmed CoV of detected peak amplitudes — the same value compared
-     * against [PpgSignalProcessor.MAX_PEAK_AMPLITUDE_COV]. Non-null whenever
+     * against [PpgSignalProcessor.MAX_PEAK_AMPLITUDE_COV_DEFAULT]. Non-null whenever
      * the pipeline reached peak detection (accept + MOTION_ARTIFACT /
      * IRREGULAR_RHYTHM rejections); null on early rejections that bailed
      * before peak detection ran. Surfaced for [PpgCalibrationLogger] so the

--- a/android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt
+++ b/android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt
@@ -49,14 +49,21 @@ object PpgSignalProcessor {
     private const val MIN_LUMINANCE_VARIANCE = 1.0      // < 1 = no finger
     private const val MAX_SATURATION_RATIO = 0.30       // >30% saturated = overexposed
     /**
-     * Coefficient-of-variation cap on peak amplitudes after trimming the
-     * lowest-amplitude quartile (those are dichrotic notches and noise the
-     * adaptive-threshold detector lets through). 0.80 is consistent with the
-     * amplitude variability seen in clean fingertip PPG due to respiratory
-     * modulation and vasomotor activity; tighter than that rejected real
-     * recordings in on-device testing.
+     * Default coefficient-of-variation cap on peak amplitudes after
+     * trimming the lowest-amplitude quartile (those are dichrotic
+     * notches and noise the adaptive-threshold detector lets
+     * through). 0.80 is consistent with the amplitude variability
+     * seen in clean fingertip PPG due to respiratory modulation and
+     * vasomotor activity; tighter than that rejected real recordings
+     * in on-device testing.
+     *
+     * Per-device overrides ([PpgDeviceProfile.maxPeakAmplitudeCov])
+     * land via [PpgDeviceProfiles] once the [PpgCalibrationLogger]
+     * distribution data is in (#266 Cut 2). The default preserves
+     * pre-Cut-2 behaviour for devices not yet in
+     * [PpgDeviceProfiles.PROFILES].
      */
-    private const val MAX_PEAK_AMPLITUDE_COV = 0.80     // higher = motion
+    const val MAX_PEAK_AMPLITUDE_COV_DEFAULT = 0.80     // higher = motion
     /**
      * Fraction of the smallest-amplitude peaks dropped before computing the
      * amplitude CoV — the adaptive-threshold detector picks up dichrotic
@@ -80,7 +87,11 @@ object PpgSignalProcessor {
      * sampled at [samplingRateHz]. Returns a [PpgResult] with either clean
      * RR intervals or a rejection reason.
      */
-    fun extract(luminanceSamples: List<Double>, samplingRateHz: Double): PpgResult {
+    fun extract(
+        luminanceSamples: List<Double>,
+        samplingRateHz: Double,
+        profile: PpgDeviceProfile = PpgDeviceProfiles.DEFAULT,
+    ): PpgResult {
         val durationSec = luminanceSamples.size / samplingRateHz
 
         if (durationSec < MIN_RECORDING_SECONDS) {
@@ -129,7 +140,7 @@ object PpgSignalProcessor {
             peakIndices.map { smoothed[it] },
             PEAK_AMPLITUDE_TRIM_FRACTION
         )
-        if (peakAmpCov > MAX_PEAK_AMPLITUDE_COV) {
+        if (peakAmpCov > profile.maxPeakAmplitudeCov) {
             return PpgResult.rejected(
                 RejectionReason.MOTION_ARTIFACT,
                 durationSec = durationSec,
@@ -151,7 +162,7 @@ object PpgSignalProcessor {
             )
         }
 
-        val sqi = compositeSqi(variance, saturation, peakAmpCov, rrCov)
+        val sqi = compositeSqi(variance, saturation, peakAmpCov, rrCov, profile.maxPeakAmplitudeCov)
         val features = computeWaveformFeatures(smoothed, peakIndices, samplingRateHz, peakAmpCov)
         return PpgResult(
             rrIntervalsMs = rrMs,
@@ -448,12 +459,13 @@ object PpgSignalProcessor {
         variance: Double,
         saturationRatio: Double,
         peakAmpCov: Double,
-        rrCov: Double
+        rrCov: Double,
+        maxPeakAmplitudeCov: Double = MAX_PEAK_AMPLITUDE_COV_DEFAULT,
     ): Int {
         // Each term 0..1 (1 = perfect); combine by geometric mean, rescale to 100.
         val varianceTerm = (variance / 50.0).coerceIn(0.0, 1.0)
         val saturationTerm = (1.0 - saturationRatio / MAX_SATURATION_RATIO).coerceIn(0.0, 1.0)
-        val ampTerm = (1.0 - peakAmpCov / MAX_PEAK_AMPLITUDE_COV).coerceIn(0.0, 1.0)
+        val ampTerm = (1.0 - peakAmpCov / maxPeakAmplitudeCov).coerceIn(0.0, 1.0)
         val rrTerm = (1.0 - rrCov / MAX_RR_COV).coerceIn(0.0, 1.0)
         val geomMean = (varianceTerm * saturationTerm * ampTerm * rrTerm)
         return (sqrt(sqrt(geomMean)) * 100.0).toInt().coerceIn(0, 100)

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -9,10 +9,12 @@ import androidx.camera.core.UseCase
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.concurrent.futures.await
 import androidx.lifecycle.LifecycleOwner
+import android.os.Build
 import com.bios.app.engine.CaptureQuality
 import com.bios.app.engine.EctopyDetector
 import com.bios.app.engine.HrvAnalyzer
 import com.bios.app.engine.PpgCalibrationLogger
+import com.bios.app.engine.PpgDeviceProfiles
 import com.bios.app.engine.PpgResult
 import com.bios.app.engine.PpgSignalProcessor
 import com.bios.app.engine.RejectionReason
@@ -74,6 +76,14 @@ class CameraPpgAdapter(private val context: Context) {
             return@withContext CaptureResult.error(RejectionReason.HARDWARE_UNAVAILABLE)
         }
 
+        // #266 Cut 2: per-device motion-rejection thresholds. Unknown
+        // models fall back to PpgDeviceProfiles.DEFAULT which preserves
+        // pre-Cut-2 behaviour — no regression on the device set that
+        // currently works. As calibration-log distribution data lands
+        // (Cut 1 toggle), specific models can be added to
+        // PpgDeviceProfiles.PROFILES.
+        val deviceProfile = PpgDeviceProfiles.forDevice(Build.MODEL)
+
         val luminance = Collections.synchronizedList(mutableListOf<Double>())
         val executor = Executors.newSingleThreadExecutor()
         val frameCounter = java.util.concurrent.atomic.AtomicInteger(0)
@@ -91,7 +101,7 @@ class CameraPpgAdapter(private val context: Context) {
                             luminance.takeLast(QUALITY_WINDOW_FRAMES)
                         }
                         qualityFlow.value = CaptureQuality.classify(
-                            window, ASSUMED_SAMPLING_HZ
+                            window, ASSUMED_SAMPLING_HZ, deviceProfile,
                         )
                     }
                 }
@@ -126,7 +136,7 @@ class CameraPpgAdapter(private val context: Context) {
         }
 
         val samplingRateHz = snapshot.size / actualDurationSec
-        val ppg = PpgSignalProcessor.extract(snapshot, samplingRateHz)
+        val ppg = PpgSignalProcessor.extract(snapshot, samplingRateHz, deviceProfile)
         val hrv = if (ppg.accepted) HrvAnalyzer.analyze(ppg.rrIntervalsMs) else null
 
         if (PpgCalibrationLogger.isEnabled(context)) {

--- a/android/app/src/test/java/com/bios/app/CaptureQualityTest.kt
+++ b/android/app/src/test/java/com/bios/app/CaptureQualityTest.kt
@@ -46,7 +46,7 @@ class CaptureQualityTest {
     fun `sustained large jumps classify as MOTION`() {
         // Square-wave-style motion: every frame jumps ±15 Y units alternately.
         // |diff| = 15 on every adjacent pair → median |diff| = 15, well above
-        // MOTION_MEDIAN_JUMP_Y (= 6). Heart-beats can't produce this pattern
+        // MOTION_MEDIAN_JUMP_Y_DEFAULT (= 6). Heart-beats can't produce this pattern
         // because the diff distribution is dominated by small flat regions.
         val window = (0 until 40).map { i ->
             60.0 + (if (i % 2 == 0) 0.0 else 15.0)
@@ -101,10 +101,10 @@ class CaptureQualityTest {
     @Test
     fun `medianJumpPercentiles on a calm signal yields a small p50 and p90`() {
         // 3 s at 20 Hz of tiny noise + slow drift — both percentiles should
-        // sit well below MOTION_MEDIAN_JUMP_Y (= 6).
+        // sit well below MOTION_MEDIAN_JUMP_Y_DEFAULT (= 6).
         val samples = (0 until 60).map { 60.0 + (it % 3) * 0.5 }
         val stats = CaptureQuality.medianJumpPercentiles(samples, fs)!!
-        assert(stats.p50 < CaptureQuality.MOTION_MEDIAN_JUMP_Y) {
+        assert(stats.p50 < CaptureQuality.MOTION_MEDIAN_JUMP_Y_DEFAULT) {
             "calm p50 should be tiny but was ${stats.p50}"
         }
         assert(stats.p90 <= stats.p50 * 2 + 1.0) {
@@ -117,8 +117,8 @@ class CaptureQualityTest {
         // Square-wave motion across the whole 3-second recording.
         val samples = (0 until 60).map { 60.0 + if (it % 2 == 0) 0.0 else 15.0 }
         val stats = CaptureQuality.medianJumpPercentiles(samples, fs)!!
-        assert(stats.p50 > CaptureQuality.MOTION_MEDIAN_JUMP_Y) {
-            "sustained-motion p50 should exceed MOTION_MEDIAN_JUMP_Y — got ${stats.p50}"
+        assert(stats.p50 > CaptureQuality.MOTION_MEDIAN_JUMP_Y_DEFAULT) {
+            "sustained-motion p50 should exceed MOTION_MEDIAN_JUMP_Y_DEFAULT — got ${stats.p50}"
         }
     }
 

--- a/android/app/src/test/java/com/bios/app/PpgDeviceProfileTest.kt
+++ b/android/app/src/test/java/com/bios/app/PpgDeviceProfileTest.kt
@@ -1,0 +1,84 @@
+package com.bios.app
+
+import com.bios.app.engine.CaptureQuality
+import com.bios.app.engine.PpgDeviceProfile
+import com.bios.app.engine.PpgDeviceProfiles
+import com.bios.app.engine.PpgSignalProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [PpgDeviceProfile] + [PpgDeviceProfiles]
+ * (#266 Cut 2). Pins the per-device threshold registry shape, the
+ * fallback contract, and the lookup case-insensitivity guarantee.
+ *
+ * The empty-PROFILES state is intentional at Cut 2 landing — the
+ * issue spec requires thresholds to be derived from calibration-log
+ * distribution data, not guessed. As specific device entries land,
+ * the [unknown_device_falls_back_to_DEFAULT] test continues to pin
+ * the no-regression contract; per-device entries get their own
+ * pinned tests at addition time.
+ */
+class PpgDeviceProfileTest {
+
+    @Test
+    fun DEFAULT_preserves_pre_cut2_thresholds_exactly() {
+        // No regression contract — DEFAULT must equal the eyeball-
+        // tuned baselines exactly so devices not yet in PROFILES see
+        // pre-Cut-2 behaviour bit-for-bit.
+        assertEquals(
+            CaptureQuality.MOTION_MEDIAN_JUMP_Y_DEFAULT,
+            PpgDeviceProfiles.DEFAULT.motionMedianJumpY,
+            1e-9,
+        )
+        assertEquals(
+            PpgSignalProcessor.MAX_PEAK_AMPLITUDE_COV_DEFAULT,
+            PpgDeviceProfiles.DEFAULT.maxPeakAmplitudeCov,
+            1e-9,
+        )
+    }
+
+    @Test
+    fun forDevice_returns_DEFAULT_for_null_model_string() {
+        // Build.MODEL can be null on emulators / oddly-configured
+        // devices. The fallback chain must handle that gracefully.
+        assertSame(PpgDeviceProfiles.DEFAULT, PpgDeviceProfiles.forDevice(null))
+    }
+
+    @Test
+    fun forDevice_returns_DEFAULT_for_unknown_model() {
+        assertSame(
+            PpgDeviceProfiles.DEFAULT,
+            PpgDeviceProfiles.forDevice("DEVICE_NOT_IN_REGISTRY"),
+        )
+    }
+
+    @Test
+    fun PpgDeviceProfile_data_class_equality_is_by_value() {
+        // A data class — relied on by the test pattern that asserts
+        // PROFILES["Pixel 9a"] == PpgDeviceProfile(...). Two equal-
+        // value instances must be `equals` and `hashCode`-equivalent.
+        val a = PpgDeviceProfile(motionMedianJumpY = 8.0, maxPeakAmplitudeCov = 0.85)
+        val b = PpgDeviceProfile(motionMedianJumpY = 8.0, maxPeakAmplitudeCov = 0.85)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun classify_uses_the_per_device_threshold_not_the_global_default() {
+        // 30 samples, frame-to-frame median |diff| = 7.0 (the test
+        // builds an alternating-magnitude trace so consecutive diffs
+        // are all 7). DEFAULT threshold = 6 → MOTION. Custom
+        // profile with motionMedianJumpY = 10 → STEADY.
+        val window = (0 until 60).map { i -> 100.0 + (if (i % 2 == 0) 0.0 else 7.0) }
+        // Sanity-check: at default threshold this fires as MOTION.
+        val atDefault = CaptureQuality.classify(window, samplingRateHz = 30.0)
+        assertEquals(CaptureQuality.MOTION, atDefault)
+        // With a more tolerant per-device profile, the same window
+        // reads as STEADY.
+        val tolerant = PpgDeviceProfile(motionMedianJumpY = 10.0, maxPeakAmplitudeCov = 0.80)
+        val atTolerant = CaptureQuality.classify(window, samplingRateHz = 30.0, profile = tolerant)
+        assertEquals(CaptureQuality.STEADY, atTolerant)
+    }
+}


### PR DESCRIPTION
## Summary
Decouples the two camera-PPG motion thresholds — [`CaptureQuality.classify`](android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt)'s median-frame-jump cutoff + [`PpgSignalProcessor.extract`](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt)'s amplitude-CoV cap — from global constants. Both now read from a [`PpgDeviceProfile`](android/app/src/main/java/com/bios/app/engine/PpgDeviceProfile.kt), selected per `Build.MODEL` via `PpgDeviceProfiles.forDevice`. Behaviour preserved **bit-for-bit** for any device not yet in the registry — the `DEFAULT` profile matches the prior eyeball-tuned constants exactly.

## Pieces
- **New: [`PpgDeviceProfile`](android/app/src/main/java/com/bios/app/engine/PpgDeviceProfile.kt)** — data class with `motionMedianJumpY` + `maxPeakAmplitudeCov`. Kept coupled per the issue's note that tuning one without the other produces real-time / offline inconsistency.
- **New: `PpgDeviceProfiles`** (same file) — static registry with `DEFAULT` (= pre-Cut-2 constants), `PROFILES` map ready for per-device entries, and a case-insensitive `forDevice(model)` lookup that tolerates null.
- **[`CaptureQuality.classify`](android/app/src/main/java/com/bios/app/engine/CaptureQuality.kt)** gains an optional `profile` param (default = `PpgDeviceProfiles.DEFAULT`). `MOTION_MEDIAN_JUMP_Y` renamed to `MOTION_MEDIAN_JUMP_Y_DEFAULT` so the static-vs-per-device distinction is obvious at the use site.
- **[`PpgSignalProcessor.extract`](android/app/src/main/java/com/bios/app/engine/PpgSignalProcessor.kt) + `compositeSqi`** same treatment. `MAX_PEAK_AMPLITUDE_COV` renamed to `MAX_PEAK_AMPLITUDE_COV_DEFAULT` and made public so `PpgDeviceProfiles` can reference it as its fallback.
- **[`CameraPpgAdapter`](android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt)** (the only production caller of both) resolves `PpgDeviceProfiles.forDevice(Build.MODEL)` once at capture start and passes it to both `classify` and `extract`.

## Why `PROFILES` is empty at landing
The issue spec is explicit: thresholds belong in this table **only** once derived from real distribution data (via the [`PpgCalibrationLogger`](android/app/src/main/java/com/bios/app/engine/PpgCalibrationLogger.kt) Cut 1 records). Adding the Pixel 9a entry that motivated this issue is a one-line registry edit once enough local logs have been collected and analyzed. This PR ships the infrastructure so that landing the actual threshold values becomes a trivial follow-up, not an architectural change.

## Test plan
- [x] **5 new unit tests** in [`PpgDeviceProfileTest`](android/app/src/test/java/com/bios/app/PpgDeviceProfileTest.kt):
  - `DEFAULT_preserves_pre_cut2_thresholds_exactly` — the no-regression contract
  - `forDevice_returns_DEFAULT_for_null_model_string` — Build.MODEL nullability guard
  - `forDevice_returns_DEFAULT_for_unknown_model` — the safe-fallback semantic
  - `PpgDeviceProfile_data_class_equality_is_by_value` — relied on by the eventual `PROFILES["Pixel 9a"] == ...` test pattern when entries land
  - `classify_uses_the_per_device_threshold_not_the_global_default` — same window goes MOTION under DEFAULT and STEADY under a tolerant per-device profile
- [x] Existing [`CaptureQualityTest`](android/app/src/test/java/com/bios/app/CaptureQualityTest.kt) updated for the renamed constant; all cases pass unchanged.
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).

## What's left from #266
- **Threshold derivation procedure**: scripts/analyze-ppg-calibration-log.md (or similar) — TBD. Once enough Pixel 9a logs have been collected by Cut-1-toggle-enabled owners, walking the CSV to derive the right `motionMedianJumpY` for `PROFILES["Pixel 9a"]` is a follow-up task.
- **Per-owner local learning** — a future cut could let each owner self-calibrate from their own log without waiting for aggregate data. Architecturally similar to [`BaselinedActivityThreshold`](android/app/src/main/java/com/bios/app/engine/BaselinedActivityThreshold.kt) from #299. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)