### PR TITLE
feat(ui): owner entry-flow refactor + Anastasis whitelist + PPG fix

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/PersonalBaselineDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/PersonalBaselineDao.kt
@@ -21,6 +21,9 @@ interface PersonalBaselineDao {
     @Query("SELECT * FROM personal_baselines ORDER BY metricType")
     suspend fun fetchAll(): List<PersonalBaseline>
 
+    @Query("DELETE FROM personal_baselines WHERE metricType = :metricType AND context = :context")
+    suspend fun delete(metricType: String, context: String = "ALL")
+
     @Query("DELETE FROM personal_baselines")
     suspend fun deleteAll()
 }

--- a/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/BaselineEngine.kt
@@ -156,7 +156,20 @@ class BaselineEngine(
         val values = sourceDao.fetchValues(
             metricType.key, startMillis, endMillis, kindFilter
         )
-        if (values.size < MIN_SAMPLES_FOR_BASELINE) return
+        if (values.size < MIN_SAMPLES_FOR_BASELINE) {
+            // Drop the stale row only when there is *truly* no data left —
+            // i.e. the owner deleted every reading for this metric. A slow
+            // week (sensor samples dipping below the in-window minimum)
+            // must NOT vanish a baseline that was validly computed from
+            // historical data, or owners with sparse-but-real records (sleep
+            // tracker offline a few nights, weight measured weekly) lose
+            // their baseline on every sync.
+            val totalRows = readingDao.count(metricType.key)
+            if (totalRows == 0) {
+                baselineDao.delete(metricType.key, context.name)
+            }
+            return
+        }
 
         val stats = Stats.compute(values)
 

--- a/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/CameraPpgAdapter.kt
@@ -1,6 +1,10 @@
 package com.bios.app.ingest
 
 import android.content.Context
+import android.hardware.camera2.CaptureRequest
+import android.util.Range
+import androidx.camera.camera2.interop.Camera2Interop
+import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
@@ -63,6 +67,7 @@ class CameraPpgAdapter(private val context: Context) {
      *    are pushed during capture so the UI can coach the owner if the
      *    finger drifts or motion is detected. Updates ~2 Hz.
      */
+    @OptIn(ExperimentalCamera2Interop::class)
     suspend fun capture(
         lifecycleOwner: LifecycleOwner,
         durationSec: Int,
@@ -87,8 +92,23 @@ class CameraPpgAdapter(private val context: Context) {
         val luminance = Collections.synchronizedList(mutableListOf<Double>())
         val executor = Executors.newSingleThreadExecutor()
         val frameCounter = java.util.concurrent.atomic.AtomicInteger(0)
-        val analysis = ImageAnalysis.Builder()
+        // Pin AE to TARGET_FPS so a dark scene + torch can't push the
+        // sensor onto a long exposure and drop the frame rate to ~17 fps.
+        // At 17 fps each frame is ~60 ms apart but a systolic upstroke is
+        // ~80–120 ms, so peaks get sampled at random phase — amplitudes
+        // swing wildly (peakAmpCov ≈ 1.6, observed on Pixel 9a) and the
+        // adaptive-threshold detector misses alternating beats, producing
+        // a half-rate HR. Forcing a faster AE keeps exposure short enough
+        // that frame rate stays at TARGET_FPS; the torch is what lights
+        // the finger anyway, AE has nothing useful to optimise here.
+        val analysisBuilder = ImageAnalysis.Builder()
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+        Camera2Interop.Extender(analysisBuilder)
+            .setCaptureRequestOption(
+                CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,
+                Range(TARGET_FPS, TARGET_FPS),
+            )
+        val analysis = analysisBuilder
             .build()
             .also {
                 it.setAnalyzer(executor) { image ->
@@ -162,6 +182,15 @@ class CameraPpgAdapter(private val context: Context) {
     }
 
     companion object {
+        /** AE target frame rate (fps). Pinned via [Camera2Interop] on the
+         *  ImageAnalysis use case so a dark scene + torch can't push the
+         *  sensor onto a long exposure and drop the effective rate to the
+         *  point where systolic upstrokes alias between frames. 30 is a
+         *  range every CameraX-supported device advertises; the HAL may
+         *  still round to the closest supported pair if (30, 30) is
+         *  unsupported on a given device. */
+        private const val TARGET_FPS = 30
+
         /** Approximate analyzer frame rate, used by the real-time quality
          *  classifier. Actual rate is measured offline; this is just the
          *  scale for the motion-window heuristic. */

--- a/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
+++ b/android/app/src/main/java/com/bios/app/provider/CompanionContract.kt
@@ -35,6 +35,9 @@ import com.bios.app.model.ReadingKind
  * - Smokeless (com.smokless.smokeless) writes INTAKE events (tobacco + cannabis,
  *   matching its Substance enum surface from Phase 2.1).
  * - Virgil (com.virgil.app) writes SAFETY events
+ * - Anastasis (com.anastasis.app) writes ACTIVITY sedentary-load primitives
+ *   (sedentary_bout + movement_break) — producer-by-capture-surface: the
+ *   sit-detector + foreground service is its unique capture path.
  */
 internal object CompanionContract {
 
@@ -123,6 +126,21 @@ internal object CompanionContract {
                 "near_miss_fall",
                 "check_in_miss",
             ),
+            defaultReadingKind = ReadingKind.DERIVED,
+            signingCertSha256 = emptySet(),
+        ),
+        Companion(
+            packageName = "com.anastasis.app",
+            displayName = "Anastasis",
+            sourceId = "companion_anastasis",
+            writableMetrics = setOf(
+                "sedentary_bout",
+                "movement_break",
+            ),
+            // Detector output (accelerometer stillness gated by step counter)
+            // is algorithmic. The owner's "Done" tap on a movement break
+            // confirms completion but does not change the kind of the underlying
+            // duration value — both are derived, not self-reported scalars.
             defaultReadingKind = ReadingKind.DERIVED,
             signingCertSha256 = emptySet(),
         ),

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -392,7 +392,7 @@ class AppViewModel(application: Application) : AndroidViewModel(application) {
         _timelineEntries.value = db.anomalyDao().fetchAll()
     }
 
-    private suspend fun refreshBaselines() {
+    internal suspend fun refreshBaselines() {
         val allBaselines = db.personalBaselineDao().fetchAll()
         _baselines.value = allBaselines
         _trackedMetricTypes.value = allBaselines.mapNotNull { MetricType.fromKey(it.metricType) }.toSet()

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModelEntries.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModelEntries.kt
@@ -1,0 +1,69 @@
+package com.bios.app.ui
+
+import com.bios.app.data.ManualReadingContext
+import com.bios.app.data.ManualReadingRepo
+import com.bios.app.engine.BaselineEngine
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Recent-entries / per-reading-delete / per-metric-coverage slice of
+ * [AppViewModel]. Kept here so the main view-model file stays under the
+ * 500-line cap. Same pattern as [AppViewModelBiomarkers].
+ *
+ * Engine isolation still holds — `deleteReading` cascades to
+ * `event_payloads` but does NOT cascade to structured-entity children
+ * (headache / migraine / cluster repos own their own delete paths; see
+ * [com.bios.app.data.dao.MetricReadingDao.deleteById] kdoc).
+ */
+data class RecentEntry(
+    val reading: MetricReading,
+    val context: ManualReadingContext,
+)
+
+suspend fun AppViewModel.getRecentReadings(
+    metricType: MetricType,
+    limit: Int = 20,
+): List<RecentEntry> {
+    val readings = db.metricReadingDao().fetchLatest(metricType.key, limit)
+    if (readings.isEmpty()) return emptyList()
+    val payloads = db.eventPayloadFieldDao().fetchForReadings(readings.map { it.id })
+    val byReadingId = payloads.groupBy { it.readingId }
+    return readings.map { r ->
+        RecentEntry(
+            reading = r,
+            context = ManualReadingRepo.rowsToContext(
+                byReadingId[r.id].orEmpty(), note = r.note,
+            ),
+        )
+    }
+}
+
+suspend fun AppViewModel.deleteReading(readingId: String) {
+    db.eventPayloadFieldDao().deleteForReading(readingId)
+    db.metricReadingDao().deleteById(readingId)
+}
+
+suspend fun AppViewModel.deleteReadings(readingIds: Collection<String>) {
+    for (id in readingIds) deleteReading(id)
+}
+
+/**
+ * Recompute the baseline for one metric and refresh the public flow. Used
+ * by the entries-history surface after an owner-initiated delete so the
+ * dashboard stops showing a baseline that no longer reflects what's on
+ * file.
+ */
+suspend fun AppViewModel.recomputeBaseline(metricType: MetricType) {
+    baselineEngine.computeBaseline(metricType)
+    refreshBaselines()
+}
+
+/**
+ * Per-metric coverage on-demand. The prebaked `metricCoverage` flow only
+ * covers `TRACKED_METRICS` (HR / HRV / RHR / SpO2 / RR / Steps / Sleep);
+ * any metric reached via the global search bar needs this fallback or
+ * its dashboard claims "no data yet" even when manual entries exist.
+ */
+suspend fun AppViewModel.coverageFor(metricType: MetricType): BaselineEngine.Coverage =
+    baselineEngine.coverageFor(metricType)

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -28,6 +28,7 @@ import com.bios.app.ui.notice.NoticeScreen
 import com.bios.app.ui.onboarding.OnboardingScreen
 import com.bios.app.ui.settings.SettingsScreen
 import com.bios.app.model.HealthEventType
+import com.bios.app.ui.clinical.AddReadingScreen
 import com.bios.app.ui.journal.HealthEventSheet
 import com.bios.app.ui.diagnostics.ConditionDetailScreen
 import androidx.navigation.NavType
@@ -155,8 +156,13 @@ fun BiosApp(viewModel: AppViewModel) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            if (selectedTab == 3) { // Journal tab
-                FloatingActionButton(onClick = {
+            when (selectedTab) {
+                // Read + Log tabs — quick-add a self-reported reading
+                0, 1 -> FloatingActionButton(onClick = { navController.navigate("add_reading") }) {
+                    Icon(Icons.Default.Add, contentDescription = "Add reading")
+                }
+                // Journal tab — log a health event
+                3 -> FloatingActionButton(onClick = {
                     eventSheetParentId = null
                     eventSheetDefaultType = null
                     showEventSheet = true
@@ -264,7 +270,7 @@ fun BiosApp(viewModel: AppViewModel) {
                 val metricKey = backStackEntry.arguments?.getString("metric")
                 TrendsScreen(
                     viewModel = viewModel,
-                    initialMetric = metricKey?.let { com.bios.contracts.MetricType.fromKey(it) }
+                    initialMetric = metricKey?.let { com.bios.contracts.MetricType.fromKey(it) },
                 )
             }
             composable("notice") {
@@ -362,6 +368,16 @@ fun BiosApp(viewModel: AppViewModel) {
                 com.bios.app.ui.clinical.ClinicalReadingEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
+                )
+            }
+            composable(
+                route = "add_reading?metric={metric}",
+                arguments = listOf(navArgument("metric") { type = NavType.StringType; nullable = true; defaultValue = null })
+            ) { backStackEntry ->
+                AddReadingScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
+                    initialMetric = backStackEntry.arguments?.getString("metric")?.let { MetricType.fromKey(it) },
                 )
             }
             composable("bbt_entry") {
@@ -475,4 +491,5 @@ fun BiosApp(viewModel: AppViewModel) {
             defaultType = eventSheetDefaultType
         )
     }
+
 }

--- a/android/app/src/main/java/com/bios/app/ui/clinical/AddReadingScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/AddReadingScreen.kt
@@ -1,0 +1,417 @@
+package com.bios.app.ui.clinical
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.data.ManualReadingContext
+import com.bios.app.ui.AppViewModel
+import com.bios.app.ui.components.metricMatchesQuery
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Single-metric entry screen reached from the global FAB or a metric
+ * dashboard's "+ New entry" button. The owner picks one metric, types one
+ * value, and the screen captures when + where the reading came from. After
+ * save the value clears but the timestamp + source persist so a pharmacy
+ * session of N readings is N quick taps rather than N round-trips through
+ * the navigation stack.
+ *
+ * Writes route through [com.bios.app.data.ManualReadingRepo] → SELF_REPORTED
+ * so single manual points don't poison sensor baselines
+ * (docs/SELF_REPORTED_DATA_HOME.md decision 3).
+ *
+ * Lab biomarkers stay on the dedicated `BiomarkerEntryScreen` (specimen +
+ * fasting + lab name provenance is richer than this surface) and
+ * reproductive metrics on their isolated repos — domain filter mirrors
+ * [ClinicalReadingRows.clinicalEntryMetrics].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddReadingScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+    initialMetric: MetricType? = null,
+) {
+    val scope = rememberCoroutineScope()
+    val repo = viewModel.manualReadingRepo
+
+    var selectedMetric by remember { mutableStateOf<MetricType?>(initialMetric) }
+    var valueText by remember { mutableStateOf("") }
+    var timestamp by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var source by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    var savedCount by remember { mutableStateOf(0) }
+    var saving by remember { mutableStateOf(false) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
+
+    val canSave by remember {
+        derivedStateOf {
+            !saving && selectedMetric != null && valueText.toDoubleOrNull() != null
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add reading") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (savedCount > 0) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer
+                    )
+                ) {
+                    Text(
+                        "Saved $savedCount reading${if (savedCount == 1) "" else "s"} in this session. " +
+                            "Add another below, or go back when done.",
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(12.dp),
+                    )
+                }
+            }
+
+            MetricSearchPicker(
+                selected = selectedMetric,
+                onSelect = { selectedMetric = it; valueText = "" },
+            )
+
+            selectedMetric?.let { metric ->
+                OutlinedTextField(
+                    value = valueText,
+                    onValueChange = { input ->
+                        valueText = input.filter { c -> c.isDigit() || c == '.' }
+                    },
+                    label = { Text("Value") },
+                    suffix = { Text(metric.unit.symbol.ifEmpty { "—" }) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Text(
+                "When",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = { showDatePicker = true },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(formatDate(timestamp))
+                }
+                OutlinedButton(
+                    onClick = { showTimePicker = true },
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(formatTime(timestamp))
+                }
+            }
+
+            OutlinedTextField(
+                value = source,
+                onValueChange = { source = it },
+                label = { Text("Where from") },
+                placeholder = { Text("e.g. Pharmacy scale, home cuff, Dr. Smith") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            OutlinedTextField(
+                value = note,
+                onValueChange = { note = it },
+                label = { Text("Note (optional)") },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Button(
+                enabled = canSave,
+                onClick = {
+                    val metric = selectedMetric ?: return@Button
+                    val parsed = valueText.toDoubleOrNull() ?: return@Button
+                    saving = true
+                    val capturedAt = timestamp
+                    val capturedSource = source.trim().ifBlank { null }
+                    val capturedNote = note.trim().ifBlank { null }
+                    scope.launch {
+                        repo.add(
+                            metricType = metric,
+                            value = parsed,
+                            timestamp = capturedAt,
+                            context = ManualReadingContext(
+                                clinicName = capturedSource,
+                                note = capturedNote,
+                            ),
+                        )
+                        savedCount += 1
+                        // Clear the per-reading fields, keep when + source so a
+                        // pharmacy / clinic session of N readings stays fast.
+                        selectedMetric = null
+                        valueText = ""
+                        note = ""
+                        saving = false
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (saving) "Saving…" else "Save and add another")
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = timestamp)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { picked ->
+                        timestamp = combineDateAndTime(date = picked, time = timestamp)
+                    }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            },
+        ) {
+            DatePicker(state = state)
+        }
+    }
+
+    if (showTimePicker) {
+        val cal = remember(timestamp) {
+            Calendar.getInstance().apply { timeInMillis = timestamp }
+        }
+        val state = rememberTimePickerState(
+            initialHour = cal.get(Calendar.HOUR_OF_DAY),
+            initialMinute = cal.get(Calendar.MINUTE),
+            is24Hour = true,
+        )
+        DatePickerDialog(
+            onDismissRequest = { showTimePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    timestamp = setHourMinute(timestamp, state.hour, state.minute)
+                    showTimePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+            },
+        ) {
+            Box(
+                modifier = Modifier.padding(16.dp),
+                contentAlignment = androidx.compose.ui.Alignment.Center,
+            ) {
+                TimePicker(state = state)
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricSearchPicker(
+    selected: MetricType?,
+    onSelect: (MetricType?) -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    val results by remember {
+        derivedStateOf {
+            val universe = manualEntryUniverse()
+            if (query.isBlank()) universe.take(20)
+            else universe.filter { metricMatchesQuery(it, query) }.take(30)
+        }
+    }
+
+    Text(
+        "What",
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+    )
+
+    if (selected != null) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer
+            ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(selected.readableName, style = MaterialTheme.typography.bodyLarge)
+                    val unitSymbol = selected.unit.symbol.ifEmpty { "—" }
+                    Text(unitSymbol, style = MaterialTheme.typography.bodySmall)
+                }
+                IconButton(onClick = { query = ""; onSelect(null) }) {
+                    Icon(Icons.Default.Close, contentDescription = "Change metric")
+                }
+            }
+        }
+    } else {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            label = { Text("Search metric") },
+            placeholder = { Text("Weight, HRV, ApoB, BMI…") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        if (results.isNotEmpty()) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 320.dp),
+                ) {
+                    items(results) { metric ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSelect(metric)
+                                    query = ""
+                                }
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+                        ) {
+                            Text(metric.readableName, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                metric.unit.symbol.ifEmpty { "—" },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The universe of metrics the search picker offers — every manual-entry
+ * key the contract allows except the domains whose provenance shape this
+ * screen can't capture: BIOMARKER (lab specimen / fasting fields live on
+ * `BiomarkerEntryScreen`) and WOMENS_HEALTH (rows belong in the isolated
+ * `ReproductiveDatabase` via BBT/Period repos). SLEEP stays in — its
+ * dedicated `SleepEntryScreen` writes to the same `metric_readings` table
+ * with no isolation, so excluding it just buried the metric one nav level
+ * deeper when an owner needed a quick override (e.g. wearable missed a
+ * night and they want to log it from the FAB).
+ */
+internal fun manualEntryUniverse(): List<MetricType> =
+    MetricType.entries
+        .filter {
+            it.allowsManualEntry &&
+                it.domain != MetricDomain.BIOMARKER &&
+                it.domain != MetricDomain.WOMENS_HEALTH
+        }
+        .sortedBy { it.readableName }
+
+private fun formatDate(epochMs: Long): String =
+    SimpleDateFormat("EEE d MMM yyyy", Locale.getDefault()).format(Date(epochMs))
+
+private fun formatTime(epochMs: Long): String =
+    SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(epochMs))
+
+private fun combineDateAndTime(date: Long, time: Long): Long {
+    val datePart = Calendar.getInstance().apply { timeInMillis = date }
+    val timePart = Calendar.getInstance().apply { timeInMillis = time }
+    return Calendar.getInstance().apply {
+        set(Calendar.YEAR, datePart.get(Calendar.YEAR))
+        set(Calendar.MONTH, datePart.get(Calendar.MONTH))
+        set(Calendar.DAY_OF_MONTH, datePart.get(Calendar.DAY_OF_MONTH))
+        set(Calendar.HOUR_OF_DAY, timePart.get(Calendar.HOUR_OF_DAY))
+        set(Calendar.MINUTE, timePart.get(Calendar.MINUTE))
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+}
+
+private fun setHourMinute(epochMs: Long, hour: Int, minute: Int): Long =
+    Calendar.getInstance().apply {
+        timeInMillis = epochMs
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -70,6 +71,7 @@ import java.util.Locale
 fun ClinicalReadingEntryScreen(
     viewModel: AppViewModel,
     onBack: () -> Unit,
+    initialPreset: MeasurementPreset = MeasurementPreset.TRIAGE,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -80,11 +82,12 @@ fun ClinicalReadingEntryScreen(
     var clinicName by remember { mutableStateOf("") }
     var visitNote by remember { mutableStateOf("") }
     var sourceUri by remember { mutableStateOf<Uri?>(null) }
+    var preset by remember { mutableStateOf(initialPreset) }
     val rows = remember { mutableStateListOf<ReadingRowState>() }
     var saveMessage by remember { mutableStateOf<String?>(null) }
 
     if (rows.isEmpty()) {
-        defaultTriageRows().forEach { rows.add(it) }
+        defaultRowsFor(preset).forEach { rows.add(it) }
     }
 
     val sourceLauncher = rememberLauncherForActivityResult(
@@ -136,11 +139,11 @@ fun ClinicalReadingEntryScreen(
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        "Vital signs you enter — from a cuff, pulse-ox, thermometer, or a triage " +
-                            "chart a clinician handed you — stay on your device. They show up in " +
-                            "trends and FHIR export, but the baseline engine and anomaly detector " +
-                            "ignore them. Single-point clinical readings would otherwise poison " +
-                            "sensor baselines.",
+                        "Readings you enter — from a cuff, pulse-ox, thermometer, scale, " +
+                            "body-composition station, or a triage chart a clinician handed you — " +
+                            "stay on your device. They show up in trends and FHIR export, but " +
+                            "the baseline engine and anomaly detector ignore them. Single-point " +
+                            "manual readings would otherwise poison sensor baselines.",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -202,6 +205,31 @@ fun ClinicalReadingEntryScreen(
                 fontWeight = FontWeight.Bold,
             )
 
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = preset == MeasurementPreset.TRIAGE,
+                    onClick = {
+                        if (preset != MeasurementPreset.TRIAGE) {
+                            preset = MeasurementPreset.TRIAGE
+                            rows.clear()
+                            defaultRowsFor(MeasurementPreset.TRIAGE).forEach { rows.add(it) }
+                        }
+                    },
+                    label = { Text("Triage") },
+                )
+                FilterChip(
+                    selected = preset == MeasurementPreset.BODY_COMPOSITION,
+                    onClick = {
+                        if (preset != MeasurementPreset.BODY_COMPOSITION) {
+                            preset = MeasurementPreset.BODY_COMPOSITION
+                            rows.clear()
+                            defaultRowsFor(MeasurementPreset.BODY_COMPOSITION).forEach { rows.add(it) }
+                        }
+                    },
+                    label = { Text("Body composition") },
+                )
+            }
+
             rows.forEachIndexed { index, row ->
                 ReadingRowCard(
                     state = row,
@@ -240,7 +268,7 @@ fun ClinicalReadingEntryScreen(
                         )
                         saveMessage = "Saved ${bundle.size} reading${if (bundle.size == 1) "" else "s"}."
                         rows.clear()
-                        defaultTriageRows().forEach { rows.add(it) }
+                        defaultRowsFor(preset).forEach { rows.add(it) }
                         clinicName = ""
                         visitNote = ""
                         sourceUri = null

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
@@ -202,21 +202,42 @@ internal data class ReadingRowState(
 }
 
 /**
- * Triage-default row order matches a Spanish ER chart's column layout
- * (TAS / TAD / Sat O2 / FC / Temp / FR / EVA / GCS / Flujo O2) — that's
- * the chart shape that motivated this surface.
+ * Pre-populated row sets the entry screen offers as chip-selectable presets.
+ * Each maps to a real owner workflow so the screen doesn't force a delete-
+ * then-re-add when the use case isn't triage.
+ *  - [TRIAGE] is the Spanish ER chart shape (TAS / TAD / Sat O2 / FC / Temp /
+ *    FR / EVA / GCS / Flujo O2) that originally motivated this surface.
+ *  - [BODY_COMPOSITION] is the pharmacy / scale shape (weight, height, BMI,
+ *    body fat %, lean + fat mass, blood pressure) — the bundle a body-
+ *    composition station prints at a weekly weigh-in.
  */
-internal fun defaultTriageRows(): List<ReadingRowState> = listOf(
-    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
-    ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
-    ReadingRowState(metric = MetricType.BLOOD_OXYGEN),
-    ReadingRowState(metric = MetricType.HEART_RATE),
-    ReadingRowState(metric = MetricType.SKIN_TEMPERATURE),
-    ReadingRowState(metric = MetricType.RESPIRATORY_RATE),
-    ReadingRowState(metric = MetricType.PAIN_SCORE),
-    ReadingRowState(metric = MetricType.CONSCIOUSNESS_LEVEL),
-    ReadingRowState(metric = MetricType.OXYGEN_FLOW_RATE),
-)
+enum class MeasurementPreset { TRIAGE, BODY_COMPOSITION }
+
+internal fun defaultRowsFor(preset: MeasurementPreset): List<ReadingRowState> = when (preset) {
+    MeasurementPreset.TRIAGE -> listOf(
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+        ReadingRowState(metric = MetricType.BLOOD_OXYGEN),
+        ReadingRowState(metric = MetricType.HEART_RATE),
+        ReadingRowState(metric = MetricType.SKIN_TEMPERATURE),
+        ReadingRowState(metric = MetricType.RESPIRATORY_RATE),
+        ReadingRowState(metric = MetricType.PAIN_SCORE),
+        ReadingRowState(metric = MetricType.CONSCIOUSNESS_LEVEL),
+        ReadingRowState(metric = MetricType.OXYGEN_FLOW_RATE),
+    )
+    MeasurementPreset.BODY_COMPOSITION -> listOf(
+        ReadingRowState(metric = MetricType.BODY_MASS),
+        ReadingRowState(metric = MetricType.HEIGHT_CM),
+        ReadingRowState(metric = MetricType.BMI_KG_PER_M2),
+        ReadingRowState(metric = MetricType.BODY_FAT_PCT),
+        ReadingRowState(metric = MetricType.LEAN_BODY_MASS_KG),
+        ReadingRowState(metric = MetricType.FAT_MASS_KG),
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+    )
+}
+
+internal fun defaultTriageRows(): List<ReadingRowState> = defaultRowsFor(MeasurementPreset.TRIAGE)
 
 /**
  * Metrics offered in the clinical-reading picker: everything that opts in

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricSearch.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricSearch.kt
@@ -1,0 +1,81 @@
+package com.bios.app.ui.components
+
+import com.bios.contracts.MetricType
+
+/**
+ * Owner-vocabulary synonyms the search bars match against in addition to
+ * each metric's `readableName` and `key`. Keys' readableName ("Body mass",
+ * "Heart rate variability", "Blood pressure systolic") rarely match what
+ * an owner actually types ("weight", "HRV", "BP"). Cover the typed-name
+ * gap here rather than renaming canonical keys (which would break every
+ * companion pinned to the current contract).
+ *
+ * Includes the Spanish ER triage abbreviations (TAS/TAD/FC/FR) and the
+ * French BMI label (IMC) since CLAUDE.md and the clinical entry surface
+ * already adopt that vocabulary.
+ */
+internal val MetricSynonyms: Map<MetricType, List<String>> = mapOf(
+    // Anthropometry / body composition
+    MetricType.BODY_MASS to listOf("weight", "poids"),
+    MetricType.HEIGHT_CM to listOf("height", "taille"),
+    MetricType.BMI_KG_PER_M2 to listOf("bmi", "imc"),
+    MetricType.BODY_FAT_PCT to listOf("fat", "body fat", "graisse"),
+    MetricType.FAT_MASS_KG to listOf("fat mass"),
+    MetricType.LEAN_BODY_MASS_KG to listOf("lean mass", "muscle mass", "lbm"),
+    MetricType.BODY_WATER_PCT to listOf("water"),
+    MetricType.BONE_MASS to listOf("bone"),
+
+    // Cardiovascular
+    MetricType.HEART_RATE to listOf("hr", "pulse", "fc", "pouls"),
+    MetricType.RESTING_HEART_RATE to listOf("rhr", "resting hr", "resting"),
+    MetricType.HEART_RATE_VARIABILITY to listOf("hrv", "rmssd", "vfc"),
+    MetricType.BLOOD_PRESSURE_SYSTOLIC to listOf("bp", "blood pressure", "tas", "systolic"),
+    MetricType.BLOOD_PRESSURE_DIASTOLIC to listOf("bp", "blood pressure", "tad", "diastolic"),
+    MetricType.BLOOD_OXYGEN to listOf("spo2", "sat", "saturation", "oxygen", "o2"),
+    MetricType.VO2_MAX to listOf("vo2"),
+
+    // Respiratory
+    MetricType.RESPIRATORY_RATE to listOf("breath", "breathing", "rr", "fr"),
+    MetricType.OXYGEN_FLOW_RATE to listOf("o2 flow", "flujo o2"),
+
+    // Temperature
+    MetricType.SKIN_TEMPERATURE to listOf("temp", "fever", "temperature"),
+    MetricType.BASAL_BODY_TEMPERATURE to listOf("bbt", "basal temp"),
+
+    // Neurology / pain
+    MetricType.PAIN_SCORE to listOf("pain", "eva", "vas"),
+    MetricType.CONSCIOUSNESS_LEVEL to listOf("gcs", "avpu", "consciousness"),
+
+    // Metabolic / glucose
+    MetricType.BLOOD_GLUCOSE to listOf("glucose", "sugar"),
+    MetricType.FASTING_GLUCOSE to listOf("fasting sugar"),
+
+    // Lipids
+    MetricType.TOTAL_CHOLESTEROL to listOf("cholesterol", "tc"),
+    MetricType.LDL_CHOLESTEROL to listOf("ldl"),
+    MetricType.HDL_CHOLESTEROL to listOf("hdl"),
+    MetricType.APO_B to listOf("apob"),
+    MetricType.LIPOPROTEIN_A to listOf("lp(a)", "lipo a"),
+
+    // Common biomarker shorthands
+    MetricType.HBA1C to listOf("a1c"),
+    MetricType.HSCRP to listOf("crp"),
+
+    // Activity / sleep
+    MetricType.STEPS to listOf("step count", "podometer"),
+    MetricType.SLEEP_DURATION to listOf("sleep"),
+)
+
+/**
+ * True when `q` matches any of: the metric's readable name, its canonical
+ * key, or any of the owner-vocabulary synonyms. Empty queries match nothing
+ * — callers handle the empty-state separately.
+ */
+internal fun metricMatchesQuery(metric: MetricType, q: String): Boolean {
+    val needle = q.trim().lowercase()
+    if (needle.isEmpty()) return false
+    if (metric.readableName.lowercase().contains(needle)) return true
+    if (metric.key.contains(needle)) return true
+    val synonyms = MetricSynonyms[metric] ?: return false
+    return synonyms.any { it.contains(needle) }
+}

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.bios.app.ui.home
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,11 +8,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -23,6 +27,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.HourglassBottom
 import androidx.compose.material.icons.filled.Medication
 import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
@@ -31,10 +36,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,6 +56,7 @@ import com.bios.app.ingest.SyncWorker
 import com.bios.app.ui.AppViewModel
 import com.bios.app.ui.components.MetricCard
 import com.bios.app.ui.components.MetricInfoSheet
+import com.bios.app.ui.components.metricMatchesQuery
 import com.bios.contracts.MetricType
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -109,6 +117,8 @@ fun HomeScreen(
                     )
                 }
             }
+
+            MetricSearchBar(onSelect = onNavigateToMetric)
 
             val staleThresholdMillis = SyncWorker.STALE_THRESHOLD_HOURS * 3600 * 1000L
             val isStale = lastSync != null &&
@@ -245,6 +255,64 @@ fun BaselineCountdown(currentDays: Int, requiredDays: Int) {
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.primary,
             )
+        }
+    }
+}
+
+/**
+ * App-level search to jump straight into a metric's dashboard. Universe is
+ * every [MetricType] the contract knows — sensor-only, derived, and manual-
+ * entry alike — because the search lands on the trend dashboard, not the
+ * entry screen. From the dashboard the "+ New entry" button (visible when
+ * the metric allows manual entry) hops to AddReadingScreen pre-filled.
+ */
+@Composable
+private fun MetricSearchBar(onSelect: (MetricType) -> Unit) {
+    var query by remember { mutableStateOf("") }
+    val results by remember {
+        derivedStateOf {
+            if (query.isBlank()) emptyList()
+            else MetricType.entries
+                .filter { metricMatchesQuery(it, query) }
+                .sortedBy { it.readableName }
+                .take(20)
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            placeholder = { Text("Search metrics — Weight, HRV, BMI, ApoB…") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (results.isNotEmpty()) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                LazyColumn(modifier = Modifier.heightIn(max = 280.dp)) {
+                    items(results) { metric ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSelect(metric)
+                                    query = ""
+                                }
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(metric.readableName, style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                metric.unit.symbol.ifEmpty { "—" },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/log/LogScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/log/LogScreen.kt
@@ -97,7 +97,7 @@ fun LogScreen(
         HomeEntryCard(
             icon = Icons.Default.MedicalServices,
             title = "Clinical reading",
-            subtitle = "Blood pressure, SpO2, temperature",
+            subtitle = "Weight, height, BMI, BP, SpO2, body composition, HRV — bundle entry",
             onClick = onNavigateToClinicalEntry,
         )
         HomeEntryCard(

--- a/android/app/src/main/java/com/bios/app/ui/trends/MetricBrowserSheet.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/MetricBrowserSheet.kt
@@ -1,0 +1,121 @@
+package com.bios.app.ui.trends
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.ui.components.metricMatchesQuery
+import com.bios.contracts.MetricType
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun MetricBrowserSheet(
+    selected: MetricType,
+    onSelect: (MetricType) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    val results by remember {
+        derivedStateOf {
+            val all = MetricType.entries.sortedBy { it.readableName }
+            if (query.isBlank()) all
+            else all.filter { metricMatchesQuery(it, query) }
+        }
+    }
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                "Choose a metric",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                label = { Text("Search metric") },
+                placeholder = { Text("HRV, weight, BP, ApoB…") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(8.dp))
+            if (results.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "No metric matches \"$query\".",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 560.dp),
+                ) {
+                    items(results) { metric ->
+                        val isSelected = metric == selected
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(metric) }
+                                .padding(horizontal = 4.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                metric.readableName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                                color = if (isSelected) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                metric.unit.symbol.ifEmpty { "—" },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/trends/MetricChartCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/MetricChartCard.kt
@@ -1,0 +1,159 @@
+package com.bios.app.ui.trends
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.ui.RecentEntry
+import com.bios.contracts.MetricType
+
+@Composable
+internal fun MetricChart(
+    metric: MetricType,
+    entries: List<RecentEntry>,
+    loaded: Boolean,
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            if (!loaded) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(120.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "Loading…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                return@Column
+            }
+
+            if (entries.size < 2) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(120.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        if (entries.isEmpty()) "No readings yet."
+                        else "Need at least two readings to chart.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                return@Column
+            }
+
+            val sorted = entries.sortedBy { it.reading.timestamp }
+            val values = sorted.map { it.reading.value }
+            val minV = values.min()
+            val maxV = values.max()
+            val range = (maxV - minV).coerceAtLeast(1e-6)
+            val firstTs = sorted.first().reading.timestamp
+            val lastTs = sorted.last().reading.timestamp
+            val spanMs = (lastTs - firstTs).coerceAtLeast(1L).toDouble()
+            val unit = metric.unit.symbol.ifEmpty { "" }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Last ${sorted.size} readings",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    buildString {
+                        append(formatStat(values.last()))
+                        if (unit.isNotEmpty()) {
+                            append(' ')
+                            append(unit)
+                        }
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            val lineColor = MaterialTheme.colorScheme.primary
+            val pointColor = MaterialTheme.colorScheme.tertiary
+            Canvas(
+                modifier = Modifier.fillMaxWidth().height(120.dp),
+            ) {
+                val w = size.width
+                val h = size.height
+                val padY = 4f
+                val usableH = h - 2 * padY
+                fun yFor(v: Double): Float =
+                    h - padY - ((v - minV) / range).toFloat() * usableH
+                fun xFor(t: Long): Float =
+                    ((t - firstTs) / spanMs).toFloat() * w
+
+                for (i in 1 until sorted.size) {
+                    val a = sorted[i - 1].reading
+                    val b = sorted[i].reading
+                    drawLine(
+                        color = lineColor,
+                        start = Offset(xFor(a.timestamp), yFor(a.value)),
+                        end = Offset(xFor(b.timestamp), yFor(b.value)),
+                        strokeWidth = 4f,
+                        cap = StrokeCap.Round,
+                    )
+                }
+                for (entry in sorted) {
+                    drawCircle(
+                        color = pointColor,
+                        radius = 3f,
+                        center = Offset(xFor(entry.reading.timestamp), yFor(entry.reading.value)),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    "min ${formatStat(minV)}${if (unit.isNotEmpty()) " $unit" else ""}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    formatEntryTimestamp(firstTs) + " → " + formatEntryTimestamp(lastTs),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    "max ${formatStat(maxV)}${if (unit.isNotEmpty()) " $unit" else ""}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/trends/RecentEntriesSection.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/RecentEntriesSection.kt
@@ -1,0 +1,208 @@
+package com.bios.app.ui.trends
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.ui.RecentEntry
+import com.bios.contracts.MetricType
+
+@Composable
+internal fun RecentEntriesSection(
+    metric: MetricType,
+    entries: List<RecentEntry>,
+    loaded: Boolean,
+    selectedIds: Set<String>,
+    onLongPress: (String) -> Unit,
+    onToggle: (String) -> Unit,
+    onDeleteOne: (RecentEntry) -> Unit,
+    onCancelSelection: () -> Unit,
+    onRequestBatchDelete: () -> Unit,
+) {
+    val inSelectMode = selectedIds.isNotEmpty()
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            if (inSelectMode) "${selectedIds.size} selected" else "Recent entries",
+            style = MaterialTheme.typography.titleMedium,
+        )
+        if (inSelectMode) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                TextButton(onClick = onRequestBatchDelete) { Text("Delete") }
+                IconButton(onClick = onCancelSelection) {
+                    Icon(Icons.Default.Close, contentDescription = "Cancel selection")
+                }
+            }
+        }
+    }
+
+    if (!loaded) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Text(
+                "Loading…",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+        return
+    }
+
+    if (entries.isEmpty()) {
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        ) {
+            Text(
+                "No ${metric.readableName.lowercase()} entries yet.",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+        return
+    }
+
+    if (!inSelectMode) {
+        Text(
+            "Long-press a row to multi-select.",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    Card {
+        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+            entries.forEachIndexed { index, entry ->
+                EntryRow(
+                    metric = metric,
+                    entry = entry,
+                    inSelectMode = inSelectMode,
+                    isSelected = entry.reading.id in selectedIds,
+                    onLongPress = { onLongPress(entry.reading.id) },
+                    onToggle = { onToggle(entry.reading.id) },
+                    onDelete = { onDeleteOne(entry) },
+                )
+                if (index < entries.lastIndex) {
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun EntryRow(
+    metric: MetricType,
+    entry: RecentEntry,
+    inSelectMode: Boolean,
+    isSelected: Boolean,
+    onLongPress: () -> Unit,
+    onToggle: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val unit = metric.unit.symbol.ifEmpty { "" }
+    val rowBg = if (isSelected) MaterialTheme.colorScheme.secondaryContainer
+                else MaterialTheme.colorScheme.surface
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(rowBg)
+            .combinedClickable(
+                onClick = { if (inSelectMode) onToggle() },
+                onLongClick = onLongPress,
+            )
+            .padding(start = 16.dp, end = 4.dp, top = 6.dp, bottom = 6.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (inSelectMode) {
+            Checkbox(
+                checked = isSelected,
+                onCheckedChange = { onToggle() },
+            )
+            Spacer(Modifier.width(4.dp))
+        }
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    buildString {
+                        append(formatStat(entry.reading.value))
+                        if (unit.isNotEmpty()) {
+                            append(' ')
+                            append(unit)
+                        }
+                    },
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    formatEntryTimestamp(entry.reading.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            entry.context.clinicName?.takeIf { it.isNotBlank() }?.let { src ->
+                Text(
+                    "From: $src",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            entry.context.note?.takeIf { it.isNotBlank() }?.let { note ->
+                Text(
+                    note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (!inSelectMode) {
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Outlined.DeleteOutline,
+                    contentDescription = "Delete entry",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsBaselineCards.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsBaselineCards.kt
@@ -1,0 +1,147 @@
+package com.bios.app.ui.trends
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.engine.BaselineEngine
+import com.bios.app.model.PersonalBaseline
+import com.bios.app.model.TrendDirection
+
+@Composable
+fun BaselineSummaryCard(baseline: PersonalBaseline) {
+    val trend = TrendDirection.valueOf(baseline.trend)
+
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Personal Baseline", style = MaterialTheme.typography.titleSmall)
+                TrendBadge(trend)
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                StatCell("Mean", formatStat(baseline.mean))
+                StatCell("Std Dev", formatStat(baseline.stdDev))
+                StatCell("Range", "${formatStat(baseline.p5)} - ${formatStat(baseline.p95)}")
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            Text(
+                "Trend: ${baseline.trend.lowercase()} (${String.format("%+.2f", baseline.trendSlope)}/day) | Window: ${baseline.windowDays} days",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatCell(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+fun TrendBadge(trend: TrendDirection) {
+    val (arrow, color) = when (trend) {
+        TrendDirection.RISING -> "↗" to MaterialTheme.colorScheme.error
+        TrendDirection.STABLE -> "→" to MaterialTheme.colorScheme.primary
+        TrendDirection.FALLING -> "↘" to MaterialTheme.colorScheme.tertiary
+    }
+    Text(arrow, color = color, fontWeight = FontWeight.Bold)
+}
+
+@Composable
+fun NoBaselineCard(
+    metricLabel: String,
+    coverage: BaselineEngine.Coverage?
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp).fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            val (title, body) = noBaselineMessage(metricLabel, coverage)
+            Text(title, style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+internal fun noBaselineMessage(
+    metricLabel: String,
+    coverage: BaselineEngine.Coverage?
+): Pair<String, String> {
+    if (coverage == null || !coverage.hasAnyData) {
+        return "No $metricLabel data yet" to
+            "Bios hasn't received any $metricLabel readings. " +
+            "Check that your watch is sending $metricLabel to Health Connect, " +
+            "or that the source you use (Gadgetbridge, Oura, etc.) is connected and syncing."
+    }
+    // Owner has data, but every row is self-reported (zero sensor rows in the
+    // baseline window). Baselines stay sensor-only by design
+    // (docs/SELF_REPORTED_DATA_HOME.md decision 3) — say that plainly instead
+    // of pretending there's no data at all.
+    if (coverage.sensorSamplesInWindow == 0 && coverage.totalSamples > 0) {
+        val n = coverage.totalSamples
+        return "$metricLabel — manual entries only" to
+            "You have $n manual ${if (n == 1) "entry" else "entries"} on file. " +
+            "Bios computes baselines from sensor data only — your entries still " +
+            "show in trends and exports, but they don't drive the baseline math."
+    }
+    val staleHours = coverage.lastTimestamp?.let {
+        (System.currentTimeMillis() - it) / (3600L * 1000)
+    } ?: Long.MAX_VALUE
+    if (staleHours >= 48) {
+        val days = (staleHours / 24).toInt()
+        return "$metricLabel feed looks stale" to
+            "Last $metricLabel reading was $days day${if (days == 1) "" else "s"} ago. " +
+            "Bios has ${coverage.totalSamples} reading${if (coverage.totalSamples == 1) "" else "s"} on file, " +
+            "but the source seems to have stopped syncing."
+    }
+    if (!coverage.meetsBaselineMinimum) {
+        return "Building $metricLabel baseline" to
+            "Bios has ${coverage.sensorSamplesInWindow} sensor reading${if (coverage.sensorSamplesInWindow == 1) "" else "s"} " +
+            "in the last ${BaselineEngine.DEFAULT_WINDOW_DAYS} days. " +
+            "Need at least ${BaselineEngine.MIN_SAMPLES_FOR_BASELINE} to compute a baseline."
+    }
+    return "Baseline pending" to
+        "Bios has ${coverage.sensorSamplesInWindow} recent $metricLabel readings. " +
+        "Baseline will compute on the next sync."
+}

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsFormatters.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsFormatters.kt
@@ -1,0 +1,14 @@
+package com.bios.app.ui.trends
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+internal fun formatStat(value: Double): String = when {
+    value >= 1000 -> String.format("%.0f", value)
+    value >= 100 -> String.format("%.0f", value)
+    else -> String.format("%.1f", value)
+}
+
+internal fun formatEntryTimestamp(epochMs: Long): String =
+    SimpleDateFormat("d MMM, HH:mm", Locale.getDefault()).format(Date(epochMs))

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -1,43 +1,85 @@
 package com.bios.app.ui.trends
 
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.engine.BaselineEngine
-import com.bios.contracts.MetricType
-import com.bios.app.model.PersonalBaseline
-import com.bios.app.model.TrendDirection
 import com.bios.app.ui.AppViewModel
+import com.bios.app.ui.RecentEntry
+import com.bios.app.ui.coverageFor
+import com.bios.app.ui.deleteReading
+import com.bios.app.ui.deleteReadings
+import com.bios.app.ui.getRecentReadings
+import com.bios.app.ui.recomputeBaseline
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.launch
 
+/**
+ * Per-metric dashboard. Renders the metric name as a clickable header
+ * (opens the metric-browser sheet for switching), then a small line chart
+ * of the recent values, the personal baseline (or a status card when one
+ * is missing), and a list of recent entries with single + multi-select
+ * delete. Lab biomarker + reproductive metrics have dedicated dashboards;
+ * everything else lands here via the global search bar or the Home cards.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrendsScreen(
     viewModel: AppViewModel,
-    initialMetric: MetricType? = null
+    initialMetric: MetricType? = null,
 ) {
     val baselines by viewModel.baselines.collectAsState()
     val coverage by viewModel.metricCoverage.collectAsState()
     var selectedMetric by remember(initialMetric) {
         mutableStateOf(initialMetric ?: MetricType.HEART_RATE)
     }
+    var showBrowser by remember { mutableStateOf(false) }
+    var recentEntries by remember { mutableStateOf<List<RecentEntry>>(emptyList()) }
+    var entriesLoaded by remember(selectedMetric) { mutableStateOf(false) }
+    var entriesRefreshKey by remember { mutableIntStateOf(0) }
+    var pendingDelete by remember { mutableStateOf<RecentEntry?>(null) }
+    var selectedEntryIds by remember(selectedMetric) { mutableStateOf(emptySet<String>()) }
+    var pendingBatchDelete by remember { mutableStateOf(false) }
+    var liveCoverage by remember(selectedMetric) { mutableStateOf<BaselineEngine.Coverage?>(null) }
+    val coroutineScope = rememberCoroutineScope()
 
-    val trackableMetrics = listOf(
-        MetricType.HEART_RATE to "Heart Rate",
-        MetricType.HEART_RATE_VARIABILITY to "HRV",
-        MetricType.RESTING_HEART_RATE to "Resting HR",
-        MetricType.BLOOD_OXYGEN to "SpO2",
-        MetricType.RESPIRATORY_RATE to "Resp. Rate",
-        MetricType.STEPS to "Steps",
-        MetricType.SKIN_TEMPERATURE_DEVIATION to "Skin Temp",
-        MetricType.SLEEP_DURATION to "Sleep",
-    )
+    LaunchedEffect(selectedMetric, entriesRefreshKey) {
+        entriesLoaded = false
+        recentEntries = viewModel.getRecentReadings(selectedMetric, limit = 30)
+        entriesLoaded = true
+        // Pre-baked coverage map only covers TRACKED_METRICS (HR/HRV/etc.).
+        // For everything else (Weight, BMI, biomarkers, ...) compute on demand.
+        liveCoverage = viewModel.coverageFor(selectedMetric)
+    }
 
     Column(
         modifier = Modifier
@@ -46,190 +88,114 @@ fun TrendsScreen(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text("Trends", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
-
-        // Metric picker
         Row(
-            modifier = Modifier.horizontalScroll(rememberScrollState()),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { showBrowser = true }
+                .padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            trackableMetrics.forEach { (metric, name) ->
-                FilterChip(
-                    selected = selectedMetric == metric,
-                    onClick = { selectedMetric = metric },
-                    label = { Text(name) }
-                )
-            }
+            Text(
+                selectedMetric.readableName,
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Browse metrics")
         }
 
-        // Baseline summary
-        val selectedBaseline = baselines.find { it.metricType == selectedMetric.key }
+        MetricChart(metric = selectedMetric, entries = recentEntries, loaded = entriesLoaded)
 
+        val selectedBaseline = baselines.find { it.metricType == selectedMetric.key }
         if (selectedBaseline != null) {
             BaselineSummaryCard(selectedBaseline)
         } else {
-            val metricLabel = trackableMetrics.firstOrNull { it.first == selectedMetric }?.second
-                ?: selectedMetric.readableName
-            NoBaselineCard(metricLabel, coverage[selectedMetric])
+            NoBaselineCard(
+                metricLabel = selectedMetric.readableName,
+                coverage = liveCoverage ?: coverage[selectedMetric],
+            )
         }
 
-        // All baselines
-        if (baselines.isNotEmpty()) {
-            Text("All Baselines", style = MaterialTheme.typography.titleMedium)
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+        RecentEntriesSection(
+            metric = selectedMetric,
+            entries = recentEntries,
+            loaded = entriesLoaded,
+            selectedIds = selectedEntryIds,
+            onLongPress = { id -> selectedEntryIds = selectedEntryIds + id },
+            onToggle = { id ->
+                selectedEntryIds = if (id in selectedEntryIds) selectedEntryIds - id
+                                   else selectedEntryIds + id
+            },
+            onDeleteOne = { entry -> pendingDelete = entry },
+            onCancelSelection = { selectedEntryIds = emptySet() },
+            onRequestBatchDelete = { pendingBatchDelete = true },
+        )
+    }
+
+    if (showBrowser) {
+        MetricBrowserSheet(
+            selected = selectedMetric,
+            onSelect = { metric ->
+                selectedMetric = metric
+                showBrowser = false
+            },
+            onDismiss = { showBrowser = false },
+        )
+    }
+
+    pendingDelete?.let { entry ->
+        val unit = selectedMetric.unit.symbol.ifEmpty { "" }
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete this entry?") },
+            text = {
+                Text(
+                    "${formatStat(entry.reading.value)} $unit on " +
+                        "${formatEntryTimestamp(entry.reading.timestamp)} — " +
+                        "this is permanent."
                 )
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    baselines.forEachIndexed { index, baseline ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                MetricType.fromKey(baseline.metricType)?.readableName ?: baseline.metricType,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                Text(
-                                    formatStat(baseline.mean),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                                TrendBadge(TrendDirection.valueOf(baseline.trend))
-                            }
-                        }
-                        if (index < baselines.lastIndex) {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-                        }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val id = entry.reading.id
+                    val metric = selectedMetric
+                    pendingDelete = null
+                    coroutineScope.launch {
+                        viewModel.deleteReading(id)
+                        viewModel.recomputeBaseline(metric)
+                        entriesRefreshKey += 1
                     }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun BaselineSummaryCard(baseline: PersonalBaseline) {
-    val trend = TrendDirection.valueOf(baseline.trend)
-
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+            },
         )
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text("Personal Baseline", style = MaterialTheme.typography.titleSmall)
-                TrendBadge(trend)
-            }
-
-            Spacer(Modifier.height(16.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                StatCell("Mean", formatStat(baseline.mean))
-                StatCell("Std Dev", formatStat(baseline.stdDev))
-                StatCell("Range", "${formatStat(baseline.p5)} - ${formatStat(baseline.p95)}")
-            }
-
-            Spacer(Modifier.height(12.dp))
-
-            Text(
-                "Trend: ${baseline.trend.lowercase()} (${String.format("%+.2f", baseline.trendSlope)}/day) | Window: ${baseline.windowDays} days",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
     }
-}
 
-@Composable
-private fun StatCell(label: String, value: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-}
-
-@Composable
-fun TrendBadge(trend: TrendDirection) {
-    val (arrow, color) = when (trend) {
-        TrendDirection.RISING -> "↗" to MaterialTheme.colorScheme.error
-        TrendDirection.STABLE -> "→" to MaterialTheme.colorScheme.primary
-        TrendDirection.FALLING -> "↘" to MaterialTheme.colorScheme.tertiary
-    }
-    Text(arrow, color = color, fontWeight = FontWeight.Bold)
-}
-
-@Composable
-fun NoBaselineCard(
-    metricLabel: String,
-    coverage: BaselineEngine.Coverage?
-) {
-    Card(
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+    if (pendingBatchDelete) {
+        val count = selectedEntryIds.size
+        AlertDialog(
+            onDismissRequest = { pendingBatchDelete = false },
+            title = { Text("Delete $count ${if (count == 1) "entry" else "entries"}?") },
+            text = { Text("This is permanent.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    val ids = selectedEntryIds.toList()
+                    val metric = selectedMetric
+                    pendingBatchDelete = false
+                    selectedEntryIds = emptySet()
+                    coroutineScope.launch {
+                        viewModel.deleteReadings(ids)
+                        viewModel.recomputeBaseline(metric)
+                        entriesRefreshKey += 1
+                    }
+                }) { Text("Delete $count") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingBatchDelete = false }) { Text("Cancel") }
+            },
         )
-    ) {
-        Column(
-            modifier = Modifier.padding(24.dp).fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            val (title, body) = noBaselineMessage(metricLabel, coverage)
-            Text(title, style = MaterialTheme.typography.titleSmall)
-            Spacer(Modifier.height(4.dp))
-            Text(
-                body,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-}
-
-internal fun noBaselineMessage(
-    metricLabel: String,
-    coverage: BaselineEngine.Coverage?
-): Pair<String, String> {
-    if (coverage == null || !coverage.hasAnyData) {
-        return "No $metricLabel data yet" to
-            "Bios hasn't received any $metricLabel readings. " +
-            "Check that your watch is sending $metricLabel to Health Connect, " +
-            "or that the source you use (Gadgetbridge, Oura, etc.) is connected and syncing."
-    }
-    val staleHours = coverage.lastTimestamp?.let {
-        (System.currentTimeMillis() - it) / (3600L * 1000)
-    } ?: Long.MAX_VALUE
-    if (staleHours >= 48) {
-        val days = (staleHours / 24).toInt()
-        return "$metricLabel feed looks stale" to
-            "Last $metricLabel reading was $days day${if (days == 1) "" else "s"} ago. " +
-            "Bios has ${coverage.totalSamples} reading${if (coverage.totalSamples == 1) "" else "s"} on file, " +
-            "but the source seems to have stopped syncing."
-    }
-    if (!coverage.meetsBaselineMinimum) {
-        return "Building $metricLabel baseline" to
-            "Bios has ${coverage.sensorSamplesInWindow} sensor reading${if (coverage.sensorSamplesInWindow == 1) "" else "s"} " +
-            "in the last ${BaselineEngine.DEFAULT_WINDOW_DAYS} days. " +
-            "Need at least ${BaselineEngine.MIN_SAMPLES_FOR_BASELINE} to compute a baseline."
-    }
-    return "Baseline pending" to
-        "Bios has ${coverage.sensorSamplesInWindow} recent $metricLabel readings. " +
-        "Baseline will compute on the next sync."
-}
-
-private fun formatStat(value: Double): String {
-    return when {
-        value >= 1000 -> String.format("%.0f", value)
-        value >= 100 -> String.format("%.0f", value)
-        else -> String.format("%.1f", value)
     }
 }

--- a/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiosHealthProviderContractTest.kt
@@ -143,6 +143,45 @@ class BiosHealthProviderContractTest {
     }
 
     @Test
+    fun `companion whitelist contains Anastasis sedentary-load keys`() {
+        // Anastasis is the producer-by-capture-surface for both sedentary bouts
+        // (foreground service consuming accelerometer + step counter) and the
+        // owner-acknowledged movement breaks that follow.
+        assertTrue("sedentary_bout" in CompanionContract.WRITABLE_METRICS)
+        assertTrue("movement_break" in CompanionContract.WRITABLE_METRICS)
+    }
+
+    @Test
+    fun `Anastasis may only write its own sedentary-load keys`() {
+        val a = "com.anastasis.app"
+        assertTrue(CompanionContract.canWrite(a, "sedentary_bout"))
+        assertTrue(CompanionContract.canWrite(a, "movement_break"))
+        // Cross-package isolation — Anastasis must not write any other
+        // companion's keys.
+        assertFalse(CompanionContract.canWrite(a, "tobacco_use"))
+        assertFalse(CompanionContract.canWrite(a, "mood_drift_score"))
+        assertFalse(CompanionContract.canWrite(a, "fall_event"))
+        assertFalse(CompanionContract.canWrite(a, "sleep_duration"))
+    }
+
+    @Test
+    fun `sedentary-load keys are ACTIVITY domain with SECONDS unit`() {
+        assertEquals(MetricDomain.ACTIVITY, MetricType.SEDENTARY_BOUT.domain)
+        assertEquals(MetricUnit.SECONDS, MetricType.SEDENTARY_BOUT.unit)
+        assertEquals(MetricDomain.ACTIVITY, MetricType.MOVEMENT_BREAK.domain)
+        assertEquals(MetricUnit.SECONDS, MetricType.MOVEMENT_BREAK.unit)
+    }
+
+    @Test
+    fun `Anastasis companion source is tagged DERIVED`() {
+        // Bout duration is sensor-derived; the owner's "Done" tap confirms
+        // the break happened but does not change the kind of the underlying
+        // duration value. Mirrors W2F / Virgil rather than Smokeless.
+        val anastasis = CompanionContract.sourceFor("com.anastasis.app")!!
+        assertEquals(ReadingKind.DERIVED, anastasis.defaultReadingKind)
+    }
+
+    @Test
     fun `safety metric types are SAFETY domain with EVENT unit`() {
         assertEquals(MetricDomain.SAFETY, MetricType.FALL_EVENT.domain)
         assertEquals(MetricUnit.EVENT, MetricType.FALL_EVENT.unit)

--- a/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/ManualReadingSelectorsTest.kt
@@ -3,6 +3,9 @@ package com.bios.app
 import com.bios.app.data.AvpuLevel
 import com.bios.app.data.GcsBounds
 import com.bios.app.data.ManualReadingContext
+import com.bios.app.ui.clinical.MeasurementPreset
+import com.bios.app.ui.clinical.defaultRowsFor
+import com.bios.app.ui.clinical.manualEntryUniverse
 import com.bios.contracts.MetricDomain
 import com.bios.contracts.MetricType
 import com.bios.contracts.MetricUnit
@@ -44,6 +47,79 @@ class ManualReadingSelectorsTest {
             assertTrue(
                 "${t.key} must allow manual entry — triage chart column",
                 t.allowsManualEntry
+            )
+        }
+    }
+
+    @Test
+    fun add_reading_screen_universe_covers_every_clinical_manual_metric() {
+        // The FAB → AddReadingScreen search picker writes through
+        // ManualReadingRepo.add which require()s allowsManualEntry. The
+        // universe filter must cover every manual-entry metric outside the
+        // dedicated provenance-shaped domains (biomarker has its lab screen,
+        // women's health has the isolated reproductive DB). Sleep stays in —
+        // its dedicated screen writes the same shape; excluding it just
+        // buried the override path.
+        val universe = manualEntryUniverse().toSet()
+        val expected = MetricType.entries.filter {
+            it.allowsManualEntry &&
+                it.domain != MetricDomain.BIOMARKER &&
+                it.domain != MetricDomain.WOMENS_HEALTH
+        }.toSet()
+        assertEquals(expected, universe)
+        for (m in universe) {
+            assertTrue(
+                "${m.key} in add-reading universe must allow manual entry",
+                m.allowsManualEntry
+            )
+        }
+    }
+
+    @Test
+    fun add_reading_universe_includes_owner_typed_targets() {
+        // Pharmacy weigh-in shape + HRV4Training morning reading + cuff/
+        // pulse-ox vitals + sleep override must all be findable via the
+        // search picker.
+        val universe = manualEntryUniverse().toSet()
+        val mustFind = setOf(
+            MetricType.BODY_MASS, MetricType.HEIGHT_CM, MetricType.BMI_KG_PER_M2,
+            MetricType.BODY_FAT_PCT, MetricType.LEAN_BODY_MASS_KG, MetricType.FAT_MASS_KG,
+            MetricType.BLOOD_PRESSURE_SYSTOLIC, MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.HEART_RATE, MetricType.RESTING_HEART_RATE,
+            MetricType.HEART_RATE_VARIABILITY, MetricType.BLOOD_OXYGEN,
+            MetricType.SKIN_TEMPERATURE,
+            MetricType.SLEEP_DURATION,
+        )
+        for (m in mustFind) {
+            assertTrue(
+                "${m.key} must appear in the AddReadingScreen search universe",
+                m in universe
+            )
+        }
+    }
+
+    @Test
+    fun body_composition_preset_matches_pharmacy_weighin_shape() {
+        // A pharmacy / scale weigh-in prints weight, height, BMI, body fat %,
+        // fat mass, lean mass, plus blood pressure. The preset must cover that
+        // bundle so the owner doesn't delete triage rows and re-add body comp
+        // rows by hand every visit. Order matches the receipt printout.
+        val expected = listOf(
+            MetricType.BODY_MASS,
+            MetricType.HEIGHT_CM,
+            MetricType.BMI_KG_PER_M2,
+            MetricType.BODY_FAT_PCT,
+            MetricType.LEAN_BODY_MASS_KG,
+            MetricType.FAT_MASS_KG,
+            MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC,
+        )
+        val actual = defaultRowsFor(MeasurementPreset.BODY_COMPOSITION).map { it.metric }
+        assertEquals(expected, actual)
+        for (m in expected) {
+            assertTrue(
+                "${m.key} must opt in to manual entry — body composition preset",
+                m.allowsManualEntry
             )
         }
     }

--- a/android/app/src/test/java/com/bios/app/MetricSearchTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricSearchTest.kt
@@ -1,0 +1,67 @@
+package com.bios.app
+
+import com.bios.app.ui.components.metricMatchesQuery
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pin the owner-vocabulary searches a typed user expects to "just work".
+ * Each row is `(query, expected metric)`; if a regression breaks any of
+ * these, the search bar silently fails to surface the metric and the owner
+ * thinks Bios doesn't track it.
+ */
+class MetricSearchTest {
+
+    @Test
+    fun owner_typed_queries_resolve_to_canonical_metrics() {
+        val cases = listOf(
+            "weight" to MetricType.BODY_MASS,
+            "Weight" to MetricType.BODY_MASS,
+            "poids" to MetricType.BODY_MASS,
+            "bmi" to MetricType.BMI_KG_PER_M2,
+            "imc" to MetricType.BMI_KG_PER_M2,
+            "hrv" to MetricType.HEART_RATE_VARIABILITY,
+            "rmssd" to MetricType.HEART_RATE_VARIABILITY,
+            "bp" to MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            "tas" to MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            "tad" to MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            "spo2" to MetricType.BLOOD_OXYGEN,
+            "saturation" to MetricType.BLOOD_OXYGEN,
+            "fc" to MetricType.HEART_RATE,
+            "pulse" to MetricType.HEART_RATE,
+            "rhr" to MetricType.RESTING_HEART_RATE,
+            "fat" to MetricType.BODY_FAT_PCT,
+            "lean mass" to MetricType.LEAN_BODY_MASS_KG,
+            "a1c" to MetricType.HBA1C,
+            "crp" to MetricType.HSCRP,
+            "apob" to MetricType.APO_B,
+            "ldl" to MetricType.LDL_CHOLESTEROL,
+            "hdl" to MetricType.HDL_CHOLESTEROL,
+        )
+        for ((query, expected) in cases) {
+            assertTrue(
+                "search '$query' must find ${expected.key}",
+                metricMatchesQuery(expected, query)
+            )
+        }
+    }
+
+    @Test
+    fun empty_query_matches_nothing() {
+        for (m in MetricType.entries) {
+            assertEquals(false, metricMatchesQuery(m, ""))
+            assertEquals(false, metricMatchesQuery(m, "   "))
+        }
+    }
+
+    @Test
+    fun substring_in_readable_name_still_matches() {
+        // Synonym map is additive, not a replacement — the existing
+        // readableName/key fallthrough must keep working.
+        assertTrue(metricMatchesQuery(MetricType.HEART_RATE, "heart"))
+        assertTrue(metricMatchesQuery(MetricType.HEART_RATE_VARIABILITY, "variability"))
+        assertTrue(metricMatchesQuery(MetricType.SKIN_TEMPERATURE, "skin"))
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -36,7 +36,7 @@ enum class MetricType(
 ) {
     // Cardiovascular
     HEART_RATE("heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
-    HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR),
+    HEART_RATE_VARIABILITY("heart_rate_variability", MetricUnit.MILLISECONDS, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
     PARASYMPATHETIC_TONE("parasympathetic_tone", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     STRESS_SCORE("stress_score", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
     LF_HF_RATIO("lf_hf_ratio", MetricUnit.SCORE, MetricDomain.CARDIOVASCULAR),
@@ -186,7 +186,7 @@ enum class MetricType(
     // utc, avg_hr_bpm, rpe) live in event_payloads keyed by reading id —
     // see docs/DATA_MODEL.md field-key vocabulary.
     EXERCISE_SESSION("exercise_session", MetricUnit.EVENT, MetricDomain.ACTIVITY),
-
+    SEDENTARY_BOUT("sedentary_bout", MetricUnit.SECONDS, MetricDomain.ACTIVITY), MOVEMENT_BREAK("movement_break", MetricUnit.SECONDS, MetricDomain.ACTIVITY), // Anastasis sedentary primitives
     // Metabolic
     BLOOD_GLUCOSE("blood_glucose", MetricUnit.MG_PER_DL, MetricDomain.METABOLIC, allowsManualEntry = true),
     // CGM-derived variability keys (#28). Computed over the last 24h of

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -246,6 +246,9 @@ class MetricTypeKeysSnapshotTest {
         "bmi_kg_per_m2",
         "lean_body_mass_kg",
         "fat_mass_kg",
+        // Sedentary-load primitives (Anastasis companion)
+        "sedentary_bout",
+        "movement_break",
     )
 
     @Test

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeTest.kt
@@ -288,8 +288,10 @@ class MetricTypeTest {
     fun allows_manual_entry_defaults_false_for_pure_sensor_keys() {
         // Spot-check: streaming sensor / derived signals must never opt in
         // to the manual-reading surface, or the picker fills with noise.
+        // HRV_LF_POWER / HRV_HF_POWER stay non-manual (PSD outputs of an IBI
+        // series), but HRV itself opts in — phone-PPG apps like HRV4Training
+        // give the owner a number to type. See manual_vital assertions.
         val notManual = listOf(
-            MetricType.HEART_RATE_VARIABILITY,
             MetricType.HRV_LF_POWER, MetricType.HRV_HF_POWER,
             MetricType.PARASYMPATHETIC_TONE, MetricType.STRESS_SCORE,
             MetricType.LF_HF_RATIO, MetricType.VO2_MAX,
@@ -312,6 +314,7 @@ class MetricTypeTest {
     fun allows_manual_entry_true_for_clinical_vitals() {
         val manual = listOf(
             MetricType.HEART_RATE, MetricType.RESTING_HEART_RATE,
+            MetricType.HEART_RATE_VARIABILITY,
             MetricType.BLOOD_PRESSURE_SYSTOLIC, MetricType.BLOOD_PRESSURE_DIASTOLIC,
             MetricType.BLOOD_OXYGEN, MetricType.RESPIRATORY_RATE,
             MetricType.SKIN_TEMPERATURE,

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/NeurologyAttackEventInvariantsTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/NeurologyAttackEventInvariantsTest.kt
@@ -30,8 +30,8 @@ class NeurologyAttackEventInvariantsTest {
             assertEquals(MetricDomain.NEUROLOGICAL, t.domain)
             assertEquals(MetricUnit.EVENT, t.unit)
             assertTrue(
-                "${t.key} must allow manual entry — owner is the only source",
                 t.allowsManualEntry,
+                "${t.key} must allow manual entry — owner is the only source",
             )
         }
     }


### PR DESCRIPTION
## Summary

Three feature streams that overlapped in the same working tree on this branch — bundled here for shippability; squash on merge.

### Owner entry-flow refactor

- **FAB on Read + Log tabs** → `AddReadingScreen` (`add_reading?metric=KEY`) with searchable picker over every manual-entry metric (single value, when, where-from + note, loops with timestamp + source preserved).
- **HomeScreen `MetricSearchBar`** at top of Read — searches all metrics (sensor / derived / manual), opens the per-metric dashboard.
- **TrendsScreen recent entries** with single-row trash + long-press multi-select batch delete; both paths recompute the baseline.
- **"+ New {metric} entry"** button on TrendsScreen for manual-entry metrics.
- **Synonym map** — `weight`/`hrv`/`bp`/`spo2`/`fc`/`tas`/`tad`/`imc`/`poids` resolve to canonical metrics.
- **`ClinicalReadingEntryScreen`** preset chips (Triage / Body composition) so bundle entry isn't locked to the ER chart shape.
- **`LogScreen`** "Clinical reading" subtitle now reflects actual contents.

### Baseline integrity
- `recomputeBaseline(metric)` after delete; baseline drops **only** when `count(metric) == 0`, not on a slow week.
- `coverageFor(metric)` on-demand — dashboards reached via search no longer claim "no data" when manual entries exist.
- `NoBaselineCard` gains a "manual entries only" branch.

### Anastasis whitelist
- `CompanionContract` allowlist gains Anastasis; new `SEDENTARY_BOUT` + `MOVEMENT_BREAK` keys; snapshot test updated.

### Piggybacked fixes
- `HEART_RATE_VARIABILITY.allowsManualEntry = true` (phone-PPG owner-source path; engine isolation via SELF_REPORTED).
- `NeurologyAttackEventInvariantsTest` — JUnit 5 `assertTrue` arg order (was blocking bios-contracts compile).
- `CameraPpgAdapter` pins AE `TARGET_FPS_RANGE` so dark scenes can't drop Pixel 9a to 17 fps and alias systolic upstrokes (#266).

### File splits (500-line cap)
- `TrendsScreen` → `TrendsScreen` + `MetricChartCard` + `MetricBrowserSheet` + `RecentEntriesSection` + `TrendsBaselineCards` + `TrendsFormatters`.
- `AppViewModel` entries methods → `AppViewModelEntries` (extension-function pattern matching `AppViewModelBiomarkers`).

### Known lint warning
`CameraPpgAdapter.kt:106` — `Camera2Interop.Extender` usage flagged for `@OptIn(ExperimentalCamera2Interop::class)` scope. The annotation is on the enclosing `capture()` function but lint wants it closer to the call site. Non-blocking for the pre-commit hook but will likely surface in CI — easy follow-up to relocate the opt-in.

### Follow-ups filed
- #310 entries history on TrendsScreen — **shipped here**
- #311 chip-row regression on search-opened metrics
- #312 HC adapter stable record id (root cause of phantom-row sleep loss)
- #313 `ForensicRiskMonitor.wipeRecentData` TODO landmine

## Test plan
- [ ] Tap FAB on Read → search "weight" → enter value + when + where → save → confirm appears in Body mass dashboard
- [ ] Pharmacy session: open Body mass dashboard, hit "+ New", save 8 metrics (weight, BMI, BP sys/dia, body fat, lean/fat mass) in one flow
- [ ] Home → search "hrv" → opens HRV dashboard with recent entries
- [ ] On a metric with duplicates: long-press a row, tap others, hit "Delete N" → confirm baseline updates
- [ ] Anastasis sedentary keys resolve via `MetricType.fromKey("sedentary_bout")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)