### PR TITLE
fix(sleep): compute regularity from manual entries missing durationSec

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
+++ b/android/app/src/main/java/com/bios/app/data/SleepEntryRepo.kt
@@ -30,6 +30,7 @@ class SleepEntryRepo(private val db: BiosDatabase) {
                 metricType = MetricType.SLEEP_DURATION.key,
                 value = durationSeconds.toDouble(),
                 timestamp = timestamp,
+                durationSec = durationSeconds.toInt(),
                 sourceId = sourceId,
                 confidence = ConfidenceTier.HIGH.level
             )

--- a/android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepRegularityCalculator.kt
@@ -71,21 +71,21 @@ object SleepRegularityCalculator {
             .asSequence()
             .filter { it.metricType == MetricType.SLEEP_DURATION.key }
             .filter { it.timestamp >= cutoff && it.timestamp <= nowMs }
-            .filter { (it.durationSec ?: 0) > 0 }
-            .sortedBy { it.timestamp }
+            .mapNotNull { reading -> effectiveDurationSec(reading)?.let { reading to it } }
+            .sortedBy { (r, _) -> r.timestamp }
             .toList()
         if (nights.size < MIN_NIGHTS) return null
 
-        val midpointVarMin = circularStdMinutes(nights.map { midnightAngle(it.timestamp) })
-        val bedtimeVarMin = circularStdMinutes(nights.map {
-            midnightAngle(it.timestamp - (it.durationSec!! * 1000L) / 2L)
+        val midpointVarMin = circularStdMinutes(nights.map { (r, _) -> midnightAngle(r.timestamp) })
+        val bedtimeVarMin = circularStdMinutes(nights.map { (r, d) ->
+            midnightAngle(r.timestamp - (d * 1000L) / 2L)
         })
-        val wakeVarMin = circularStdMinutes(nights.map {
-            midnightAngle(it.timestamp + (it.durationSec!! * 1000L) / 2L)
+        val wakeVarMin = circularStdMinutes(nights.map { (r, d) ->
+            midnightAngle(r.timestamp + (d * 1000L) / 2L)
         })
 
         val score = scoreFromMidpointVariance(midpointVarMin)
-        val confidence = nights.minOf { it.confidence }
+        val confidence = nights.minOf { (r, _) -> r.confidence }
 
         val reading = MetricReading(
             metricType = MetricType.SLEEP_REGULARITY.key,
@@ -114,6 +114,20 @@ object SleepRegularityCalculator {
             ),
         )
         return Result(reading, payload)
+    }
+
+    /**
+     * Session length in seconds for a SLEEP_DURATION reading. Wearable
+     * adapters (Health Connect, Gadgetbridge) populate `durationSec`
+     * alongside `value`; manual entries via SleepEntryRepo historically
+     * stored the duration only in `value`. For this metric the two carry
+     * the same quantity, so falling back to `value` keeps a month of
+     * manually-logged sleep from being filtered out of the calculation.
+     */
+    private fun effectiveDurationSec(reading: MetricReading): Int? {
+        reading.durationSec?.takeIf { it > 0 }?.let { return it }
+        val fromValue = reading.value.toLong()
+        return if (fromValue > 0) fromValue.toInt() else null
     }
 
     /** Epoch-ms timestamp → angle on the 24h unit circle, in radians. */

--- a/android/app/src/test/java/com/bios/app/SleepRegularityCalculatorTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepRegularityCalculatorTest.kt
@@ -154,6 +154,28 @@ class SleepRegularityCalculatorTest {
     }
 
     @Test
+    fun `manual entries with duration only in value still contribute to regularity`() {
+        // SleepEntryRepo historically stored sleep duration solely in `value`
+        // (durationSec = null). The calculator must fall back to `value` so a
+        // month of manually-logged nights is not silently filtered out.
+        val nights = (1..7).map { i ->
+            val nightStart = now - i.toLong() * 24 * hour
+            val durSec = 8 * 3600
+            MetricReading(
+                metricType = MetricType.SLEEP_DURATION.key,
+                value = durSec.toDouble(),
+                timestamp = nightStart + 23 * hour + (durSec * 1000L) / 2L,
+                durationSec = null,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.HIGH.level
+            )
+        }
+        val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)
+        assertNotNull(result)
+        assertEquals(100.0, result!!.reading.value, 0.5)
+    }
+
+    @Test
     fun `output is a SLEEP_REGULARITY reading carrying the window as duration`() {
         val nights = (1..7).map { sleepNight(daysAgo = it, bedHour = 23, durationH = 8) }
         val result = SleepRegularityCalculator.derive(nights, sourceId, nowMs = now)!!


### PR DESCRIPTION
## Summary
- Owners with a month of manually-logged sleep saw an empty Sleep Regularity card because `SleepEntryRepo` stored duration only in `MetricReading.value`, leaving `durationSec` null, and `SleepRegularityCalculator.derive()` silently filtered every such row out at the `(durationSec ?: 0) > 0` gate.
- Calculator now falls back to `value` (same quantity as `durationSec` for `SLEEP_DURATION`), so existing manual data starts contributing immediately.
- `SleepEntryRepo.add()` also populates `durationSec` for new entries, matching `HealthConnectAdapter` so the column stays consistent going forward.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest --tests com.bios.app.SleepRegularityCalculatorTest` — passes, including new regression test covering `durationSec = null` nights.
- [x] Pre-commit `scripts/code-quality-check.sh` (file length, secrets, lint, assembleDebug for both flavors, unit tests) — all green.
- [ ] Manual: open Sleep dashboard with ≥ 3 nights of manually-logged sleep and confirm the regularity score and bedtime / midpoint / wake variance render instead of the "Need at least 3 nights" empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)