### PR TITLE
feat(ingest): TypingSpeedReader scaffold (#208 PR C)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/TypingSpeedReader.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/TypingSpeedReader.kt
@@ -1,0 +1,119 @@
+package com.bios.app.ingest
+
+import android.content.Context
+import com.bios.app.alerts.GeriatricTrajectoryStore
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+
+/**
+ * Owner-permission-gated typing-speed proxy for the cognitive-trajectory
+ * pull-side view (#208, GERIATRICS_PALLIATIVE_POV §2.4).
+ *
+ * **Status: v1 scaffold.** The full implementation requires an
+ * `InputMethodService` keyboard or an `AccessibilityService` capture
+ * surface — both are heavy and have their own permission / privacy /
+ * security review. v1 ships:
+ *
+ *  - The [MetricType.TYPING_SPEED_CHAR_PER_MIN] key.
+ *  - This reader stub that holds the opt-in check and the canonical
+ *    write path (`emit()` shape).
+ *  - The geriatric trajectory advisory's SignalRule, which gracefully
+ *    no-ops when no baseline exists (because no readings have ever been
+ *    persisted).
+ *
+ * The actual capture path lands as a follow-up (TODO below).
+ *
+ * Manifesto guard: typing-speed data is *highly* sensitive — keyboard
+ * inputs include passwords, messages, search queries. The capture
+ * surface, when it ships, must record **only the cadence** — character-
+ * count and elapsed-time aggregated into chars/min — never any character
+ * identity, never any window context, never any keystroke timing more
+ * granular than the per-session aggregate. The owner enables it
+ * explicitly via [GeriatricTrajectoryStore.cognitiveTrackingEnabled].
+ */
+class TypingSpeedReader(private val context: Context) {
+
+    private val store = GeriatricTrajectoryStore(context)
+
+    /**
+     * True when the owner has explicitly opted into cognitive trajectory
+     * tracking. The reader does nothing — emits nothing, captures
+     * nothing — until this flag is set.
+     */
+    fun isEnabled(): Boolean = store.cognitiveTrackingEnabled
+
+    /**
+     * Canonical write shape for a typing-speed sample.
+     *
+     * Takes the session-level aggregate (total chars, elapsed millis)
+     * computed *outside* this reader by the IME / accessibility-service
+     * capture surface, and returns the [MetricReading] for persistence.
+     * Returns `null` when typing-speed tracking is not enabled or the
+     * inputs are insufficient.
+     *
+     * Capture-surface contract:
+     *  - [characters] is the count of *all* keystrokes (not just
+     *    printable characters), including backspace — the cadence is
+     *    what matters, not the content.
+     *  - [elapsedMillis] covers the actively-typed window (the
+     *    capture surface drops idle gaps longer than 2 s before
+     *    aggregating).
+     *  - [sourceId] identifies the capture surface so provenance is
+     *    transparent in the data-coverage view.
+     */
+    fun toReading(
+        characters: Int,
+        elapsedMillis: Long,
+        sourceId: String,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): MetricReading? {
+        if (!isEnabled()) return null
+        val charsPerMin = charsPerMinute(characters, elapsedMillis) ?: return null
+        return MetricReading(
+            metricType = MetricType.TYPING_SPEED_CHAR_PER_MIN.key,
+            value = charsPerMin,
+            timestamp = nowMillis,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.LOW.level,
+        )
+    }
+
+    companion object {
+        /**
+         * Minimum keystroke count for a session aggregate to be
+         * meaningful. Below this, short messages would skew the
+         * trajectory toward whatever cadence happened in that
+         * particular brief burst.
+         */
+        const val MIN_CHARACTERS: Int = 20
+
+        /**
+         * Minimum elapsed window for a session aggregate. Below this,
+         * single-burst keystrokes inflate chars/min toward implausibly
+         * high values.
+         */
+        const val MIN_ELAPSED_MS: Long = 2_000L
+
+        /**
+         * Pure-compute chars-per-minute from a session aggregate. Returns
+         * null when the input fails the [MIN_CHARACTERS] / [MIN_ELAPSED_MS]
+         * floors. Extracted so the cadence math can be unit-tested in the
+         * JVM-only test source set (no Android Context required).
+         */
+        fun charsPerMinute(characters: Int, elapsedMillis: Long): Double? {
+            if (characters < MIN_CHARACTERS) return null
+            if (elapsedMillis < MIN_ELAPSED_MS) return null
+            val elapsedMinutes = elapsedMillis / 60_000.0
+            if (elapsedMinutes <= 0.0) return null
+            return characters / elapsedMinutes
+        }
+
+        // TODO(#208 follow-up): wire an InputMethodService keyboard or
+        // an opt-in AccessibilityService capture surface that streams
+        // (keystroke timestamp) → (session aggregate) into this reader.
+        // The capture surface must record only cadence — no character
+        // identity, no window context, no per-key timing beyond what is
+        // needed to compute the per-session chars/min aggregate.
+    }
+}

--- a/android/app/src/test/java/com/bios/app/TypingSpeedReaderTest.kt
+++ b/android/app/src/test/java/com/bios/app/TypingSpeedReaderTest.kt
@@ -1,0 +1,81 @@
+package com.bios.app
+
+import com.bios.app.ingest.TypingSpeedReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM-only tests for the pure cadence-math helper
+ * [TypingSpeedReader.Companion.charsPerMinute]. The Context-bound
+ * opt-in path is exercised indirectly via the same helper (the reader
+ * delegates its math to this companion). Same pattern as
+ * `PerioperativeStateStoreTest`.
+ */
+class TypingSpeedReaderTest {
+
+    @Test
+    fun returns_null_below_minimum_character_count() {
+        val cpm = TypingSpeedReader.charsPerMinute(
+            characters = TypingSpeedReader.MIN_CHARACTERS - 1,
+            elapsedMillis = 10_000L,
+        )
+        assertNull(cpm)
+    }
+
+    @Test
+    fun returns_null_below_minimum_elapsed_window() {
+        val cpm = TypingSpeedReader.charsPerMinute(
+            characters = 100,
+            elapsedMillis = TypingSpeedReader.MIN_ELAPSED_MS - 1L,
+        )
+        assertNull(cpm)
+    }
+
+    @Test
+    fun returns_null_for_zero_elapsed_millis() {
+        // Elapsed = 0 is below MIN_ELAPSED_MS but pin separately — a degenerate
+        // input should never produce a division-by-zero or an infinite cadence.
+        val cpm = TypingSpeedReader.charsPerMinute(characters = 100, elapsedMillis = 0L)
+        assertNull(cpm)
+    }
+
+    @Test
+    fun computes_60_chars_per_minute_for_60_chars_in_60_seconds() {
+        val cpm = TypingSpeedReader.charsPerMinute(
+            characters = 60,
+            elapsedMillis = 60_000L,
+        )
+        assertNotNull(cpm)
+        assertEquals(60.0, cpm!!, 1e-9)
+    }
+
+    @Test
+    fun computes_300_chars_per_minute_for_50_chars_in_10_seconds() {
+        // 50 chars / (10/60) min = 300 chars/min — a brisk typist.
+        val cpm = TypingSpeedReader.charsPerMinute(
+            characters = 50,
+            elapsedMillis = 10_000L,
+        )
+        assertNotNull(cpm)
+        assertEquals(300.0, cpm!!, 1e-9)
+    }
+
+    @Test
+    fun accepts_the_minimum_floor_inputs_exactly() {
+        // MIN_CHARACTERS = 20, MIN_ELAPSED_MS = 2000 ms.
+        // 20 chars / (2/60) min = 600 chars/min (a single-burst implausible value).
+        // The fact that the floor accepts it but produces an unrealistically
+        // high cadence is *exactly* why the trajectory advisory reads the
+        // median over many sessions, not a single sample.
+        val cpm = TypingSpeedReader.charsPerMinute(
+            characters = TypingSpeedReader.MIN_CHARACTERS,
+            elapsedMillis = TypingSpeedReader.MIN_ELAPSED_MS,
+        )
+        assertNotNull(cpm)
+        assertTrue("floor-input cadence should be finite", cpm!!.isFinite())
+        assertEquals(600.0, cpm, 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary

**PR C of 4** for #208. Owner-permission-gated typing-speed proxy for the cognitive-trajectory pull-side view (`cognitive_trajectory_advisory`, shipped in PR A #342).

This is **v1 scaffold** — the actual keystroke capture surface (`InputMethodService` keyboard or opt-in `AccessibilityService`) is TODO'd for a follow-up because both surfaces carry their own privacy / security review. v1 ships:

- The opt-in check (`isEnabled()` → reads `GeriatricTrajectoryStore.cognitiveTrackingEnabled` from PR A).
- The canonical write shape (`toReading(characters, elapsedMillis, sourceId)` → `MetricReading(TYPING_SPEED_CHAR_PER_MIN)` from PR A).
- The cadence-math companion (`charsPerMinute(characters, elapsedMillis)`), unit-tested.

The reader does nothing until the owner explicitly enables cognitive tracking. The matching `SignalRule` in `cognitive_trajectory_advisory` already gracefully no-ops when no baseline exists.

## Manifesto guard

Typing-speed data is *highly* sensitive — keyboard inputs include passwords, messages, search queries. The capture surface, when it ships, must record **only the cadence** (per-session chars/min aggregate). **Never** character identity, **never** window context, **never** per-key timing beyond what's needed for the aggregate. The reader's API enforces this by taking only `(characters: Int, elapsedMillis: Long)` — no way to leak content through this shape.

## Departure from the agent's draft

I extracted the cadence math into `Companion.charsPerMinute(...)` so it can be unit-tested in the JVM-only test source set (no Android Context). Same pattern as `PerioperativeStateStoreTest`. The `toReading` API is unchanged for callers; it now delegates to the companion helper.

## Test plan

- [x] `./scripts/code-quality-check.sh` — all green
- [x] `TypingSpeedReaderTest` (6 tests) pins: below-min character count → null, below-min elapsed → null, zero-elapsed → null (no div-by-zero), 60c/60s → 60 cpm, 50c/10s → 300 cpm, floor inputs (20c/2s) → 600 cpm (single-burst sample is intentionally finite but the trajectory advisory reads the median to handle it)
- [ ] Manual follow-up: capture surface (separate PR — needs privacy review)

## Sibling PRs (#208 plan)

- ✅ **PR A** #342 — pull-side architecture + 3 patterns
- ✅ **PR B** #343 — GaitAnalyzer
- 🟢 **PR C** (this) — TypingSpeedReader scaffold
- ⏳ **PR D** — `GeriatricTrajectoryScreen` UI + Settings entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)