### PR TITLE
feat(sleep): backfill sleep derivations from existing SLEEP_STAGE rows

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -312,6 +312,7 @@ class IngestManager(
             // so this block is safe to call on every sync.
             circadianEngine.derive()?.let { readingDao.insert(it) }
             HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
+            SleepDerivationsBackfill(readingDao).runForLookback(lookbackDays = 30)
             RestingHeartRateBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
             _lastSyncTime.value = System.currentTimeMillis()
             updateDataAge()

--- a/android/app/src/main/java/com/bios/app/ingest/SleepDerivationsBackfill.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/SleepDerivationsBackfill.kt
@@ -1,0 +1,90 @@
+package com.bios.app.ingest
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.SleepDerivations
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+/**
+ * Re-derives sleep metrics (efficiency, TIB, latency, WASO, fragmentation,
+ * score) from SLEEP_STAGE rows already in the DB. Repairs nights where
+ * stages landed without the matching derivations — e.g. phone-inferred
+ * sessions inserted before [PhoneSleepWorker.deriveSleep] was wired up,
+ * or batches that bypassed [IngestManager.deriveAll] for any other
+ * historical reason.
+ *
+ * Idempotent: each derivation uses the session's first-stage timestamp,
+ * so re-running collapses through the unique
+ * `(sourceId, metricType, timestamp)` index. Sessions are split on
+ * inter-stage gaps > [SESSION_GAP_MS] to keep each derivation coherent
+ * against a single sleep window rather than smearing across nights.
+ */
+class SleepDerivationsBackfill(
+    private val readingDao: MetricReadingDao,
+) {
+
+    suspend fun run(windowStartMs: Long, windowEndMs: Long): Int {
+        if (windowEndMs <= windowStartMs) return 0
+        val stages = readingDao.fetch(
+            MetricType.SLEEP_STAGE.key, windowStartMs, windowEndMs,
+        )
+        if (stages.isEmpty()) return 0
+
+        val derived = mutableListOf<MetricReading>()
+        stages.groupBy { it.sourceId }.forEach { (sourceId, sourceStages) ->
+            Companion.splitSessions(sourceStages.sortedBy { it.timestamp }).forEach { session ->
+                SleepDerivations.deriveSleepLatency(session, sourceId)?.let { derived += it }
+                SleepDerivations.deriveSleepEfficiency(session, sourceId)?.let { derived += it }
+                SleepDerivations.deriveTimeInBed(session, sourceId)?.let { derived += it }
+                SleepDerivations.deriveSleepFragmentation(session, sourceId)?.let { derived += it }
+                SleepDerivations.deriveWakeAfterSleepOnset(session, sourceId)?.let { derived += it }
+                SleepDerivations.deriveSleepScore(session, sourceId)?.let { derived += it }
+            }
+        }
+        if (derived.isEmpty()) return 0
+        readingDao.insertAll(derived)
+        return derived.size
+    }
+
+    suspend fun runForLookback(lookbackDays: Long): Int = runCatching {
+        val end = Instant.now()
+        val start = end.minus(lookbackDays, ChronoUnit.DAYS)
+        run(start.toEpochMilli(), end.toEpochMilli())
+    }.getOrDefault(0)
+
+    companion object {
+        internal const val SESSION_GAP_MS: Long = 60L * 60L * 1000L
+
+        /**
+         * Splits a sorted, single-source stage list into sessions on any
+         * gap larger than [SESSION_GAP_MS] between consecutive stages.
+         * A real night's stages arrive every few minutes; a gap of an
+         * hour or more is structurally a different session — running one
+         * derivation across two nights would over-count both TIB and
+         * efficiency.
+         */
+        internal fun splitSessions(stages: List<MetricReading>): List<List<MetricReading>> {
+            if (stages.isEmpty()) return emptyList()
+            val sessions = mutableListOf<MutableList<MetricReading>>()
+            var current = mutableListOf<MetricReading>()
+            for (row in stages) {
+                val last = current.lastOrNull()
+                if (last == null) {
+                    current += row
+                    continue
+                }
+                val lastEndMs = last.timestamp + (last.durationSec ?: 0) * 1000L
+                if (row.timestamp - lastEndMs > SESSION_GAP_MS) {
+                    sessions += current
+                    current = mutableListOf(row)
+                } else {
+                    current += row
+                }
+            }
+            if (current.isNotEmpty()) sessions += current
+            return sessions
+        }
+    }
+}

--- a/android/app/src/test/java/com/bios/app/SleepDerivationsBackfillTest.kt
+++ b/android/app/src/test/java/com/bios/app/SleepDerivationsBackfillTest.kt
@@ -1,0 +1,72 @@
+package com.bios.app
+
+import com.bios.app.ingest.SleepDerivationsBackfill
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-function coverage for the session-splitter that drives the
+ * backfill. The full [SleepDerivationsBackfill.run] path needs a Room
+ * DAO and is exercised by manual sync on-device; here we only guard
+ * the split heuristic against drift.
+ */
+class SleepDerivationsBackfillTest {
+
+    @Test
+    fun `consecutive stages within an hour stay one session`() {
+        val stages = listOf(
+            stage(SleepStage.LIGHT, ts = 0L, durationSec = 1800),
+            stage(SleepStage.DEEP, ts = hours(0.5), durationSec = 1800),
+            stage(SleepStage.REM, ts = hours(1.0), durationSec = 1800),
+        )
+        val sessions = SleepDerivationsBackfill.splitSessions(stages)
+        assertEquals(1, sessions.size)
+        assertEquals(3, sessions[0].size)
+    }
+
+    @Test
+    fun `gap larger than an hour splits sessions`() {
+        val stages = listOf(
+            stage(SleepStage.LIGHT, ts = 0L, durationSec = 1800),
+            stage(SleepStage.DEEP, ts = hours(0.5), durationSec = 1800),
+            // 20h gap — clearly a different night
+            stage(SleepStage.LIGHT, ts = hours(21.0), durationSec = 1800),
+            stage(SleepStage.REM, ts = hours(21.5), durationSec = 1800),
+        )
+        val sessions = SleepDerivationsBackfill.splitSessions(stages)
+        assertEquals(2, sessions.size)
+        assertEquals(2, sessions[0].size)
+        assertEquals(2, sessions[1].size)
+    }
+
+    @Test
+    fun `gap exactly at threshold stays in same session`() {
+        val stages = listOf(
+            stage(SleepStage.LIGHT, ts = 0L, durationSec = 0),
+            // Gap == 60min, threshold is "> 60min", so still same session
+            stage(SleepStage.DEEP, ts = hours(1.0), durationSec = 0),
+        )
+        val sessions = SleepDerivationsBackfill.splitSessions(stages)
+        assertEquals(1, sessions.size)
+    }
+
+    @Test
+    fun `empty input yields no sessions`() {
+        assertEquals(0, SleepDerivationsBackfill.splitSessions(emptyList()).size)
+    }
+
+    private fun stage(s: SleepStage, ts: Long, durationSec: Int): MetricReading = MetricReading(
+        metricType = MetricType.SLEEP_STAGE.key,
+        value = s.value.toDouble(),
+        timestamp = ts,
+        durationSec = durationSec,
+        sourceId = "src",
+        confidence = ConfidenceTier.MEDIUM.level,
+    )
+
+    private fun hours(h: Double): Long = (h * 3600.0 * 1000.0).toLong()
+}


### PR DESCRIPTION
## Summary
- New `SleepDerivationsBackfill` walks SLEEP_STAGE rows already in the DB, groups them by sourceId, splits into sessions on >1h inter-stage gaps, and re-runs the six sleep derivations per session.
- Wires into `IngestManager` sync tail alongside `HrGapTibBackfill` / `RestingHeartRateBackfill`.
- Idempotent via the existing `(sourceId, metricType, timestamp)` unique index — runs every sync safely.

## Why
PRs #334 and #335 fix the *forward* path (TIB derivation + PhoneSleepWorker running derivations), but nights with stage data already on-device never got efficiency / TIB / latency / WASO / fragmentation / score rows because the original PhoneSleepWorker bypassed `IngestManager.deriveAll`. Reporter confirms sleep efficiency card is still empty post-#335 — historical nights need this backfill.

## Test plan
- [x] `./scripts/code-quality-check.sh` — build + unit tests pass
- [x] `SleepDerivationsBackfillTest` covers the session-split heuristic
- [ ] On-device: next sync should populate efficiency for past nights with existing stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)