### PR TITLE
feat(sleep): derive TIME_IN_BED from SLEEP_STAGE durations

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
+++ b/android/app/src/main/java/com/bios/app/engine/SleepDerivations.kt
@@ -97,6 +97,44 @@ object SleepDerivations {
     }
 
     /**
+     * Time in bed (TIB): total session span as the sum of all SLEEP_STAGE
+     * durations. AWAKE rows at session boundaries and mid-session count
+     * toward TIB — matching the in-bed-but-awake semantics of the clinical
+     * definition. TIB >= SLEEP_DURATION is structurally guaranteed because
+     * the asleep span is a subset of the stage sum.
+     *
+     * Fallback derivation only: adapters that emit TIME_IN_BED natively
+     * (Oura, WHOOP, Garmin) still take precedence via Deduplicator. We
+     * derive here so nights from stage-only sources (Health Connect,
+     * Gadgetbridge) and HR-gap-uninferable nights (device worn through)
+     * still get a TIB row instead of leaving it null.
+     *
+     * Returns null when [readings] has no stage rows or all durations
+     * are zero — there is no session to bound.
+     */
+    fun deriveTimeInBed(
+        readings: List<MetricReading>,
+        sourceId: String
+    ): MetricReading? {
+        val stages = readings
+            .filter { it.metricType == MetricType.SLEEP_STAGE.key }
+            .sortedBy { it.timestamp }
+        if (stages.isEmpty()) return null
+
+        val total = stages.sumOf { it.durationSec ?: 0 }
+        if (total == 0) return null
+
+        return MetricReading(
+            metricType = MetricType.TIME_IN_BED.key,
+            value = total.toDouble(),
+            timestamp = stages.first().timestamp,
+            durationSec = total,
+            sourceId = sourceId,
+            confidence = stages.first().confidence
+        )
+    }
+
+    /**
      * Sleep fragmentation index: count of awakenings after initial sleep onset.
      * An awakening is a transition from a non-AWAKE stage to an AWAKE stage that
      * occurs after the first non-AWAKE row in the session. The initial AWAKE

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -333,6 +333,7 @@ class IngestManager(
         quality.groupBy { it.sourceId }.forEach { (sourceId, rows) ->
             SleepDerivations.deriveSleepLatency(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepEfficiency(rows, sourceId)?.let { derived += it }
+            SleepDerivations.deriveTimeInBed(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepFragmentation(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveWakeAfterSleepOnset(rows, sourceId)?.let { derived += it }
             SleepDerivations.deriveSleepScore(rows, sourceId)?.let { derived += it }

--- a/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepDerivationsTest.kt
@@ -130,6 +130,58 @@ class SleepDerivationsTest {
         assertNull(SleepDerivations.deriveSleepEfficiency(emptyList(), "src"))
     }
 
+    // MARK: - Time in bed
+
+    @Test
+    fun `time in bed sums all stage durations including AWAKE`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),  // 300s awake
+            stage(SleepStage.LIGHT, 1_300_000L),  // 300s
+            stage(SleepStage.DEEP, 1_600_000L),   // 300s
+            stage(SleepStage.AWAKE, 1_900_000L),  // 300s awake
+        )
+        val tib = SleepDerivations.deriveTimeInBed(readings, "src")!!
+        assertEquals(MetricType.TIME_IN_BED.key, tib.metricType)
+        assertEquals(1200.0, tib.value, 0.0)
+        assertEquals(1200, tib.durationSec)
+        assertEquals(1_000_000L, tib.timestamp)
+    }
+
+    @Test
+    fun `time in bed is at least sleep duration (TIB greater-equal TST invariant)`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L),
+            stage(SleepStage.LIGHT, 1_300_000L),
+            stage(SleepStage.DEEP, 1_600_000L),
+            stage(SleepStage.REM, 1_900_000L),
+            stage(SleepStage.AWAKE, 2_200_000L),
+        )
+        val tib = SleepDerivations.deriveTimeInBed(readings, "src")!!
+        val efficiency = SleepDerivations.deriveSleepEfficiency(readings, "src")!!
+        val tst = efficiency.value / 100.0 * efficiency.durationSec!!
+        assertTrue("TIB (${tib.value}) must be >= TST ($tst)", tib.value >= tst)
+    }
+
+    @Test
+    fun `time in bed is null when no stage rows`() {
+        assertNull(SleepDerivations.deriveTimeInBed(emptyList(), "src"))
+    }
+
+    @Test
+    fun `time in bed is null when all durations are zero`() {
+        val readings = listOf(
+            MetricReading(
+                metricType = MetricType.SLEEP_STAGE.key,
+                value = SleepStage.LIGHT.value.toDouble(),
+                timestamp = 1_000_000L,
+                durationSec = 0,
+                sourceId = "src",
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+        )
+        assertNull(SleepDerivations.deriveTimeInBed(readings, "src"))
+    }
+
     // MARK: - Fragmentation
 
     @Test


### PR DESCRIPTION
## Summary
- Add `SleepDerivations.deriveTimeInBed` returning the sum of all SLEEP_STAGE durations (AWAKE included) as a TIME_IN_BED reading.
- Wire it into `IngestManager.deriveAll` alongside the other sleep derivations, so every night with stage data now produces a TIB row instead of only the ones with native-adapter TIB or an HR-gap inference.
- The `TIB ≥ SLEEP_DURATION` contract is structurally satisfied because the asleep span is a subset of the stage sum.

## Why
Sleep efficiency was landing on the read view ([#332](https://github.com/thdelmas/Bios/pull/332)) but TIME_IN_BED stayed null for nights where the device was worn through (no HR gap) and the adapter didn't emit TIB natively (Health Connect, Gadgetbridge). The efficiency formula already uses the stage sum as its TIB denominator — this PR just persists that span as a first-class metric so the owner can see it.

## Test plan
- [x] `./scripts/code-quality-check.sh` — build + unit tests pass
- [x] New `SleepDerivationsTest` cases cover: stage sum equals TIB, TIB ≥ TST invariant, null on empty input, null on all-zero durations
- [ ] Manual sync on device → confirm TIME_IN_BED row appears for tonight

🤖 Generated with [Claude Code](https://claude.com/claude-code)