### PR TITLE
feat(ui): add Hour window to per-metric chart selector

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/trends/MetricChartTimeWindow.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/MetricChartTimeWindow.kt
@@ -8,16 +8,17 @@ package com.bios.app.ui.trends
  * `ALL` queries from epoch to now; the DAO range filter is inclusive so
  * passing `0L` as start safely returns every reading on file.
  */
-enum class MetricChartTimeWindow(val label: String, val days: Int?) {
-    DAY("Day", 1),
-    WEEK("Week", 7),
-    MONTH("Month", 30),
-    YEAR("Year", 365),
+enum class MetricChartTimeWindow(val label: String, val durationMillis: Long?) {
+    HOUR("Hour", MILLIS_PER_HOUR),
+    DAY("Day", 24L * MILLIS_PER_HOUR),
+    WEEK("Week", 7L * 24L * MILLIS_PER_HOUR),
+    MONTH("Month", 30L * 24L * MILLIS_PER_HOUR),
+    YEAR("Year", 365L * 24L * MILLIS_PER_HOUR),
     ALL("All", null);
 
     /** Inclusive lower-bound timestamp (epoch ms) for this window. */
     fun startMillis(now: Long = System.currentTimeMillis()): Long =
-        days?.let { now - it.toLong() * MILLIS_PER_DAY } ?: 0L
+        durationMillis?.let { now - it } ?: 0L
 
     companion object {
         /** Default window — small enough to feel responsive on the first paint. */
@@ -29,10 +30,10 @@ enum class MetricChartTimeWindow(val label: String, val days: Int?) {
          * but the visual turns into spaghetti and the GPU bill climbs.
          */
         const val MAX_CHART_POINTS: Int = 500
-
-        private const val MILLIS_PER_DAY: Long = 24L * 60L * 60L * 1000L
     }
 }
+
+private const val MILLIS_PER_HOUR: Long = 60L * 60L * 1000L
 
 /**
  * Uniformly subsample [readings] when the count exceeds

--- a/android/app/src/test/java/com/bios/app/MetricChartTimeWindowTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricChartTimeWindowTest.kt
@@ -15,7 +15,13 @@ import org.junit.Test
 class MetricChartTimeWindowTest {
 
     private val now: Long = 1_700_000_000_000L
-    private val day: Long = 24L * 60L * 60L * 1000L
+    private val hour: Long = 60L * 60L * 1000L
+    private val day: Long = 24L * hour
+
+    @Test
+    fun hour_window_subtracts_one_hour() {
+        assertEquals(now - hour, MetricChartTimeWindow.HOUR.startMillis(now))
+    }
 
     @Test
     fun day_window_subtracts_24_hours() {


### PR DESCRIPTION
## Summary

Adds `Hour` to the chart's time-window selector (PR #317 shipped Day / Week / Month / Year / All). Switches the enum's duration field from `days: Int?` to `durationMillis: Long?` so sub-day windows fit naturally — no special-case math.

Hour is most useful for the auto-sampled metrics (HR, HRV, SpO2) where Week+ on a Pixel can mean thousands of points but the owner usually wants "what just happened" — last 60 minutes at native cadence.

## Test plan

- [x] `MetricChartTimeWindowTest` updated — adds `hour_window_subtracts_one_hour` and reuses an `hour` constant in the day-math (8 tests total, all passing)
- [x] Pre-commit script green (file-length, secret scan, build, unit tests)
- [ ] Manual on Pixel 9a — open a high-cadence metric (HR), select Hour, confirm dense per-minute trend without spaghetti; switch to Year to confirm downsampling still kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)