### PR TITLE
fix(ui): scientific references render as tappable DOI/web links (#305)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerReference.kt
@@ -22,7 +22,7 @@ data class BiomarkerReference(
     val normalRange: String,
     val whyItMatters: String,
     val limitations: String,
-    val citations: List<String>
+    val citations: List<Citation>,
 )
 
 object BiomarkerReferences {
@@ -51,10 +51,19 @@ object BiomarkerReferences {
         whyItMatters = "Chronic low-grade inflammation accelerates aging and is implicated in cardiovascular disease, type 2 diabetes, neurodegeneration, and cancer. Catching inflammatory episodes early — even via proxy signals — allows earlier investigation.",
         limitations = "Resting HR and HRV respond to many stimuli beyond inflammation: exercise, stress, alcohol, sleep debt. A sustained multi-day deviation is more meaningful than a single reading. A blood test is required for definitive hsCRP measurement.",
         citations = listOf(
-            "Ridker PM (2003) - C-reactive protein: a simple test to help predict risk of heart attack and stroke",
-            "Furman D et al. (2019) - Chronic inflammation in the etiology of disease across the life span",
-            "Mishra T et al. (2020) - Pre-symptomatic detection of COVID-19 from smartwatch data"
-        )
+            Citation.doi(
+                text = "Ridker PM (2003) — C-reactive protein: a simple test to help predict risk of heart attack and stroke. Circulation 108(12):e81–e85.",
+                doi = "10.1161/01.CIR.0000093381.57779.67",
+            ),
+            Citation.doi(
+                text = "Furman D et al. (2019) — Chronic inflammation in the etiology of disease across the life span. Nature Medicine 25:1822–1832.",
+                doi = "10.1038/s41591-019-0675-0",
+            ),
+            Citation.doi(
+                text = "Mishra T et al. (2020) — Pre-symptomatic detection of COVID-19 from smartwatch data. Nature Biomedical Engineering 4:1208–1220.",
+                doi = "10.1038/s41551-020-00640-6",
+            ),
+        ),
     )
 
     val metabolicHealth = BiomarkerReference(
@@ -72,9 +81,15 @@ object BiomarkerReferences {
         whyItMatters = "Metabolic health underpins nearly every organ system. Early detection of glucose dysregulation — before symptoms appear — enables lifestyle adjustments that can prevent or reverse pre-diabetes.",
         limitations = "CGM data reflects real-time glucose, not the 3-month average that HbA1c represents. Sleep and HR are indirect proxies. Without a CGM connected, Bios can only detect metabolic stress through secondary signals. A blood HbA1c test is required for diagnosis.",
         citations = listOf(
-            "Hall H et al. (2018) - Glucotypes reveal new patterns of glucose dysregulation",
-            "Zeevi D et al. (2015) - Personalized nutrition by prediction of glycemic responses"
-        )
+            Citation.doi(
+                text = "Hall H et al. (2018) — Glucotypes reveal new patterns of glucose dysregulation. PLoS Biology 16(7):e2005143.",
+                doi = "10.1371/journal.pbio.2005143",
+            ),
+            Citation.doi(
+                text = "Zeevi D et al. (2015) — Personalized nutrition by prediction of glycemic responses. Cell 163(5):1079–1094.",
+                doi = "10.1016/j.cell.2015.11.001",
+            ),
+        ),
     )
 
     val cardiorespFitness = BiomarkerReference(
@@ -91,10 +106,19 @@ object BiomarkerReferences {
         whyItMatters = "A 1 MET (3.5 mL/kg/min) increase in fitness is associated with a 13% reduction in all-cause mortality. VO2 max decline with age is modifiable through exercise — tracking the trend helps the owner see whether fitness is improving, stable, or declining.",
         limitations = "Wearable VO2 max estimates are approximations based on HR-pace algorithms and vary significantly between devices. Resting HR and HRV are influenced by many factors beyond fitness. A lab-based cardiopulmonary exercise test is the definitive measurement.",
         citations = listOf(
-            "Ross R et al. (2016) - Importance of assessing cardiorespiratory fitness in clinical practice",
-            "Kodama S et al. (2009) - Cardiorespiratory fitness as a quantitative predictor of all-cause mortality",
-            "Mandsager K et al. (2018) - Association of cardiorespiratory fitness with long-term mortality"
-        )
+            Citation.doi(
+                text = "Ross R et al. (2016) — Importance of assessing cardiorespiratory fitness in clinical practice. Circulation 134(24):e653–e699.",
+                doi = "10.1161/CIR.0000000000000461",
+            ),
+            Citation.doi(
+                text = "Kodama S et al. (2009) — Cardiorespiratory fitness as a quantitative predictor of all-cause mortality and cardiovascular events. JAMA 301(19):2024–2035.",
+                doi = "10.1001/jama.2009.681",
+            ),
+            Citation.doi(
+                text = "Mandsager K et al. (2018) — Association of cardiorespiratory fitness with long-term mortality. JAMA Network Open 1(6):e183605.",
+                doi = "10.1001/jamanetworkopen.2018.3605",
+            ),
+        ),
     )
 
     val arterialHealth = BiomarkerReference(
@@ -111,9 +135,15 @@ object BiomarkerReferences {
         whyItMatters = "Arterial stiffness is a leading indicator of hypertension, stroke, and heart failure. It progresses silently for years. Tracking blood pressure trends at home catches the drift before a clinical visit would.",
         limitations = "Consumer blood pressure monitors have measurement variability. Bios does not measure pulse wave velocity directly — only tracks BP trends as a proxy. Requires a connected BP device (not available from wrist wearables alone). Clinical assessment via pulse wave analysis is the gold standard.",
         citations = listOf(
-            "Vlachopoulos C et al. (2010) - Prediction of cardiovascular events with arterial stiffness",
-            "Williams B et al. (2018) - ESC/ESH guidelines for management of arterial hypertension"
-        )
+            Citation.doi(
+                text = "Vlachopoulos C et al. (2010) — Prediction of cardiovascular events and all-cause mortality with arterial stiffness. JACC 55(13):1318–1327.",
+                doi = "10.1016/j.jacc.2009.10.061",
+            ),
+            Citation.doi(
+                text = "Williams B et al. (2018) — 2018 ESC/ESH guidelines for the management of arterial hypertension. European Heart Journal 39(33):3021–3104.",
+                doi = "10.1093/eurheartj/ehy339",
+            ),
+        ),
     )
 
     val stressLoad = BiomarkerReference(
@@ -130,9 +160,15 @@ object BiomarkerReferences {
         whyItMatters = "Chronic stress is a root driver of inflammation, metabolic dysfunction, and immune suppression. Unlike acute stress (which is healthy), sustained stress load accumulates silently. Wearable proxies can reveal the pattern weeks before burnout or illness.",
         limitations = "HRV responds to fitness, hydration, alcohol, and illness — not just psychological stress. Sleep disruption has many causes. No wearable measures cortisol directly. A saliva or blood cortisol test provides definitive measurement.",
         citations = listOf(
-            "McEwen BS (2008) - Central effects of stress hormones in health and disease",
-            "Kim HG et al. (2018) - Stress and heart rate variability: a meta-analysis"
-        )
+            Citation.doi(
+                text = "McEwen BS (2008) — Central effects of stress hormones in health and disease. European Journal of Pharmacology 583(2-3):174–185.",
+                doi = "10.1016/j.ejphar.2007.11.071",
+            ),
+            Citation.doi(
+                text = "Kim HG et al. (2018) — Stress and heart rate variability: a meta-analysis and review of the literature. Psychiatry Investigation 15(3):235–245.",
+                doi = "10.30773/pi.2017.08.17",
+            ),
+        ),
     )
 
     val bodyComposition = BiomarkerReference(
@@ -149,9 +185,15 @@ object BiomarkerReferences {
         whyItMatters = "Visceral fat is metabolically active and produces inflammatory cytokines. Excess visceral fat independently predicts type 2 diabetes, cardiovascular disease, and certain cancers, even at a normal BMI.",
         limitations = "Activity metrics are a very indirect proxy for body composition. Step counts and calories burned do not account for diet, which is the primary driver of fat gain or loss. DEXA scanning is the clinical gold standard for body composition analysis.",
         citations = listOf(
-            "Neeland IJ et al. (2019) - Visceral and ectopic fat, atherosclerosis, and cardiometabolic disease",
-            "Ross R et al. (2020) - Waist circumference as a vital sign in clinical practice"
-        )
+            Citation.doi(
+                text = "Neeland IJ et al. (2019) — Visceral and ectopic fat, atherosclerosis, and cardiometabolic disease. The Lancet Diabetes & Endocrinology 7(9):715–725.",
+                doi = "10.1016/S2213-8587(19)30084-1",
+            ),
+            Citation.doi(
+                text = "Ross R et al. (2020) — Waist circumference as a vital sign in clinical practice. Nature Reviews Endocrinology 16:177–189.",
+                doi = "10.1038/s41574-019-0310-7",
+            ),
+        ),
     )
 
     val sleepArchitecture = BiomarkerReference(
@@ -168,9 +210,18 @@ object BiomarkerReferences {
         whyItMatters = "Deep sleep drives physical recovery, immune function, and growth hormone release. REM sleep supports memory consolidation and emotional regulation. Disrupted architecture — even at normal duration — impairs immune defense and accelerates cognitive decline.",
         limitations = "Consumer wearable sleep staging is less accurate than clinical polysomnography, particularly for distinguishing light from deep sleep. Single-night variation is high; trends over weeks are more meaningful. Environmental factors (noise, temperature, partner) affect architecture independently of health status.",
         citations = listOf(
-            "Walker M (2017) - Why We Sleep: Unlocking the Power of Sleep and Dreams",
-            "Prather AA et al. (2015) - Behaviorally assessed sleep and susceptibility to the common cold",
-            "Smarr BL et al. (2020) - Feasibility of continuous fever monitoring using wearable devices"
-        )
+            Citation(
+                text = "Walker M (2017) — Why We Sleep: Unlocking the Power of Sleep and Dreams. Scribner.",
+                url = "https://www.simonandschuster.com/books/Why-We-Sleep/Matthew-Walker/9781501144325",
+            ),
+            Citation.doi(
+                text = "Prather AA et al. (2015) — Behaviorally assessed sleep and susceptibility to the common cold. Sleep 38(9):1353–1359.",
+                doi = "10.5665/sleep.4968",
+            ),
+            Citation.doi(
+                text = "Smarr BL et al. (2020) — Feasibility of continuous fever monitoring using wearable devices. Scientific Reports 10:21640.",
+                doi = "10.1038/s41598-020-78355-6",
+            ),
+        ),
     )
 }

--- a/android/app/src/main/java/com/bios/app/alerts/Citation.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/Citation.kt
@@ -1,0 +1,28 @@
+package com.bios.app.alerts
+
+/**
+ * A scientific reference the owner can verify themselves. Every
+ * citation surfaced by Bios must carry a stable, alive web URL —
+ * a plain prose citation is unverifiable and rots silently
+ * (#305). DOIs are preferred over publisher URLs because they
+ * survive journal mergers and URL reshuffles.
+ *
+ * Construct via [doi] for journal articles, or the primary
+ * constructor for guideline PDFs, books, and other web-stable
+ * sources.
+ */
+data class Citation(
+    val text: String,
+    val url: String,
+) {
+    init {
+        require(url.startsWith("https://")) {
+            "Citation URL must be https — got: $url"
+        }
+    }
+
+    companion object {
+        fun doi(text: String, doi: String): Citation =
+            Citation(text = text, url = "https://doi.org/$doi")
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
@@ -18,6 +18,7 @@ import com.bios.app.alerts.BiomarkerReference
 import com.bios.app.alerts.BiomarkerReferences
 import com.bios.app.alerts.ConditionPatterns
 import com.bios.app.alerts.DeviationDirection
+import com.bios.app.ui.reference.CitationText
 import com.bios.app.ui.AppViewModel
 import kotlin.math.abs
 
@@ -443,10 +444,9 @@ private fun BiomarkerReferenceCard(biomarker: BiomarkerReference) {
                         fontWeight = FontWeight.Bold
                     )
                     biomarker.citations.forEach { citation ->
-                        Text(
-                            citation,
+                        CitationText(
+                            citation = citation,
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }

--- a/android/app/src/main/java/com/bios/app/ui/reference/CitationText.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/CitationText.kt
@@ -1,0 +1,46 @@
+package com.bios.app.ui.reference
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import com.bios.app.alerts.Citation
+
+/**
+ * Renders a scientific [Citation] as a tappable annotated string
+ * (#305). The whole citation is one link target — tapping anywhere
+ * on the row opens the URL in the system browser via the platform
+ * URI handler.
+ */
+@Composable
+fun CitationText(
+    citation: Citation,
+    modifier: Modifier = Modifier,
+    style: TextStyle = LocalTextStyle.current,
+) {
+    val linkColor = MaterialTheme.colorScheme.primary
+    val annotated = buildAnnotatedString {
+        withLink(
+            LinkAnnotation.Url(
+                url = citation.url,
+                styles = TextLinkStyles(
+                    style = SpanStyle(
+                        color = linkColor,
+                        textDecoration = TextDecoration.Underline,
+                    ),
+                ),
+            )
+        ) {
+            append(citation.text)
+        }
+    }
+    Text(text = annotated, modifier = modifier, style = style)
+}

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.alerts.BiomarkerReference
 import com.bios.app.alerts.BiomarkerReferences
+import com.bios.app.alerts.Citation
 import com.bios.app.config.BiomarkerBand
 import com.bios.app.config.RegionConfigProvider
 import com.bios.contracts.MetricType
@@ -84,16 +85,27 @@ fun LongevityReferenceScreen(
                 )
                 Spacer(Modifier.height(4.dp))
                 val sources = listOf(
-                    "Blueprint protocol — publicly available at blueprint.bryanjohnson.com",
-                    "Levine ME (2018) — An epigenetic biomarker of aging (PhenoAge)",
-                    "Belsky DW et al. (2020) — DunedinPACE, a DNA methylation biomarker of the pace of aging",
-                    "Attia P (2023) — Outlive: The Science and Art of Longevity"
+                    Citation(
+                        text = "Blueprint protocol — publicly available at blueprint.bryanjohnson.com",
+                        url = "https://blueprint.bryanjohnson.com",
+                    ),
+                    Citation.doi(
+                        text = "Levine ME et al. (2018) — An epigenetic biomarker of aging for lifespan and healthspan (PhenoAge). Aging 10(4):573–591.",
+                        doi = "10.18632/aging.101414",
+                    ),
+                    Citation.doi(
+                        text = "Belsky DW et al. (2020) — Quantification of the pace of biological aging in humans (DunedinPACE precursor). eLife 9:e54870.",
+                        doi = "10.7554/eLife.54870",
+                    ),
+                    Citation(
+                        text = "Attia P (2023) — Outlive: The Science and Art of Longevity. Harmony.",
+                        url = "https://peterattiamd.com/outlive/",
+                    ),
                 )
                 sources.forEach { source ->
-                    Text(
-                        source,
+                    CitationText(
+                        citation = source,
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
                 Spacer(Modifier.height(24.dp))
@@ -394,10 +406,9 @@ private fun BiomarkerCard(
                         fontWeight = FontWeight.Bold
                     )
                     biomarker.citations.forEach { citation ->
-                        Text(
-                            citation,
+                        CitationText(
+                            citation = citation,
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }

--- a/android/app/src/main/java/com/bios/app/ui/sleep/GuideSleepScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/sleep/GuideSleepScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.bios.app.alerts.Citation
+import com.bios.app.ui.reference.CitationText
 
 /**
  * Static evidence-anchored sleep-medicine reference (#303 / #135
@@ -203,7 +205,7 @@ private fun ReferencesCard() {
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
                 "References",
@@ -211,10 +213,9 @@ private fun ReferencesCard() {
                 fontWeight = FontWeight.Bold,
             )
             REFERENCES.forEach { ref ->
-                Text(
-                    ref,
+                CitationText(
+                    citation = ref,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -247,27 +248,59 @@ private fun GuideCard(title: String, body: String) {
 }
 
 private val REFERENCES = listOf(
-    "Phillips AJK et al. (2017) — Irregular sleep/wake patterns are " +
-        "associated with poorer academic performance and delayed circadian and " +
-        "sleep/wake timing. Scientific Reports 7:3216.",
-    "Windred DP et al. (2024) — Sleep regularity is a stronger predictor of " +
-        "mortality risk than sleep duration. Sleep 47(1).",
-    "Cho CH et al. (2015) — Effects of artificial light at night on melatonin " +
-        "secretion and cardiovascular regulation. Chronobiology International " +
-        "32(9):1294–1310.",
-    "Okamoto-Mizuno K, Mizuno K (2012) — Effects of thermal environment on " +
-        "sleep and circadian rhythm. Journal of Physiological Anthropology 31:14.",
-    "WHO Regional Office for Europe (2018) — Environmental Noise Guidelines " +
-        "for the European Region.",
-    "Chang AM et al. (2015) — Evening use of light-emitting eReaders " +
-        "negatively affects sleep, circadian timing, and next-morning alertness. " +
-        "PNAS 112(4):1232–1237.",
-    "Drake C et al. (2013) — Caffeine effects on sleep taken 0, 3, or 6 hours " +
-        "before going to bed. Journal of Clinical Sleep Medicine 9(11):1195–1200.",
-    "Roehrs T, Roth T (2001) — Sleep, sleepiness, sleep disorders and alcohol " +
-        "use and abuse. Sleep Medicine Reviews 5(4):287–297.",
-    "Cole RJ et al. (1992) — Automatic sleep/wake identification from wrist " +
-        "activity. Sleep 15(5):461–469.",
-    "Walker M (2017) — Why We Sleep: Unlocking the Power of Sleep and Dreams. " +
-        "Scribner.",
+    Citation.doi(
+        text = "Phillips AJK et al. (2017) — Irregular sleep/wake patterns are " +
+            "associated with poorer academic performance and delayed circadian " +
+            "and sleep/wake timing. Scientific Reports 7:3216.",
+        doi = "10.1038/s41598-017-03171-4",
+    ),
+    Citation.doi(
+        text = "Windred DP et al. (2024) — Sleep regularity is a stronger " +
+            "predictor of mortality risk than sleep duration. Sleep 47(1).",
+        doi = "10.1093/sleep/zsad253",
+    ),
+    Citation.doi(
+        text = "Cho CH et al. (2015) — Effects of artificial light at night on " +
+            "melatonin secretion and cardiovascular regulation. Chronobiology " +
+            "International 32(9):1294–1310.",
+        doi = "10.3109/07420528.2015.1073158",
+    ),
+    Citation.doi(
+        text = "Okamoto-Mizuno K, Mizuno K (2012) — Effects of thermal " +
+            "environment on sleep and circadian rhythm. Journal of " +
+            "Physiological Anthropology 31:14.",
+        doi = "10.1186/1880-6805-31-14",
+    ),
+    Citation(
+        text = "WHO Regional Office for Europe (2018) — Environmental Noise " +
+            "Guidelines for the European Region.",
+        url = "https://www.who.int/europe/publications/i/item/9789289053563",
+    ),
+    Citation.doi(
+        text = "Chang AM et al. (2015) — Evening use of light-emitting eReaders " +
+            "negatively affects sleep, circadian timing, and next-morning " +
+            "alertness. PNAS 112(4):1232–1237.",
+        doi = "10.1073/pnas.1418490112",
+    ),
+    Citation.doi(
+        text = "Drake C et al. (2013) — Caffeine effects on sleep taken 0, 3, " +
+            "or 6 hours before going to bed. Journal of Clinical Sleep " +
+            "Medicine 9(11):1195–1200.",
+        doi = "10.5664/jcsm.3170",
+    ),
+    Citation.doi(
+        text = "Roehrs T, Roth T (2001) — Sleep, sleepiness, sleep disorders " +
+            "and alcohol use and abuse. Sleep Medicine Reviews 5(4):287–297.",
+        doi = "10.1053/smrv.2001.0162",
+    ),
+    Citation.doi(
+        text = "Cole RJ et al. (1992) — Automatic sleep/wake identification " +
+            "from wrist activity. Sleep 15(5):461–469.",
+        doi = "10.1093/sleep/15.5.461",
+    ),
+    Citation(
+        text = "Walker M (2017) — Why We Sleep: Unlocking the Power of Sleep " +
+            "and Dreams. Scribner.",
+        url = "https://www.simonandschuster.com/books/Why-We-Sleep/Matthew-Walker/9781501144325",
+    ),
 )

--- a/android/app/src/test/java/com/bios/app/CitationLinksTest.kt
+++ b/android/app/src/test/java/com/bios/app/CitationLinksTest.kt
@@ -1,0 +1,58 @@
+package com.bios.app
+
+import com.bios.app.alerts.BiomarkerReferences
+import com.bios.app.alerts.Citation
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the contract from #305 — every scientific reference Bios
+ * surfaces must carry a stable, alive https URL the owner can follow
+ * back to the source themselves.
+ *
+ * This test pins the URL invariant on every shipped reference. It
+ * does not perform a live HEAD check (offline CI), but DOI links
+ * resolve through doi.org which redirects to the current publisher
+ * URL — so as long as a real DOI is captured, the link survives
+ * publisher migrations.
+ */
+class CitationLinksTest {
+
+    @Test
+    fun citation_constructor_rejects_a_non_https_url() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Citation(text = "anything", url = "http://example.com")
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            Citation(text = "anything", url = "")
+        }
+    }
+
+    @Test
+    fun every_biomarker_reference_citation_has_an_https_url() {
+        val offenders = BiomarkerReferences.all
+            .flatMap { ref -> ref.citations.map { ref.id to it } }
+            .filterNot { (_, c) -> c.url.startsWith("https://") && c.text.isNotBlank() }
+        assertTrue(
+            "Citations missing an https URL or text: $offenders",
+            offenders.isEmpty(),
+        )
+    }
+
+    @Test
+    fun every_biomarker_reference_has_at_least_one_citation() {
+        val empty = BiomarkerReferences.all.filter { it.citations.isEmpty() }
+        assertTrue(
+            "Biomarker references without any citation: ${empty.map { it.id }}",
+            empty.isEmpty(),
+        )
+    }
+
+    @Test
+    fun doi_helper_builds_a_doi_org_url() {
+        val c = Citation.doi(text = "Ridker 2003", doi = "10.1161/01.CIR.0000093381.57779.67")
+        assertTrue(c.url.startsWith("https://doi.org/"))
+        assertTrue(c.url.endsWith("10.1161/01.CIR.0000093381.57779.67"))
+    }
+}


### PR DESCRIPTION
Closes #305.

## Summary

- New `Citation(text, url)` type — every reference now carries a stable https URL; the constructor rejects non-https values, and a `Citation.doi(...)` helper builds canonical `https://doi.org/...` links so journal sources survive publisher migrations.
- New `CitationText` composable renders a citation as a tappable annotated string via `LinkAnnotation.Url`, opening in the system browser through the platform URI handler.
- Updated reference surfaces: `GuideSleepScreen` (10 sleep-medicine refs), `LongevityReferenceScreen` (4 longevity refs + per-biomarker citations), and the biomarker cards inside `ConditionDetailScreen`. Every previously-string citation now has a DOI or publisher URL.
- `BiomarkerReferences` data class moved its `citations` field from `List<String>` to `List<Citation>` — 16 biomarker citations gained DOIs.
- `CitationLinksTest` pins the contract: the constructor refuses non-https URLs, every shipped biomarker citation has a non-blank https URL, and the `doi` helper resolves via `doi.org`.

## Test plan

- [x] `./scripts/code-quality-check.sh` — green (file-length, secrets, lint, `assembleDebug`)
- [x] `./gradlew :app:testStandaloneDebugUnitTest --tests CitationLinksTest --tests BiomarkerReferencesTest` — all 9 pass
- [ ] Manual smoke on device: tap a citation in Settings → Sleep guide and confirm it opens in the browser; same in Longevity reference and a Condition detail card

🤖 Generated with [Claude Code](https://claude.com/claude-code)