### PR TITLE
fix(ingest): route phone-sleep FGS start through alarm relay (#315)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,21 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!--
+      Exact-alarm permission for the receiver-launch relay (#315). A
+      background BroadcastReceiver cannot call startForegroundService
+      on Android 12+ for non-allowlisted broadcasts like
+      ACTION_POWER_CONNECTED. Alarms scheduled with
+      setExactAndAllowWhileIdle() are on the FGS launch-exemption list,
+      so PowerConnectionReceiver schedules a short-deferred alarm and
+      PhoneSleepAlarmReceiver issues the legal startForegroundService.
+
+      SCHEDULE_EXACT_ALARM is auto-granted on API 31–32 and
+      user-revocable on API 33+. When revoked, the receiver logs
+      honestly and falls back to the 15-min PhoneSleepWorker safety net.
+    -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
     <!-- Step counter. Android 10+ silently delivers zero events to
          Sensor.TYPE_STEP_COUNTER without this permission, even though
          the sensor itself reports `hasStepCounter = true`. Without this
@@ -217,6 +232,25 @@
             android:name=".ingest.PhoneSleepCollectionService"
             android:exported="false"
             android:foregroundServiceType="health" />
+
+        <!-- Alarm relay that legally starts PhoneSleepCollectionService
+             from the background (#315). PowerConnectionReceiver cannot
+             call startForegroundService itself on Android 12+, so it
+             schedules an exact alarm and this receiver — fired by the
+             alarm subsystem, which carries the FGS-launch exemption —
+             issues the real startForegroundService call.
+
+             Manifest-declared because the alarm PendingIntent targets
+             this class explicitly; explicit intents bypass the implicit-
+             broadcast restriction. Not exported: only our own
+             PendingIntent triggers it. -->
+        <receiver
+            android:name=".ingest.PhoneSleepAlarmReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.bios.app.ingest.action.START_SLEEP_COLLECTION" />
+            </intent-filter>
+        </receiver>
 
         <!-- Wearable convulsive-seizure detector foreground service
              (#269 Cut 3b). Owner opt-in via SeizureDetectionPrefs;

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAlarmReceiver.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepAlarmReceiver.kt
@@ -1,0 +1,158 @@
+package com.bios.app.ingest
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+
+/**
+ * Alarm relay that legally launches [PhoneSleepCollectionService] from
+ * the background (#315 — fixes the original #241 Cut 1 receiver).
+ *
+ * ## Why this exists
+ *
+ * `PowerConnectionReceiver.onReceive` runs as a background broadcast.
+ * Since Android 12, a background receiver cannot call
+ * `startForegroundService` for `ACTION_POWER_CONNECTED` — the system
+ * throws `ForegroundServiceStartNotAllowedException` and the service
+ * never starts. Real-world consequence: no overnight sleep collection.
+ *
+ * Alarms scheduled via `AlarmManager.setExactAndAllowWhileIdle` *are*
+ * on the FGS-from-background exemption list. So the flow is:
+ *
+ *   ACTION_POWER_CONNECTED → schedule exact alarm (~3 s out)
+ *     → alarm fires → this receiver → startForegroundService (legal)
+ *
+ * The short delay is essentially free — quiet-hours collection at
+ * per-minute cadence; a 3-second deferral on the start makes no
+ * difference to inference quality.
+ *
+ * ## Permission shape
+ *
+ * `setExactAndAllowWhileIdle` requires `SCHEDULE_EXACT_ALARM` on
+ * API 31+. Auto-granted on API 31–32; user-revocable on 33+. Callers
+ * must check [canScheduleExactAlarms] and fall back honestly (log,
+ * let the periodic [PhoneSleepWorker] handle the night) when the
+ * permission has been revoked.
+ */
+class PhoneSleepAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_START_COLLECTION) {
+            Log.w(TAG, "ignoring unexpected action: ${intent.action}")
+            return
+        }
+        // Defensive re-check: the alarm could fire seconds after the
+        // owner unplugged the phone (race) or after quiet-hours ended
+        // (clock jump). The service does the same check itself, but
+        // surfacing the decision here keeps the log honest.
+        if (!PhoneSleepQuietHours.isInQuietHoursNow()) {
+            Log.i(TAG, "alarm fired but no longer in quiet hours; skipping FGS start")
+            return
+        }
+        val serviceIntent = Intent(context, PhoneSleepCollectionService::class.java)
+        try {
+            ContextCompat.startForegroundService(context, serviceIntent)
+            Log.i(TAG, "FGS launch issued from alarm context")
+        } catch (e: Exception) {
+            // Should not happen: alarm-triggered receivers carry the
+            // FGS-launch exemption. If it does, the periodic worker
+            // remains the safety net.
+            Log.w(TAG, "FGS launch from alarm failed: ${e.message}", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "PhoneSleepAlarmReceiver"
+
+        /** Explicit action so the receiver only handles our own intents. */
+        const val ACTION_START_COLLECTION =
+            "com.bios.app.ingest.action.START_SLEEP_COLLECTION"
+
+        /**
+         * Stable request code for the PendingIntent. Stable means a
+         * re-schedule replaces the prior alarm rather than stacking.
+         */
+        private const val PI_REQUEST_CODE = 0x515A
+
+        /**
+         * Short deferral between scheduling and firing. Long enough for
+         * the alarm subsystem to register the request as a fresh event
+         * (and thus grant the FGS-launch exemption), short enough that
+         * the owner perceives the service as starting "immediately on
+         * plug-in".
+         */
+        const val SCHEDULE_DELAY_MS: Long = 3_000L
+
+        /**
+         * Schedule a one-shot alarm that will start the collection
+         * service [SCHEDULE_DELAY_MS] from now. Returns true iff the
+         * alarm was scheduled — false means the exact-alarm permission
+         * has been revoked and the caller should log + fall back to the
+         * periodic worker.
+         */
+        fun scheduleStart(context: Context): Boolean {
+            val alarmManager = context.getSystemService(AlarmManager::class.java) ?: run {
+                Log.w(TAG, "AlarmManager unavailable; cannot schedule start")
+                return false
+            }
+            if (!canScheduleExactAlarms(alarmManager)) {
+                Log.w(
+                    TAG,
+                    "exact-alarm permission revoked; falling back to periodic worker",
+                )
+                return false
+            }
+            val pi = pendingIntent(context)
+            val triggerAt = System.currentTimeMillis() + SCHEDULE_DELAY_MS
+            try {
+                alarmManager.setExactAndAllowWhileIdle(
+                    AlarmManager.RTC_WAKEUP,
+                    triggerAt,
+                    pi,
+                )
+                Log.i(TAG, "exact alarm scheduled for +${SCHEDULE_DELAY_MS}ms")
+                return true
+            } catch (e: SecurityException) {
+                // Race: permission revoked between canScheduleExactAlarms()
+                // and the schedule call. Treat as fallback.
+                Log.w(TAG, "exact-alarm scheduling threw: ${e.message}", e)
+                return false
+            }
+        }
+
+        /** Cancel any pending start alarm. Idempotent. */
+        fun cancelStart(context: Context) {
+            val alarmManager = context.getSystemService(AlarmManager::class.java) ?: return
+            alarmManager.cancel(pendingIntent(context))
+        }
+
+        private fun pendingIntent(context: Context): PendingIntent {
+            val intent = Intent(context, PhoneSleepAlarmReceiver::class.java)
+                .setAction(ACTION_START_COLLECTION)
+            // FLAG_IMMUTABLE is required on API 31+; FLAG_UPDATE_CURRENT
+            // ensures a re-schedule replaces the prior alarm.
+            val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            return PendingIntent.getBroadcast(
+                context,
+                PI_REQUEST_CODE,
+                intent,
+                flags,
+            )
+        }
+
+        private fun canScheduleExactAlarms(alarmManager: AlarmManager): Boolean {
+            // canScheduleExactAlarms() ships on API 31. On older releases
+            // SCHEDULE_EXACT_ALARM is implicit and always granted.
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                alarmManager.canScheduleExactAlarms()
+            } else {
+                true
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PowerConnectionReceiver.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PowerConnectionReceiver.kt
@@ -4,20 +4,30 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import androidx.core.content.ContextCompat
 
 /**
- * Charge edge-trigger for [PhoneSleepCollectionService] (#241 Cut 1).
+ * Charge edge-trigger for [PhoneSleepCollectionService] (#241 Cut 1,
+ * receiver-launch path repaired in #315).
  *
  * The receiver listens for the OS-broadcast power events:
  *
- * - `ACTION_POWER_CONNECTED` — start collection iff
- *   [PhoneSleepQuietHours.isInQuietHoursNow] is true. Daytime charging
- *   (commute, desk, café power bank) is not sleep and never triggers
- *   the service.
- * - `ACTION_POWER_DISCONNECTED` — stop collection unconditionally. The
- *   morning unplug is the canonical end-of-night signal for phone-only
- *   inference.
+ * - `ACTION_POWER_CONNECTED` — schedule an exact alarm (via
+ *   [PhoneSleepAlarmReceiver]) iff [PhoneSleepQuietHours.isInQuietHoursNow]
+ *   is true. Daytime charging (commute, desk, café power bank) is not
+ *   sleep and never triggers the service.
+ * - `ACTION_POWER_DISCONNECTED` — cancel any pending start alarm and
+ *   stop the collection service unconditionally. The morning unplug is
+ *   the canonical end-of-night signal for phone-only inference.
+ *
+ * ## Why not start the FGS directly?
+ *
+ * Since Android 12, a background `BroadcastReceiver` cannot call
+ * `startForegroundService` for non-allowlisted broadcasts.
+ * `ACTION_POWER_CONNECTED` is not on the allowlist, so the direct call
+ * threw `ForegroundServiceStartNotAllowedException` every night (#315).
+ * Alarms scheduled via `setExactAndAllowWhileIdle` *are* on the FGS
+ * launch-exemption list — so we schedule a short-deferred alarm and let
+ * [PhoneSleepAlarmReceiver] perform the legal launch.
  *
  * Both power actions are protected broadcasts: the receiver cannot be
  * targeted by other apps and the system delivers them with at-least-once
@@ -37,14 +47,26 @@ class PowerConnectionReceiver : BroadcastReceiver() {
         when (action) {
             Intent.ACTION_POWER_CONNECTED -> {
                 if (!PhoneSleepQuietHours.isInQuietHoursNow()) {
-                    Log.i(TAG, "power connected outside quiet-hours; not starting service")
+                    Log.i(TAG, "power connected outside quiet-hours; not scheduling start")
                     return
                 }
-                Log.i(TAG, "power connected during quiet-hours; starting collection service")
-                ContextCompat.startForegroundService(context, serviceIntent)
+                Log.i(TAG, "power connected during quiet-hours; scheduling alarm-relay start")
+                val scheduled = PhoneSleepAlarmReceiver.scheduleStart(context)
+                if (!scheduled) {
+                    // Permission-revoked fallback: the 15-min PhoneSleepWorker
+                    // remains the safety net. We deliberately do NOT call
+                    // startForegroundService here — it throws from a background
+                    // receiver context (#315). Honest logging is the contract;
+                    // a dashboard surface is a follow-up.
+                    Log.w(
+                        TAG,
+                        "alarm-relay unavailable; relying on PhoneSleepWorker for the night",
+                    )
+                }
             }
             Intent.ACTION_POWER_DISCONNECTED -> {
-                Log.i(TAG, "power disconnected; stopping collection service")
+                Log.i(TAG, "power disconnected; cancelling pending alarm and stopping service")
+                PhoneSleepAlarmReceiver.cancelStart(context)
                 context.stopService(serviceIntent)
             }
         }

--- a/android/app/src/test/java/com/bios/app/PhoneSleepAlarmReceiverConstantsTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepAlarmReceiverConstantsTest.kt
@@ -1,0 +1,49 @@
+package com.bios.app
+
+import com.bios.app.ingest.PhoneSleepAlarmReceiver
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM contract checks for the alarm-relay receiver (#315).
+ * Verifies the two pieces of public surface the receiver exposes
+ * to other parts of the app — the action string and the schedule
+ * delay — without needing Robolectric.
+ *
+ * The action string is part of the manifest contract: changing it
+ * silently in source while leaving the manifest entry behind would
+ * make the receiver never fire. The delay is part of the
+ * UX-perceived "starts immediately on plug-in" contract — anything
+ * much longer would feel laggy and risk the owner unplugging before
+ * collection begins.
+ */
+class PhoneSleepAlarmReceiverConstantsTest {
+
+    @Test
+    fun action_string_matches_manifest_filter() {
+        // The receiver in AndroidManifest.xml declares this exact action
+        // in its <intent-filter>. Drift between this constant and the
+        // manifest would silently break the alarm path.
+        assertEquals(
+            "com.bios.app.ingest.action.START_SLEEP_COLLECTION",
+            PhoneSleepAlarmReceiver.ACTION_START_COLLECTION,
+        )
+    }
+
+    @Test
+    fun schedule_delay_is_short_enough_to_feel_immediate() {
+        // 3 s is the chosen balance: long enough that the alarm
+        // subsystem registers it as a fresh event (and grants the
+        // FGS-launch exemption); short enough that the owner perceives
+        // collection as starting at plug-in.
+        assertTrue(
+            "schedule delay must be under 10s to feel immediate",
+            PhoneSleepAlarmReceiver.SCHEDULE_DELAY_MS < 10_000L,
+        )
+        assertTrue(
+            "schedule delay must be > 0 so the alarm path is taken",
+            PhoneSleepAlarmReceiver.SCHEDULE_DELAY_MS > 0L,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #315. `PowerConnectionReceiver` was calling `startForegroundService` directly from a background broadcast, which Android 12+ rejects for non-allowlisted broadcasts like `ACTION_POWER_CONNECTED`. Net effect: `PhoneSleepCollectionService` never started overnight and the dashboard reported no sleep.
- Replaces the direct call with an exact-alarm relay: `setExactAndAllowWhileIdle` → new `PhoneSleepAlarmReceiver` → FGS launch. Alarms scheduled via `setExactAndAllowWhileIdle` are on the documented FGS launch-exemption list.
- Falls back to the periodic `PhoneSleepWorker` safety net when `SCHEDULE_EXACT_ALARM` has been revoked by the owner.

## Real-world evidence

From the reporter's Pixel 9a, 2026-05-25:

```
01:17:45 E AndroidRuntime: ForegroundServiceStartNotAllowedException
  at PowerConnectionReceiver.onReceive(PowerConnectionReceiver.kt:44)
01:53:12 E AndroidRuntime: <same exception, same call site>
```

Both crashes correspond to plug-in events. After this fix, the receiver no longer launches the FGS directly — the alarm subsystem does, from a context that holds the exemption.

## Test plan

- [x] Unit: `PhoneSleepAlarmReceiverConstantsTest` — action-string ↔ manifest contract, schedule-delay range
- [x] Unit: existing `PhoneSleepQuietHoursTest` still green (gate logic unchanged)
- [x] `./scripts/code-quality-check.sh` — file-length, secret scan, build, unit tests all pass
- [ ] Manual on Pixel 9a — plug in during quiet hours, confirm `PhoneSleepCollectionService` started notification appears, confirm samples accumulate, confirm tomorrow morning's inference fires
- [ ] Manual: revoke `SCHEDULE_EXACT_ALARM` in Settings → Apps → Bios → Alarms & reminders, plug in, confirm log message `"alarm-relay unavailable; relying on PhoneSleepWorker for the night"` and no crash

## Follow-ups (not in this PR)

- Owner-facing diagnostics card surfacing "FGS could not start last night" so failures don't go silent. Today the only signal is logcat.
- Settings UI for quiet-hours window override (existing #241 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)