### PR TITLE
fix(ui): virtualize per-metric history to stop OOM on Steps

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/AppViewModelEntries.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModelEntries.kt
@@ -27,7 +27,11 @@ suspend fun AppViewModel.getRecentReadings(
 ): List<RecentEntry> {
     val readings = db.metricReadingDao().fetchLatest(metricType.key, limit)
     if (readings.isEmpty()) return emptyList()
-    val payloads = db.eventPayloadFieldDao().fetchForReadings(readings.map { it.id })
+    // SQLite's SQLITE_MAX_VARIABLE_NUMBER is 999 on API 28/29 (raised to
+    // 32k on newer Android). Step histories blow that, so chunk the IN().
+    val payloads = readings.map { it.id }
+        .chunked(SQLITE_IN_CHUNK)
+        .flatMap { db.eventPayloadFieldDao().fetchForReadings(it) }
     val byReadingId = payloads.groupBy { it.readingId }
     return readings.map { r ->
         RecentEntry(
@@ -38,6 +42,8 @@ suspend fun AppViewModel.getRecentReadings(
         )
     }
 }
+
+private const val SQLITE_IN_CHUNK = 900
 
 suspend fun AppViewModel.deleteReading(readingId: String) {
     db.eventPayloadFieldDao().deleteForReading(readingId)

--- a/android/app/src/main/java/com/bios/app/ui/trends/RecentEntriesSection.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/RecentEntriesSection.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.DeleteOutline
@@ -30,8 +32,14 @@ import androidx.compose.ui.unit.dp
 import com.bios.app.ui.RecentEntry
 import com.bios.contracts.MetricType
 
-@Composable
-internal fun RecentEntriesSection(
+/**
+ * Adds the "Recent entries" header + entry rows as LazyColumn items so the
+ * full per-metric history can render without composing every row eagerly.
+ * Lives as a LazyListScope extension because the per-metric screen needs
+ * virtualization — Steps can have tens of thousands of entries and the
+ * old Column(verticalScroll) implementation OOM'd at 256 MB.
+ */
+internal fun LazyListScope.recentEntriesSection(
     metric: MetricType,
     entries: List<RecentEntry>,
     loaded: Boolean,
@@ -44,13 +52,72 @@ internal fun RecentEntriesSection(
 ) {
     val inSelectMode = selectedIds.isNotEmpty()
 
+    item(key = "recent-entries-header") {
+        RecentEntriesHeader(
+            inSelectMode = inSelectMode,
+            selectedCount = selectedIds.size,
+            onRequestBatchDelete = onRequestBatchDelete,
+            onCancelSelection = onCancelSelection,
+        )
+    }
+
+    if (!loaded) {
+        item(key = "recent-entries-loading") { RecentEntriesPlaceholder("Loading…") }
+        return
+    }
+
+    if (entries.isEmpty()) {
+        item(key = "recent-entries-empty") {
+            RecentEntriesPlaceholder("No ${metric.readableName.lowercase()} entries yet.")
+        }
+        return
+    }
+
+    if (!inSelectMode) {
+        item(key = "recent-entries-hint") {
+            Text(
+                "Long-press a row to multi-select.",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+    itemsIndexed(
+        entries,
+        key = { _, entry -> entry.reading.id },
+    ) { index, entry ->
+        Column {
+            EntryRow(
+                metric = metric,
+                entry = entry,
+                inSelectMode = inSelectMode,
+                isSelected = entry.reading.id in selectedIds,
+                onLongPress = { onLongPress(entry.reading.id) },
+                onToggle = { onToggle(entry.reading.id) },
+                onDelete = { onDeleteOne(entry) },
+            )
+            if (index < entries.lastIndex) {
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentEntriesHeader(
+    inSelectMode: Boolean,
+    selectedCount: Int,
+    onRequestBatchDelete: () -> Unit,
+    onCancelSelection: () -> Unit,
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            if (inSelectMode) "${selectedIds.size} selected" else "Recent entries",
+            if (inSelectMode) "$selectedCount selected" else "Recent entries",
             style = MaterialTheme.typography.titleMedium,
         )
         if (inSelectMode) {
@@ -62,62 +129,20 @@ internal fun RecentEntriesSection(
             }
         }
     }
+}
 
-    if (!loaded) {
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            )
-        ) {
-            Text(
-                "Loading…",
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(16.dp),
-            )
-        }
-        return
-    }
-
-    if (entries.isEmpty()) {
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            )
-        ) {
-            Text(
-                "No ${metric.readableName.lowercase()} entries yet.",
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(16.dp),
-            )
-        }
-        return
-    }
-
-    if (!inSelectMode) {
-        Text(
-            "Long-press a row to multi-select.",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+@Composable
+private fun RecentEntriesPlaceholder(text: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
         )
-    }
-
-    Card {
-        Column(modifier = Modifier.padding(vertical = 4.dp)) {
-            entries.forEachIndexed { index, entry ->
-                EntryRow(
-                    metric = metric,
-                    entry = entry,
-                    inSelectMode = inSelectMode,
-                    isSelected = entry.reading.id in selectedIds,
-                    onLongPress = { onLongPress(entry.reading.id) },
-                    onToggle = { onToggle(entry.reading.id) },
-                    onDelete = { onDeleteOne(entry) },
-                )
-                if (index < entries.lastIndex) {
-                    HorizontalDivider()
-                }
-            }
-        }
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt
@@ -2,14 +2,13 @@ package com.bios.app.ui.trends
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.AlertDialog
@@ -101,49 +100,53 @@ fun TrendsScreen(
         chartLoaded = true
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp))
-                .clickable { showBrowser = true }
-                .padding(vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                selectedMetric.readableName,
-                style = MaterialTheme.typography.headlineLarge,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f),
-            )
-            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Browse metrics")
+        item(key = "metric-header") {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { showBrowser = true }
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    selectedMetric.readableName,
+                    style = MaterialTheme.typography.headlineLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Browse metrics")
+            }
         }
 
-        MetricChart(
-            metric = selectedMetric,
-            readings = chartReadings,
-            loaded = chartLoaded,
-            selectedWindow = chartWindow,
-            onSelectWindow = { chartWindow = it },
-        )
-
-        val selectedBaseline = baselines.find { it.metricType == selectedMetric.key }
-        if (selectedBaseline != null) {
-            BaselineSummaryCard(selectedBaseline, selectedMetric.unit)
-        } else {
-            NoBaselineCard(
-                metricLabel = selectedMetric.readableName,
-                coverage = liveCoverage ?: coverage[selectedMetric],
+        item(key = "metric-chart") {
+            MetricChart(
+                metric = selectedMetric,
+                readings = chartReadings,
+                loaded = chartLoaded,
+                selectedWindow = chartWindow,
+                onSelectWindow = { chartWindow = it },
             )
         }
 
-        RecentEntriesSection(
+        item(key = "metric-baseline") {
+            val selectedBaseline = baselines.find { it.metricType == selectedMetric.key }
+            if (selectedBaseline != null) {
+                BaselineSummaryCard(selectedBaseline, selectedMetric.unit)
+            } else {
+                NoBaselineCard(
+                    metricLabel = selectedMetric.readableName,
+                    coverage = liveCoverage ?: coverage[selectedMetric],
+                )
+            }
+        }
+
+        recentEntriesSection(
             metric = selectedMetric,
             entries = recentEntries,
             loaded = entriesLoaded,


### PR DESCRIPTION
## Summary
- Per-metric view crashed on Steps: lifting the Recent entries cap to `Int.MAX_VALUE` (commit 15a8d16) eagerly composed every row inside a `Column(verticalScroll)`. Tens of thousands of step entries pushed the composition graph past the 256 MB per-app heap clamp and Android killed the process.
- Convert `TrendsScreen`'s outer scroller to a `LazyColumn` so only visible rows compose. `RecentEntriesSection` becomes a `LazyListScope.recentEntriesSection(...)` extension that emits header / placeholder / per-entry items.
- Chunk `EventPayloadFieldDao.fetchForReadings` to 900 IDs per query. `SQLITE_MAX_VARIABLE_NUMBER` is 999 on API 28/29 and an un-capped step ID list would have blown the `IN (...)` clause before composition even started.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes
- [x] `make install` deploys cleanly
- [ ] Open Steps per-metric view on a device with a large step history — no OOM, scroll is smooth
- [ ] Verify single-select delete, multi-select delete, and "Long-press to multi-select" hint still work
- [ ] Verify other metrics with small histories (HR, HRV, SpO2, Weight, biomarkers) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)