### PR TITLE
feat(sleep): TIME_IN_BED metric + HR-gap inference

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/DisconnectDetector.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/DisconnectDetector.kt
@@ -198,6 +198,7 @@ internal val SourceType.label: String
         SourceType.DIRECT_SENSOR -> "Direct sensor"
         SourceType.PHONE_SENSOR -> "Phone sensor"
         SourceType.PHONE_SENSOR_DERIVED -> "Phone sleep fusion"
+        SourceType.BIOS_INFERRED -> "Bios inference"
         SourceType.CAMERA_PPG -> "Camera PPG"
         SourceType.BLE_PERIPHERAL -> "Air-quality sensor"
         SourceType.SELF_REPORTED -> "Self-reported"

--- a/android/app/src/main/java/com/bios/app/engine/HrGapTibInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrGapTibInference.kt
@@ -1,0 +1,128 @@
+package com.bios.app.engine
+
+import com.bios.app.model.ConfidenceTier
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Rule-based `TIME_IN_BED` inference from gaps in the heart-rate stream.
+ *
+ * Motivation: owners who remove their wearable to sleep leave a multi-hour
+ * absence of HR samples overnight. That absence is honestly a "lying down
+ * with watch off" signal — never claim it as `SLEEP_DURATION`, because the
+ * watch could equally be on the nightstand charger while the owner reads,
+ * watches a movie, or has insomnia. Time-in-bed is the honest framing
+ * (matches the in-bed-but-awake semantics of TIB in the existing
+ * sleep-efficiency derivation in [SleepDerivations.deriveSleepEfficiency]).
+ *
+ * Confidence ladder:
+ *  - LOW when only the HR-gap is present
+ *  - MEDIUM when a same-night companion-written `sleep_duration` window
+ *    (e.g. W2F's screen-off derivation) overlaps the gap
+ *
+ * Nocturnal anchor: a gap is only emitted as a TIB candidate if it spans
+ * local-time 02:00–05:00 on some day inside the gap. This is the cheapest
+ * filter that catches "watch off for sleep" without producing TIB rows
+ * for a 4-hour afternoon meeting or a long drive. It misses owners whose
+ * sleep window never crosses 02:00–05:00 local — primarily night-shift
+ * workers — for whom the toggle surface is the escape hatch (disable
+ * BIOS_INFERRED→TIME_IN_BED until the engine learns their schedule).
+ *
+ * Pure JVM-only object so unit tests don't need an Android device. The
+ * DB-aware orchestration lives in [com.bios.app.ingest.HrGapTibBackfill].
+ */
+object HrGapTibInference {
+
+    /** Heart-rate sample reduced to just its timestamp — gap detection
+     *  doesn't care about the bpm value. */
+    data class HrSample(val timestamp: Long)
+
+    /** Companion-reported sleep window. Companions (W2F today) write
+     *  `sleep_duration` at the window midpoint with `durationSec` covering
+     *  the full sleep span, so the start/end of the in-bed period are
+     *  derived as `midpoint ± durationSec/2`. */
+    data class SleepWindow(val midpointMs: Long, val durationSec: Int)
+
+    /** One inferred TIB window. */
+    data class TibCandidate(
+        val startMs: Long,
+        val endMs: Long,
+        val confidence: ConfidenceTier,
+        val corroboratedByCompanionSleep: Boolean,
+    ) {
+        val durationSec: Int get() = ((endMs - startMs) / 1000L).toInt()
+    }
+
+    /**
+     * Scan [hrSamples] for gaps ≥ [minGapMs] that overlap the nocturnal
+     * anchor. For each surviving gap, emit a [TibCandidate]. Confidence is
+     * MEDIUM when [companionSleepWindows] corroborates the gap, otherwise
+     * LOW.
+     *
+     * Idempotent: re-running with the same inputs produces the same set of
+     * candidates. Combined with the `(sourceId, metricType, timestamp)`
+     * unique index on `metric_readings`, repeated backfills collapse to
+     * in-place updates rather than parallel rows.
+     */
+    fun infer(
+        hrSamples: List<HrSample>,
+        companionSleepWindows: List<SleepWindow> = emptyList(),
+        zone: ZoneId = ZoneId.systemDefault(),
+        minGapMs: Long = MIN_GAP_MS,
+    ): List<TibCandidate> {
+        if (hrSamples.size < 2) return emptyList()
+        val sorted = hrSamples.sortedBy { it.timestamp }
+        val out = mutableListOf<TibCandidate>()
+        for (i in 1 until sorted.size) {
+            val prev = sorted[i - 1].timestamp
+            val curr = sorted[i].timestamp
+            val gap = curr - prev
+            if (gap < minGapMs) continue
+            if (!gapOverlapsNocturnalAnchor(prev, curr, zone)) continue
+            val corroborated = companionSleepWindows.any { w ->
+                val halfMs = (w.durationSec * 1000L) / 2L
+                val ws = w.midpointMs - halfMs
+                val we = w.midpointMs + halfMs
+                ws < curr && we > prev
+            }
+            out += TibCandidate(
+                startMs = prev,
+                endMs = curr,
+                confidence = if (corroborated) ConfidenceTier.MEDIUM else ConfidenceTier.LOW,
+                corroboratedByCompanionSleep = corroborated,
+            )
+        }
+        return out
+    }
+
+    /** True when [startMs, endMs] overlaps the [NOCTURNAL_ANCHOR_START_HOUR,
+     *  NOCTURNAL_ANCHOR_END_HOUR] window on any local-zone day inside the
+     *  interval. Iterates at most a few days per call. */
+    private fun gapOverlapsNocturnalAnchor(
+        startMs: Long, endMs: Long, zone: ZoneId,
+    ): Boolean {
+        val startDate = Instant.ofEpochMilli(startMs).atZone(zone).toLocalDate()
+        val endDate = Instant.ofEpochMilli(endMs).atZone(zone).toLocalDate()
+        var d = startDate
+        while (!d.isAfter(endDate)) {
+            val anchorStart = d.atTime(NOCTURNAL_ANCHOR_START_HOUR, 0)
+                .atZone(zone).toInstant().toEpochMilli()
+            val anchorEnd = d.atTime(NOCTURNAL_ANCHOR_END_HOUR, 0)
+                .atZone(zone).toInstant().toEpochMilli()
+            if (anchorStart < endMs && anchorEnd > startMs) return true
+            d = d.plusDays(1)
+        }
+        return false
+    }
+
+    // Below this, a gap is more likely a long meeting / commute than sleep.
+    // Matches `PhoneSleepInference.MIN_SLEEP_WINDOW_MS` so the two engines
+    // agree on what counts as a viable overnight window.
+    internal const val MIN_GAP_MS: Long = 4L * 60L * 60L * 1000L
+
+    // Local-time anchor window. Picked narrow (02:00–05:00) so a 4h gap
+    // ending at 02:30 ("late dinner, watch off till 02:30") doesn't count
+    // but a 4h gap from 23:00 to 03:00 does.
+    internal const val NOCTURNAL_ANCHOR_START_HOUR = 2
+    internal const val NOCTURNAL_ANCHOR_END_HOUR = 5
+}

--- a/android/app/src/main/java/com/bios/app/ingest/HrGapTibBackfill.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HrGapTibBackfill.kt
@@ -1,0 +1,98 @@
+package com.bios.app.ingest
+
+import com.bios.app.data.dao.DataSourceDao
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.HrGapTibInference
+import com.bios.app.model.DataSource
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Walks recent `HEART_RATE` readings, finds multi-hour gaps that overlap
+ * the nocturnal anchor, and persists each gap as a `TIME_IN_BED` reading
+ * attributed to the synthetic `BIOS_INFERRED` source.
+ *
+ * Idempotent: the unique index on `(sourceId, metricType, timestamp)`
+ * collapses re-runs to in-place updates, so this can run on every sync
+ * or be triggered by an owner-initiated backfill button without
+ * producing parallel duplicate rows.
+ *
+ * Companion `sleep_duration` rows in the same window corroborate a gap
+ * — when found, the emitted reading is MEDIUM confidence; otherwise LOW.
+ * The math itself lives in [HrGapTibInference]; this class is the
+ * DB-aware orchestration layer.
+ */
+class HrGapTibBackfill(
+    private val readingDao: MetricReadingDao,
+    private val sourceDao: DataSourceDao,
+    private val zone: ZoneId = ZoneId.systemDefault(),
+) {
+
+    /**
+     * Run the inference over [windowStartMs, windowEndMs] and persist any
+     * resulting TIB candidates. Returns the number of rows written
+     * (after REPLACE collapse — equals the candidate count for fresh
+     * runs, zero for unchanged re-runs only if every candidate is
+     * byte-identical to its stored row).
+     */
+    suspend fun run(windowStartMs: Long, windowEndMs: Long): Int {
+        if (windowEndMs <= windowStartMs) return 0
+        val hr = readingDao.fetch(MetricType.HEART_RATE.key, windowStartMs, windowEndMs)
+        if (hr.size < 2) return 0
+        val companionSleep = readingDao
+            .fetch(MetricType.SLEEP_DURATION.key, windowStartMs, windowEndMs)
+            .filter { it.durationSec != null && it.durationSec > 0 }
+            .map { HrGapTibInference.SleepWindow(it.timestamp, it.durationSec!!) }
+        val candidates = HrGapTibInference.infer(
+            hrSamples = hr.map { HrGapTibInference.HrSample(it.timestamp) },
+            companionSleepWindows = companionSleep,
+            zone = zone,
+        )
+        if (candidates.isEmpty()) return 0
+        val sourceId = getOrCreateInferredSource()
+        val rows = candidates.map { c ->
+            MetricReading(
+                metricType = MetricType.TIME_IN_BED.key,
+                value = c.durationSec.toDouble(),
+                timestamp = c.startMs,
+                durationSec = c.durationSec,
+                sourceId = sourceId,
+                confidence = c.confidence.level,
+            )
+        }
+        readingDao.insertAll(rows)
+        return rows.size
+    }
+
+    /** Convenience wrapper: runs over a window ending now and spanning the
+     *  past [lookbackDays] days. Failures are swallowed so a stale HR
+     *  fetch can't kill the surrounding sync. */
+    suspend fun runForLookback(lookbackDays: Long): Int = runCatching {
+        val end = Instant.now()
+        val start = end.minus(lookbackDays, ChronoUnit.DAYS)
+        run(start.toEpochMilli(), end.toEpochMilli())
+    }.getOrDefault(0)
+
+    private suspend fun getOrCreateInferredSource(): String {
+        val existing = sourceDao.findByType(SourceType.BIOS_INFERRED.key)
+        if (existing != null) return existing.id
+        val source = DataSource(
+            sourceType = SourceType.BIOS_INFERRED.key,
+            deviceName = SOURCE_DEVICE_NAME,
+            sensorType = SensorType.DERIVED.name,
+        )
+        sourceDao.insert(source)
+        return source.id
+    }
+
+    companion object {
+        // Surfaced in the per-metric sources screen — owner-readable hint
+        // that this isn't a real device.
+        private const val SOURCE_DEVICE_NAME = "HR-gap inference"
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -247,7 +247,7 @@ class IngestManager(
             }
 
             deriveCircadianPhaseShift()
-
+            HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 14)
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {
@@ -307,7 +307,7 @@ class IngestManager(
             }
 
             deriveCircadianPhaseShift()
-
+            HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {

--- a/android/app/src/main/java/com/bios/app/model/Enums.kt
+++ b/android/app/src/main/java/com/bios/app/model/Enums.kt
@@ -22,6 +22,12 @@ enum class SourceType(val key: String) {
     // PHONE_SENSOR so DataSource provenance separates "raw accel reading"
     // from "sleep duration inferred from accel + screen + charge".
     PHONE_SENSOR_DERIVED("phone_sensor_derived"),
+    // Bios-internal inference that runs over already-ingested readings rather
+    // than capturing fresh sensor data. Currently used by the HR-gap →
+    // TIME_IN_BED backfill (owner removed the watch to sleep, so the only
+    // available signal is the absence of HR samples). Distinct from
+    // PHONE_SENSOR_DERIVED because the inputs aren't phone sensors.
+    BIOS_INFERRED("bios_inferred"),
     CAMERA_PPG("camera_ppg"),
     BLE_PERIPHERAL("ble_peripheral"),
     SELF_REPORTED("self_reported")

--- a/android/app/src/test/java/com/bios/app/HrGapTibInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrGapTibInferenceTest.kt
@@ -1,0 +1,165 @@
+package com.bios.app
+
+import com.bios.app.engine.HrGapTibInference
+import com.bios.app.engine.HrGapTibInference.HrSample
+import com.bios.app.engine.HrGapTibInference.SleepWindow
+import com.bios.app.model.ConfidenceTier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Pins the HR-gap → TIME_IN_BED inference. The owner removes their wearable
+ * to sleep; the resulting multi-hour HR-stream gap is the only on-device
+ * signal that they were lying down. These tests fix the contract: which
+ * gaps emit TIB, which don't, and how companion-written sleep_duration
+ * upgrades the confidence.
+ */
+class HrGapTibInferenceTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+    private val anchorDate: LocalDate = LocalDate.of(2026, 5, 25)
+    private val hourMs = 3_600_000L
+
+    private fun at(hour: Int, minute: Int = 0, dayOffset: Long = 0L): Long =
+        ZonedDateTime.of(anchorDate.plusDays(dayOffset), java.time.LocalTime.of(hour, minute), zone)
+            .toInstant().toEpochMilli()
+
+    @Test
+    fun `empty input produces no candidates`() {
+        assertTrue(HrGapTibInference.infer(emptyList(), zone = zone).isEmpty())
+    }
+
+    @Test
+    fun `single sample produces no candidates`() {
+        val candidates = HrGapTibInference.infer(listOf(HrSample(at(12))), zone = zone)
+        assertTrue(candidates.isEmpty())
+    }
+
+    @Test
+    fun `2-hour gap is below the minimum and is ignored`() {
+        val samples = listOf(HrSample(at(2)), HrSample(at(4)))
+        assertTrue(HrGapTibInference.infer(samples, zone = zone).isEmpty())
+    }
+
+    @Test
+    fun `overnight gap crossing the nocturnal anchor emits a LOW-confidence candidate`() {
+        // Watch removed at 23:00, put back on at 07:00 next day → 8h gap
+        // that includes 02:00–05:00 on day+1.
+        val samples = listOf(
+            HrSample(at(23)),
+            HrSample(at(7, dayOffset = 1)),
+        )
+        val candidates = HrGapTibInference.infer(samples, zone = zone)
+        assertEquals(1, candidates.size)
+        val c = candidates.single()
+        assertEquals(8 * 3600, c.durationSec)
+        assertEquals(ConfidenceTier.LOW, c.confidence)
+        assertFalse(c.corroboratedByCompanionSleep)
+    }
+
+    @Test
+    fun `4-hour afternoon gap does not overlap the anchor and is ignored`() {
+        // 12:00 to 17:00 — five-hour gap, but entirely daytime.
+        val samples = listOf(HrSample(at(12)), HrSample(at(17)))
+        assertTrue(HrGapTibInference.infer(samples, zone = zone).isEmpty())
+    }
+
+    @Test
+    fun `corroborating companion sleep_duration upgrades confidence to MEDIUM`() {
+        val gapStart = at(23)
+        val gapEnd = at(7, dayOffset = 1)
+        val samples = listOf(HrSample(gapStart), HrSample(gapEnd))
+        // W2F-style midpoint write covering roughly the same window.
+        val midpoint = gapStart + (gapEnd - gapStart) / 2
+        val companion = SleepWindow(midpointMs = midpoint, durationSec = 7 * 3600)
+        val candidates = HrGapTibInference.infer(
+            samples, companionSleepWindows = listOf(companion), zone = zone,
+        )
+        assertEquals(1, candidates.size)
+        assertEquals(ConfidenceTier.MEDIUM, candidates.single().confidence)
+        assertTrue(candidates.single().corroboratedByCompanionSleep)
+    }
+
+    @Test
+    fun `companion window with no temporal overlap does not corroborate`() {
+        val samples = listOf(HrSample(at(23)), HrSample(at(7, dayOffset = 1)))
+        // Companion sleep window from a different night entirely.
+        val priorNight = SleepWindow(
+            midpointMs = at(3, dayOffset = -1),
+            durationSec = 7 * 3600,
+        )
+        val candidates = HrGapTibInference.infer(
+            samples, companionSleepWindows = listOf(priorNight), zone = zone,
+        )
+        assertEquals(1, candidates.size)
+        assertEquals(ConfidenceTier.LOW, candidates.single().confidence)
+        assertFalse(candidates.single().corroboratedByCompanionSleep)
+    }
+
+    @Test
+    fun `gap ending right at 02_00 still overlaps the anchor`() {
+        // Watch off 21:30, put back on at 02:30 — gap = 5h, ends inside
+        // the 02:00–05:00 anchor.
+        val start = at(21, 30, dayOffset = -1)
+        val end = at(2, 30)
+        val candidates = HrGapTibInference.infer(
+            listOf(HrSample(start), HrSample(end)), zone = zone,
+        )
+        assertEquals(1, candidates.size)
+    }
+
+    @Test
+    fun `repeated nights emit one candidate per night`() {
+        // Three consecutive nights of watch-off-overnight.
+        val samples = listOf(
+            HrSample(at(22)),
+            HrSample(at(7, dayOffset = 1)),
+            HrSample(at(22, dayOffset = 1)),
+            HrSample(at(7, dayOffset = 2)),
+            HrSample(at(22, dayOffset = 2)),
+            HrSample(at(7, dayOffset = 3)),
+        )
+        val candidates = HrGapTibInference.infer(samples, zone = zone)
+        assertEquals(3, candidates.size)
+        candidates.forEach { assertEquals(9 * 3600, it.durationSec) }
+    }
+
+    @Test
+    fun `unsorted input is sorted before scanning`() {
+        // Same overnight gap, samples passed in reverse order.
+        val samples = listOf(
+            HrSample(at(7, dayOffset = 1)),
+            HrSample(at(23)),
+        )
+        val candidates = HrGapTibInference.infer(samples, zone = zone)
+        assertEquals(1, candidates.size)
+    }
+
+    @Test
+    fun `minimum gap of exactly 4 hours overlapping anchor emits a candidate`() {
+        val samples = listOf(HrSample(at(1)), HrSample(at(5)))
+        val candidates = HrGapTibInference.infer(samples, zone = zone)
+        assertEquals(1, candidates.size)
+        assertEquals(4 * 3600, candidates.single().durationSec)
+    }
+
+    @Test
+    fun `dense daytime samples around the gap do not produce extra candidates`() {
+        val samples = buildList {
+            // Daytime hourly samples on day-before
+            for (h in 8..22) add(HrSample(at(h, dayOffset = -1)))
+            // Overnight gap (watch off)
+            // Daytime hourly samples on next day
+            for (h in 8..22) add(HrSample(at(h)))
+        }
+        val candidates = HrGapTibInference.infer(samples, zone = zone)
+        assertEquals(1, candidates.size)
+        // 22:00 prior day to 08:00 current day = 10h
+        assertEquals(10 * 3600, candidates.single().durationSec)
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -158,7 +158,7 @@ enum class MetricType(
 
     // Sleep
     SLEEP_STAGE("sleep_stage", MetricUnit.CATEGORY, MetricDomain.SLEEP),
-    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP, allowsManualEntry = true),
+    SLEEP_DURATION("sleep_duration", MetricUnit.SECONDS, MetricDomain.SLEEP, allowsManualEntry = true), TIME_IN_BED("time_in_bed", MetricUnit.SECONDS, MetricDomain.SLEEP, allowsManualEntry = true), // in-bed window incl. quiet wake; SLEEP_DURATION <= TIME_IN_BED
     SLEEP_LATENCY("sleep_latency", MetricUnit.SECONDS, MetricDomain.SLEEP),
     SLEEP_EFFICIENCY("sleep_efficiency", MetricUnit.PERCENT, MetricDomain.SLEEP),
     SLEEP_FRAGMENTATION_INDEX("sleep_fragmentation_index", MetricUnit.COUNT, MetricDomain.SLEEP),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -74,6 +74,7 @@ class MetricTypeKeysSnapshotTest {
         // Sleep
         "sleep_stage",
         "sleep_duration",
+        "time_in_bed",
         "sleep_latency",
         "sleep_efficiency",
         "sleep_fragmentation_index",


### PR DESCRIPTION
## Summary

- New `TIME_IN_BED` `MetricType` (SECONDS, SLEEP, manual entry allowed) — promotes the implicit denominator of the existing sleep-efficiency derivation to a visible metric. A 9h TIB with 7h `SLEEP_DURATION` encodes fragmentation/latency information that collapses without it.
- `HrGapTibInference` derives `TIME_IN_BED` windows from multi-hour gaps in the `HEART_RATE` stream that overlap a local-time 02:00–05:00 nocturnal anchor. The anchor is the filter that keeps a 4h afternoon meeting or long drive from being mis-emitted as in-bed.
- Confidence ladder: **LOW** for HR-gap only; **MEDIUM** when a same-night companion-written `sleep_duration` (W2F screen-off) overlaps the gap.
- New `BIOS_INFERRED` `SourceType` — distinct from `PHONE_SENSOR_DERIVED` because the inputs aren't phone sensors. The per-(source, metric) toggle surface from #322 picks up `BIOS_INFERRED -> TIME_IN_BED` automatically.
- Wired into both `runSync` (14-day lookback) and `syncHistoricalData` (30-day lookback). Idempotent against the unique index on `(sourceId, metricType, timestamp)`.

## Why this framing

The owner removes their wearable to sleep, so the only on-device signal that they were lying down is the absence of HR samples. That absence is honestly a "watch off during plausible bed hours" signal — never `SLEEP_DURATION`, because the watch could equally be on the charger while the owner reads, watches a movie, or has insomnia. Matches the codebase's "absent data is more honest than a confidently wrong value" stance ([SleepDerivations.kt:23](android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt#L23)).

## Manifesto fit

Instrument, not coach. The metric describes "the wearable wasn't on between X and Y, and your phone says it was bedtime hours" — not "you slept N hours." Evaluation belongs to the owner. The toggle surface remains the escape hatch for noisy nights.

## Test plan

- [ ] `MetricTypeKeysSnapshotTest` and `HrGapTibInferenceTest` pass via `./gradlew test`
- [ ] On a device with HR data from a wearable that the owner removes overnight, run a sync and confirm `TIME_IN_BED` rows appear attributed to the **Bios inference** source in **Settings → Per-metric sources**
- [ ] A `TIME_IN_BED` row's `durationSec` equals the gap length and `value` equals `durationSec` in seconds
- [ ] Re-running the sync twice produces no duplicate rows (idempotency via the unique index)
- [ ] Toggle off `BIOS_INFERRED -> TIME_IN_BED` from the per-metric sources screen; confirm new TIB rows stop appearing on the next sync (historical rows stay, by design)
- [ ] When W2F is installed and has written `sleep_duration` overlapping the same window, the new TIB row is `MEDIUM` confidence; otherwise `LOW`

## Out of scope (follow-ups)

- Diagnostic UI for missing-TIB nights (separate PR)
- One-shot "Backfill now" button in settings (separate PR)
- Night-shift owner support — the 02:00–05:00 anchor misses them by design; will need a learned per-owner window
- HRBS metric (#309)

🤖 Generated with [Claude Code](https://claude.com/claude-code)