### PR TITLE
fix(seizure): survive background-context start denial (#327)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionService.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SeizureDetectionService.kt
@@ -278,11 +278,27 @@ class SeizureDetectionService : Service() {
         const val SOURCE_DEVICE_NAME = "Wearable seizure detector"
 
         /** Start the service from app init / the Settings toggle. No-op
-         *  when the opt-in is off. */
+         *  when the opt-in is off.
+         *
+         *  Swallows [IllegalStateException] (and its API-31+ subclass
+         *  `ForegroundServiceStartNotAllowedException`) so a background
+         *  process spawn — e.g. WorkManager or a broadcast receiver
+         *  reviving Bios while the screen is locked — doesn't tear the
+         *  whole app down. The service is retried from
+         *  `MainActivity.onCreate` on the next foreground entry, which
+         *  always has a valid context for starting a foreground service. */
         fun startIfOptedIn(context: Context) {
             if (!SeizureDetectionPrefs.isEnabled(context)) return
             val intent = Intent(context, SeizureDetectionService::class.java)
-            ContextCompat.startForegroundService(context.applicationContext, intent)
+            try {
+                ContextCompat.startForegroundService(context.applicationContext, intent)
+            } catch (e: IllegalStateException) {
+                Log.w(
+                    TAG,
+                    "startForegroundService denied (likely background context); " +
+                        "will retry on next foreground entry: ${e.message}",
+                )
+            }
         }
 
         /** Stop the service. Safe to call when already stopped. */

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -49,6 +49,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        // Retry the seizure foreground service from a foreground context;
+        // Application.onCreate's call no-ops on background process spawns.
+        com.bios.app.ingest.SeizureDetectionService.startIfOptedIn(this)
+
         setContent {
             BiosTheme {
                 BiosRoot()


### PR DESCRIPTION
## Summary
- `BiosApplication.onCreate` unconditionally called `SeizureDetectionService.startIfOptedIn()`. On API 31+ the OS throws `ForegroundServiceStartNotAllowedException` whenever the process is spawned from a background context (WorkManager, broadcast receiver, locked-screen `am start`). The exception propagated up and killed the app before `MainActivity` could be shown.
- `SeizureDetectionService.startIfOptedIn` now catches `IllegalStateException` (the API-portable supertype of the API-31+ subclass) and logs the deferral.
- `MainActivity.onCreate` retries `startIfOptedIn` so a missed background start is recovered from the next foreground entry, which always has a valid context for foreground-service starts.

## Verification
Reproduced on a Pixel 9a (Android 16) via `am force-stop` + `am start` while the process was in `CEM` (cached / empty) state. Logcat with the fix:

```
ActivityManager: Background started FGS: Disallowed [callingPackage: com.bios.app; uidState: CEM ...]
ActivityManager: startForegroundService() not allowed due to mAllowStartForeground false
SeizureDetectionService: startForegroundService denied (likely background context); will retry on next foreground entry: ...
ActivityManager: Background started FGS: Allowed [callingPackage: com.bios.app; uidState: TOP ...]
SeizureDetectionService: service onCreate — foreground notification posted
```

No process crash. Service starts on the foreground retry.

## Test plan
- [x] `./scripts/code-quality-check.sh` passes
- [x] Cold launch from background no longer crashes (reproduced + verified)
- [x] Service starts cleanly on the `MainActivity.onCreate` retry
- [ ] Toggle seizure detection off → on from Settings still starts the service (this code path was untouched)

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)