### PR TITLE
feat(engine): nightly SleepRegularityWorker persists derivations (#135)

### DIFF
--- a/android/app/src/main/java/com/bios/app/BiosApplication.kt
+++ b/android/app/src/main/java/com/bios/app/BiosApplication.kt
@@ -122,6 +122,14 @@ class BiosApplication : Application() {
         // headache-event metric_readings rows the #293 writer mirrors.
         com.bios.app.alerts.ChronicMigraineWorker.schedule(this)
 
+        // Schedule the nightly sleep-regularity derivation worker (#135
+        // deliverable 2 — closes the gap between SleepRegularityCalculator
+        // existing and rows actually landing on the bus). Pull-side
+        // metric only — no alert. The worker is a no-op when fewer than
+        // the minimum nights are available, so it's safe to enqueue
+        // unconditionally.
+        com.bios.app.engine.SleepRegularityWorker.schedule(this)
+
         // Schedule daily paediatric-band recompute (#198). Idempotent and
         // a no-op when no birth date is on file — safe to enqueue on every
         // launch.

--- a/android/app/src/main/java/com/bios/app/engine/SleepRegularityWorker.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepRegularityWorker.kt
@@ -1,0 +1,133 @@
+package com.bios.app.engine
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.bios.app.data.BiosDatabase
+import com.bios.app.model.DataSource
+import com.bios.app.model.ReadingKind
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+import java.util.concurrent.TimeUnit
+
+/**
+ * Nightly worker that persists [MetricType.SLEEP_REGULARITY] readings
+ * derived by [SleepRegularityCalculator] (#135 deliverable 2 — the
+ * gap between the calculator being ready and actual rows landing on
+ * the bus).
+ *
+ * Before this worker, `derive()` was only called inline from
+ * [com.bios.app.ui.sleep.SleepDashboardScreen] as an on-demand
+ * preview — the result was never persisted, so no downstream
+ * consumer (trending, alerts, future condition patterns crossing
+ * sleep ↔ HRV / glucose / mood) could read SLEEP_REGULARITY from
+ * `metric_readings`. The worker closes that loop.
+ *
+ * ## Cadence
+ *
+ * Daily. Sleep regularity is a chronic-pattern metric — a single
+ * extra night doesn't move the rolling 7-day window in any
+ * clinically interesting way, and a more frequent cadence would
+ * burn battery without earning information. Mirrors
+ * [com.bios.app.alerts.MohScreeningWorker] scheduling shape.
+ *
+ * ## No alert surface
+ *
+ * SLEEP_REGULARITY is a pull-side metric per #135 manifesto:
+ * no notification, no nudge, no score-as-judgment surface. The worker's
+ * single output is the `metric_readings` row + its sidecar payload.
+ * The owner reads it from the dashboard (or a future trend / detail
+ * surface); evaluation belongs to the owner.
+ */
+class SleepRegularityWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val context = applicationContext
+        val db = BiosDatabase.getInstance(context)
+        val readingDao = db.metricReadingDao()
+        val payloadDao = db.eventPayloadFieldDao()
+        val sourceDao = db.dataSourceDao()
+
+        return try {
+            val now = System.currentTimeMillis()
+            // The calculator filters internally to the window; we fetch
+            // a comfortably-wider span (2× the window) so a delayed
+            // worker firing doesn't truncate.
+            val fetchStart = now -
+                (SleepRegularityCalculator.DEFAULT_WINDOW_DAYS * 2L * MS_PER_DAY)
+            val sleepDurations = readingDao.fetch(
+                MetricType.SLEEP_DURATION.key, fetchStart, now,
+            )
+            val sourceId = ensureSource(sourceDao)
+            val result = SleepRegularityCalculator.derive(
+                sleepDurations = sleepDurations,
+                sourceId = sourceId,
+                nowMs = now,
+            )
+            if (result == null) {
+                Log.i(TAG, "insufficient nights for derivation; skipping")
+                return Result.success()
+            }
+            readingDao.insert(result.reading)
+            payloadDao.insertAll(result.payload)
+            Log.i(
+                TAG,
+                "wrote SLEEP_REGULARITY reading id=${result.reading.id} " +
+                    "score=${result.reading.value}",
+            )
+            Result.success()
+        } catch (t: Throwable) {
+            Log.w(TAG, "SleepRegularityWorker failed: ${t.message}", t)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        private const val TAG = "SleepRegularityWorker"
+        const val WORK_NAME = "bios_sleep_regularity"
+        private const val MS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+
+        /** Stable deviceName for the DataSource row that owns the
+         *  derived SLEEP_REGULARITY rows. Distinct from the phone-
+         *  sleep inference source so provenance reads cleanly. */
+        const val SOURCE_DEVICE_NAME = "Sleep regularity"
+
+        /** Daily cadence. Idempotent via WorkManager unique-work
+         *  policy. The worker is a no-op when fewer than the minimum
+         *  nights are available, so it's safe to enqueue
+         *  unconditionally from app init. */
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<SleepRegularityWorker>(
+                24, TimeUnit.HOURS,
+            ).build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+        }
+
+        internal suspend fun ensureSource(dao: com.bios.app.data.dao.DataSourceDao): String {
+            val existing = dao.findByTypeAndDeviceName(
+                SourceType.PHONE_SENSOR_DERIVED.key,
+                SOURCE_DEVICE_NAME,
+            )
+            if (existing != null) return existing.id
+            val source = DataSource(
+                sourceType = SourceType.PHONE_SENSOR_DERIVED.key,
+                sensorType = "sleep_regularity",
+                deviceName = SOURCE_DEVICE_NAME,
+                readingKind = ReadingKind.DERIVED.name,
+            )
+            dao.insert(source)
+            return source.id
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes the load-bearing gap in [#135](https://github.com/thdelmas/Bios/issues/135)'s second deliverable. Auditing surfaced that [`SleepRegularityCalculator`](android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt) + `SLEEP_REGULARITY` MetricType + sidecar fields all shipped already (with full unit tests), but the only caller of `derive()` was [`SleepDashboardScreen`](android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt) using `sourceId = "dashboard-preview"` — and the result was **thrown away**. No `SLEEP_REGULARITY` rows ever landed in `metric_readings`, so trending, alerts, future cross-correlation patterns (sleep ↔ HRV / mood / glucose) — none of them could read the metric.

This PR closes that loop.

## Pieces
- **New: [`SleepRegularityWorker`](android/app/src/main/java/com/bios/app/engine/SleepRegularityWorker.kt)** — daily `WorkManager` periodic, mirrors [`MohScreeningWorker`](android/app/src/main/java/com/bios/app/alerts/MohScreeningWorker.kt) / [`ChronicMigraineWorker`](android/app/src/main/java/com/bios/app/alerts/ChronicMigraineWorker.kt) scheduling shape. Fetches `SLEEP_DURATION` readings over 2× the calculator's default window (so a delayed firing doesn't truncate input), invokes `derive()`, and persists the resulting `MetricReading` + payload sidecar. No-op when the calculator returns null (insufficient nights — needs ≥3 for a meaningful circular std-deviation).
- **Source**: `PHONE_SENSOR_DERIVED` type with `deviceName = "Sleep regularity"` so provenance stays distinct from the existing phone-sleep inference source. Uses [`DataSourceDao.findByTypeAndDeviceName`](android/app/src/main/java/com/bios/app/data/dao/DataSourceDao.kt) (added in [#293](https://github.com/thdelmas/Bios/pull/293)).
- **[`BiosApplication.onCreate`](android/app/src/main/java/com/bios/app/BiosApplication.kt)** schedules the worker alongside the other daily workers. Idempotent via WorkManager unique-work policy.

## Pull-side only
Per the [#135](https://github.com/thdelmas/Bios/issues/135) manifesto guard: no notification, no nudge, no judgmental score surface. The worker's single output is a `metric_readings` row + its sidecar payload. The owner reads `SLEEP_REGULARITY` from the dashboard (or a future trend / detail surface). Evaluation belongs to the owner.

## Why no worker-specific tests
The worker is thin integration wiring around the already-tested calculator:
- [`SleepRegularityCalculator.derive()`](android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt) — fully covered by [`SleepRegularityCalculatorTest`](android/app/src/test/java/com/bios/app/SleepRegularityCalculatorTest.kt) (circular statistics, midpoint variance, sidecar field shape, MIN_NIGHTS gate).
- DAO call shapes (`fetch`, `insert`, `insertAll`, `findByTypeAndDeviceName`, `ensureSource`) match the patterns the other daily workers (`MohScreeningWorker`, `ChronicMigraineWorker`, `SeizureDetectionService`) all use.
- No decideFireOrSkip-style pure logic to test — the write/skip decision is delegated entirely to `derive()` returning non-null.

Same exclusion documented in `PpgCalibrationLoggerTest` / `SeizureDetectionPrefs` test scope.

## Test plan
- [x] `code-quality-check.sh` green (file length, secrets, lint, assembleDebug both flavours, unit tests).
- [ ] Manual: after this lands, run an overnight cycle on a device with ≥3 nights of `SLEEP_DURATION` readings, then force-run the worker (or wait 24h). Open the #277 metric_readings debug screen; confirm a `SLEEP_REGULARITY` row appears with `confidence = min(input nights' confidence)`, and the payload sidecar carries `bedtime_variance_min` / `wake_variance_min` / `midpoint_variance_min` / `window_days`.

## What's left for #135
After this PR lands, the audit shows:
- ✅ **Deliverable 1** (Sleep dashboard screen) — shipped at v1 scope per [`SleepDashboardScreen.kt`](android/app/src/main/java/com/bios/app/ui/sleep/SleepDashboardScreen.kt) docstring. Heatmap visual + stage breakdown + correlation surfaces explicitly deferred there as "out of scope for v1."
- ✅ **Deliverable 2** (SLEEP_REGULARITY metric + derivation) — calculator + worker now both shipped.
- ❌ **Deliverable 3** (`GuideSleepScreen` static reference) — missing.

I'll close #135 after merge and carve a focused follow-up for D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)