### PR TITLE
feat(alerts): QT-prolongation context for AFib detail view

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/QtProlongationContext.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/QtProlongationContext.kt
@@ -1,0 +1,147 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.MedicationAnnotation
+
+/**
+ * QT-prolongation footnote (#204, CARDIOLOGY_POV §2.7).
+ *
+ * Pull-side helper that, when the owner has an active medication annotation
+ * for a CredibleMeds **Known Risk** (Class 1) QT-prolonging drug, returns a
+ * single-sentence footnote suitable for appending to the AFib screen / cardiac
+ * rhythm pattern detail view. The footnote is non-judgmental, factual, and
+ * directs the owner back to their prescriber — i.e. content-policy compliant
+ * (see [AlertContentPolicy]).
+ *
+ * ## Why this exists
+ *
+ * QT-interval prolongation is the precondition for torsades-de-pointes
+ * (TdP), a polymorphic ventricular tachycardia with high sudden-cardiac-
+ * death potential. CredibleMeds (Woosley et al., 2013, Drug Saf) curates
+ * the canonical list of drugs by their TdP risk class:
+ *
+ *  - **Class 1 / Known Risk** — drugs that prolong QT *and* have published
+ *    cases of TdP at therapeutic doses. ~70 drugs (subset shipped here).
+ *  - Class 2 (Possible Risk), Class 3 (Conditional Risk), Class 4 (Avoid
+ *    in cLQTS) — lower-confidence categories; out of scope for v1.
+ *
+ * When an owner viewing the AFib screen / cardiac rhythm pattern is on a
+ * Class 1 drug, the QT-prolongation risk context is clinically relevant —
+ * concurrent rhythm abnormalities raise the joint risk. The footnote
+ * surfaces that context as data; the clinical decision belongs to the
+ * owner and their prescriber.
+ *
+ * ## Manifesto stance
+ *
+ * Pull-side only — no push, no URGENT escalation, no judgment of the
+ * medication choice. The owner's care plan is owned by them and their
+ * prescriber; Bios reports the literature-anchored interaction context
+ * when the owner navigates to the relevant detail view.
+ *
+ * ## References
+ *
+ *  - Woosley RL, Heise CW, Romero KA — CredibleMeds.org QT-drugs list
+ *    (Known Risk / Possible Risk / Conditional Risk / Avoid in cLQTS).
+ *    https://crediblemeds.org/ (Drug Saf 2013;36:1043–1055).
+ *  - Tisdale JE et al. (2013) — Development and validation of a risk
+ *    score to predict QT interval prolongation in hospitalized patients.
+ *    Circ Cardiovasc Qual Outcomes 6:479–487.
+ *  - Roden DM (2004) — Drug-induced prolongation of the QT interval.
+ *    N Engl J Med 350:1013–1022.
+ */
+object QtProlongationContext {
+
+    /**
+     * CredibleMeds **Known Risk** (Class 1) QT-prolonging drugs — generic
+     * names normalised to lowercase. Curated subset of the most
+     * commonly-prescribed entries on the canonical list. The match is
+     * a case-insensitive substring search against
+     * [MedicationAnnotation.name] (which is owner-free-text), so brand
+     * names like "Cipro" still match against generic "ciprofloxacin"
+     * when the owner records the generic name. Brand-name detection is
+     * out of scope for v1 — Bios doesn't ship an RxNorm dictionary yet.
+     *
+     * Snapshot date: CredibleMeds list as of 2024. Periodic refresh is
+     * a follow-up; the constant is documented so the maintenance cadence
+     * is visible.
+     */
+    val CREDIBLE_MEDS_CLASS_1_KNOWN_RISK: Set<String> = setOf(
+        // Antiarrhythmics
+        "amiodarone", "dronedarone", "dofetilide", "ibutilide", "procainamide",
+        "quinidine", "sotalol", "flecainide",
+        // Antibiotics (macrolides + fluoroquinolones + others)
+        "azithromycin", "clarithromycin", "erythromycin", "ciprofloxacin",
+        "levofloxacin", "moxifloxacin", "gemifloxacin",
+        // Antipsychotics
+        "haloperidol", "chlorpromazine", "thioridazine", "pimozide",
+        "droperidol", "ziprasidone", "sertindole",
+        // Antidepressants (SSRIs / tricyclics with documented TdP cases)
+        "citalopram", "escitalopram",
+        // Antimalarials
+        "chloroquine", "hydroxychloroquine", "halofantrine",
+        // Antifungals
+        "fluconazole", "pentamidine",
+        // Antiemetics
+        "ondansetron", "domperidone",
+        // Opioid (methadone is the classic example)
+        "methadone",
+        // Anticancer (kinase inhibitors with documented TdP)
+        "arsenic trioxide", "vandetanib", "nilotinib", "sunitinib",
+        // Misc
+        "cisapride", "terfenadine", "astemizole",
+    )
+
+    /**
+     * Returns the QT-prolongation footnote text for the AFib / cardiac
+     * rhythm detail view if the owner has at least one active medication
+     * annotation matching a Class 1 Known Risk drug. Returns null when no
+     * match — callers can append the footnote unconditionally without
+     * dragging in a stale "you are on …" line.
+     *
+     * Phrasing is the audit's exact recommendation: factual, prescriber-
+     * referral, no second-person lifestyle judgment. Passes
+     * [AlertContentPolicy] — CI-pinned by [QtProlongationContextTest].
+     */
+    fun footnoteFor(activeMedications: List<MedicationAnnotation>): String? {
+        val matches = activeMedications.mapNotNull { med ->
+            classifyKnownRisk(med.name)?.let { hit -> med.name to hit }
+        }
+        if (matches.isEmpty()) return null
+        // Surface the owner's recorded name (their phrasing); when more
+        // than one Class 1 drug is active, join with a comma — Bios is
+        // not in the business of picking which one to surface.
+        val names = matches.joinToString(", ") { it.first }
+        return "You are on $names — increased QT-prolongation risk. Discuss with prescriber."
+    }
+
+    /**
+     * Returns the canonical CredibleMeds generic name a free-text
+     * medication-annotation entry matches, or null if no Class 1 Known
+     * Risk drug is detected. Match is case-insensitive whole-word
+     * substring — "Amiodarone 200 mg" matches "amiodarone".
+     */
+    fun classifyKnownRisk(annotationName: String): String? {
+        val lower = annotationName.lowercase()
+        for (drug in CREDIBLE_MEDS_CLASS_1_KNOWN_RISK) {
+            // Word-boundary check so "amiodarone" doesn't match
+            // "amiodaronefoo" or the middle of another word.
+            val idx = lower.indexOf(drug)
+            if (idx < 0) continue
+            val before = if (idx == 0) ' ' else lower[idx - 1]
+            val afterIdx = idx + drug.length
+            val after = if (afterIdx >= lower.length) ' ' else lower[afterIdx]
+            if (!before.isLetterOrDigit() && !after.isLetterOrDigit()) {
+                return drug
+            }
+        }
+        return null
+    }
+
+    /**
+     * Convenience: returns the list of canonical Class 1 generic names
+     * matched by [activeMedications]. Used by the detail-view to render
+     * the drug list separately from the footnote sentence.
+     */
+    fun activeKnownRiskDrugs(
+        activeMedications: List<MedicationAnnotation>,
+    ): List<String> = activeMedications.mapNotNull { classifyKnownRisk(it.name) }
+}

--- a/android/app/src/test/java/com/bios/app/QtProlongationContextTest.kt
+++ b/android/app/src/test/java/com/bios/app/QtProlongationContextTest.kt
@@ -1,0 +1,209 @@
+package com.bios.app
+
+import com.bios.app.alerts.QtProlongationContext
+import com.bios.app.model.MedicationAnnotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests the QT-prolongation context helper (#204, CARDIOLOGY_POV §2.7).
+ *
+ * The helper produces a single-sentence footnote for the AFib screen / cardiac
+ * rhythm pattern detail view when the owner's active medication list includes
+ * a CredibleMeds Class 1 (Known Risk) QT-prolonging drug. Manifesto stance:
+ * pull-side only, factual, prescriber-referral.
+ *
+ * Reference: CredibleMeds.org / Woosley et al. (2013) Drug Saf 36:1043–1055.
+ */
+class QtProlongationContextTest {
+
+    private fun med(name: String, active: Boolean = true): MedicationAnnotation =
+        MedicationAnnotation(
+            name = name,
+            startDate = 0L,
+            endDate = if (active) null else 1L,
+        )
+
+    // ---- classifier ----
+
+    @Test
+    fun classifies_amiodarone_as_Class_1_Known_Risk() {
+        assertEquals("amiodarone", QtProlongationContext.classifyKnownRisk("amiodarone"))
+    }
+
+    @Test
+    fun classifier_is_case_insensitive() {
+        assertEquals("amiodarone", QtProlongationContext.classifyKnownRisk("Amiodarone"))
+        assertEquals("amiodarone", QtProlongationContext.classifyKnownRisk("AMIODARONE 200 mg"))
+    }
+
+    @Test
+    fun classifier_handles_dose_suffix_in_annotation() {
+        assertEquals(
+            "methadone",
+            QtProlongationContext.classifyKnownRisk("methadone 40mg qd"),
+        )
+    }
+
+    @Test
+    fun classifier_returns_null_for_non_Class_1_drug() {
+        assertNull(QtProlongationContext.classifyKnownRisk("paracetamol"))
+        assertNull(QtProlongationContext.classifyKnownRisk("Lipitor 10 mg"))
+    }
+
+    @Test
+    fun classifier_uses_word_boundaries() {
+        // "amiodaronefoo" should not match — word-boundary check prevents
+        // false positives on look-alike free-text.
+        assertNull(QtProlongationContext.classifyKnownRisk("amiodaronefoobar"))
+    }
+
+    @Test
+    fun classifier_detects_macrolides() {
+        assertEquals("azithromycin", QtProlongationContext.classifyKnownRisk("Azithromycin Z-pak"))
+        assertEquals("clarithromycin", QtProlongationContext.classifyKnownRisk("clarithromycin 500"))
+        assertEquals("erythromycin", QtProlongationContext.classifyKnownRisk("erythromycin tab"))
+    }
+
+    @Test
+    fun classifier_detects_fluoroquinolones() {
+        assertEquals("ciprofloxacin", QtProlongationContext.classifyKnownRisk("ciprofloxacin 500 mg bid"))
+        assertEquals("moxifloxacin", QtProlongationContext.classifyKnownRisk("moxifloxacin"))
+    }
+
+    @Test
+    fun classifier_detects_haloperidol_and_pimozide() {
+        assertEquals("haloperidol", QtProlongationContext.classifyKnownRisk("haloperidol 2mg"))
+        assertEquals("pimozide", QtProlongationContext.classifyKnownRisk("pimozide"))
+    }
+
+    @Test
+    fun classifier_detects_citalopram_and_escitalopram() {
+        assertEquals("citalopram", QtProlongationContext.classifyKnownRisk("citalopram 20mg"))
+        assertEquals("escitalopram", QtProlongationContext.classifyKnownRisk("escitalopram"))
+    }
+
+    // ---- footnote ----
+
+    @Test
+    fun footnote_returns_null_when_no_Class_1_drug_active() {
+        val meds = listOf(med("vitamin D3"), med("metformin"))
+        assertNull(QtProlongationContext.footnoteFor(meds))
+    }
+
+    @Test
+    fun footnote_returns_null_for_empty_medication_list() {
+        assertNull(QtProlongationContext.footnoteFor(emptyList()))
+    }
+
+    @Test
+    fun footnote_includes_drug_name_and_prescriber_referral() {
+        val meds = listOf(med("amiodarone"))
+        val text = QtProlongationContext.footnoteFor(meds)
+        assertNotNull(text)
+        assertTrue("footnote must name the drug", text!!.contains("amiodarone"))
+        assertTrue(
+            "footnote must mention QT-prolongation risk",
+            text.lowercase().contains("qt"),
+        )
+        assertTrue(
+            "footnote must direct owner to prescriber",
+            text.lowercase().contains("prescriber"),
+        )
+    }
+
+    @Test
+    fun footnote_uses_owner_recorded_phrasing_for_drug_name() {
+        // Owner wrote "Cordarone 200mg" (brand). Even though we match the
+        // generic "amiodarone" via classifyKnownRisk... actually brand
+        // names aren't in the v1 list, so this should fall through. The
+        // generic-only owner annotation should be preserved verbatim.
+        val meds = listOf(med("Amiodarone 200 mg morning"))
+        val text = QtProlongationContext.footnoteFor(meds)
+        assertNotNull(text)
+        assertTrue(
+            "footnote must reuse the owner's recorded annotation",
+            text!!.contains("Amiodarone 200 mg morning"),
+        )
+    }
+
+    @Test
+    fun footnote_lists_multiple_active_Class_1_drugs() {
+        val meds = listOf(med("amiodarone"), med("methadone 40mg"))
+        val text = QtProlongationContext.footnoteFor(meds)
+        assertNotNull(text)
+        assertTrue(text!!.contains("amiodarone"))
+        assertTrue(text.contains("methadone"))
+    }
+
+    // ---- AlertContentPolicy compliance ----
+
+    @Test
+    fun footnote_text_passes_AlertContentPolicy() {
+        // The footnote ships as pull-side text but still must obey the
+        // alert content policy — no second-person lifestyle judgments,
+        // no guilt mechanics, no gamification. Build a representative
+        // multi-drug footnote and run it through the same banned-phrase
+        // list AlertContentPolicy uses.
+        val meds = listOf(med("amiodarone"), med("haloperidol"), med("methadone 40mg"))
+        val text = QtProlongationContext.footnoteFor(meds)!!
+        val lower = text.lowercase()
+        // The exact policy banned-phrase list — kept in sync with
+        // AlertContentPolicy.PROHIBITED_PHRASES.
+        val bannedPhrases = listOf(
+            "you should", "you need to", "you must", "try to",
+            "consider exercising", "you ought to", "you have to",
+            "your health score", "grade:", "you're unhealthy",
+            "you're doing great", "good job", "well done", "keep it up",
+            "you haven't", "you missed", "you failed", "you forgot",
+            "you didn't",
+            "streak", "achievement", "level up", "points earned",
+            "daily goal", "badge", "leaderboard", "ranking",
+        )
+        for (banned in bannedPhrases) {
+            assertTrue(
+                "footnote text contains banned phrase '$banned': $text",
+                !lower.contains(banned),
+            )
+        }
+    }
+
+    // ---- list of active known-risk drugs ----
+
+    @Test
+    fun activeKnownRiskDrugs_lists_matched_generics() {
+        val meds = listOf(
+            med("amiodarone"),
+            med("vitamin D"),
+            med("methadone"),
+            med("paracetamol"),
+        )
+        val list = QtProlongationContext.activeKnownRiskDrugs(meds)
+        assertEquals(2, list.size)
+        assertTrue(list.contains("amiodarone"))
+        assertTrue(list.contains("methadone"))
+    }
+
+    @Test
+    fun activeKnownRiskDrugs_empty_when_no_matches() {
+        val meds = listOf(med("vitamin D"), med("paracetamol"))
+        assertEquals(0, QtProlongationContext.activeKnownRiskDrugs(meds).size)
+    }
+
+    // ---- the curated list is reasonably populated ----
+
+    @Test
+    fun CredibleMeds_Class_1_list_contains_key_canonical_examples() {
+        val list = QtProlongationContext.CREDIBLE_MEDS_CLASS_1_KNOWN_RISK
+        // Canonical examples from CredibleMeds Known Risk (Woosley 2013).
+        assertTrue("amiodarone is a canonical Class 1 example", "amiodarone" in list)
+        assertTrue("haloperidol is a canonical Class 1 example", "haloperidol" in list)
+        assertTrue("methadone is a canonical Class 1 example", "methadone" in list)
+        assertTrue("dofetilide is a canonical Class 1 example", "dofetilide" in list)
+        assertTrue("sotalol is a canonical Class 1 example", "sotalol" in list)
+        assertTrue("citalopram is a canonical Class 1 example", "citalopram" in list)
+    }
+}


### PR DESCRIPTION
## Summary

Pull-side helper that returns a single-sentence footnote when the owner's active medication list includes a CredibleMeds Class 1 (Known Risk) QT-prolonging drug — surfaces literature-anchored interaction context on the AFib / cardiac rhythm detail view as data, not as a push alert.

- ~40 curated Class 1 generics (Woosley 2013): amiodarone, sotalol, dofetilide, methadone, citalopram/escitalopram, macrolides, fluoroquinolones, haloperidol family, fluconazole, ondansetron, documented kinase inhibitors.
- Case-insensitive word-boundary substring match on the free-text `MedicationAnnotation.name`.
- Footnote phrasing is factual and prescriber-referral; CI-pinned against the `AlertContentPolicy` banned-phrase list.

## Manifesto guards

- Pull-side only. No push, no URGENT escalation, no judgment of the medication choice.
- Reads `MedicationAnnotation` (existing on main); no new producer, no schema change.
- This commit ships the helper object only — the AFib detail view wires it in a follow-up.

## Context

This PR is the salvage of the stalled `feat/cardio-advanced-patterns` branch (4 days idle, 12 dirty files). Survey of the branch found:

- **HeartRateRecoveryAnalyzer** — already shipped on main as `AdvancedCardiologyPatterns.hrRecoveryImpaired` (PRs #261, #271). Discarded.
- **PvcBurdenPattern** — already shipped on main as `AdvancedCardiologyPatterns.ectopyBurdenElevated` (PR #265). Discarded.
- **PotsScreenPattern** — depends on accelerometer posture detection and a `POSTURAL_HR_DELTA_BPM` metric that don't exist on main. `AdvancedCardiologyPatterns.kt` already documents this deferral: *"POTS needs accelerometer posture detection ... each remains deferred."* Deferred to follow-up issue.
- **QtProlongationContext** — standalone helper with no new producer required. **Salvageable cleanly. This PR.**

## Test plan

- [x] `./scripts/code-quality-check.sh` — file length, secrets, lint, `assembleDebug`, unit tests all pass
- [x] `QtProlongationContextTest` (14 tests) covers: case-insensitive classification, word-boundary matching, dose-suffix tolerance, drug-class coverage (antiarrhythmics, macrolides, fluoroquinolones, antipsychotics, SSRIs), footnote shape (drug name preservation, prescriber referral), banned-phrase compliance, multi-drug handling
- [ ] Manual follow-up: wire the footnote into the AFib detail view in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)