### PR TITLE
style(ui): Bios-theme token sync — alert + diagnostic surfaces

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/components/AlertCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/AlertCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.bios.app.alerts.ConditionPatterns
 import com.bios.app.model.AlertTier
 import com.bios.app.model.Anomaly
+import com.bios.app.ui.theme.BiosTokens
 import org.json.JSONObject
 import kotlin.math.abs
 
@@ -40,7 +41,7 @@ fun AlertCard(
     var expanded by remember { mutableStateOf(false) }
     var showFeedback by remember { mutableStateOf(false) }
     val tier = AlertTier.fromLevel(anomaly.severity)
-    val tierColor = tierColor(tier)
+    val tierColor = BiosTokens.tierColor(tier)
     val hasFeedback = anomaly.feedbackAt != null
     val pattern = remember(anomaly.patternId) {
         anomaly.patternId?.let { id ->
@@ -74,7 +75,7 @@ fun AlertCard(
                     Icon(
                         Icons.Default.CheckCircle,
                         contentDescription = "Feedback given",
-                        tint = Color(0xFF4CAF50),
+                        tint = BiosTokens.success,
                         modifier = Modifier.size(16.dp)
                     )
                 }
@@ -328,9 +329,10 @@ private fun YesNoQuestion(
 
 @Composable
 private fun FeedbackSummary(anomaly: Anomaly) {
+    val tint = BiosTokens.success
     Surface(
         shape = RoundedCornerShape(8.dp),
-        color = Color(0xFF4CAF50).copy(alpha = 0.08f)
+        color = tint.copy(alpha = 0.08f)
     ) {
         Column(
             modifier = Modifier.padding(8.dp),
@@ -340,7 +342,7 @@ private fun FeedbackSummary(anomaly: Anomaly) {
                 "Your Journal Entry",
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = Color(0xFF4CAF50)
+                color = tint
             )
 
             anomaly.feltSick?.let {
@@ -425,7 +427,7 @@ private fun DeviationScoresList(scoresJson: String) {
                     Text(
                         String.format("%+.1fσ", zScore),
                         style = MaterialTheme.typography.labelSmall,
-                        color = if (abs(zScore) > 2) Color(0xFFFF9800) else Color(0xFFFFC107)
+                        color = if (abs(zScore) > 2) BiosTokens.attention else BiosTokens.warning
                     )
                 }
             }
@@ -433,11 +435,3 @@ private fun DeviationScoresList(scoresJson: String) {
     }
 }
 
-private fun tierColor(tier: AlertTier): Color {
-    return when (tier) {
-        AlertTier.OBSERVATION -> Color.Gray
-        AlertTier.NOTICE -> Color(0xFFFFC107)
-        AlertTier.ADVISORY -> Color(0xFFFF9800)
-        AlertTier.URGENT -> Color(0xFFF44336)
-    }
-}

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.bios.contracts.MetricType
 import com.bios.app.model.PersonalBaseline
 import com.bios.app.ui.AppViewModel
+import com.bios.app.ui.theme.BiosTokens
 import kotlin.math.abs
 
 /**
@@ -152,10 +153,12 @@ private fun MetricCardBody(
 @Composable
 private fun DeviationIndicator(value: Double, baseline: PersonalBaseline) {
     val z = baseline.zScore(value)
-    val (text, color) = when {
-        abs(z) < 1.0 -> "OK" to Color(0xFF4CAF50)
-        abs(z) < 2.0 -> String.format("%.1fσ", z) to Color(0xFFFFC107)
-        else -> String.format("%.1fσ", z) to Color(0xFFFF9800)
+    val abs = abs(z)
+    val text = if (abs < 1.0) "OK" else String.format("%.1fσ", z)
+    val color = when {
+        abs < 1.0 -> BiosTokens.success
+        abs < 2.0 -> BiosTokens.warning
+        else -> BiosTokens.attention
     }
 
     Text(

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/ConditionDetailScreen.kt
@@ -20,6 +20,7 @@ import com.bios.app.alerts.ConditionPatterns
 import com.bios.app.alerts.DeviationDirection
 import com.bios.app.ui.reference.CitationText
 import com.bios.app.ui.AppViewModel
+import com.bios.app.ui.theme.BiosTokens
 import kotlin.math.abs
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -93,7 +94,7 @@ fun ConditionDetailScreen(
                 KnowledgeSection(
                     icon = Icons.Default.Visibility,
                     title = "Early Detection",
-                    color = Color(0xFF2196F3),
+                    color = MaterialTheme.colorScheme.tertiary,
                     content = pattern.earlyDetection
                 )
             }
@@ -102,7 +103,7 @@ fun ConditionDetailScreen(
                 KnowledgeSection(
                     icon = Icons.Default.Shield,
                     title = "Prevention",
-                    color = Color(0xFF4CAF50),
+                    color = BiosTokens.success,
                     content = pattern.prevention
                 )
             }
@@ -111,7 +112,7 @@ fun ConditionDetailScreen(
                 KnowledgeSection(
                     icon = Icons.Default.Healing,
                     title = "Healing",
-                    color = Color(0xFF009688),
+                    color = MaterialTheme.colorScheme.primary,
                     content = pattern.healing
                 )
             }
@@ -120,7 +121,7 @@ fun ConditionDetailScreen(
                 KnowledgeSection(
                     icon = Icons.Default.Warning,
                     title = "Risks If Untreated",
-                    color = Color(0xFFFF9800),
+                    color = BiosTokens.attention,
                     content = pattern.risks
                 )
             }
@@ -171,7 +172,7 @@ fun ConditionDetailScreen(
 @Composable
 private fun ProbabilityCard(result: DiagnosticResult) {
     val pct = (result.probability * 100).toInt()
-    val color = probabilityColor(result.probability)
+    val color = BiosTokens.probabilityColor(result.probability)
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -294,11 +295,10 @@ private fun SignalDetailRow(signal: SignalStatus) {
     }
 
     val valueColor = when {
-        !signal.hasBaseline || signal.currentZScore == null ->
-            Color.Gray
-        signal.isActive -> Color(0xFFF44336)
-        abs(signal.currentZScore) > signal.thresholdSigma * 0.5 -> Color(0xFFFFC107)
-        else -> Color(0xFF4CAF50)
+        !signal.hasBaseline || signal.currentZScore == null -> BiosTokens.muted
+        signal.isActive -> BiosTokens.error
+        abs(signal.currentZScore) > signal.thresholdSigma * 0.5 -> BiosTokens.warning
+        else -> BiosTokens.success
     }
 
     Row(
@@ -330,17 +330,9 @@ private fun SignalDetailRow(signal: SignalStatus) {
                 else Icons.Default.RadioButtonUnchecked,
             contentDescription = if (signal.isActive) "Active" else "Inactive",
             modifier = Modifier.size(12.dp),
-            tint = if (signal.isActive) Color(0xFFF44336)
-                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
+            tint = if (signal.isActive) BiosTokens.error else BiosTokens.muted
         )
     }
-}
-
-private fun probabilityColor(probability: Double): Color = when {
-    probability >= 0.75 -> Color(0xFFF44336)
-    probability >= 0.50 -> Color(0xFFFF9800)
-    probability >= 0.25 -> Color(0xFFFFC107)
-    else -> Color(0xFF4CAF50)
 }
 
 @Composable
@@ -362,7 +354,7 @@ private fun BiomarkerReferenceCard(biomarker: BiomarkerReference) {
                     Icons.Default.Info,
                     contentDescription = null,
                     modifier = Modifier.size(20.dp),
-                    tint = Color(0xFF7C4DFF)
+                    tint = MaterialTheme.colorScheme.tertiary
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(

--- a/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/diagnostics/DiagnosticCard.kt
@@ -10,16 +10,16 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.bios.app.ui.theme.BiosTokens
 import kotlin.math.abs
 
 @Composable
 fun DiagnosticCard(result: DiagnosticResult, onNavigateToDetail: (String) -> Unit = {}) {
     var expanded by remember { mutableStateOf(false) }
     val pct = (result.probability * 100).toInt()
-    val color = probabilityColor(result.probability)
+    val color = BiosTokens.probabilityColor(result.probability)
 
     Card(
         modifier = Modifier
@@ -156,8 +156,7 @@ private fun SignalRow(signal: SignalStatus) {
                 else Icons.Default.RadioButtonUnchecked,
             contentDescription = null,
             modifier = Modifier.size(10.dp),
-            tint = if (signal.isActive) probabilityColor(1.0)
-                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+            tint = if (signal.isActive) BiosTokens.error else BiosTokens.muted
         )
 
         Spacer(Modifier.width(8.dp))
@@ -179,18 +178,10 @@ private fun SignalRow(signal: SignalStatus) {
             },
             style = MaterialTheme.typography.bodySmall,
             color = when {
-                signal.isActive -> probabilityColor(1.0)
-                !signal.hasBaseline || signal.currentZScore == null ->
-                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+                signal.isActive -> BiosTokens.error
+                !signal.hasBaseline || signal.currentZScore == null -> BiosTokens.muted
                 else -> MaterialTheme.colorScheme.onSurfaceVariant
             }
         )
     }
-}
-
-private fun probabilityColor(probability: Double): Color = when {
-    probability >= 0.75 -> Color(0xFFF44336)
-    probability >= 0.50 -> Color(0xFFFF9800)
-    probability >= 0.25 -> Color(0xFFFFC107)
-    else -> Color(0xFF4CAF50)
 }

--- a/android/app/src/main/java/com/bios/app/ui/theme/BiosTokens.kt
+++ b/android/app/src/main/java/com/bios/app/ui/theme/BiosTokens.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.em
+import com.bios.app.model.AlertTier
 
 /**
  * Compose mappings of the ecosystem semantic tokens
@@ -23,6 +24,12 @@ object BiosTokens {
 
     private val Success = Color(0xFF00E5A0)
     private val Warning = Color(0xFFFFB830)
+    // Bios-specific extension of the canonical role set: a deep amber for the
+    // tier between warning and error. Lets the 4-tier AlertTier and 4-band
+    // probability gradients stay legible without collapsing two tiers onto
+    // one color. The design system permits app-level role additions
+    // (docs/DESIGN_SYSTEM.md §2).
+    private val Attention = Color(0xFFFF8A00)
     private val Pending = Color(0xFFFFF4DA)
 
     val success: Color
@@ -34,6 +41,11 @@ object BiosTokens {
         @Composable
         @ReadOnlyComposable
         get() = Warning
+
+    val attention: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = Attention
 
     val error: Color
         @Composable
@@ -63,4 +75,31 @@ object BiosTokens {
             fontFamily = FontFamily.Monospace,
             letterSpacing = 0.04.em,
         )
+
+    /**
+     * Canonical color for an AlertTier. Shared by AlertCard and TimelineScreen
+     * so the same anomaly reads the same wherever it surfaces.
+     */
+    @Composable
+    @ReadOnlyComposable
+    fun tierColor(tier: AlertTier): Color = when (tier) {
+        AlertTier.OBSERVATION -> muted
+        AlertTier.NOTICE -> warning
+        AlertTier.ADVISORY -> attention
+        AlertTier.URGENT -> error
+    }
+
+    /**
+     * Canonical color for a diagnostic match probability. Shared by
+     * DiagnosticCard and ConditionDetailScreen so a given probability
+     * reads the same on the card and on the detail screen.
+     */
+    @Composable
+    @ReadOnlyComposable
+    fun probabilityColor(probability: Double): Color = when {
+        probability >= 0.75 -> error
+        probability >= 0.50 -> attention
+        probability >= 0.25 -> warning
+        else -> success
+    }
 }

--- a/android/app/src/main/java/com/bios/app/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/bios/app/ui/theme/Theme.kt
@@ -7,19 +7,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
-val BiosPink = Color(0xFFE91E63)
-val BiosPinkDark = Color(0xFFF48FB1)
+// Bios identity hue is Material teal — the quiet, instrument-room register
+// for the ecosystem hub (docs/design-tokens/colors.yaml: apps.bios).
+val BiosTeal = Color(0xFF009688)
+val BiosTealDark = Color(0xFF26A69A)
 
 private val DarkColorScheme = darkColorScheme(
-    primary = BiosPinkDark,
-    secondary = Color(0xFFCE93D8),
-    tertiary = Color(0xFF80CBC4)
+    primary = BiosTealDark,
+    secondary = Color(0xFF80CBC4),
+    tertiary = Color(0xFF4DD0E1)
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = BiosPink,
-    secondary = Color(0xFF9C27B0),
-    tertiary = Color(0xFF009688)
+    primary = BiosTeal,
+    secondary = Color(0xFF26A69A),
+    tertiary = Color(0xFF00BCD4)
 )
 
 @Composable

--- a/android/app/src/main/java/com/bios/app/ui/timeline/TimelineScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/timeline/TimelineScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.model.ActionItem
@@ -23,6 +22,7 @@ import com.bios.app.ui.AppViewModel
 import com.bios.app.ui.components.AlertCard
 import com.bios.app.ui.components.HealthEventCard
 import com.bios.app.ui.components.eventTypeColor
+import com.bios.app.ui.theme.BiosTokens
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -159,7 +159,7 @@ private fun TimelineAlertEntry(
             Icon(
                 Icons.Default.Circle,
                 contentDescription = null,
-                tint = tierColor(tier),
+                tint = BiosTokens.tierColor(tier),
                 modifier = Modifier.size(10.dp)
             )
             HorizontalDivider(
@@ -332,11 +332,3 @@ private fun EmptyTimeline(onLogSymptom: () -> Unit) {
     }
 }
 
-private fun tierColor(tier: AlertTier): Color {
-    return when (tier) {
-        AlertTier.OBSERVATION -> Color.Gray
-        AlertTier.NOTICE -> Color(0xFFFFC107)
-        AlertTier.ADVISORY -> Color(0xFFFF9800)
-        AlertTier.URGENT -> Color(0xFFF44336)
-    }
-}


### PR DESCRIPTION
## Summary

Follow-up to #307 (canonical ecosystem design system). Replaces hardcoded Material color literals across the alert + diagnostic surfaces with `BiosTokens` lookups, and switches the Bios primary identity hue from Pink (legacy Material 3 sample) to canonical Bios teal documented in [docs/design-tokens/colors.yaml](docs/design-tokens/colors.yaml).

- **Theme.kt** — Pink → Teal (`#009688` / `#26A69A`), matching `apps.bios` in `colors.yaml`. Secondary + tertiary realigned to teal/cyan family for the static pre-Android-S color scheme.
- **BiosTokens.kt** — adds an `attention` role (deep amber `#FF8A00`), an app-level role extension permitted under [docs/DESIGN_SYSTEM.md §2](docs/DESIGN_SYSTEM.md). Keeps the 4-tier `AlertTier` and the 4-band diagnostic probability gradient legible without collapsing two tiers onto one color. Also exposes two shared `@Composable` helpers — `tierColor(AlertTier)` and `probabilityColor(Double)` — so the same anomaly reads the same wherever it surfaces.
- **MetricCard / AlertCard / TimelineScreen / DiagnosticCard / ConditionDetailScreen** — all hardcoded `Color(0xFF…)` literals on these surfaces replaced with `BiosTokens.*`. Duplicate `tierColor` helpers (AlertCard + TimelineScreen) and duplicate `probabilityColor` helpers (DiagnosticCard + ConditionDetailScreen) collapsed onto the shared BiosTokens helpers.

### Token mapping

| Domain band | Token |
|---|---|
| AlertTier.OBSERVATION | `muted` |
| AlertTier.NOTICE | `warning` |
| AlertTier.ADVISORY | `attention` |
| AlertTier.URGENT | `error` |
| probability ≥ 0.75 | `error` |
| probability ≥ 0.50 | `attention` |
| probability ≥ 0.25 | `warning` |
| probability < 0.25 | `success` |
| MetricCard <1σ / 1–2σ / >2σ | `success` / `warning` / `attention` |
| SignalDetailRow active / borderline / OK / no-baseline | `error` / `warning` / `success` / `muted` |

### Out of scope (next pass)

Still carry isolated hardcoded color literals — didn't fit the alert/diagnostic surface boundary of this change:

- `HomeScreen.kt` (1 use)
- `LogScreen.kt` (1 use)
- `PipelineHealthScreen.kt` (4 uses)
- `HealthEventCard.kt` (2 uses)

## Test plan

- [x] `./scripts/code-quality-check.sh` passes (both `lethe` and `standalone` build flavors).
- [x] `:app:testStandaloneDebugUnitTest` passes.
- [ ] Visual spot-check on device: confirm pink → teal swap on the home screen toolbar, FAB tints, and Health Connect prompt accents.
- [ ] Visual spot-check on device: confirm 4-tier alert tinting still reads as a clear severity gradient (yellow → amber → red) on the timeline and inside the alert card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)