### PR TITLE
feat(ui): add sleep efficiency card; lead read grid with sleep

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -235,6 +235,8 @@ internal fun formatValue(value: Double, metricType: MetricType): String {
             val minutes = totalMinutes % 60
             "${hours}h ${minutes}m"
         }
+        MetricType.SLEEP_EFFICIENCY ->
+            "${value.toInt()}%"
         else -> String.format("%.1f", value)
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.HourglassBottom
 import androidx.compose.material.icons.filled.Medication
+import androidx.compose.material.icons.filled.Percent
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Thermostat
@@ -134,13 +135,14 @@ fun HomeScreen(
             Text("Today's Vitals", style = MaterialTheme.typography.titleMedium)
 
             val metrics = listOf(
+                Triple(MetricType.SLEEP_DURATION, "Sleep", Icons.Default.Bedtime),
+                Triple(MetricType.SLEEP_EFFICIENCY, "Sleep Eff.", Icons.Default.Percent),
                 Triple(MetricType.HEART_RATE, "Heart Rate", Icons.Default.Favorite),
                 Triple(MetricType.HEART_RATE_VARIABILITY, "HRV", Icons.AutoMirrored.Filled.ShowChart),
                 Triple(MetricType.BLOOD_OXYGEN, "SpO2", Icons.Default.Air),
                 Triple(MetricType.RESPIRATORY_RATE, "Resp. Rate", Icons.Default.Air),
                 Triple(MetricType.STEPS, "Steps", Icons.AutoMirrored.Filled.DirectionsWalk),
                 Triple(MetricType.SKIN_TEMPERATURE_DEVIATION, "Skin Temp", Icons.Default.Thermostat),
-                Triple(MetricType.SLEEP_DURATION, "Sleep", Icons.Default.Bedtime),
             )
 
             LazyVerticalGrid(


### PR DESCRIPTION
## Summary
- Read view now shows 8 vital cards instead of 7.
- New ordering: **Sleep · Sleep Eff. · Heart Rate · HRV · SpO2 · Resp. Rate · Steps · Skin Temp**
- 2-column grid fills exactly 4 rows — no half-row, no height tweak needed.

## Why
Owner wants last night's sleep data leading the instrument: sleep is the daily-rhythm signal you check first thing after waking, not something buried at the bottom of the grid. Sleep efficiency (TST/TIB %) is a meaningful companion to duration — a 9-hour night with 60% efficiency tells a different story than 7 hours at 92%.

## Plumbing
- `SLEEP_EFFICIENCY` is already a `MetricType`, already computed by `SleepDerivations.deriveSleepEfficiency`, and already persisted via `IngestManager` — no new pipeline needed.
- `MetricCard.formatValue` gains an integer-percent case for `SLEEP_EFFICIENCY` ("85%").
- Icon: `Icons.Default.Percent`.

## Test plan
- [x] `./scripts/code-quality-check.sh` (build + tests)
- [ ] Manual: open the Read tab, verify Sleep + Sleep Eff. cards appear at top of the grid
- [ ] Manual: with a populated DB, confirm "Sleep Eff." renders as "NN%" not as a raw decimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)