### PR TITLE
feat(ui): time-window selector for the per-metric chart

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/trends/MetricChartCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/MetricChartCard.kt
@@ -1,6 +1,7 @@
 package com.bios.app.ui.trends
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,8 +10,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,14 +24,23 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.bios.app.ui.RecentEntry
+import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
 
+/**
+ * Per-metric line chart with a Day / Week / Month / Year / All
+ * time-window selector. The owner picks the range; this composable
+ * renders whatever the parent fetched for that range. The "Recent
+ * entries" list below the chart uses its own row-limit fetch and is
+ * unaffected by the window.
+ */
 @Composable
 internal fun MetricChart(
     metric: MetricType,
-    entries: List<RecentEntry>,
+    readings: List<MetricReading>,
     loaded: Boolean,
+    selectedWindow: MetricChartTimeWindow,
+    onSelectWindow: (MetricChartTimeWindow) -> Unit,
 ) {
     Card(
         colors = CardDefaults.cardColors(
@@ -35,42 +48,29 @@ internal fun MetricChart(
         )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
+            TimeWindowSelector(selected = selectedWindow, onSelect = onSelectWindow)
+            Spacer(Modifier.height(12.dp))
+
             if (!loaded) {
-                Box(
-                    modifier = Modifier.fillMaxWidth().height(120.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        "Loading…",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                CenteredMessage("Loading…")
                 return@Column
             }
 
-            if (entries.size < 2) {
-                Box(
-                    modifier = Modifier.fillMaxWidth().height(120.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        if (entries.isEmpty()) "No readings yet."
-                        else "Need at least two readings to chart.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+            if (readings.size < 2) {
+                CenteredMessage(
+                    if (readings.isEmpty()) "No readings in this window."
+                    else "Need at least two readings to chart."
+                )
                 return@Column
             }
 
-            val sorted = entries.sortedBy { it.reading.timestamp }
-            val values = sorted.map { it.reading.value }
+            val sorted = readings.sortedBy { it.timestamp }
+            val values = sorted.map { it.value }
             val minV = values.min()
             val maxV = values.max()
             val range = (maxV - minV).coerceAtLeast(1e-6)
-            val firstTs = sorted.first().reading.timestamp
-            val lastTs = sorted.last().reading.timestamp
+            val firstTs = sorted.first().timestamp
+            val lastTs = sorted.last().timestamp
             val spanMs = (lastTs - firstTs).coerceAtLeast(1L).toDouble()
             val unit = metric.unit.symbol.ifEmpty { "" }
 
@@ -80,7 +80,7 @@ internal fun MetricChart(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    "Last ${sorted.size} readings",
+                    "${sorted.size} readings",
                     style = MaterialTheme.typography.titleSmall,
                 )
                 Text(
@@ -100,6 +100,9 @@ internal fun MetricChart(
 
             val lineColor = MaterialTheme.colorScheme.primary
             val pointColor = MaterialTheme.colorScheme.tertiary
+            // Skip per-point dots when the sample count is high — they
+            // turn into a dense band that hides the line trend.
+            val showPoints = sorted.size <= POINT_DOT_THRESHOLD
             Canvas(
                 modifier = Modifier.fillMaxWidth().height(120.dp),
             ) {
@@ -113,8 +116,8 @@ internal fun MetricChart(
                     ((t - firstTs) / spanMs).toFloat() * w
 
                 for (i in 1 until sorted.size) {
-                    val a = sorted[i - 1].reading
-                    val b = sorted[i].reading
+                    val a = sorted[i - 1]
+                    val b = sorted[i]
                     drawLine(
                         color = lineColor,
                         start = Offset(xFor(a.timestamp), yFor(a.value)),
@@ -123,12 +126,14 @@ internal fun MetricChart(
                         cap = StrokeCap.Round,
                     )
                 }
-                for (entry in sorted) {
-                    drawCircle(
-                        color = pointColor,
-                        radius = 3f,
-                        center = Offset(xFor(entry.reading.timestamp), yFor(entry.reading.value)),
-                    )
+                if (showPoints) {
+                    for (entry in sorted) {
+                        drawCircle(
+                            color = pointColor,
+                            radius = 3f,
+                            center = Offset(xFor(entry.timestamp), yFor(entry.value)),
+                        )
+                    }
                 }
             }
 
@@ -157,3 +162,42 @@ internal fun MetricChart(
         }
     }
 }
+
+@Composable
+private fun TimeWindowSelector(
+    selected: MetricChartTimeWindow,
+    onSelect: (MetricChartTimeWindow) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        MetricChartTimeWindow.entries.forEach { window ->
+            FilterChip(
+                selected = window == selected,
+                onClick = { onSelect(window) },
+                label = { Text(window.label) },
+                colors = FilterChipDefaults.filterChipColors(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CenteredMessage(text: String) {
+    Box(
+        modifier = Modifier.fillMaxWidth().height(120.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** Above this point count, per-sample dots clutter the trend line. */
+private const val POINT_DOT_THRESHOLD = 60

--- a/android/app/src/main/java/com/bios/app/ui/trends/MetricChartTimeWindow.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/MetricChartTimeWindow.kt
@@ -1,0 +1,55 @@
+package com.bios.app.ui.trends
+
+/**
+ * Time-window choices for the per-metric chart on the trends dashboard.
+ * Controls only the chart fetch — the "Recent entries" list below it
+ * stays on its own row-limit fetch, unchanged.
+ *
+ * `ALL` queries from epoch to now; the DAO range filter is inclusive so
+ * passing `0L` as start safely returns every reading on file.
+ */
+enum class MetricChartTimeWindow(val label: String, val days: Int?) {
+    DAY("Day", 1),
+    WEEK("Week", 7),
+    MONTH("Month", 30),
+    YEAR("Year", 365),
+    ALL("All", null);
+
+    /** Inclusive lower-bound timestamp (epoch ms) for this window. */
+    fun startMillis(now: Long = System.currentTimeMillis()): Long =
+        days?.let { now - it.toLong() * MILLIS_PER_DAY } ?: 0L
+
+    companion object {
+        /** Default window — small enough to feel responsive on the first paint. */
+        val DEFAULT: MetricChartTimeWindow = WEEK
+
+        /**
+         * Soft ceiling on how many points the line chart renders. Above
+         * this we sample uniformly; Canvas can draw thousands of segments
+         * but the visual turns into spaghetti and the GPU bill climbs.
+         */
+        const val MAX_CHART_POINTS: Int = 500
+
+        private const val MILLIS_PER_DAY: Long = 24L * 60L * 60L * 1000L
+    }
+}
+
+/**
+ * Uniformly subsample [readings] when the count exceeds
+ * [MetricChartTimeWindow.MAX_CHART_POINTS]. Preserves first + last
+ * samples so the rendered range still matches the underlying data.
+ * Returns the input unchanged when it's already small enough.
+ */
+fun <T> downsampleForChart(readings: List<T>): List<T> {
+    val max = MetricChartTimeWindow.MAX_CHART_POINTS
+    if (readings.size <= max) return readings
+    val stride = readings.size.toDouble() / max
+    val out = ArrayList<T>(max)
+    var i = 0.0
+    while (i < readings.size && out.size < max - 1) {
+        out += readings[i.toInt()]
+        i += stride
+    }
+    out += readings.last()
+    return out
+}

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.bios.app.engine.BaselineEngine
+import com.bios.app.model.MetricReading
 import com.bios.app.ui.AppViewModel
 import com.bios.app.ui.RecentEntry
 import com.bios.app.ui.coverageFor
@@ -70,6 +71,11 @@ fun TrendsScreen(
     var selectedEntryIds by remember(selectedMetric) { mutableStateOf(emptySet<String>()) }
     var pendingBatchDelete by remember { mutableStateOf(false) }
     var liveCoverage by remember(selectedMetric) { mutableStateOf<BaselineEngine.Coverage?>(null) }
+    var chartWindow by remember(selectedMetric) {
+        mutableStateOf(MetricChartTimeWindow.DEFAULT)
+    }
+    var chartReadings by remember { mutableStateOf<List<MetricReading>>(emptyList()) }
+    var chartLoaded by remember(selectedMetric, chartWindow) { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(selectedMetric, entriesRefreshKey) {
@@ -79,6 +85,20 @@ fun TrendsScreen(
         // Pre-baked coverage map only covers TRACKED_METRICS (HR/HRV/etc.).
         // For everything else (Weight, BMI, biomarkers, ...) compute on demand.
         liveCoverage = viewModel.coverageFor(selectedMetric)
+    }
+
+    LaunchedEffect(selectedMetric, chartWindow, entriesRefreshKey) {
+        chartLoaded = false
+        val now = System.currentTimeMillis()
+        val raw = viewModel.db.metricReadingDao().fetch(
+            metricType = selectedMetric.key,
+            startMillis = chartWindow.startMillis(now),
+            endMillis = now,
+        )
+        // Downsample on the UI thread is cheap — fetch already returns
+        // sorted ASC, and the helper preserves first + last.
+        chartReadings = downsampleForChart(raw)
+        chartLoaded = true
     }
 
     Column(
@@ -105,7 +125,13 @@ fun TrendsScreen(
             Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Browse metrics")
         }
 
-        MetricChart(metric = selectedMetric, entries = recentEntries, loaded = entriesLoaded)
+        MetricChart(
+            metric = selectedMetric,
+            readings = chartReadings,
+            loaded = chartLoaded,
+            selectedWindow = chartWindow,
+            onSelectWindow = { chartWindow = it },
+        )
 
         val selectedBaseline = baselines.find { it.metricType == selectedMetric.key }
         if (selectedBaseline != null) {

--- a/android/app/src/test/java/com/bios/app/MetricChartTimeWindowTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricChartTimeWindowTest.kt
@@ -1,0 +1,65 @@
+package com.bios.app
+
+import com.bios.app.ui.trends.MetricChartTimeWindow
+import com.bios.app.ui.trends.downsampleForChart
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-JVM contract checks for the per-metric chart time-window.
+ * Covers (a) the start-millis math the dashboard uses to query the
+ * DAO, and (b) the downsampler that keeps Canvas rendering tractable
+ * for "Year" / "All" windows on auto-sampled metrics.
+ */
+class MetricChartTimeWindowTest {
+
+    private val now: Long = 1_700_000_000_000L
+    private val day: Long = 24L * 60L * 60L * 1000L
+
+    @Test
+    fun day_window_subtracts_24_hours() {
+        assertEquals(now - day, MetricChartTimeWindow.DAY.startMillis(now))
+    }
+
+    @Test
+    fun week_window_subtracts_seven_days() {
+        assertEquals(now - 7 * day, MetricChartTimeWindow.WEEK.startMillis(now))
+    }
+
+    @Test
+    fun year_window_subtracts_365_days() {
+        assertEquals(now - 365 * day, MetricChartTimeWindow.YEAR.startMillis(now))
+    }
+
+    @Test
+    fun all_window_starts_at_epoch() {
+        // 0L is inclusive on the DAO range filter, so "All" covers every
+        // reading on file without needing a separate query path.
+        assertEquals(0L, MetricChartTimeWindow.ALL.startMillis(now))
+    }
+
+    @Test
+    fun downsample_is_a_no_op_below_the_ceiling() {
+        val input = (1..100).toList()
+        assertEquals(input, downsampleForChart(input))
+    }
+
+    @Test
+    fun downsample_caps_at_max_chart_points() {
+        val input = (1..5000).toList()
+        val out = downsampleForChart(input)
+        assertTrue("expected <= MAX_CHART_POINTS, got ${out.size}",
+            out.size <= MetricChartTimeWindow.MAX_CHART_POINTS)
+    }
+
+    @Test
+    fun downsample_preserves_first_and_last() {
+        // The chart's x-axis spans first..last sample; losing either
+        // endpoint would visually shrink the range.
+        val input = (1..5000).toList()
+        val out = downsampleForChart(input)
+        assertEquals(1, out.first())
+        assertEquals(5000, out.last())
+    }
+}


### PR DESCRIPTION
## Summary

- The per-metric dashboard chart was capped at the last 30 readings. For manually-entered metrics that's ~30 days; for auto-sampled HR it's ~30 minutes — same UI, wildly different time spans, no way for the owner to control it.
- Adds Day / Week / Month / Year / All FilterChips inside the chart card. The chart re-fetches via the existing `MetricReadingDao.fetch(start, end)` range query when the window changes. Default is Week.
- Recent-entries list below the chart is untouched — it's an itemized log keyed off row count, not a time series.

## Implementation

- New [MetricChartTimeWindow.kt](android/app/src/main/java/com/bios/app/ui/trends/MetricChartTimeWindow.kt) — enum + `startMillis(now)` helper + `downsampleForChart()` for Year/All on high-cadence metrics.
- [MetricChartCard.kt](android/app/src/main/java/com/bios/app/ui/trends/MetricChartCard.kt) — signature now takes `List<MetricReading>` directly (the chart never used `RecentEntry.context`), plus `selectedWindow` + `onSelectWindow` callbacks. Per-sample dots hide above 60 points so the trend reads cleanly on dense windows.
- [TrendsScreen.kt](android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt) — holds `chartWindow` state, separate `LaunchedEffect` keyed on `(metric, chartWindow, refreshKey)` issues the range fetch. Selected window resets to the default when the owner switches metric.

## Test plan

- [x] `MetricChartTimeWindowTest` — start-millis math for each window, downsample cap + first/last preservation (7 tests)
- [x] `./scripts/code-quality-check.sh` — file-length, secret scan, build, unit tests all pass
- [ ] Manual on Pixel 9a — switch metric, switch window, confirm chart re-renders with the right span; "All" loads thousands of HR points without jank; "Day" with no recent data shows empty state
- [ ] Manual: delete an entry, confirm chart and recent-entries both refresh (shared `entriesRefreshKey`)

## Follow-ups (not in this PR)

- Persist the owner's window choice per-metric across sessions (today it resets to Week on screen entry).
- Y-axis labels / horizontal gridlines for longer windows where the range becomes meaningful at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)