### PR TITLE
feat(ui): show all recent entries on the per-metric view

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -80,7 +80,7 @@ fun TrendsScreen(
 
     LaunchedEffect(selectedMetric, entriesRefreshKey) {
         entriesLoaded = false
-        recentEntries = viewModel.getRecentReadings(selectedMetric, limit = 30)
+        recentEntries = viewModel.getRecentReadings(selectedMetric, limit = Int.MAX_VALUE)
         entriesLoaded = true
         // Pre-baked coverage map only covers TRACKED_METRICS (HR/HRV/etc.).
         // For everything else (Weight, BMI, biomarkers, ...) compute on demand.


### PR DESCRIPTION
## Summary
- Removes the 30-row cap on the per-metric "Recent entries" list so the owner can scroll through every reading for a metric, not just the latest 30.
- The section already sits inside the page's `verticalScroll`, so no layout change is needed — only the fetch limit moves to `Int.MAX_VALUE`.

## Test plan
- [ ] Open a metric with >30 entries (e.g. Heart Rate) from Home → confirm the full list is reachable by scrolling.
- [ ] Confirm long-press multi-select and per-row delete still work on rows past the old 30 cutoff.
- [ ] Confirm chart + baseline cards above the list still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)