### PR TITLE
feat(engine): Derive resting heart rate from HR + Steps

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/RestingHeartRateInference.kt
+++ b/android/app/src/main/java/com/bios/app/engine/RestingHeartRateInference.kt
@@ -1,0 +1,153 @@
+package com.bios.app.engine
+
+import com.bios.app.model.ConfidenceTier
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Derives one resting-heart-rate (RHR) value per calendar day from raw
+ * HEART_RATE samples gated by STEPS activity.
+ *
+ * Method: for each HR sample, decide whether it sits in a "quiet window"
+ * — no STEPS bucket with `value > 0` overlapping the sample, and none
+ * ending inside a post-exertion cooldown preceding it. The day's RHR is
+ * the [PERCENTILE]-th percentile of HR values inside its quiet windows,
+ * emitted only when at least [MIN_QUIET_SAMPLES] samples qualify.
+ *
+ * Why a low percentile rather than the raw minimum: single-beat artifacts
+ * and momentary contact dropouts produce isolated bpm samples in the 30s
+ * that don't reflect physiological RHR. The 10th-percentile smoothes
+ * across those without overshooting the genuine resting band.
+ *
+ * Why a cooldown: HR remains elevated for several minutes after activity
+ * ends (vagal reactivation is gradual). Including those samples would
+ * bias the percentile upward on active days; [COOLDOWN_MS] strips them.
+ *
+ * Step convention: this engine assumes STEPS readings carry per-bucket
+ * counts — `value` is the step count over `[timestamp, timestamp +
+ * durationSec]`, matching how HealthConnectAdapter, PhoneSensorAdapter,
+ * and the API adapters emit them. Adapters that emit cumulative
+ * running totals would appear as constant non-zero values and produce
+ * no quiet windows; those owners would need a sensor-native RHR feed
+ * (Garmin, Oura, Whoop all provide one) or manual entry.
+ *
+ * Pure JVM-only object — DB orchestration lives in
+ * [com.bios.app.ingest.RestingHeartRateBackfill].
+ */
+object RestingHeartRateInference {
+
+    /** One HR sample reduced to (timestamp, bpm). */
+    data class HrSample(val timestamp: Long, val bpm: Double)
+
+    /**
+     * One STEPS bucket. `durationSec` is optional — instantaneous step
+     * readings (some direct-sensor paths) are treated as a point event
+     * at `timestamp`, with no width.
+     */
+    data class StepsBucket(val timestamp: Long, val value: Double, val durationSec: Int?)
+
+    /** One derived RHR value for a calendar day. */
+    data class RhrCandidate(
+        val dayStartMs: Long,
+        val rhrBpm: Double,
+        val sampleCount: Int,
+        val confidence: ConfidenceTier,
+    )
+
+    /**
+     * Derive RHR per local-zone day from [hrSamples] gated by [stepsBuckets].
+     *
+     * Returns one [RhrCandidate] per day that has at least
+     * [MIN_QUIET_SAMPLES] HR samples in quiet windows. Days with sparse
+     * HR coverage, all-day activity, or no HR at all produce nothing —
+     * an absent value is more honest than a confidently wrong one.
+     */
+    fun infer(
+        hrSamples: List<HrSample>,
+        stepsBuckets: List<StepsBucket>,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): List<RhrCandidate> {
+        if (hrSamples.isEmpty()) return emptyList()
+        val activeBuckets = stepsBuckets
+            .filter { it.value > 0.0 }
+            .map { ActiveInterval(it.timestamp, it.timestamp + (it.durationSec?.toLong() ?: 0L) * 1000L) }
+            .sortedBy { it.startMs }
+
+        val quietByDay = hrSamples
+            .asSequence()
+            .filter { isQuiet(it.timestamp, activeBuckets) }
+            .groupBy { sample ->
+                Instant.ofEpochMilli(sample.timestamp).atZone(zone).toLocalDate()
+            }
+
+        return quietByDay.entries
+            .mapNotNull { (date, samples) ->
+                if (samples.size < MIN_QUIET_SAMPLES) return@mapNotNull null
+                val rhr = percentile(samples.map { it.bpm }, PERCENTILE)
+                val dayStartMs = date.atStartOfDay(zone).toInstant().toEpochMilli()
+                RhrCandidate(
+                    dayStartMs = dayStartMs,
+                    rhrBpm = rhr,
+                    sampleCount = samples.size,
+                    confidence = ConfidenceTier.MEDIUM,
+                )
+            }
+            .sortedBy { it.dayStartMs }
+    }
+
+    /** Closed activity interval [startMs, endMs] for one steps bucket. */
+    private data class ActiveInterval(val startMs: Long, val endMs: Long)
+
+    /**
+     * True when `t` is neither inside an active steps interval nor inside
+     * the [COOLDOWN_MS] window after one ends. The check is bounded to
+     * one descending lookup per HR sample by walking active intervals
+     * back from the position where `startMs > t`.
+     */
+    private fun isQuiet(t: Long, activeIntervalsSortedByStart: List<ActiveInterval>): Boolean {
+        if (activeIntervalsSortedByStart.isEmpty()) return true
+        // Walk back from intervals starting at-or-before t. Any interval
+        // whose endMs + cooldown is still in the future relative to t
+        // disqualifies the sample.
+        var idx = activeIntervalsSortedByStart.size - 1
+        while (idx >= 0) {
+            val interval = activeIntervalsSortedByStart[idx]
+            if (interval.startMs > t) {
+                idx--
+                continue
+            }
+            // First interval starting ≤ t. Anything earlier ends earlier,
+            // so the cooldown check on this one is sufficient.
+            return interval.endMs + COOLDOWN_MS <= t
+        }
+        return true
+    }
+
+    /**
+     * Linear-interpolated percentile. Sorted input, fractional index
+     * between adjacent samples — avoids the discontinuity of a nearest-
+     * rank percentile when the sample count is small.
+     */
+    internal fun percentile(values: List<Double>, percent: Double): Double {
+        val sorted = values.sorted()
+        if (sorted.size == 1) return sorted[0]
+        val rank = percent / 100.0 * (sorted.size - 1)
+        val lo = rank.toInt()
+        val hi = (lo + 1).coerceAtMost(sorted.size - 1)
+        val frac = rank - lo
+        return sorted[lo] * (1.0 - frac) + sorted[hi] * frac
+    }
+
+    /** Post-exertion cooldown stripped from HR samples. 15 min covers the
+     *  steep portion of vagal reactivation; longer would over-strip days
+     *  with frequent light activity and leave too few quiet samples. */
+    internal const val COOLDOWN_MS: Long = 15L * 60L * 1000L
+
+    /** Minimum HR samples in a day's quiet windows for a credible
+     *  percentile. Below this the percentile is too unstable to publish. */
+    internal const val MIN_QUIET_SAMPLES: Int = 30
+
+    /** Percentile used as the RHR. 10th balances "low enough to reflect
+     *  rest" with "high enough to ignore single-beat dropouts." */
+    internal const val PERCENTILE: Double = 10.0
+}

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -246,8 +246,9 @@ class IngestManager(
                 ingestBlock()
             }
 
-            deriveCircadianPhaseShift()
+            circadianEngine.derive()?.let { readingDao.insert(it) }
             HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 14)
+            RestingHeartRateBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 14)
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {
@@ -306,24 +307,18 @@ class IngestManager(
                 _syncProgress.value = completedDays / totalDays
             }
 
-            deriveCircadianPhaseShift()
+            // Each derivation/backfill is idempotent and self-skips when
+            // preconditions aren't met (e.g. <4 days of sleep history),
+            // so this block is safe to call on every sync.
+            circadianEngine.derive()?.let { readingDao.insert(it) }
             HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
+            RestingHeartRateBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()
         } finally {
             _isSyncing.value = false
             _syncProgress.value = 1f
         }
-    }
-
-    /**
-     * Run the circadian-phase-shift derivation against the readings now in DB.
-     * Self-skips when fewer than 4 days of SLEEP_DURATION exist or when today's
-     * shift has already been emitted, so this is safe to call on every sync.
-     */
-    private suspend fun deriveCircadianPhaseShift() {
-        val reading = circadianEngine.derive() ?: return
-        readingDao.insert(reading)
     }
 
     // MARK: - Derivations

--- a/android/app/src/main/java/com/bios/app/ingest/RestingHeartRateBackfill.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/RestingHeartRateBackfill.kt
@@ -1,0 +1,105 @@
+package com.bios.app.ingest
+
+import com.bios.app.data.dao.DataSourceDao
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.RestingHeartRateInference
+import com.bios.app.model.DataSource
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SensorType
+import com.bios.app.model.SourceType
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Walks recent `HEART_RATE` and `STEPS` readings, derives one
+ * `RESTING_HEART_RATE` per local-zone day from quiet windows, and
+ * persists results under the synthetic `BIOS_INFERRED` source.
+ *
+ * Will not overwrite a sensor- or vendor-reported RHR. If any day in the
+ * window already has a `RESTING_HEART_RATE` row from a non-`BIOS_INFERRED`
+ * source, that day is skipped — Garmin/Whoop/Oura native RHR is treated
+ * as more authoritative than a derivation off cross-source HR + STEPS.
+ *
+ * Idempotent: re-runs collapse to in-place updates via the unique index
+ * on `(sourceId, metricType, timestamp)`. Safe to call on every sync.
+ *
+ * Math itself lives in [RestingHeartRateInference]; this class is the
+ * DB-aware orchestration layer (mirrors [HrGapTibBackfill]).
+ */
+class RestingHeartRateBackfill(
+    private val readingDao: MetricReadingDao,
+    private val sourceDao: DataSourceDao,
+    private val zone: ZoneId = ZoneId.systemDefault(),
+) {
+
+    suspend fun run(windowStartMs: Long, windowEndMs: Long): Int {
+        if (windowEndMs <= windowStartMs) return 0
+        val hr = readingDao.fetch(MetricType.HEART_RATE.key, windowStartMs, windowEndMs)
+        if (hr.size < RestingHeartRateInference.MIN_QUIET_SAMPLES) return 0
+        val steps = readingDao.fetch(MetricType.STEPS.key, windowStartMs, windowEndMs)
+
+        val candidates = RestingHeartRateInference.infer(
+            hrSamples = hr.map { RestingHeartRateInference.HrSample(it.timestamp, it.value) },
+            stepsBuckets = steps.map {
+                RestingHeartRateInference.StepsBucket(it.timestamp, it.value, it.durationSec)
+            },
+            zone = zone,
+        )
+        if (candidates.isEmpty()) return 0
+
+        val inferredSourceId = getOrCreateInferredSource()
+        val existing = readingDao.fetch(
+            MetricType.RESTING_HEART_RATE.key, windowStartMs, windowEndMs
+        )
+        val daysWithExternalRhr = existing
+            .filter { it.sourceId != inferredSourceId }
+            .map { dayStartMs(it.timestamp) }
+            .toSet()
+
+        val rows = candidates
+            .filter { it.dayStartMs !in daysWithExternalRhr }
+            .map { c ->
+                MetricReading(
+                    metricType = MetricType.RESTING_HEART_RATE.key,
+                    value = c.rhrBpm,
+                    timestamp = c.dayStartMs,
+                    sourceId = inferredSourceId,
+                    confidence = c.confidence.level,
+                )
+            }
+        if (rows.isEmpty()) return 0
+        readingDao.insertAll(rows)
+        return rows.size
+    }
+
+    /** Run over a window ending now and spanning [lookbackDays] back.
+     *  Failures are swallowed so a transient fetch error can't kill the
+     *  surrounding sync. */
+    suspend fun runForLookback(lookbackDays: Long): Int = runCatching {
+        val end = Instant.now()
+        val start = end.minus(lookbackDays, ChronoUnit.DAYS)
+        run(start.toEpochMilli(), end.toEpochMilli())
+    }.getOrDefault(0)
+
+    private fun dayStartMs(timestampMs: Long): Long =
+        Instant.ofEpochMilli(timestampMs).atZone(zone).toLocalDate()
+            .atStartOfDay(zone).toInstant().toEpochMilli()
+
+    private suspend fun getOrCreateInferredSource(): String {
+        val existing = sourceDao.findByType(SourceType.BIOS_INFERRED.key)
+        if (existing != null) return existing.id
+        val source = DataSource(
+            sourceType = SourceType.BIOS_INFERRED.key,
+            deviceName = SOURCE_DEVICE_NAME,
+            sensorType = SensorType.DERIVED.name,
+        )
+        sourceDao.insert(source)
+        return source.id
+    }
+
+    companion object {
+        private const val SOURCE_DEVICE_NAME = "Bios derivation"
+    }
+}

--- a/android/app/src/test/java/com/bios/app/RestingHeartRateInferenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/RestingHeartRateInferenceTest.kt
@@ -1,0 +1,216 @@
+package com.bios.app
+
+import com.bios.app.engine.RestingHeartRateInference
+import com.bios.app.engine.RestingHeartRateInference.HrSample
+import com.bios.app.engine.RestingHeartRateInference.StepsBucket
+import com.bios.app.model.ConfidenceTier
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RestingHeartRateInferenceTest {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+    private val baseDate: LocalDate = LocalDate.of(2026, 5, 25)
+    private val dayStartMs: Long = baseDate.atStartOfDay(zone).toInstant().toEpochMilli()
+
+    private fun atOffsetMs(hours: Int, minutes: Int = 0): Long =
+        dayStartMs + hours * 3_600_000L + minutes * 60_000L
+
+    private fun quietHrSeries(
+        startHour: Int,
+        endHourExclusive: Int,
+        bpmFloor: Double = 55.0,
+        bpmCeiling: Double = 70.0,
+        sampleEveryMin: Int = 1,
+    ): List<HrSample> {
+        val out = mutableListOf<HrSample>()
+        val totalMinutes = (endHourExclusive - startHour) * 60
+        var i = 0
+        var minute = 0
+        while (minute < totalMinutes) {
+            // Sweep deterministically across the range so the 10th
+            // percentile lands at a predictable value.
+            val bpm = bpmFloor + ((i % 10) / 9.0) * (bpmCeiling - bpmFloor)
+            out += HrSample(atOffsetMs(startHour, minute), bpm)
+            minute += sampleEveryMin
+            i++
+        }
+        return out
+    }
+
+    @Test
+    fun `quiet night emits one RHR at day start`() {
+        val hr = quietHrSeries(startHour = 1, endHourExclusive = 6, bpmFloor = 50.0, bpmCeiling = 60.0)
+        val steps = emptyList<StepsBucket>()
+
+        val candidates = RestingHeartRateInference.infer(hr, steps, zone)
+
+        assertEquals(1, candidates.size)
+        val c = candidates.first()
+        assertEquals(dayStartMs, c.dayStartMs)
+        assertEquals(ConfidenceTier.MEDIUM, c.confidence)
+        assertTrue("RHR should sit in the resting band, got ${c.rhrBpm}", c.rhrBpm in 50.0..60.0)
+        // The 10th percentile of a 50-60 ramp should land near 51.
+        assertEquals(51.0, c.rhrBpm, 1.5)
+    }
+
+    @Test
+    fun `samples during steps activity are excluded`() {
+        // 30 minutes of resting HR + 30 minutes during a walk (high HR).
+        val resting = quietHrSeries(startHour = 2, endHourExclusive = 3, bpmFloor = 55.0, bpmCeiling = 60.0)
+            .take(30)
+        val walking = (0 until 30).map { i ->
+            HrSample(atOffsetMs(3, i), 110.0 + (i % 10))
+        }
+        val stepsBucket = StepsBucket(
+            timestamp = atOffsetMs(3, 0),
+            value = 1500.0,
+            durationSec = 30 * 60,
+        )
+
+        val candidates = RestingHeartRateInference.infer(
+            hrSamples = resting + walking,
+            stepsBuckets = listOf(stepsBucket),
+            zone = zone,
+        )
+
+        // Only 30 quiet samples remain — exactly the minimum, so emission
+        // is expected and the percentile must reflect resting HR only.
+        assertEquals(1, candidates.size)
+        assertTrue(
+            "RHR should reflect resting samples only, got ${candidates.first().rhrBpm}",
+            candidates.first().rhrBpm < 70.0,
+        )
+    }
+
+    @Test
+    fun `cooldown after activity excludes post-exertion samples`() {
+        // Steps bucket from 02:00-02:10. HR samples at 02:15 (within 15-min
+        // cooldown) should be excluded; samples at 02:30 (past cooldown)
+        // should count.
+        val stepsBucket = StepsBucket(
+            timestamp = atOffsetMs(2, 0),
+            value = 600.0,
+            durationSec = 10 * 60,
+        )
+        val cooldownSample = HrSample(atOffsetMs(2, 15), 90.0)
+        val recoveredSamples = (0 until 50).map { i ->
+            HrSample(atOffsetMs(2, 30 + i), 58.0 + (i % 5))
+        }
+
+        val candidates = RestingHeartRateInference.infer(
+            hrSamples = listOf(cooldownSample) + recoveredSamples,
+            stepsBuckets = listOf(stepsBucket),
+            zone = zone,
+        )
+
+        assertEquals(1, candidates.size)
+        val rhr = candidates.first().rhrBpm
+        // 90.0 from the cooldown sample would skew the percentile up; if
+        // it were included alongside the 58-62 recovered band, the 10th
+        // percentile of 51 mixed samples would still land near 58 but
+        // the sample count would not match. We verify both.
+        assertEquals("recovered samples should be the only contributors", 50, candidates.first().sampleCount)
+        assertTrue("RHR should reflect recovered samples, got $rhr", rhr < 65.0)
+    }
+
+    @Test
+    fun `sparse day below minimum quiet samples emits nothing`() {
+        // 29 quiet samples — one below MIN_QUIET_SAMPLES.
+        val hr = (0 until 29).map { i -> HrSample(atOffsetMs(3, i), 60.0) }
+        assertTrue(hr.size < RestingHeartRateInference.MIN_QUIET_SAMPLES)
+        val candidates = RestingHeartRateInference.infer(hr, emptyList(), zone)
+        assertTrue("expected no candidate for sparse day", candidates.isEmpty())
+    }
+
+    @Test
+    fun `multiple days each get their own RHR`() {
+        val day1Hr = quietHrSeries(startHour = 1, endHourExclusive = 4, bpmFloor = 52.0, bpmCeiling = 58.0)
+        val day2Offset = 24 * 60
+        val day2Hr = (0 until 180).map { i ->
+            HrSample(atOffsetMs(0, day2Offset + i), 62.0 + (i % 5))
+        }
+
+        val candidates = RestingHeartRateInference.infer(
+            hrSamples = day1Hr + day2Hr,
+            stepsBuckets = emptyList(),
+            zone = zone,
+        )
+
+        assertEquals(2, candidates.size)
+        val day1 = candidates.first { it.dayStartMs == dayStartMs }
+        val day2 = candidates.first { it.dayStartMs == dayStartMs + 24 * 3_600_000L }
+        assertNotNull(day1)
+        assertNotNull(day2)
+        assertTrue(
+            "day-2 RHR ($day2.rhrBpm) should sit above day-1 RHR (${day1.rhrBpm})",
+            day2.rhrBpm > day1.rhrBpm,
+        )
+    }
+
+    @Test
+    fun `all-day activity yields no RHR`() {
+        val hr = quietHrSeries(startHour = 8, endHourExclusive = 22, bpmFloor = 100.0, bpmCeiling = 130.0)
+        // One long active bucket covering the whole HR window.
+        val steps = listOf(
+            StepsBucket(
+                timestamp = atOffsetMs(8, 0),
+                value = 12_000.0,
+                durationSec = 14 * 60 * 60,
+            )
+        )
+        val candidates = RestingHeartRateInference.infer(hr, steps, zone)
+        assertTrue("expected no candidate when every sample is gated out", candidates.isEmpty())
+    }
+
+    @Test
+    fun `percentile interpolates linearly between adjacent samples`() {
+        val values = listOf(60.0, 62.0, 64.0, 66.0, 68.0, 70.0, 72.0, 74.0, 76.0, 78.0, 80.0)
+        // 10th percentile of an 11-sample 60..80 ramp = sample at rank 1 = 62.0.
+        assertEquals(62.0, RestingHeartRateInference.percentile(values, 10.0), 0.001)
+        // 50th percentile = sample at rank 5 = 70.0.
+        assertEquals(70.0, RestingHeartRateInference.percentile(values, 50.0), 0.001)
+    }
+
+    @Test
+    fun `empty input is silent`() {
+        assertTrue(RestingHeartRateInference.infer(emptyList(), emptyList(), zone).isEmpty())
+    }
+
+    @Test
+    fun `zero-step buckets do not gate HR samples`() {
+        val hr = quietHrSeries(startHour = 1, endHourExclusive = 3)
+        val zeroSteps = listOf(
+            StepsBucket(timestamp = atOffsetMs(1, 30), value = 0.0, durationSec = 5 * 60),
+            StepsBucket(timestamp = atOffsetMs(2, 30), value = 0.0, durationSec = 5 * 60),
+        )
+        val candidates = RestingHeartRateInference.infer(hr, zeroSteps, zone)
+        assertEquals(1, candidates.size)
+        // All 120 minutes' worth of samples should qualify — zero-step
+        // buckets carry no activity gating.
+        assertEquals(120, candidates.first().sampleCount)
+    }
+
+    @Test
+    fun `local zone boundary groups samples to the right day`() {
+        val parisZone = ZoneId.of("Europe/Paris")
+        // 22:30 UTC on baseDate = 00:30 Paris on the NEXT day — must be
+        // grouped under baseDate + 1, not baseDate.
+        val parisDayStart = baseDate.plusDays(1).atStartOfDay(parisZone).toInstant().toEpochMilli()
+        val baseUtcMidnight = baseDate.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
+        val hr = (0 until 60).map { i ->
+            HrSample(baseUtcMidnight + 22 * 3_600_000L + 30 * 60_000L + i * 60_000L, 56.0 + (i % 4))
+        }
+
+        val candidates = RestingHeartRateInference.infer(hr, emptyList(), parisZone)
+
+        assertEquals(1, candidates.size)
+        assertEquals(parisDayStart, candidates.first().dayStartMs)
+    }
+}


### PR DESCRIPTION
## Summary

Derives one `RESTING_HEART_RATE` per local-zone day from `HEART_RATE` samples gated by `STEPS` activity. Math is the standard low-percentile-of-quiet-window approach used by Fitbit/Apple/Garmin; orchestration mirrors the existing `HrGapTibBackfill` pattern.

- **Pure inference**: [RestingHeartRateInference.kt](android/app/src/main/java/com/bios/app/engine/RestingHeartRateInference.kt) — for each HR sample, "quiet" means no `STEPS` bucket with `value > 0` overlaps it or ends within a 15-min cooldown. Day's RHR = 10th percentile of qualifying samples, emitted only when ≥30 samples qualify.
- **DB orchestration**: [RestingHeartRateBackfill.kt](android/app/src/main/java/com/bios/app/ingest/RestingHeartRateBackfill.kt) — runs over a lookback window, attributes to the synthetic `BIOS_INFERRED` source, idempotent via the existing `(sourceId, metricType, timestamp)` unique index.
- **Never overwrites sensor RHR**: days with a `RESTING_HEART_RATE` row from any non-`BIOS_INFERRED` source (Garmin/Whoop/Oura/etc.) are skipped. Native vendor RHR is treated as more authoritative.
- **Wired into both sync paths** in `IngestManager` next to `HrGapTibBackfill` (14-day lookback on regular sync, 30-day on historical sync).
- **UI surface**: automatic — the existing `MetricType.RESTING_HEART_RATE` entry already shows up in `TrendsScreen` via `MetricBrowserSheet` with chart + baseline + history. No UI changes.

The pure derivation is unit-tested (10 tests covering quiet nights, activity exclusion, cooldown, sparse-day skip, multi-day grouping, all-day activity, percentile interpolation, zone boundaries).

## Manifesto fit

RHR is a *reading*, not a judgment — Bios surfaces it so the owner can read their own resting trend. No nudging, no scoring, no comparison against population norms. Evaluation belongs to the owner.

## Test plan

- [ ] Build verified locally via `./scripts/code-quality-check.sh` (passes; pre-existing lint warning in `CameraPpgAdapter.kt` is unrelated)
- [ ] Unit tests: `./gradlew :app:testLetheDebugUnitTest --tests RestingHeartRateInferenceTest` (10/10 pass)
- [ ] On-device: after a sync with HR + Steps history, `RESTING_HEART_RATE` chart in TrendsScreen shows derived points for days without vendor RHR; days with vendor RHR remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)