### PR TITLE
feat(engine): GaitAnalyzer — stride-time CoV + postural sway (#208 PR B)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/GaitAnalyzer.kt
+++ b/android/app/src/main/java/com/bios/app/engine/GaitAnalyzer.kt
@@ -1,0 +1,218 @@
+package com.bios.app.engine
+
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlin.math.abs
+import kotlin.math.sqrt
+
+/**
+ * Phone-sensor gait analysis (#208, GERIATRICS_PALLIATIVE_POV §2.3 +
+ * Neurology MCI audit).
+ *
+ * Computes stride-time coefficient of variation (CoV) from a series of
+ * step-event timestamps. The anchor literature:
+ *
+ *  - **Hausdorff 2007** — *Gait variability: methods, modeling and meaning*.
+ *    Defines stride-time CoV as the canonical measure of gait timing
+ *    irregularity. CoV ≥ ~3 % is the broadly-cited cohort threshold above
+ *    which fall risk in older adults rises non-linearly.
+ *  - **Verghese 2009** — *Quantitative gait dysfunction and risk of cognitive
+ *    decline and dementia*. Establishes the link between stride-time
+ *    variability and incident MCI / dementia in community-dwelling older
+ *    adults.
+ *  - **Maki 1994** — postural sway amplitude correlates with future falls
+ *    in older adults; informs the companion POSTURAL_SWAY_AP_AMPLITUDE_MM
+ *    metric (computed by a separate one-shot standing-still capture).
+ *
+ * ## Manifesto framing
+ *
+ * GaitAnalyzer is a **data substrate**. It writes the [MetricType.GAIT_VARIABILITY_COV]
+ * reading and stops. It does not classify, score the person, or push a
+ * notification. The geriatric trajectory advisories
+ * ([com.bios.app.alerts.GeriatricTrajectoryPatterns]) read this signal
+ * alongside frailty + polypharmacy + age, but every one of those advisories
+ * is `pullSideOnly = true` — the owner navigates into the trajectory view
+ * to read their own trend. Bios never says "your fall risk increased".
+ *
+ * ## Algorithm
+ *
+ * Input: a list of step-event timestamps (epoch-millis), typically from a
+ * rolling 24 h window of [MetricType.STEPS] readings or step-counter
+ * deltas.
+ *
+ * 1. Compute inter-step intervals (ms between consecutive timestamps).
+ * 2. Drop intervals outside the physiologically plausible band
+ *    ([MIN_STRIDE_MS]..[MAX_STRIDE_MS]) — anything tighter is double-tap
+ *    noise; anything looser is a pause between walking bouts, not a stride.
+ * 3. Require at least [MIN_INTERVALS] surviving intervals; otherwise the
+ *    sample is insufficient and the analyzer returns `null`.
+ * 4. Compute the coefficient of variation: `stdDev / mean × 100`. Reported
+ *    as a percent (CoV × 100), per the convention in the Hausdorff
+ *    literature.
+ *
+ * The speed-corrected variant ([gaitVariabilitySpeedCorrected]) divides
+ * the raw CoV by the mean inter-step interval normalised against a
+ * reference 1-second cadence — this removes the slow-walking inflation
+ * effect Hausdorff 2007 calls out (slow gait has structurally higher
+ * CoV regardless of pathology).
+ *
+ * ## Calling shape
+ *
+ * The engine is pure-Kotlin and side-effect-free — no Room, no
+ * SharedPreferences, no Android context. The caller (typically a
+ * SyncWorker stage) decides how often to run it, how to persist the
+ * resulting reading, and which source-id to tag.
+ */
+object GaitAnalyzer {
+
+    /**
+     * Minimum stride-time interval, in milliseconds. Anything tighter is
+     * not a stride — it's accelerometer noise or a step-counter double-fire.
+     * 250 ms = 240 steps/min ceiling (sprinting); even elite sprinters
+     * rarely exceed this for sustained windows.
+     */
+    const val MIN_STRIDE_MS: Long = 250L
+
+    /**
+     * Maximum stride-time interval, in milliseconds. Anything looser is a
+     * pause between walking bouts and shouldn't count as a single stride.
+     * 2000 ms = 30 steps/min floor. Older adults with parkinsonian gait
+     * can dip near the floor; the trajectory signal is the trend, not
+     * any single sample.
+     */
+    const val MAX_STRIDE_MS: Long = 2_000L
+
+    /**
+     * Minimum number of in-band intervals required to compute a stable CoV.
+     * Hausdorff 2007 recommends ≥30 strides; the wearable / phone-derived
+     * literature uses ≥20 for shorter capture windows. We pick 20 as the
+     * conservative floor that still gives a meaningful variance estimate.
+     */
+    const val MIN_INTERVALS: Int = 20
+
+    /** Reference cadence used by the speed-corrected CoV. 1 stride/sec is
+     *  the rough adult comfortable-walking cadence (Hausdorff 2007). */
+    private const val REFERENCE_INTERVAL_MS: Double = 1_000.0
+
+    /**
+     * Computes stride-time CoV as a percent (CoV × 100) from a list of
+     * step-event epoch-millis timestamps. Returns `null` when the input
+     * doesn't have enough in-band intervals to be meaningful.
+     *
+     * @param stepTimestampsMillis ascending-sorted (or unsorted; the
+     *   function sorts defensively) epoch-millisecond step events.
+     */
+    fun strideTimeCoVPercent(stepTimestampsMillis: List<Long>): Double? {
+        val intervals = inBandIntervals(stepTimestampsMillis) ?: return null
+        val mean = intervals.average()
+        if (mean <= 0.0) return null
+        val variance = intervals.fold(0.0) { acc, v -> acc + (v - mean) * (v - mean) } / intervals.size
+        val stdDev = sqrt(variance)
+        return stdDev / mean * 100.0
+    }
+
+    /**
+     * Speed-corrected stride-time CoV. Normalises the raw CoV against the
+     * deviation of the mean inter-step interval from the 1 s/stride
+     * reference cadence. Removes the slow-walking inflation effect
+     * (Hausdorff 2007). Returns `null` under the same conditions as
+     * [strideTimeCoVPercent].
+     */
+    fun gaitVariabilitySpeedCorrected(stepTimestampsMillis: List<Long>): Double? {
+        val intervals = inBandIntervals(stepTimestampsMillis) ?: return null
+        val mean = intervals.average()
+        if (mean <= 0.0) return null
+        val variance = intervals.fold(0.0) { acc, v -> acc + (v - mean) * (v - mean) } / intervals.size
+        val stdDev = sqrt(variance)
+        val rawCov = stdDev / mean * 100.0
+        // Speed correction: divide by the ratio of mean to reference.
+        // Slow gait (mean > 1000 ms) shrinks the corrected value; fast
+        // gait (mean < 1000 ms) inflates it modestly. The intent is a
+        // metric that's comparable across owners with different
+        // baseline cadences.
+        val speedFactor = mean / REFERENCE_INTERVAL_MS
+        return if (speedFactor > 0.0) rawCov / speedFactor else null
+    }
+
+    /**
+     * Wraps [strideTimeCoVPercent] in a [MetricReading] tagged with the
+     * caller-supplied [sourceId]. Returns `null` when there isn't enough
+     * data; the caller decides whether to persist or skip.
+     */
+    fun toReading(
+        stepTimestampsMillis: List<Long>,
+        sourceId: String,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): MetricReading? {
+        val cov = strideTimeCoVPercent(stepTimestampsMillis) ?: return null
+        return MetricReading(
+            metricType = MetricType.GAIT_VARIABILITY_COV.key,
+            value = cov,
+            timestamp = nowMillis,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.LOW.level,
+        )
+    }
+
+    /**
+     * Returns the in-band intervals (in ms) between consecutive step
+     * timestamps, or `null` when there aren't enough surviving intervals.
+     */
+    private fun inBandIntervals(stepTimestampsMillis: List<Long>): List<Double>? {
+        if (stepTimestampsMillis.size < MIN_INTERVALS + 1) return null
+        val sorted = stepTimestampsMillis.sorted()
+        val intervals = mutableListOf<Double>()
+        for (i in 1 until sorted.size) {
+            val dt = sorted[i] - sorted[i - 1]
+            if (dt in MIN_STRIDE_MS..MAX_STRIDE_MS) {
+                intervals.add(dt.toDouble())
+            }
+        }
+        if (intervals.size < MIN_INTERVALS) return null
+        return intervals
+    }
+
+    /**
+     * Computes an anterior-posterior postural-sway amplitude estimate
+     * (in millimetres) from a stream of accelerometer samples taken
+     * during a standing-still capture. The owner holds the phone against
+     * their chest, eyes open, ~30 s — the standard "Romberg-on-phone"
+     * surrogate. The amplitude is approximated by double-integrating the
+     * AP-axis acceleration over the capture window after removing the
+     * gravity offset, and taking the peak-to-peak displacement.
+     *
+     * This is a coarse phone-sensor proxy for laboratory force-plate
+     * postural sway (Maki 1994). It is offered as a substrate metric;
+     * the geriatric trajectory advisories do not currently fire on it,
+     * but the pull-side view shows its trend.
+     *
+     * Returns `null` when the input is too short to estimate.
+     *
+     * @param apAccelerationsMps2 anterior-posterior axis acceleration
+     *   samples in m/s² (already gravity-removed by the caller).
+     * @param sampleRateHz sampling rate; typical 50–100 Hz from phone
+     *   accelerometers.
+     */
+    fun posturalSwayAmplitudeMm(
+        apAccelerationsMps2: List<Double>,
+        sampleRateHz: Double,
+    ): Double? {
+        if (apAccelerationsMps2.size < 50) return null
+        if (sampleRateHz <= 0.0) return null
+        val dt = 1.0 / sampleRateHz
+        var v = 0.0
+        var x = 0.0
+        var maxX = Double.NEGATIVE_INFINITY
+        var minX = Double.POSITIVE_INFINITY
+        for (a in apAccelerationsMps2) {
+            v += a * dt
+            x += v * dt
+            if (x > maxX) maxX = x
+            if (x < minX) minX = x
+        }
+        // m → mm (×1000), peak-to-peak amplitude.
+        val amplitudeMm = abs(maxX - minX) * 1000.0
+        return amplitudeMm
+    }
+}

--- a/android/app/src/test/java/com/bios/app/GaitAnalyzerTest.kt
+++ b/android/app/src/test/java/com/bios/app/GaitAnalyzerTest.kt
@@ -1,0 +1,190 @@
+package com.bios.app
+
+import com.bios.app.engine.GaitAnalyzer
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/**
+ * Pure-math tests for [GaitAnalyzer] (#208, GERIATRICS_PALLIATIVE_POV §2.3).
+ *
+ * Stride-time CoV is the canonical Hausdorff 2007 gait-variability
+ * scalar — coefficient of variation of inter-step intervals, reported as
+ * a percent. The tests verify:
+ *  - Constant-cadence walk → CoV ≈ 0.
+ *  - Highly irregular cadence → CoV well above the clinical 3 % cohort
+ *    threshold the Hausdorff / Verghese literature uses.
+ *  - Out-of-band intervals (double-tap noise, between-bout pauses) are
+ *    rejected.
+ *  - Insufficient sample → null (no false-confidence reading).
+ *  - The MetricReading writer tags the canonical key.
+ */
+class GaitAnalyzerTest {
+
+    @Test
+    fun constant_cadence_walk_has_near_zero_cov() {
+        // Perfectly regular 1 Hz cadence — 1000 ms between steps.
+        val timestamps = (0 until 40).map { it * 1000L }
+        val cov = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        assertNotNull(cov)
+        assertTrue("Constant cadence should be near-zero CoV, got $cov", cov!! < 0.001)
+    }
+
+    @Test
+    fun mildly_variable_cadence_produces_modest_cov() {
+        // Alternating 950 / 1050 ms intervals — mean 1000, stdDev 50,
+        // CoV = 5 %. Above the literature cohort cutoff (~3 %).
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (i in 0 until 40) {
+            t += if (i % 2 == 0) 950L else 1050L
+            timestamps.add(t)
+        }
+        val cov = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        assertNotNull(cov)
+        assertTrue("Alternating cadence should yield CoV ~5%, got $cov", abs(cov!! - 5.0) < 0.1)
+    }
+
+    @Test
+    fun highly_variable_cadence_produces_large_cov() {
+        // Random-ish intervals in the 500–1500 ms band. Variability >>
+        // the Hausdorff cohort cutoff.
+        val intervals = listOf(
+            500L, 1500L, 700L, 1300L, 900L, 1100L, 600L, 1400L, 800L, 1200L,
+            500L, 1500L, 700L, 1300L, 900L, 1100L, 600L, 1400L, 800L, 1200L,
+            500L, 1500L, 700L, 1300L, 900L, 1100L, 600L, 1400L, 800L, 1200L,
+        )
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (dt in intervals) {
+            t += dt
+            timestamps.add(t)
+        }
+        val cov = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        assertNotNull(cov)
+        assertTrue("Highly variable cadence should produce CoV well above the 3 % cohort cutoff, got $cov", cov!! > 20.0)
+    }
+
+    @Test
+    fun out_of_band_intervals_are_filtered_out() {
+        // Embed a 100 ms double-tap (below MIN_STRIDE_MS) and a 5 s
+        // between-bout pause (above MAX_STRIDE_MS) in an otherwise
+        // regular 1 s cadence. Filters should drop both.
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (i in 0 until 30) {
+            t += 1000L
+            timestamps.add(t)
+        }
+        // Insert a 100 ms double-tap.
+        timestamps.add(timestamps.last() + 100L)
+        // Insert a 5 s pause then resume cadence.
+        t = timestamps.last() + 5_000L
+        timestamps.add(t)
+        for (i in 0 until 20) {
+            t += 1000L
+            timestamps.add(t)
+        }
+        val cov = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        assertNotNull(cov)
+        // After filtering, the surviving intervals are all 1000 ms — CoV ≈ 0.
+        assertTrue("Out-of-band intervals should be filtered, CoV near 0, got $cov", cov!! < 0.01)
+    }
+
+    @Test
+    fun insufficient_sample_returns_null() {
+        // 10 steps → 9 intervals, below MIN_INTERVALS = 20.
+        val timestamps = (0 until 10).map { it * 1000L }
+        val cov = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        assertNull("Below MIN_INTERVALS the analyzer must return null", cov)
+    }
+
+    @Test
+    fun empty_input_returns_null() {
+        assertNull(GaitAnalyzer.strideTimeCoVPercent(emptyList()))
+    }
+
+    @Test
+    fun to_reading_wraps_with_canonical_key_and_tier() {
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (i in 0 until 40) {
+            t += if (i % 2 == 0) 950L else 1050L
+            timestamps.add(t)
+        }
+        val reading = GaitAnalyzer.toReading(timestamps, sourceId = "phone_sensor")
+        assertNotNull(reading)
+        assertEquals(MetricType.GAIT_VARIABILITY_COV.key, reading!!.metricType)
+        assertTrue("Reading value should be positive CoV", reading.value > 0.0)
+    }
+
+    @Test
+    fun to_reading_returns_null_for_insufficient_data() {
+        val reading = GaitAnalyzer.toReading(listOf(0L, 1000L, 2000L), sourceId = "phone_sensor")
+        assertNull(reading)
+    }
+
+    @Test
+    fun speed_corrected_cov_normalises_against_reference_cadence() {
+        // Same alternating 950/1050 cadence — mean 1000 ms = reference,
+        // so corrected ≈ raw.
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (i in 0 until 40) {
+            t += if (i % 2 == 0) 950L else 1050L
+            timestamps.add(t)
+        }
+        val raw = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        val corrected = GaitAnalyzer.gaitVariabilitySpeedCorrected(timestamps)
+        assertNotNull(raw)
+        assertNotNull(corrected)
+        assertTrue(
+            "At reference cadence, corrected and raw should agree, got raw=$raw corrected=$corrected",
+            abs(raw!! - corrected!!) < 0.01,
+        )
+    }
+
+    @Test
+    fun speed_corrected_cov_deflates_slow_walking() {
+        // Slow cadence at the upper end of the in-band window: 1800/1900 ms
+        // alternation (mean 1850, both inside MIN..MAX). Corrected should
+        // be smaller than raw because speedFactor = 1.85 > 1.
+        val timestamps = mutableListOf<Long>(0)
+        var t = 0L
+        for (i in 0 until 40) {
+            t += if (i % 2 == 0) 1800L else 1900L
+            timestamps.add(t)
+        }
+        val raw = GaitAnalyzer.strideTimeCoVPercent(timestamps)
+        val corrected = GaitAnalyzer.gaitVariabilitySpeedCorrected(timestamps)
+        assertNotNull(raw)
+        assertNotNull(corrected)
+        assertTrue(
+            "Slow-walking corrected CoV should be smaller than raw, got raw=$raw corrected=$corrected",
+            corrected!! < raw!!,
+        )
+    }
+
+    @Test
+    fun postural_sway_amplitude_returns_null_for_short_input() {
+        assertNull(GaitAnalyzer.posturalSwayAmplitudeMm(listOf(0.0, 0.0, 0.0), 50.0))
+    }
+
+    @Test
+    fun postural_sway_amplitude_returns_positive_for_oscillating_input() {
+        // 100 samples at 50 Hz, sinusoidal accel — non-zero amplitude.
+        val n = 200
+        val rateHz = 50.0
+        val accels = (0 until n).map { i ->
+            val tSec = i / rateHz
+            0.5 * kotlin.math.sin(2 * kotlin.math.PI * 0.5 * tSec) // 0.5 Hz oscillation
+        }
+        val amp = GaitAnalyzer.posturalSwayAmplitudeMm(accels, rateHz)
+        assertNotNull(amp)
+        assertTrue("Oscillating accel should yield positive postural-sway amplitude, got $amp", amp!! > 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

**PR B of 4** for #208. Pure-Kotlin engine producing the gait-variability substrate that `GeriatricTrajectoryPatterns` (shipped in PR A #342) reads.

- **`strideTimeCoVPercent`** — Hausdorff 2007 stride-time CoV from a list of step-event timestamps. In-band floor 250 ms / ceiling 2000 ms drops noise and inter-bout pauses. Requires ≥20 surviving intervals; returns `null` below threshold.
- **`gaitVariabilitySpeedCorrected`** — same CoV normalised against a 1 s/stride reference, neutralises the slow-walking inflation effect Hausdorff calls out.
- **`toReading`** — wraps the raw CoV into a `MetricReading(GAIT_VARIABILITY_COV)` with caller-supplied `sourceId`. `ConfidenceTier.LOW` (phone-sensor-derived).
- **`posturalSwayAmplitudeMm`** — Maki 1994 anterior-posterior sway amplitude from accelerometer samples via double-integration + peak-to-peak. Returns a raw mm value; the matching MetricType key will ship with its first consumer (no consumer in this PR, so no contract change here).

## Manifesto framing

GaitAnalyzer is a **data substrate**. It writes the reading and stops — no classification, no person-scoring, no push notification. The geriatric trajectory advisories that read this signal are all `pullSideOnly = true` (PR A).

## What's net-new

Just the engine + its test — no Android dependencies, no Room, no SharedPreferences, no MetricType changes. PR A already shipped `MetricType.GAIT_VARIABILITY_COV`; this PR fills in the producer.

## Test plan

- [x] `./scripts/code-quality-check.sh` — all green
- [x] `GaitAnalyzerTest` (190 lines) pins: regular gait → low CoV, irregular gait → high CoV, insufficient samples → null, out-of-band intervals filtered, speed correction sanity, postural-sway peak-to-peak math
- [ ] Manual follow-up: wire a SyncWorker stage that pulls step-event timestamps from the accelerometer adapter and persists the resulting `GAIT_VARIABILITY_COV` reading — that's PR D (UI) or a separate wiring PR

## Sibling PRs (#208 plan)

- ✅ **PR A** #342 — pull-side architecture + 3 patterns
- 🟢 **PR B** (this) — GaitAnalyzer
- ⏳ **PR C** — TypingSpeedReader (IME cadence → `TYPING_SPEED_CHAR_PER_MIN`)
- ⏳ **PR D** — `GeriatricTrajectoryScreen` UI + Settings entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)