### PR TITLE
feat(sleep): owner-configurable wake hour + manual infer trigger

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepPrefs.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepPrefs.kt
@@ -1,0 +1,44 @@
+package com.bios.app.ingest
+
+import android.content.Context
+
+/**
+ * Owner-configurable knobs for [PhoneSleepWorker] / [PhoneSleepScheduler].
+ *
+ * Currently exposes the morning wake-hour: the local hour-of-day at or
+ * after which the worker considers the previous night "complete" and
+ * fires the inference. Default 9, matching the legacy hardcoded value;
+ * owners who wake earlier can lower it from Settings so the inference
+ * fires on the first post-wake worker tick instead of waiting until 9.
+ *
+ * Stored in plain SharedPreferences — no secrets, owner-tunable, and
+ * the read happens on the worker thread once per firing so a synchronous
+ * pref read is fine. Mirrors [com.bios.app.engine.SeizureDetectionPrefs]
+ * so the settings-card pattern is uniform.
+ */
+object PhoneSleepPrefs {
+
+    private const val PREFS_NAME = "bios_phone_sleep"
+    private const val KEY_WAKE_HOUR = "wake_hour"
+
+    /** Inclusive bounds for the wake-hour setting. 4 AM covers extreme
+     *  early risers; noon covers extreme late sleepers. Outside this
+     *  range the noon-to-noon overnight window stops being a sane
+     *  partition. */
+    const val MIN_WAKE_HOUR: Int = 4
+    const val MAX_WAKE_HOUR: Int = 12
+
+    fun wakeHour(context: Context): Int {
+        val stored = context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getInt(KEY_WAKE_HOUR, PhoneSleepScheduler.DEFAULT_WAKE_HOUR)
+        return stored.coerceIn(MIN_WAKE_HOUR, MAX_WAKE_HOUR)
+    }
+
+    fun setWakeHour(context: Context, hour: Int) {
+        val clamped = hour.coerceIn(MIN_WAKE_HOUR, MAX_WAKE_HOUR)
+        context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putInt(KEY_WAKE_HOUR, clamped).apply()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -124,6 +124,7 @@ class PhoneSleepWorker(
             val decision = PhoneSleepScheduler.decide(
                 nowMs = System.currentTimeMillis(),
                 zoneId = zone,
+                wakeHour = PhoneSleepPrefs.wakeHour(context),
                 lastInferredMidpointMs = lastMidpoint,
             )
             if (decision !is PhoneSleepScheduler.TriggerDecision.Fire) {

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsPhoneSleepCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsPhoneSleepCard.kt
@@ -1,0 +1,177 @@
+package com.bios.app.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.bios.app.ingest.PhoneSleepPrefs
+import com.bios.app.ingest.PhoneSleepWorker
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Sleep inference card.
+ *
+ * Two owner controls for the phone-sensor sleep auto-derivation:
+ *
+ *  1. **Wake hour** — the local hour-of-day at or after which the
+ *     periodic worker considers last night "complete" and fires the
+ *     inference. Lowering it means an early riser sees the sleep card
+ *     populated sooner; raising it means a late sleeper avoids a
+ *     partial pre-wake inference that the scheduler's dedupe would
+ *     then permanently freeze.
+ *
+ *  2. **Infer last night now** — on-demand escape hatch that ignores
+ *     the wake-hour gate and the midpoint dedupe, so a misconfigured
+ *     hour or a weird-schedule night never leaves the owner waiting
+ *     on the clock. Calls [PhoneSleepWorker.runImmediateInference].
+ *
+ * Lives in its own file because [SettingsScreen] is near the 500-line
+ * limit; new cards land here per the file-organization convention.
+ */
+@Composable
+internal fun SettingsPhoneSleepCard() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var wakeHour by remember { mutableStateOf(PhoneSleepPrefs.wakeHour(context)) }
+    var inferring by remember { mutableStateOf(false) }
+    var lastResult by remember { mutableStateOf<String?>(null) }
+
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Sleep inference", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                "Bios infers last night's sleep from phone sensors after you wake. " +
+                    "Adjust the wake hour if you rise before 9 AM, or tap " +
+                    "\"Infer now\" to skip the wait.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Wake hour", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        formatHour(wakeHour) + " local",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(
+                        onClick = {
+                            val next = (wakeHour - 1).coerceAtLeast(PhoneSleepPrefs.MIN_WAKE_HOUR)
+                            if (next != wakeHour) {
+                                wakeHour = next
+                                PhoneSleepPrefs.setWakeHour(context, next)
+                            }
+                        },
+                        enabled = wakeHour > PhoneSleepPrefs.MIN_WAKE_HOUR,
+                    ) { Text("–", style = MaterialTheme.typography.titleLarge) }
+                    Text(
+                        wakeHour.toString(),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.width(28.dp),
+                    )
+                    IconButton(
+                        onClick = {
+                            val next = (wakeHour + 1).coerceAtMost(PhoneSleepPrefs.MAX_WAKE_HOUR)
+                            if (next != wakeHour) {
+                                wakeHour = next
+                                PhoneSleepPrefs.setWakeHour(context, next)
+                            }
+                        },
+                        enabled = wakeHour < PhoneSleepPrefs.MAX_WAKE_HOUR,
+                    ) { Text("+", style = MaterialTheme.typography.titleLarge) }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = {
+                    if (inferring) return@OutlinedButton
+                    inferring = true
+                    lastResult = null
+                    scope.launch {
+                        val outcome = runCatching {
+                            PhoneSleepWorker.runImmediateInference(context)
+                        }
+                        inferring = false
+                        lastResult = outcome.fold(
+                            onSuccess = ::describeResult,
+                            onFailure = { "Inference failed: ${it.message ?: it.javaClass.simpleName}" },
+                        )
+                    }
+                },
+                enabled = !inferring,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (inferring) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Inferring…")
+                } else {
+                    Text("Infer last night now")
+                }
+            }
+
+            lastResult?.let { msg ->
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    msg,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun formatHour(hour: Int): String = when {
+    hour == 0 -> "12 AM"
+    hour < 12 -> "$hour AM"
+    hour == 12 -> "12 PM"
+    else -> "${hour - 12} PM"
+}
+
+private fun describeResult(result: PhoneSleepWorker.ImmediateResult): String = when (result) {
+    is PhoneSleepWorker.ImmediateResult.Written ->
+        "Wrote ${result.count} reading${if (result.count == 1) "" else "s"}."
+    PhoneSleepWorker.ImmediateResult.NoSensor ->
+        "No accelerometer on this device — phone-sensor inference unavailable."
+    PhoneSleepWorker.ImmediateResult.NotEnoughSamples ->
+        "Not enough phone-sensor samples buffered yet. The worker needs to run a few times first."
+    PhoneSleepWorker.ImmediateResult.NoSleepWindow ->
+        "No viable sleep window found in the recent buffer."
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -404,6 +404,8 @@ fun SettingsScreen(
 
         SettingsFeedbackCard()
 
+        SettingsPhoneSleepCard()
+
         SettingsSeizureDetectionCard(onViewDetections = onNavigateToSeizureTimeline)
 
         SettingsDiagnosticsCard()


### PR DESCRIPTION
## Summary
- Phone-sensor sleep inference is no longer locked to a hardcoded 9 AM wake-hour. Owners who wake earlier (or later) can tune it from `Settings → Sleep inference`.
- Added an `Infer last night now` button that bypasses both the wake-hour gate and the midpoint-dedupe via the existing `PhoneSleepWorker.runImmediateInference` path — escape hatch for a misconfigured hour or an odd-schedule night.

## Why
Owner woke up at 08:15 today; sleep card was empty because `PhoneSleepScheduler.DEFAULT_WAKE_HOUR = 9` made the morning trigger return `Skip`. The constant's docstring already flagged this: *"Owner-configurable surface is a follow-up"*. This is that follow-up.

## Changes
- New `PhoneSleepPrefs` (SharedPreferences, 4..12, default 9 — same shape as `SeizureDetectionPrefs`)
- `PhoneSleepWorker.doWork()` reads the pref and passes `wakeHour` to `PhoneSleepScheduler.decide()`
- New `SettingsPhoneSleepCard` — wake-hour stepper + inline `Infer now` button with result text. Sits in its own file because `SettingsScreen.kt` is at the 500-line limit.
- No DB / contract changes. No new permissions.

## Tradeoffs
- Lower wake-hour → earlier daily readings, but the scheduler's midpoint-dedupe means a partial pre-wake inference becomes permanent. The manual trigger is the recovery path.
- Pref bounds clamp to 4..12 to keep the noon-to-noon overnight window sane.

## Test plan
- [x] `./scripts/code-quality-check.sh` (build + unit tests)
- [x] `PhoneSleepSchedulerTest` already covers `custom wake hour shifts both the threshold and the window end`; no scheduler logic changed
- [ ] Manual: open `Settings → Sleep inference`, lower wake hour, tap `Infer last night now`, confirm result text matches the `ImmediateResult` outcome
- [ ] Manual: confirm sleep card on dashboard populates after the next worker tick once wake hour is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)