### PR TITLE
fix(sleep): run sleep derivations on phone-inferred stage rows

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/PhoneSleepWorker.kt
@@ -13,7 +13,9 @@ import androidx.work.WorkerParameters
 import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.BaselinedActivityThreshold
 import com.bios.app.engine.PhoneSleepInference
+import com.bios.app.engine.SleepDerivations
 import com.bios.app.model.DataSource
+import com.bios.app.model.MetricReading
 import com.bios.app.model.PhoneSleepSample
 import com.bios.app.model.ReadingKind
 import com.bios.app.model.SourceType
@@ -165,8 +167,12 @@ class PhoneSleepWorker(
             val sourceId = ensureSource(sourceDao)
             val readings = adapter.infer(samples, sourceId)
             if (readings.isNotEmpty()) {
-                readingDao.insertAll(readings)
-                Log.i(TAG, "diag: inferred readings=${readings.size}")
+                val derived = deriveSleep(readings, sourceId)
+                readingDao.insertAll(readings + derived)
+                Log.i(
+                    TAG,
+                    "diag: inferred readings=${readings.size} derived=${derived.size}"
+                )
             } else {
                 Log.i(TAG, "diag: inferred readings=0 (no viable window in buffer)")
             }
@@ -252,8 +258,30 @@ class PhoneSleepWorker(
             val sourceId = ensureSource(sourceDao)
             val readings = adapter.infer(samples, sourceId)
             if (readings.isEmpty()) return ImmediateResult.NoSleepWindow
-            readingDao.insertAll(readings)
-            return ImmediateResult.Written(readings.size)
+            val derived = deriveSleep(readings, sourceId)
+            readingDao.insertAll(readings + derived)
+            return ImmediateResult.Written(readings.size + derived.size)
+        }
+
+        /**
+         * Phone-inferred SLEEP_STAGE rows skip IngestManager.deriveAll, so
+         * efficiency / TIB / latency / WASO / fragmentation / score would
+         * never populate without this. Mirrors the per-source grouping
+         * IngestManager uses so derivations stay coherent against a single
+         * session's stage rows.
+         */
+        internal fun deriveSleep(
+            readings: List<MetricReading>,
+            sourceId: String,
+        ): List<MetricReading> {
+            val derived = mutableListOf<MetricReading>()
+            SleepDerivations.deriveSleepLatency(readings, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepEfficiency(readings, sourceId)?.let { derived += it }
+            SleepDerivations.deriveTimeInBed(readings, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepFragmentation(readings, sourceId)?.let { derived += it }
+            SleepDerivations.deriveWakeAfterSleepOnset(readings, sourceId)?.let { derived += it }
+            SleepDerivations.deriveSleepScore(readings, sourceId)?.let { derived += it }
+            return derived
         }
 
         private suspend fun ensureSource(dao: com.bios.app.data.dao.DataSourceDao): String {

--- a/android/app/src/test/java/com/bios/app/PhoneSleepWorkerDeriveTest.kt
+++ b/android/app/src/test/java/com/bios/app/PhoneSleepWorkerDeriveTest.kt
@@ -1,0 +1,48 @@
+package com.bios.app
+
+import com.bios.app.ingest.PhoneSleepWorker
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression guard for the bug where phone-inferred SLEEP_STAGE rows
+ * landed in the DB without running through SleepDerivations, leaving
+ * the sleep efficiency / TIB / latency / WASO / fragmentation / score
+ * cards empty on phone-only nights.
+ */
+class PhoneSleepWorkerDeriveTest {
+
+    @Test
+    fun `deriveSleep produces efficiency and TIB from phone stage rows`() {
+        val readings = listOf(
+            stage(SleepStage.AWAKE, 1_000_000L, 300),
+            stage(SleepStage.LIGHT, 1_300_000L, 3600),
+            stage(SleepStage.AWAKE, 4_900_000L, 120),
+            stage(SleepStage.LIGHT, 5_020_000L, 3600),
+        )
+        val derived = PhoneSleepWorker.deriveSleep(readings, "phone_src")
+        val kinds = derived.map { it.metricType }.toSet()
+        assertTrue("expected SLEEP_EFFICIENCY in $kinds", MetricType.SLEEP_EFFICIENCY.key in kinds)
+        assertTrue("expected TIME_IN_BED in $kinds", MetricType.TIME_IN_BED.key in kinds)
+        assertTrue("expected SLEEP_LATENCY in $kinds", MetricType.SLEEP_LATENCY.key in kinds)
+    }
+
+    @Test
+    fun `deriveSleep returns empty for empty input`() {
+        val derived = PhoneSleepWorker.deriveSleep(emptyList(), "phone_src")
+        assertTrue(derived.isEmpty())
+    }
+
+    private fun stage(s: SleepStage, ts: Long, durationSec: Int): MetricReading = MetricReading(
+        metricType = MetricType.SLEEP_STAGE.key,
+        value = s.value.toDouble(),
+        timestamp = ts,
+        durationSec = durationSec,
+        sourceId = "phone_src",
+        confidence = ConfidenceTier.MEDIUM.level,
+    )
+}


### PR DESCRIPTION
## Summary
- `PhoneSleepWorker` was inserting `SLEEP_DURATION` + `SLEEP_STAGE` directly via `readingDao.insertAll`, bypassing `IngestManager.deriveAll`.
- On phone-only nights (no wearable adapter syncing) sleep efficiency / TIB / latency / WASO / fragmentation / score cards stayed empty even though stage data was in the DB.
- Add `PhoneSleepWorker.deriveSleep` and call it from both the periodic `doWork` and the on-demand `runImmediateInference` paths.

## Why
Reported by owner: the new sleep efficiency card (#332) and the derived TIME_IN_BED row (#334) were empty for tonight despite a phone-tracked sleep session being present.

## Test plan
- [x] `./scripts/code-quality-check.sh` — build + unit tests pass
- [x] New `PhoneSleepWorkerDeriveTest` confirms efficiency / TIB / latency rows come out of the helper
- [ ] On-device: tomorrow's phone-inferred sleep should populate the sleep efficiency card

🤖 Generated with [Claude Code](https://claude.com/claude-code)