### PR TITLE
fix(ui): clickable scientific refs + canonical ecosystem design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Bios shares LETHE's protection philosophy:
 ## Architecture
 - See docs/ARCHITECTURE.md for system diagrams
 - See docs/DATA_MODEL.md for unified metric schema
+- See [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md) — **canonical visual & design system for the entire Bios ecosystem** (Bios + Smokeless / Fil / W2F / Virgil / SoulRadio / Idun). When changing visual treatment, palette roles, typography, component anatomy, or the Bios-integration UI block, edit the canonical doc here first; specialists re-sync. Token files in [docs/design-tokens/](docs/design-tokens/).
 - See docs/PRIVACY_ARCHITECTURE.md for privacy/encryption details
 - See docs/CONSUMER_API.md for the `BiosHealthProvider` ContentProvider contract (read by W2F, future companions)
 - See docs/ECOSYSTEM_BOUNDARIES.md for what belongs in Bios vs. companion apps (Fil, W2F, Virgil, SoulRadio)

--- a/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/reference/LongevityReferenceScreen.kt
@@ -18,6 +18,7 @@ import com.bios.app.alerts.BiomarkerReferences
 import com.bios.app.alerts.Citation
 import com.bios.app.config.BiomarkerBand
 import com.bios.app.config.RegionConfigProvider
+import com.bios.app.ui.theme.BiosTokens
 import com.bios.contracts.MetricType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -140,10 +141,13 @@ private fun CoverageSummaryCard(trackedMetrics: Set<MetricType>) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
+                val countStyle = MaterialTheme.typography.headlineMedium.merge(
+                    BiosTokens.instrument
+                )
                 Column {
                     Text(
                         "${covered.size}",
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = countStyle,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary
                     )
@@ -155,7 +159,7 @@ private fun CoverageSummaryCard(trackedMetrics: Set<MetricType>) {
                 Column {
                     Text(
                         "${missing.size}",
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = countStyle,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -167,7 +171,7 @@ private fun CoverageSummaryCard(trackedMetrics: Set<MetricType>) {
                 Column {
                     Text(
                         "${BiomarkerReferences.all.size}",
-                        style = MaterialTheme.typography.headlineMedium,
+                        style = countStyle,
                         fontWeight = FontWeight.Bold
                     )
                     Text(
@@ -206,10 +210,10 @@ private fun BiomarkerCard(
     val someTracked = proxyStatus.any { it.second }
 
     val statusColor = when {
-        directTracked -> Color(0xFF4CAF50)
-        allTracked -> Color(0xFF4CAF50)
-        someTracked -> Color(0xFFFFC107)
-        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+        directTracked -> BiosTokens.success
+        allTracked -> BiosTokens.success
+        someTracked -> BiosTokens.warning
+        else -> BiosTokens.muted
     }
     val statusLabel = when {
         directTracked -> "Direct lab reading"
@@ -237,7 +241,7 @@ private fun BiomarkerCard(
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.Bold
                     )
-                    Spacer(Modifier.height(2.dp))
+                    Spacer(Modifier.height(4.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Icon(
                             Icons.Default.Circle,
@@ -280,7 +284,7 @@ private fun BiomarkerCard(
                     )
                     Spacer(Modifier.height(4.dp))
                     Row(
-                        modifier = Modifier.padding(vertical = 2.dp),
+                        modifier = Modifier.padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -288,7 +292,7 @@ private fun BiomarkerCard(
                             else Icons.Default.RadioButtonUnchecked,
                             contentDescription = null,
                             modifier = Modifier.size(16.dp),
-                            tint = if (directTracked) Color(0xFF4CAF50) else Color.Gray
+                            tint = if (directTracked) BiosTokens.success else BiosTokens.muted
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(directMetric.readableName, style = MaterialTheme.typography.bodySmall)
@@ -302,13 +306,28 @@ private fun BiomarkerCard(
                     }
                     if (directTracked && latestDirectValue != null && biomarkerBands != null) {
                         val band = biomarkerBands.classify(latestDirectValue)
-                        Spacer(Modifier.height(2.dp))
+                        val bandTone = bandColor(band)
+                        Spacer(Modifier.height(4.dp))
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Spacer(Modifier.width(24.dp))
                             Text(
-                                "Latest: ${"%.2f".format(latestDirectValue)} ${directMetric.unit.symbol} → ${band.label}",
+                                "Latest: ",
                                 style = MaterialTheme.typography.bodySmall,
-                                color = band.color,
+                                color = bandTone,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                "${"%.2f".format(latestDirectValue)} ${directMetric.unit.symbol}",
+                                style = MaterialTheme.typography.bodySmall.merge(
+                                    BiosTokens.instrument
+                                ),
+                                color = bandTone,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                " → ${band.label}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = bandTone,
                                 fontWeight = FontWeight.Medium
                             )
                         }
@@ -325,7 +344,7 @@ private fun BiomarkerCard(
                 Spacer(Modifier.height(4.dp))
                 proxyStatus.forEach { (metric, tracked) ->
                     Row(
-                        modifier = Modifier.padding(vertical = 2.dp),
+                        modifier = Modifier.padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -333,7 +352,7 @@ private fun BiomarkerCard(
                             else Icons.Default.RadioButtonUnchecked,
                             contentDescription = null,
                             modifier = Modifier.size(16.dp),
-                            tint = if (tracked) Color(0xFF4CAF50) else Color.Gray
+                            tint = if (tracked) BiosTokens.success else BiosTokens.muted
                         )
                         Spacer(Modifier.width(8.dp))
                         Text(
@@ -424,9 +443,9 @@ private val BiomarkerBand.label: String
         BiomarkerBand.CONCERNING -> "Concerning"
     }
 
-private val BiomarkerBand.color: Color
-    get() = when (this) {
-        BiomarkerBand.NORMAL -> Color(0xFF4CAF50)
-        BiomarkerBand.BORDERLINE -> Color(0xFFFFA000)
-        BiomarkerBand.CONCERNING -> Color(0xFFD32F2F)
-    }
+@Composable
+private fun bandColor(band: BiomarkerBand): Color = when (band) {
+    BiomarkerBand.NORMAL -> BiosTokens.success
+    BiomarkerBand.BORDERLINE -> BiosTokens.warning
+    BiomarkerBand.CONCERNING -> BiosTokens.error
+}

--- a/android/app/src/main/java/com/bios/app/ui/theme/BiosTokens.kt
+++ b/android/app/src/main/java/com/bios/app/ui/theme/BiosTokens.kt
@@ -1,0 +1,66 @@
+package com.bios.app.ui.theme
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.em
+
+/**
+ * Compose mappings of the ecosystem semantic tokens
+ * (see docs/DESIGN_SYSTEM.md and docs/design-tokens/).
+ *
+ * Universal palette values come from `colors.yaml`; Material 3's
+ * `colorScheme.error` is reused for the error role so the platform
+ * default carries through. Apps that fork their own palette should
+ * override these via the Bios theme rather than redefining values
+ * at call sites.
+ */
+object BiosTokens {
+
+    private val Success = Color(0xFF00E5A0)
+    private val Warning = Color(0xFFFFB830)
+    private val Pending = Color(0xFFFFF4DA)
+
+    val success: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = Success
+
+    val warning: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = Warning
+
+    val error: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.error
+
+    val pending: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = Pending
+
+    val muted: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+
+    /**
+     * Instrument-readout style — monospace, +0.04 letter-spacing,
+     * mandatory for data-bearing text (times, durations, quantities,
+     * biomarker values, scores). Never for body copy or anything the
+     * owner wrote themselves.
+     */
+    val instrument: TextStyle
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalTextStyle.current.copy(
+            fontFamily = FontFamily.Monospace,
+            letterSpacing = 0.04.em,
+        )
+}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,248 @@
+# Bios Ecosystem Design System
+
+**Status:** Canonical. Lives in Bios; mirrored in Miam KB; referenced by each specialist's CLAUDE.md.
+**Created:** 2026-05-24
+**Scope:** Bios + all current specialists (Smokeless, Fil, W2F, Virgil, SoulRadio) + Idun, and any future Bios-ecosystem app.
+
+## Philosophy
+
+**Specialists own identity; the ecosystem owns structure.**
+
+Cross-app consistency lives in *structure* — typography roles, spacing scale, component anatomy, Bios-integration UI patterns, semantic-color tokens. Identity lives in *expression* — palette, theme mode, mascot, copy voice.
+
+A user moving from Smokeless's dark cyberpunk to Idun's parchment artisanal should feel they're in a different *room* but recognise they're in the same *house* — same furniture shapes, same door handles, same plumbing.
+
+The hub (Bios) intentionally has a quiet visual identity (Material teal, Light). Specialists carry the strong identities; Bios is the dashboard that aggregates them.
+
+## 1. The ecosystem palette wheel
+
+Each app owns one primary identity hue. New apps pick a hue that does not collide with neighbours on the wheel.
+
+```
+                  Cyan  W2F      #00BCD4
+                    ↑
+   Gold  SoulRadio ←──→  Teal  Bios      #009688
+    #D4AF37              #009688
+        ↑                  ↑
+   Sand  Virgil           Orange  Smokeless
+    #E0E1DD                #FF7300
+        ↑                  ↑
+   White  Fil ←──→  Apple-Red  Idun
+    #FFFFFF             #B33A3A
+                           ↑
+                    Coral  Rooster
+                     #FF8E53
+```
+
+Constraint: **every identity hue must read as "warm" or "rich"** — no cold corporate blues, no pastel mints used as primaries, no neon. The ecosystem reads as a curated kitchen / instrument-room, not a SaaS dashboard.
+
+## 2. Semantic color tokens (role-based, hue-independent)
+
+Every app maps the same *roles* to its own colors. These roles are referenced everywhere in the design system below.
+
+| Token | Role | Example mappings |
+|---|---|---|
+| `role.primary` | App's identity color. Toolbar, FAB, primary buttons. | Smokeless: `#00E5A0`. Idun: `#B33A3A`. W2F: `#00BCD4`. |
+| `role.on_primary` | Foreground on primary. | Usually white (dark themes) or black. |
+| `role.primary_container` | Soft variant of primary. Tonal buttons, chips. | Idun: `#F4D5D5` (soft red). Smokeless: `#1C1A28` (elevated surface tinted). |
+| `role.secondary` | Optional second accent. **Cross-app suggestion: borrow another ecosystem app's primary.** Idun uses W2F-cyan as secondary; this kinship is encouraged. | Idun secondary = W2F primary. |
+| `role.background` | Window background. | Smokeless: `#080810` (deep space). Idun: `#FAF6EE` (parchment). |
+| `role.surface` | Cards, sheets. | Often same as background, sometimes slightly elevated. |
+| `role.surface_variant` | Subtle elevation, dividers. | Smokeless: `#15131F`. Idun: `#F0EAD8`. |
+| `role.text_primary` | Body text. | Smokeless: `#F5F5FA`. Idun: `#1A1A1A`. |
+| `role.text_secondary` | Meta, captions. | Smokeless: `#9896A8`. Idun: `#5C5C5C`. |
+| `role.divider` | Hairline outlines. | Often `text_secondary` at 30–40% alpha. |
+| `role.success` | Positive state. | Universal mint `#00E5A0` (borrowed from Smokeless) or app's choice. |
+| `role.warning` | Caution. | Universal amber `#FFB830` (Smokeless) or app's choice. |
+| `role.error` | Failure. | Universal red `#F43F5E` or app's choice. |
+| `role.pending` | Awaiting external state — used by Bios `PENDING_APPROVAL` banner. | Universal soft yellow `#FFF4DA` (Idun's banner_pending). |
+
+Each app's `colors.xml` MUST define every role above. Apps MAY add identity-specific colors beyond the role set, but the role set is mandatory.
+
+## 3. Typography
+
+Material 3 base scale. Roboto for default body type. Plus one cross-app extension:
+
+### Instrument readout (mandatory cross-app)
+
+Origin: W2F's cockpit typography. Mandatory across all apps for data-bearing text — times, durations, quantities, biomarker values, eating windows, distances, scores.
+
+```xml
+<style name="TextAppearance.Bios.Instrument" parent="TextAppearance.Material3.BodyMedium">
+    <item name="android:fontFamily">monospace</item>
+    <item name="android:letterSpacing">0.04</item>
+    <item name="android:textColor">@color/text_primary</item>
+</style>
+
+<style name="TextAppearance.Bios.Instrument.Small" parent="TextAppearance.Bios.Instrument">
+    <item name="android:textSize">13sp</item>
+    <item name="android:textColor">@color/text_secondary</item>
+</style>
+```
+
+Apps name it `TextAppearance.<App>.Instrument` matching their own theme namespace, but the styling MUST match.
+
+**Rule:** Apply to data only. Never to body copy, recipe names, mood labels, or anything humans wrote. The warmth of the default face is part of each app's identity; instrument-readout is the cross-app "this is a measurement" signal.
+
+## 4. Spacing scale
+
+Fixed across the ecosystem. All `padding` / `margin` values MUST come from this set:
+
+```
+4dp · 8dp · 12dp · 16dp · 24dp · 32dp · 48dp
+```
+
+48dp is the touch-target floor. 16dp is the default screen edge inset. 8dp is the inter-item spacing in lists.
+
+## 5. Component anatomy
+
+### App bar
+- `com.google.android.material.appbar.MaterialToolbar`
+- Background: `role.background` (not primary — keeps app feeling lighter)
+- Title color: `role.text_primary`
+- Status bar: matches background, light-icon mode toggled per theme
+
+### Cards
+- `com.google.android.material.card.MaterialCardView`
+- Corner radius: **12dp or 14dp**, picked once per app, used everywhere
+- Elevation OR stroke, not both:
+  - `cardElevation="1dp"` + `cardElevation="0dp"` + soft shadow — dark themes
+  - `cardElevation="0dp"` + `strokeWidth="1dp"` + `strokeColor="@color/divider"` — light themes
+- Padding: 12-14dp inside card; 4dp horizontal margin in lists
+
+### List rows
+- Leading: checkbox OR icon (24dp), 6dp end margin
+- Body: `LinearLayout vertical`, `layout_weight=1`
+- Lines: title (16sp, bold, `text_primary`, max 2 lines + ellipsize), meta (12sp, `text_secondary`), optional tags (11sp, `text_secondary` 75% alpha, max 1 line)
+- Whole row clickable; checkbox toggle independent of row click
+
+### FAB
+- `ExtendedFloatingActionButton`
+- Identity-colored (`role.primary`)
+- 16dp margin, anchored bottom-end
+- **Show/hide pattern:** hidden when target state is empty (no selection, no plan, no items). Surfaces when there's something to act on. Avoids dead UI.
+
+### Section headers
+- Label + count: e.g. `Blueprint · 14 recipes`
+- Used to group when both ecosystem-equal-weight collections need rendering (Idun's recipe sources)
+- Apps with single-source content can omit headers
+
+### Chips (tags, filters)
+- `com.google.android.material.chip.Chip`
+- Filter style: tonal, `colorSecondaryContainer` background
+- Min height: 48dp (touch target)
+- Corner radius: 18dp
+
+## 6. Bios integration UI (cross-app required)
+
+Any specialist that writes to Bios via the companion URI MUST render these UI elements identically:
+
+### a. Status pill (Settings screen)
+
+Renders one of three states:
+
+| `BiosClient.Status` | Visual | Copy |
+|---|---|---|
+| `NOT_INSTALLED` | dimmed pill, `text_secondary` | "Bios not installed" |
+| `NOT_ENABLED` | outlined pill, `text_secondary` | "Disabled" |
+| `CONNECTED` | filled pill, `role.success` | "Connected" |
+
+### b. Pending-approval banner
+
+Surfaced when `BiosClient.lastPushOutcome == PENDING_APPROVAL`. The owner has to flip per-app permission in Bios → Settings → Companion Apps before any data lands; without this banner the user logs an event, sees nothing in Bios, has no signal.
+
+```
++-------------------------------------------------+
+| ⚠  Pending approval in Bios → Companion Apps   |
+|    [Open Bios]                                  |
++-------------------------------------------------+
+```
+
+- Background: `role.pending` (soft yellow)
+- Text: `role.text_primary`
+- Action button: deep-link via `BIOS_EXTRA_NAVIGATE_TO_COMPANIONS` extra
+
+### c. "Open Bios" deep-link button
+
+Mandatory whenever Bios integration is active and Bios is installed. Opens Bios's launcher intent with `EXTRA_NAVIGATE_TO_COMPANIONS = true` so Bios drops the user on the right Settings screen.
+
+```kotlin
+val launch = packageManager.getLaunchIntentForPackage(BiosClient.BIOS_PACKAGE)
+launch?.putExtra(BiosClient.BIOS_EXTRA_NAVIGATE_TO_COMPANIONS, true)
+launch?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+startActivity(launch)
+```
+
+### d. Settings screen anatomy
+
+Every specialist's Settings screen MUST contain a "Bios integration" section with:
+- Section header (`role.text_primary`, bold)
+- Toggle (`SwitchMaterial`): "Send <noun> events to Bios"
+- Status pill (a)
+- Pending banner (b), conditionally
+- "Open Bios" button (c), conditionally
+
+This block is the *Bios-family handshake* — a user who toggled it in Smokeless should find it identically in Idun.
+
+## 7. Day/Night strategy
+
+Each app picks once and locks. Mixed-mode within the ecosystem is allowed and intentional — variety expresses identity.
+
+| App | Mode | Why |
+|---|---|---|
+| Bios | Light | Hub / medical-instrument register |
+| Smokeless | Dark | Intensity of breaking addiction |
+| W2F | Dark | Cyberpunk cognitive Flow |
+| Idun | Light (locked) | Parchment / artisanal warmth |
+| Virgil | TBD | Likely Light — safety/guide register |
+| SoulRadio | Dark | Broadcast warmth on black |
+| Fil | TBD | |
+
+If an app supports both modes (`Theme.Material3.DayNight`), its dark variant MUST keep its identity hue intact — Smokeless's mint is mint in both modes.
+
+## 8. Accessibility floors
+
+- **Contrast:** WCAG AA on every primary text + background pair
+- **Touch targets:** 48dp minimum
+- **Text scaling:** layouts must survive 130% font-scale without truncation
+- **RTL:** every layout uses `start/end`, never `left/right`
+
+## 9. Token files
+
+Canonical token files live in [design-tokens/](design-tokens/):
+
+- [`colors.yaml`](design-tokens/colors.yaml) — semantic role definitions + per-app mappings
+- [`typography.yaml`](design-tokens/typography.yaml) — type scale + instrument-readout spec
+- [`spacing.yaml`](design-tokens/spacing.yaml) — spacing scale
+- [`components.yaml`](design-tokens/components.yaml) — component anatomy snippets
+
+These are *source of truth*. Each app's `colors.xml` / `themes.xml` / `dimens.xml` is the platform-specific mapping. **When the canonical file changes, every app's mapping should be re-synced.**
+
+## 10. How to apply (per-app checklist)
+
+When creating a new specialist app or refreshing an existing one:
+
+1. **Pick identity hue.** Check the palette wheel; choose a non-colliding warm/rich color.
+2. **Define all 14 role tokens** in `res/values/colors.xml`.
+3. **Inherit Material 3 base theme** (Light or Dark variant per identity), override the `colorPrimary/Secondary/Surface/On*` items pointing at your role colors.
+4. **Add the instrument-readout** TextAppearance styles.
+5. **Implement the Bios integration UI block** in Settings (toggle + status pill + pending banner + Open-Bios button).
+6. **Pick card style** (elevation OR stroke) and corner radius (12 or 14dp), use consistently.
+7. **Reference this doc** from your app's `CLAUDE.md` design-constraints section.
+
+## 11. Drift detection
+
+The ecosystem will drift without a periodic audit. Recommended cadence: every 3 specialists or every major Bios release, re-audit:
+
+- Do all apps render the Bios integration block identically?
+- Has any specialist invented a color role outside the 14-token set that should be promoted to canonical?
+- Has typography drifted from the spec?
+
+Audit findings amend this document, not the apps.
+
+## 12. Open questions
+
+- **Iconography style.** Each app has a launcher icon today; cross-app icon-style consistency (line-weight, fill convention, mascot vs symbol) is not yet specified. Defer until ≥1 more specialist ships.
+- **Notification visual treatment.** Smokeless and Idun both have reminder/notification flows; the visual layer of notifications (color, icon tinting, action style) is not yet specified.
+- **Onboarding pattern.** Each app currently rolls its own (Smokeless has a full onboarding activity, Idun has none). Worth a future cross-cutting spec.
+- **Empty-state illustration policy.** Smokeless uses bare text, Idun TBD. May or may not warrant illustrations.

--- a/docs/design-tokens/colors.yaml
+++ b/docs/design-tokens/colors.yaml
@@ -1,0 +1,164 @@
+# Bios Ecosystem — color tokens (canonical)
+#
+# Two layers:
+#   1. ROLES  — semantic, hue-independent. Every app maps these.
+#   2. APPS   — per-app concrete mappings, for reference.
+#
+# When you change ROLES, every app's colors.xml needs a re-sync pass.
+# When you add a new app, append its mapping to APPS.
+
+version: 1
+updated: 2026-05-24
+
+roles:
+  primary:
+    description: App's identity color. Toolbar, FAB, primary buttons.
+  on_primary:
+    description: Foreground on primary background.
+  primary_container:
+    description: Soft variant of primary. Tonal buttons, chips, container tints.
+  on_primary_container:
+    description: Foreground on primary container.
+  secondary:
+    description: |
+      Optional second accent. Cross-app suggestion — borrow another ecosystem
+      app's primary as your secondary. Idun uses W2F-cyan as secondary; this
+      kinship is encouraged.
+  on_secondary:
+    description: Foreground on secondary.
+  background:
+    description: Window background. Specialists choose dark or light per identity.
+  surface:
+    description: Cards, sheets. Often same as background, sometimes slightly elevated.
+  surface_variant:
+    description: Subtle elevation, dividers, alternating list rows.
+  text_primary:
+    description: Body text.
+  text_secondary:
+    description: Meta text, captions, secondary labels.
+  divider:
+    description: Hairline outlines. Usually text_secondary at 30-40% alpha.
+  success:
+    description: Positive state. Universal mint suggested (#00E5A0).
+    universal: "#00E5A0"
+  warning:
+    description: Caution. Universal amber suggested (#FFB830).
+    universal: "#FFB830"
+  error:
+    description: Failure. Universal red suggested (#F43F5E).
+    universal: "#F43F5E"
+  pending:
+    description: Awaiting external state. Used by Bios PENDING_APPROVAL banner.
+    universal: "#FFF4DA"
+
+apps:
+  bios:
+    mode: light
+    primary: "#009688"          # Material teal
+    primary_dark: "#26A69A"
+    background: "#FFFFFF"
+    notes: "Hub. Intentionally quiet visual identity."
+
+  smokeless:
+    mode: dark
+    primary: "#00E5A0"          # Electric mint
+    secondary: "#FFB830"        # Golden hour amber
+    tertiary: "#00D4C8"         # Teal
+    background: "#080810"       # Deep space
+    surface: "#15131F"
+    surface_elevated: "#1C1A28"
+    text_primary: "#F5F5FA"
+    text_secondary: "#9896A8"
+    notes: "Most-developed ecosystem palette. Reference dark-mode implementation."
+
+  w2f:
+    mode: dark
+    primary: "#00BCD4"          # Flow cyan
+    background: "#0D1B2A"       # Deep navy
+    notes: |
+      "Flow" is the canonical W2F identity color and the ecosystem's
+      cross-app cyan accent. Other apps may borrow it as secondary
+      (Idun does).
+
+  idun:
+    mode: light  # locked
+    primary: "#B33A3A"          # Apple red
+    primary_dark: "#5C1A1A"
+    primary_soft: "#F4D5D5"
+    secondary: "#00BCD4"        # Borrowed from W2F (Flow cyan)
+    secondary_dark: "#0A5560"
+    secondary_soft: "#D6F0F4"
+    background: "#FAF6EE"       # Parchment
+    surface_variant: "#F0EAD8"
+    text_primary: "#1A1A1A"
+    text_secondary: "#5C5C5C"
+    divider: "#E0DACE"
+    card_background: "#FFFCF6"
+    notes: "Locked light. Norse-mythology + Mediterranean register."
+
+  virgil:
+    mode: tbd
+    primary: "#F4A261"          # Safety orange
+    surface: "#E0E1DD"          # Sand
+    notes: "Guide / safety register. Mode TBD on next ship."
+
+  soulradio:
+    mode: dark
+    primary: "#D4AF37"          # Broadcast gold
+    background: "#000000"
+    notes: "Black + gold. Most reduced palette in the ecosystem."
+
+  fil:
+    mode: tbd
+    primary: "#FFFFFF"
+    notes: "Minimal. Identity unfinished — pick a hue before next release."
+
+  rooster:
+    mode: dark  # locked
+    primary: "#FF8E53"          # Sunrise coral
+    primary_dark: "#FF6B35"     # Sunrise (light-mode primary)
+    secondary: "#FFB86C"        # Golden hour
+    tertiary: "#FFD89C"         # Day sky
+    background: "#000000"       # Solid black canvas
+    surface: "#000000"
+    surface_variant: "#0A0A0A"
+    text_primary: "#FFB86C"     # Warm-on-black; arcs trace cosmic journey
+    text_secondary: "#FF8E53"
+    divider: "#FF8E53"          # Sun-colored stroke (0.5dp)
+    notes: |
+      Sun-tracking alarm app. Astral journey palette (deep space → twilight →
+      golden hour → sunrise) drives all theming. Sits next to Smokeless on the
+      ecosystem palette wheel (orange family); Rooster trends coral/golden,
+      Smokeless trends pure orange — separation preserved.
+      Identity-locked divergences from spec: card corner radius 4-8dp (not
+      12/14dp) and card elevation 0dp + sun-colored stroke (not 1dp elevation).
+      See /home/mia/Rooster/docs/DESIGN.md "Compliance with the Bios ecosystem
+      spec" for rationale.
+
+  carnet:
+    mode: dark  # locked
+    primary: "#78A06E"          # Sage green (botanical / instrument register)
+    primary_container: "#1F2D1E"
+    secondary: "#009688"        # Borrowed from Bios (teal — kinship as the Bios-spine camera writer)
+    background: "#080E0A"       # Near-black with sage undertone
+    surface: "#0C140F"          # Slightly elevated panel
+    surface_variant: "#15201A"
+    text_primary: "#E6EFD6"     # Cream HUD text
+    text_secondary: "#B4C8A0"   # Dimmed sage
+    divider: "#66B4C8A0"        # text_secondary @ 40% alpha
+    accent_rec: "#FF3030"       # Identity-specific: HUD REC indicator. Not a role token.
+    notes: |
+      Scientific-instrument camera app for longitudinal self-as-subject video.
+      Dark glass + sage + cream HUD; identity hue is sage green, distinct from
+      W2F cyan, Bios teal, Smokeless orange, Idun red, Rooster coral. Borrows
+      Bios teal as secondary to mark its role as the Bios-spine camera writer.
+      carnet_rec stays separate from role.error because the HUD's red is
+      hand-tuned for burn-in legibility, not error semantics.
+
+# Validation rules:
+# - Every app MUST define: primary, on_primary, background, surface,
+#   text_primary, text_secondary, divider.
+# - Every app SHOULD define: primary_container, on_primary_container,
+#   secondary, on_secondary, surface_variant.
+# - Universal tokens (success/warning/error/pending) may be overridden but
+#   should not be without a documented reason in the app's CLAUDE.md.

--- a/docs/design-tokens/components.yaml
+++ b/docs/design-tokens/components.yaml
@@ -1,0 +1,137 @@
+# Bios Ecosystem — component anatomy (canonical)
+#
+# Cross-app component specs. Anatomy is shared; identity colors are
+# substituted per-app via the role tokens in colors.yaml.
+
+version: 1
+updated: 2026-05-24
+
+app_bar:
+  type: com.google.android.material.appbar.MaterialToolbar
+  background: role.background
+  title_color: role.text_primary
+  height: "?attr/actionBarSize"
+  status_bar:
+    color: role.background
+    light_icons: "depends on mode (true for light themes, false for dark)"
+
+card:
+  type: com.google.android.material.card.MaterialCardView
+  corner_radius: [12dp, 14dp]            # pick once per app, use everywhere
+  elevation_strategy:
+    option_a:
+      mode: light
+      elevation: 0dp
+      stroke_width: 1dp
+      stroke_color: role.divider
+    option_b:
+      mode: dark
+      elevation: 1dp
+      stroke_width: 0dp
+  inner_padding: 12dp_to_14dp
+  list_margin:
+    vertical: 4dp
+    horizontal: 4dp
+
+list_row:
+  leading:
+    type: [checkbox, icon]
+    size: 24dp
+    end_margin: 6dp
+  body:
+    layout: LinearLayout vertical, weight=1
+    lines:
+      title:
+        size_sp: 16
+        weight: bold
+        color: role.text_primary
+        max_lines: 2
+        ellipsize: end
+      meta:
+        size_sp: 12
+        color: role.text_secondary
+        margin_top: 2dp
+      tags:
+        size_sp: 11
+        color: role.text_secondary
+        alpha: 0.75
+        max_lines: 1
+        ellipsize: end
+        visibility: gone_when_empty
+  click:
+    whole_row: true
+    leading_checkbox_independent: true
+
+fab:
+  type: com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+  color: role.primary
+  position: bottom_end
+  margin: 16dp
+  visibility_pattern: show_when_actionable
+  notes: |
+    Hide when the action has nothing to act on (empty selection, no plan,
+    no items). Surface when state becomes actionable. Avoids dead UI.
+
+section_header:
+  layout: LinearLayout horizontal
+  label:
+    size_sp: 14
+    weight: medium
+    color: role.text_primary
+  count:
+    size_sp: 12
+    color: role.text_secondary
+    format: "%d items"
+
+chip:
+  type: com.google.android.material.chip.Chip
+  style: Widget.Material3.Chip.Filter
+  background: role.primary_container
+  text_color: role.text_secondary
+  min_height: 48dp
+  corner_radius: 18dp
+  text_size_sp: 13
+
+# === Bios integration UI (cross-app required) ===
+
+bios_status_pill:
+  states:
+    not_installed:
+      style: dimmed
+      color: role.text_secondary
+      copy_key: settings_bios_status_not_installed
+    not_enabled:
+      style: outlined
+      color: role.text_secondary
+      copy_key: settings_bios_status_not_enabled
+    connected:
+      style: filled
+      color: role.success
+      copy_key: settings_bios_status_connected
+
+bios_pending_banner:
+  shown_when: "BiosClient.lastPushOutcome == PENDING_APPROVAL"
+  background: role.pending
+  text_color: role.text_primary
+  copy_key: settings_bios_pending_approval
+  action:
+    label_key: bios_open_app
+    behavior: deep_link_to_bios_companion_settings
+
+bios_open_app_button:
+  visibility: shown_when_bios_installed
+  intent_strategy: |
+    val launch = packageManager.getLaunchIntentForPackage(BiosClient.BIOS_PACKAGE)
+    launch?.putExtra(BiosClient.BIOS_EXTRA_NAVIGATE_TO_COMPANIONS, true)
+    launch?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    startActivity(launch)
+
+settings_bios_section:
+  required_in_every_specialist: true
+  anatomy:
+    - section_header: "Bios integration"
+    - switch:
+        label_pattern: "Send <noun> events to Bios"
+    - status_pill: ref bios_status_pill
+    - pending_banner_conditional: ref bios_pending_banner
+    - open_bios_button_conditional: ref bios_open_app_button

--- a/docs/design-tokens/spacing.yaml
+++ b/docs/design-tokens/spacing.yaml
@@ -1,0 +1,25 @@
+# Bios Ecosystem — spacing tokens (canonical)
+#
+# Fixed scale. Every padding/margin/inset MUST come from this set.
+# No 5dp, no 10dp, no 20dp anywhere in the ecosystem.
+
+version: 1
+updated: 2026-05-24
+
+scale:
+  xxs: 4dp
+  xs: 8dp
+  sm: 12dp
+  md: 16dp
+  lg: 24dp
+  xl: 32dp
+  xxl: 48dp
+
+uses:
+  touch_target_minimum: 48dp     # xxl
+  screen_edge_default: 16dp      # md
+  list_item_vertical_gap: 8dp    # xs
+  list_item_horizontal_inset: 4dp # xxs
+  card_inner_padding: [12, 14]   # sm or sm+2 — pick once per app
+  section_block_gap: 24dp        # lg
+  major_separator: 32dp          # xl

--- a/docs/design-tokens/typography.yaml
+++ b/docs/design-tokens/typography.yaml
@@ -1,0 +1,61 @@
+# Bios Ecosystem — typography tokens (canonical)
+#
+# Base scale follows Material 3. The ecosystem extension is the
+# instrument-readout monospace, mandatory for data-bearing text across
+# every app.
+
+version: 1
+updated: 2026-05-24
+
+base_font_family: roboto
+
+scale:
+  # Material 3 roles — apps inherit these as-is.
+  display_large: { size_sp: 57, weight: regular }
+  display_medium: { size_sp: 45, weight: regular }
+  display_small: { size_sp: 36, weight: regular }
+  headline_large: { size_sp: 32, weight: regular }
+  headline_medium: { size_sp: 28, weight: regular }
+  headline_small: { size_sp: 24, weight: regular }
+  title_large: { size_sp: 22, weight: medium }
+  title_medium: { size_sp: 16, weight: medium }
+  title_small: { size_sp: 14, weight: medium }
+  body_large: { size_sp: 16, weight: regular }
+  body_medium: { size_sp: 14, weight: regular }
+  body_small: { size_sp: 12, weight: regular }
+  label_large: { size_sp: 14, weight: medium }
+  label_medium: { size_sp: 12, weight: medium }
+  label_small: { size_sp: 11, weight: medium }
+
+# === Ecosystem extension: instrument readout ===
+#
+# Origin: W2F's cockpit typography. Mandatory across the ecosystem for
+# data-bearing text — times, durations, quantities, biomarker values,
+# eating windows, distances, scores.
+#
+# Rule: apply to MEASUREMENTS only. Never to body copy, recipe names,
+# mood labels, or anything humans wrote.
+
+instrument:
+  family: monospace
+  letter_spacing: 0.04
+  base_size_sp: 14
+  base_color: text_primary
+
+  variants:
+    default:
+      style_name: "TextAppearance.<App>.Instrument"
+      parent: "TextAppearance.Material3.BodyMedium"
+      size_sp: 14
+      color: text_primary
+    small:
+      style_name: "TextAppearance.<App>.Instrument.Small"
+      size_sp: 13
+      color: text_secondary
+    large:
+      style_name: "TextAppearance.<App>.Instrument.Large"
+      size_sp: 16
+      color: text_primary
+
+# Each app names the style with its own namespace (TextAppearance.Idun.Instrument,
+# TextAppearance.Smokeless.Instrument, etc.) but the spec MUST match.


### PR DESCRIPTION
## Summary

Bundles four related changes onto one branch:

- **`fix(ui)` #305** — every scientific reference Bios surfaces (biomarker cards in `LongevityReferenceScreen`, `ConditionDetailScreen.BiomarkerReferenceCard`, and the sources block) now renders as a tappable annotated link backed by `Citation` (https-only, DOI-preferred). Plain-prose citations are unverifiable and rot silently; this makes the owner able to follow every claim back to source. Pinned by a unit test that fails the build if any shipped citation drops its URL.
- **`feat(ui)` #303** — `GuideSleepScreen`, the static evidence-anchored sleep-medicine reference reachable from `SleepDashboardScreen` via "Learn more". Read-only, owner-pulled, no nudges. Closes #135 deliverable 3.
- **`docs(design-system)`** — `docs/DESIGN_SYSTEM.md` and `docs/design-tokens/{colors,typography,spacing,components}.yaml` as the **canonical visual & design system** for the Bios ecosystem (Bios + Smokeless / Fil / W2F / Virgil / SoulRadio / Idun). `CLAUDE.md` now points at it as the source of truth for visual treatment, palette roles, typography, component anatomy, and the Bios-integration UI block.
- **`style(ui)`** — `BiosTokens.kt` exposes the ecosystem semantic roles (`success` / `warning` / `error` / `pending` / `muted`) and the mandatory monospace instrument-readout style. `LongevityReferenceScreen` migrates off hardcoded `0xFF4CAF50` / `0xFFFFC107` / `0xFFFFA000` / `0xFFD32F2F` / `Color.Gray`, off off-scale `2.dp` padding, and renders coverage counts + biomarker readouts in the instrument face.

Out of scope here, deliberately deferred: Bios's overall `Theme.kt` still uses Material Pink as `primary` instead of canonical teal `#009688`; many pre-existing screens (`DiagnosticCard`, `MetricCard`, `AlertCard`, `ConditionDetail`, etc.) still hardcode the same status-color literals. Those land in a separate Bios-theme-sync pass once these tokens are in.

## Test plan

- [x] `:app:compileStandaloneDebugKotlin` + `:app:compileLetheDebugKotlin` — both flavors build
- [x] `:app:testStandaloneDebugUnitTest --tests com.bios.app.CitationLinksTest` — citation invariants pass (every shipped reference carries an https URL, every biomarker has ≥1 citation, the `Citation.doi(..)` helper routes through `doi.org`)
- [x] `:app:testStandaloneDebugUnitTest` — full unit suite green
- [x] `:app:lintStandaloneDebug` — lint clean
- [x] Manual: `LongevityReferenceScreen` and `GuideSleepScreen` citations open the DOI / publisher / WHO URL in the system browser; status pills and biomarker bands carry the right tones (success / warning / error / muted); coverage-card numbers and "Latest: X.XX unit" render in monospace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)