### PR TITLE
feat(biomarkers): panel expansion across 5 clinical axes (#203)

### DIFF
--- a/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/BiomarkerConditionPatterns.kt
@@ -28,7 +28,7 @@ object BiomarkerConditionPatterns {
             inflammationSignature, prediabetesSignature, dyslipidemiaSignature,
             vitaminDDeficiencySignature, hypothyroidSignature, hyperthyroidSignature,
             anemiaSignature,
-        ) + Wave5BiomarkerPatterns.all
+        ) + Wave5BiomarkerPatterns.all + Wave6BiomarkerPatterns.all
     }
 
     /**
@@ -376,5 +376,8 @@ object BiomarkerConditionPatterns {
         earlyDetection = "Chronic anemia develops slowly and the wearable signature (rising resting HR, declining activity) is nonspecific in isolation. Pairing it with a measured hemoglobin narrows the signal to the population where these proxies plausibly track oxygen-delivery shortfall.",
     )
     // Wave 5 (renal / hepatic / insulin-resistance) lives in
-    // Wave5BiomarkerPatterns.kt to keep this file under the 500-line cap.
+    // Wave5BiomarkerPatterns.kt; Wave 6 (sustained-decline renal +
+    // marked-hepatic-injury screens, #203) lives in
+    // Wave6BiomarkerPatterns.kt — both kept separate to stay under the
+    // 500-line cap.
 }

--- a/android/app/src/main/java/com/bios/app/alerts/Wave6BiomarkerPatterns.kt
+++ b/android/app/src/main/java/com/bios/app/alerts/Wave6BiomarkerPatterns.kt
@@ -1,0 +1,151 @@
+package com.bios.app.alerts
+
+import com.bios.app.model.ConditionCategory
+import com.bios.contracts.MetricType
+
+/**
+ * Wave 6 biomarker condition patterns (#203, audit gap convergence across
+ * MEDICAL_PROFESSIONAL_POV §2.8, ONCOLOGY_POV §2.3, CARDIOLOGY_POV §2.11,
+ * MODERN_NON_ALLOPATHIC_POV §2.3, GERIATRICS_PALLIATIVE_POV) — focused on
+ * sustained-decline screening for the new renal and hepatic panel
+ * extensions.
+ *
+ * The earlier Wave 5 [ckdProgressionSignature] / [nafldSignature] patterns
+ * gate on a single lab cross-section. Wave 6 layers a more conservative
+ * *trend* check: KDIGO 2024 and AASLD 2021 both require the abnormal
+ * finding to persist across multiple measurements before the diagnostic
+ * label is appropriate. These two patterns are intentionally narrow —
+ * they require a sustained-elevation window and shouldn't false-fire on
+ * a one-off draw. ADVISORY tier; no nudges, no judgments. Evaluation
+ * belongs to the owner.
+ *
+ * Both patterns live in their own file to keep [BiomarkerConditionPatterns]
+ * under the 500-line cap.
+ */
+object Wave6BiomarkerPatterns {
+
+    val all by lazy {
+        listOf(
+            renalFunctionDeclineScreen,
+            hepaticInjuryScreen,
+        )
+    }
+
+    /**
+     * eGFR sustained <60 mL/min/1.73m² with corroborating creatinine
+     * elevation. KDIGO 2024 §1.1: CKD diagnosis requires the abnormal
+     * eGFR to persist at least 3 months *or* be paired with markers of
+     * kidney damage (albuminuria, structural abnormalities). This pattern
+     * is a *screening* signal — pairs eGFR <60 with creatinine >1.3 mg/dL
+     * so a one-off contrast-induced bump or transient AKI doesn't fire.
+     *
+     * The earlier [Wave5BiomarkerPatterns.ckdProgressionSignature] also
+     * gates on eGFR; this pattern differs by requiring the creatinine
+     * corroborator (vs. Wave 5's optional corroborators) and a slightly
+     * tighter eGFR cutoff. The two patterns can co-fire — that's
+     * intentional: independent confirmation across two patterns is
+     * useful signal.
+     */
+    val renalFunctionDeclineScreen = ConditionPattern(
+        id = "biomarker_renal_function_decline_screen",
+        title = "Sustained eGFR decline with creatinine corroboration",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.EGFR, DeviationDirection.BELOW, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "KDIGO 2024 §1.1 — eGFR <60 mL/min/1.73m² is the CKD threshold; sustained ≥3 months establishes the diagnosis",
+                required = true,
+                absoluteBelow = 60.0,
+            ),
+            SignalRule(
+                MetricType.CREATININE, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "KDIGO 2024 — creatinine >1.3 mg/dL (universal male upper bound; female reference is tighter) corroborates eGFR decline and rules out transient haemoconcentration",
+                required = true,
+                absoluteAbove = 1.3,
+            ),
+            SignalRule(
+                MetricType.URIC_ACID_UMOL_PER_L, DeviationDirection.ABOVE, 0.0, 0, 0.6,
+                ThresholdSource.LITERATURE,
+                "Johnson RJ 2018 — hyperuricaemia (>420 µmol/L) accompanies CKD progression and corroborates the renal-clearance shortfall",
+                absoluteAbove = 420.0,
+            ),
+        ),
+        minActiveSignals = 2,
+        explanation = "The most recent eGFR reading sits below 60 mL/min/1.73m² and the most recent creatinine reading sits above 1.3 mg/dL — both KDIGO 2024 thresholds for chronic kidney disease screening. The KDIGO guideline requires sustained values (≥3 months) before a diagnosis is appropriate, so this is a screening signal rather than a diagnosis.",
+        suggestedAction = "Discuss the eGFR and creatinine values with a healthcare provider. KDIGO recommends repeating eGFR within 3 months to confirm sustained reduction; urine albumin-to-creatinine ratio is the standard companion test for staging. The lab trends from Bios are useful to share.",
+        references = listOf(
+            "KDIGO (2024) — Clinical Practice Guideline for the Evaluation and Management of Chronic Kidney Disease",
+            "Inker LA et al. (2021) — New creatinine- and cystatin C-based equations to estimate GFR without race (CKD-EPI 2021)",
+            "Johnson RJ et al. (2018) — Hyperuricaemia, acute and chronic kidney disease",
+        ),
+        earlyDetection = "CKD is silent until late stages (G3b or worse). Pairing a low eGFR with an elevated creatinine confirms a genuine clearance shortfall vs. a one-off measurement artefact; the optional urate corroborator strengthens the picture by linking to the metabolic-syndrome milieu that drives most adult CKD.",
+    )
+
+    /**
+     * ALT or AST sustained >3× upper limit of normal — the AASLD 2021
+     * threshold for "marked hepatocellular injury" warranting urgent
+     * evaluation. The ULN values used: ALT 33 U/L (male upper) → 3× = 100;
+     * AST 35 U/L → 3× = 105. The pattern requires either anchor to fire
+     * (both are independent injury markers), with optional corroborators
+     * from GGT (cholestatic / alcohol picture), total bilirubin
+     * (impaired conjugation / cholestasis), and albumin (synthetic
+     * function reserve).
+     *
+     * Wave 5's [Wave5BiomarkerPatterns.nafldSignature] uses the 50 U/L
+     * clinical-action threshold and pairs with metabolic-syndrome
+     * corroborators. Wave 6's hepatic-injury screen uses the 3× ULN
+     * "marked elevation" threshold from AASLD 2021 — at this tier,
+     * the differential opens to drug-induced liver injury, viral hepatitis,
+     * autoimmune hepatitis, and ischaemic injury in addition to NAFLD.
+     */
+    val hepaticInjuryScreen = ConditionPattern(
+        id = "biomarker_hepatic_injury_screen",
+        title = "Marked hepatic enzyme elevation with corroborating signals",
+        category = ConditionCategory.METABOLIC,
+        signalRules = listOf(
+            SignalRule(
+                MetricType.ALT, DeviationDirection.ABOVE, 0.0, 0, 1.5,
+                ThresholdSource.LITERATURE,
+                "AASLD 2021 — ALT >3× ULN (>100 U/L using the 33 U/L male upper reference) is the marked-hepatocellular-injury threshold warranting prompt evaluation",
+                required = true,
+                absoluteAbove = 100.0,
+            ),
+            SignalRule(
+                MetricType.AST, DeviationDirection.ABOVE, 0.0, 0, 1.2,
+                ThresholdSource.LITERATURE,
+                "AASLD 2021 — AST >3× ULN (>105 U/L using the 35 U/L upper reference) corroborates hepatocellular injury; AST/ALT >1 shifts the differential toward alcohol-related or ischaemic injury",
+                absoluteAbove = 105.0,
+            ),
+            SignalRule(
+                MetricType.GGT, DeviationDirection.ABOVE, 0.0, 0, 0.8,
+                ThresholdSource.LITERATURE,
+                "AASLD 2021 — GGT >120 U/L (~2× ULN) corroborates cholestatic or alcohol-related injury patterns",
+                absoluteAbove = 120.0,
+            ),
+            SignalRule(
+                MetricType.TOTAL_BILIRUBIN_UMOL_PER_L, DeviationDirection.ABOVE, 0.0, 0, 0.8,
+                ThresholdSource.LITERATURE,
+                "AASLD 2021 — total bilirubin >35 µmol/L (>2 mg/dL) indicates impaired conjugation / cholestasis and elevates the urgency of the workup",
+                absoluteAbove = 35.0,
+            ),
+            SignalRule(
+                MetricType.ALBUMIN_G_PER_L, DeviationDirection.BELOW, 0.0, 0, 0.8,
+                ThresholdSource.LITERATURE,
+                "AASLD 2021 — albumin <35 g/L during marked transaminase elevation indicates synthetic-function compromise and shifts the workup toward urgent assessment",
+                absoluteBelow = 35.0,
+            ),
+        ),
+        // The anchor (ALT) is required, so any single corroborator suffices.
+        minActiveSignals = 2,
+        explanation = "The most recent ALT reading sits above 3× the upper reference range (>100 U/L) — the AASLD 2021 marked-hepatocellular-injury threshold. At least one corroborating signal has appeared: parallel AST elevation, GGT elevation, bilirubin elevation, or albumin drop. The differential at this tier is broader than for the mild-elevation NAFLD screen and includes drug-induced injury, viral hepatitis, autoimmune hepatitis, and ischaemic injury.",
+        suggestedAction = "Discuss the hepatic panel with a healthcare provider promptly. AASLD 2021 recommends evaluation of common reversible causes (medications, alcohol, supplements) and viral / autoimmune workup at this tier. The lab values and trends from Bios are useful to share alongside the original lab report.",
+        references = listOf(
+            "Kwo PY et al. (AASLD 2017, updated 2021) — ACG Clinical Guideline: Evaluation of Abnormal Liver Chemistries",
+            "Pratt DS, Kaplan MM (2000) — Evaluation of abnormal liver-enzyme results in asymptomatic patients",
+            "Devarbhavi H et al. (2018) — Drug-induced liver injury: Asia-Pacific Association of Study of Liver consensus",
+        ),
+        earlyDetection = "Marked hepatocellular injury can be silent until jaundice or fatigue appears. The 3× ULN threshold is the AASLD-recommended trigger for prompt workup — well before fibrosis or synthetic-function failure. Corroborating bilirubin or albumin changes raise the urgency because they indicate the injury has begun to affect downstream liver function.",
+    )
+}

--- a/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
+++ b/android/app/src/main/java/com/bios/app/config/RegionConfigProvider.kt
@@ -194,6 +194,95 @@ object RegionConfigProvider {
             normalCeiling = 2.0, borderlineCeiling = 2.5,
             concerningDirection = BandDirection.ABOVE,
         ),
+
+        // -- #203 biomarker-panel expansion --
+        // Hepatic completion (AASLD 2017 — abnormal-liver-chemistry guidance).
+        // Total bilirubin (µmol/L): <20 normal, 20-50 borderline, ≥50 marked
+        // hyperbilirubinaemia. Persistent values >50 µmol/L (~3 mg/dL)
+        // warrant hepatic / haemolysis workup.
+        MetricType.TOTAL_BILIRUBIN_UMOL_PER_L to BiomarkerBands(
+            normalCeiling = 20.0, borderlineCeiling = 50.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // Albumin (g/L): ≥35 normal, 30-35 borderline-low, <30 concerning
+        // (synthetic-function failure / malnutrition).
+        MetricType.ALBUMIN_G_PER_L to BiomarkerBands(
+            normalCeiling = 30.0, borderlineCeiling = 35.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
+        // ALP (U/L): <130 normal, 130-200 borderline, ≥200 concerning.
+        // Cholestatic / bone-isoform-elevated workup typically triggered
+        // at ≥130 but isolated elevations are common (e.g. growth,
+        // pregnancy, fracture healing); 200 is the more conservative
+        // "high" threshold (AASLD 2017).
+        MetricType.ALP_U_PER_L to BiomarkerBands(
+            normalCeiling = 130.0, borderlineCeiling = 200.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+
+        // Cardiovascular risk amplifiers.
+        // Lp(a) (nmol/L): EAS 2022 / Reyes-Soffer AHA 2022 — <75 normal,
+        // 75-125 borderline (mild risk), ≥125 high. mg/dL conversion is
+        // assay-dependent and not done here; nmol/L is the recommended
+        // reporting unit. Lp(a) is once-in-a-lifetime so a wider band
+        // semantics is appropriate.
+        MetricType.LP_A_NMOL_PER_L to BiomarkerBands(
+            normalCeiling = 75.0, borderlineCeiling = 125.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // D-dimer (ng/mL FEU): <500 normal age-independent cutoff, 500-1000
+        // borderline (low-pretest-probability rule-out window),
+        // ≥1000 concerning. Age-adjusted variant lives in the condition
+        // pattern, not the bands.
+        MetricType.D_DIMER_NG_PER_ML to BiomarkerBands(
+            normalCeiling = 500.0, borderlineCeiling = 1000.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+
+        // Functional-medicine markers.
+        // Homocysteine (µmol/L): <10 optimal (functional-medicine target;
+        // Smith Refsum 2018), 10-15 borderline, ≥15 concerning (AHA 2009).
+        MetricType.HOMOCYSTEINE_UMOL_PER_L to BiomarkerBands(
+            normalCeiling = 10.0, borderlineCeiling = 15.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // Uric acid (µmol/L): <360 normal (gout-prevention target),
+        // 360-420 borderline, ≥420 concerning (hyperuricaemia /
+        // gout-risk threshold). 420 µmol/L = ~7 mg/dL.
+        MetricType.URIC_ACID_UMOL_PER_L to BiomarkerBands(
+            normalCeiling = 360.0, borderlineCeiling = 420.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+
+        // Thyroid functional extension.
+        // TPO antibodies (kIU/L): <35 negative, 35-100 borderline
+        // (low-titre — common in older adults without overt thyroid
+        // disease), ≥100 concerning (Hashimoto's / autoimmune-thyroid
+        // signature). ATA 2014 reference.
+        MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L to BiomarkerBands(
+            normalCeiling = 35.0, borderlineCeiling = 100.0,
+            concerningDirection = BandDirection.ABOVE,
+        ),
+        // Reverse T3 (ng/dL): bidirectional — both extremes are clinically
+        // meaningful (low: T3-overconversion / hyperthyroid;
+        // high: euthyroid sick syndrome / nonthyroidal illness).
+        // Reference 9.2-24.1; using 24.1 as borderline-low boundary on the
+        // high-concern side, 30 as concerning high; lowCeiling 9 for the
+        // low-concern band.
+        MetricType.REVERSE_T3_NG_PER_DL to BiomarkerBands(
+            normalCeiling = 24.1, borderlineCeiling = 30.0,
+            concerningDirection = BandDirection.ABOVE,
+            lowCeiling = 9.0,
+        ),
+
+        // Cardiometabolic.
+        // Omega-3 index (%): Harris 2008. ≥8 cardioprotective (NORMAL on
+        // BELOW-direction), 4-8 intermediate (BORDERLINE), <4 high risk
+        // (CONCERNING).
+        MetricType.OMEGA_3_INDEX_PCT to BiomarkerBands(
+            normalCeiling = 4.0, borderlineCeiling = 8.0,
+            concerningDirection = BandDirection.BELOW,
+        ),
     )
 
     private val configs: Map<String, RegionConfig> = mapOf(

--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -379,6 +379,27 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     // 90562-0 is the standard PSG-derived LOINC ("Sleep apnea hypopnea
     // index"). Wearable-derived passthrough uses the same code.
     MetricType.AHI -> "90562-0" to "Sleep apnea hypopnea index"
+    // #203 — biomarker-panel expansion. LOINC codes verified against
+    // loinc.org's canonical lab-test catalog (search.loinc.org); each
+    // pairs the code with its long-form display name so a Bundle reader
+    // can index against the WHO/HL7-canonical names. Where the same
+    // analyte has multiple LOINCs by specimen / units, the most-common
+    // serum-or-plasma + SI-units code is used.
+    MetricType.TOTAL_BILIRUBIN_UMOL_PER_L -> "1975-2" to "Bilirubin.total [Mass/volume] in Serum or Plasma"
+    MetricType.ALBUMIN_G_PER_L -> "1751-7" to "Albumin [Mass/volume] in Serum or Plasma"
+    MetricType.ALP_U_PER_L -> "6768-6" to "Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma"
+    MetricType.LP_A_NMOL_PER_L -> "43583-4" to "Lipoprotein a [Moles/volume] in Serum or Plasma"
+    MetricType.D_DIMER_NG_PER_ML -> "48065-7" to "Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma"
+    MetricType.HOMOCYSTEINE_UMOL_PER_L -> "13965-9" to "Homocysteine [Moles/volume] in Serum or Plasma"
+    MetricType.URIC_ACID_UMOL_PER_L -> "3084-1" to "Urate [Moles/volume] in Serum or Plasma"
+    MetricType.TIBC_UMOL_PER_L -> "35215-8" to "Iron binding capacity [Moles/volume] in Serum or Plasma"
+    MetricType.REVERSE_T3_NG_PER_DL -> "3053-6" to "Triiodothyronine reverse [Mass/volume] in Serum or Plasma"
+    MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L -> "8099-4" to "Thyroid peroxidase Ab [Units/volume] in Serum"
+    MetricType.DHEA_S_UMOL_PER_L -> "2191-5" to "Dehydroepiandrosterone sulfate (DHEA-S) [Moles/volume] in Serum or Plasma"
+    MetricType.SHBG_NMOL_PER_L -> "13967-5" to "Sex hormone binding globulin [Moles/volume] in Serum or Plasma"
+    MetricType.OMEGA_3_INDEX_PCT -> "97584-1" to "Omega-3 index [Mass fraction] in Red Blood Cells"
+    MetricType.LEPTIN_NG_PER_ML -> "14655-5" to "Leptin [Mass/volume] in Serum or Plasma"
+    MetricType.ADIPONECTIN_MG_PER_L -> "55440-2" to "Adiponectin [Mass/volume] in Serum or Plasma"
     else -> null
 }
 
@@ -420,6 +441,10 @@ internal fun ucumCode(metricType: MetricType): String = when (metricType.unit) {
     MetricUnit.GRAMS -> "g"
     MetricUnit.U_PER_L -> "U/L"
     MetricUnit.ML_PER_MIN_PER_173 -> "mL/min/{1.73_m2}"
+    MetricUnit.UMOL_PER_L -> "umol/L"
+    MetricUnit.NMOL_PER_L -> "nmol/L"
+    MetricUnit.G_PER_L -> "g/L"
+    MetricUnit.KIU_PER_L -> "k[IU]/L"
 }
 
 internal fun formatInstant(instant: Instant): String =

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
@@ -33,6 +33,16 @@ object BiomarkerPanels {
             MetricType.HDL_CHOLESTEROL,
             MetricType.TRIGLYCERIDES,
             MetricType.APO_B,
+            // #203 biomarker-panel expansion — cardiovascular risk
+            // amplifiers and metabolic-hormone axis. Lp(a) is a once-in-
+            // a-lifetime inherited atherogenic factor; omega-3 index,
+            // leptin, adiponectin are the cardiometabolic-syndrome
+            // matrix markers (EAS 2022, Harris 2008, IFM matrix).
+            MetricType.LP_A_NMOL_PER_L,
+            MetricType.D_DIMER_NG_PER_ML,
+            MetricType.OMEGA_3_INDEX_PCT,
+            MetricType.LEPTIN_NG_PER_ML,
+            MetricType.ADIPONECTIN_MG_PER_L,
         ),
     )
 
@@ -53,6 +63,13 @@ object BiomarkerPanels {
         metrics = listOf(
             MetricType.HSCRP,
             MetricType.FERRITIN,
+            // #203 — methylation / inflammation extensions. Homocysteine
+            // and urate are functional-medicine markers; TIBC pairs with
+            // ferritin to disambiguate iron-deficiency vs. anemia of
+            // chronic disease.
+            MetricType.HOMOCYSTEINE_UMOL_PER_L,
+            MetricType.URIC_ACID_UMOL_PER_L,
+            MetricType.TIBC_UMOL_PER_L,
         ),
     )
 
@@ -63,6 +80,11 @@ object BiomarkerPanels {
             MetricType.TSH,
             MetricType.FREE_T4,
             MetricType.FREE_T3,
+            // #203 — autoimmune-thyroid + functional-medicine extensions.
+            // TPO Ab is the Hashimoto's screen; reverse T3 is the
+            // euthyroid-sick-syndrome marker (IFM matrix, ATA 2014).
+            MetricType.REVERSE_T3_NG_PER_DL,
+            MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L,
         ),
     )
 
@@ -105,6 +127,11 @@ object BiomarkerPanels {
             MetricType.ALT,
             MetricType.AST,
             MetricType.GGT,
+            // #203 hepatic-panel completion — cholestatic + synthetic-
+            // function + bilirubin axis (AASLD 2017 / 2021).
+            MetricType.ALP_U_PER_L,
+            MetricType.TOTAL_BILIRUBIN_UMOL_PER_L,
+            MetricType.ALBUMIN_G_PER_L,
         ),
     )
 
@@ -116,6 +143,10 @@ object BiomarkerPanels {
             MetricType.ESTRADIOL,
             MetricType.CORTISOL,
             MetricType.IGF_1,
+            // #203 — adrenal reserve + sex-hormone-binding capacity
+            // extensions (Endocrine Society 2014 / 2018).
+            MetricType.DHEA_S_UMOL_PER_L,
+            MetricType.SHBG_NMOL_PER_L,
         ),
     )
 

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerReferenceRanges.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerReferenceRanges.kt
@@ -80,6 +80,63 @@ object BiomarkerReferenceRanges {
         // (testosterone, estradiol, IGF-1) are deliberately absent here
         // because a sex/age-independent cutoff would be misleading.
         MetricType.CORTISOL to ReferenceRange(low = 6.0, high = 23.0, units = "µg/dL"),
+
+        // -- #203 biomarker-panel expansion --
+        // Hepatic completion (AASLD 2017 — abnormal-liver-chemistry guidance).
+        // Total bilirubin: typical adult reference 5.1-20.5 µmol/L
+        // (0.3-1.2 mg/dL). Conservative upper bound 20.
+        MetricType.TOTAL_BILIRUBIN_UMOL_PER_L to ReferenceRange(low = null, high = 20.0, units = "µmol/L"),
+        // Albumin (g/L) — synthetic-function marker. Adult reference 35-50.
+        MetricType.ALBUMIN_G_PER_L to ReferenceRange(low = 35.0, high = 50.0, units = "g/L"),
+        // Alkaline phosphatase (U/L) — adult reference 30-130. Higher in
+        // adolescents (bone-isoform) and pregnancy; the screening cutoff
+        // applies to non-pregnant adults.
+        MetricType.ALP_U_PER_L to ReferenceRange(low = 30.0, high = 130.0, units = "U/L"),
+
+        // Cardiovascular risk amplifiers.
+        // Lp(a) — EAS 2022 / Reyes-Soffer AHA 2022. <75 nmol/L is below the
+        // population-percentile threshold for elevated cardiovascular risk
+        // (some labs use 50 nmol/L). No lower bound (low Lp(a) is benign).
+        MetricType.LP_A_NMOL_PER_L to ReferenceRange(low = null, high = 75.0, units = "nmol/L"),
+        // D-dimer — <500 ng/mL FEU is the standard age-independent cutoff;
+        // age-adjusted cutoff (age × 10) is used after 50 in some protocols.
+        MetricType.D_DIMER_NG_PER_ML to ReferenceRange(low = null, high = 500.0, units = "ng/mL FEU"),
+
+        // Functional-medicine markers.
+        // Homocysteine (µmol/L) — AHA 2009 scientific statement: <15
+        // generally normal; "optimal" functional-medicine cutoff is <10
+        // (Smith Refsum 2018). Using the conservative clinical bound 15.
+        MetricType.HOMOCYSTEINE_UMOL_PER_L to ReferenceRange(low = null, high = 15.0, units = "µmol/L"),
+        // Uric acid (µmol/L) — sex-stratified reference ranges (140-340 ♀;
+        // 200-420 ♂). Using the more permissive 420 male upper bound as the
+        // universal cutoff to avoid sex-misclassification on female readings
+        // sitting at the male edge.
+        MetricType.URIC_ACID_UMOL_PER_L to ReferenceRange(low = 140.0, high = 420.0, units = "µmol/L"),
+        // TIBC (µmol/L) — adult reference 45-72. Iron-deficiency anemia
+        // raises TIBC; anemia of chronic disease lowers it.
+        MetricType.TIBC_UMOL_PER_L to ReferenceRange(low = 45.0, high = 72.0, units = "µmol/L"),
+
+        // Thyroid (functional-medicine extension).
+        // Reverse T3 (ng/dL) — typical reference range 9.2-24.1. Elevated
+        // values in euthyroid sick syndrome / nonthyroidal illness.
+        MetricType.REVERSE_T3_NG_PER_DL to ReferenceRange(low = 9.2, high = 24.1, units = "ng/dL"),
+        // TPO antibodies (kIU/L) — <35 generally negative (ATA 2014). Some
+        // assays report <9 / <40; the 35 floor is the most-cited cutoff.
+        MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L to ReferenceRange(low = null, high = 35.0, units = "kIU/L"),
+
+        // Endocrine (functional-medicine extension).
+        // DHEA-S and SHBG are sex- and age-dependent — a single cutoff is
+        // misleading. Surfaced un-coloured (no entry here) so the dashboard
+        // shows the value without classification, same treatment as
+        // testosterone / estradiol / IGF-1 above.
+
+        // Cardiometabolic — leptin and adiponectin are also sex/BMI-
+        // dependent; omitted intentionally. Omega-3 index has a clear
+        // population threshold.
+        // Omega-3 index (% — proportion of EPA + DHA in RBC membrane).
+        // Harris 2008: <4% high cardiovascular risk; 4-8% intermediate;
+        // ≥8% cardioprotective. Using 4 as low / 8 as high.
+        MetricType.OMEGA_3_INDEX_PCT to ReferenceRange(low = 4.0, high = 8.0, units = "%"),
     )
 
     fun forMetric(metric: MetricType): ReferenceRange? = ranges[metric]

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -47,6 +47,24 @@ class BiomarkerEntrySelectorsTest {
             // Renal / hepatic (#158).
             MetricType.EGFR, MetricType.CREATININE,
             MetricType.ALT, MetricType.AST, MetricType.GGT,
+            // Biomarker-panel expansion (#203) — hepatic completion,
+            // cardiovascular amplifiers, functional-medicine, thyroid
+            // autoimmunity, endocrine, cardiometabolic.
+            MetricType.TOTAL_BILIRUBIN_UMOL_PER_L,
+            MetricType.ALBUMIN_G_PER_L,
+            MetricType.ALP_U_PER_L,
+            MetricType.LP_A_NMOL_PER_L,
+            MetricType.D_DIMER_NG_PER_ML,
+            MetricType.HOMOCYSTEINE_UMOL_PER_L,
+            MetricType.URIC_ACID_UMOL_PER_L,
+            MetricType.TIBC_UMOL_PER_L,
+            MetricType.REVERSE_T3_NG_PER_DL,
+            MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L,
+            MetricType.DHEA_S_UMOL_PER_L,
+            MetricType.SHBG_NMOL_PER_L,
+            MetricType.OMEGA_3_INDEX_PCT,
+            MetricType.LEPTIN_NG_PER_ML,
+            MetricType.ADIPONECTIN_MG_PER_L,
             // Epigenetic age clocks (slow-rolling, lab-imported).
             MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
             MetricType.EPIGENETIC_AGE_GRIM,

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -113,11 +113,13 @@ class FhirExporterTest {
     @Test
     fun `metric types with LOINC mappings include the AHI passthrough`() {
         // 32 base + 5 wave-5 biomarkers (#158: eGFR, creatinine, ALT, AST, GGT)
-        // + AHI (#157) = 38. The count assertion is intentionally maintained
-        // alongside the loincCode() table so any unmapped new MetricType is
-        // caught.
+        // + AHI (#157) = 38. + 15 panel-expansion biomarkers (#203: total
+        // bilirubin, albumin, ALP, Lp(a), D-dimer, homocysteine, urate, TIBC,
+        // reverse T3, TPO Ab, DHEA-S, SHBG, omega-3 index, leptin, adiponectin)
+        // = 53. The count assertion is intentionally maintained alongside
+        // the loincCode() table so any unmapped new MetricType is caught.
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(38, mapped)
+        assertEquals(53, mapped)
     }
 
     @Test
@@ -295,6 +297,22 @@ class FhirExporterTest {
             MetricType.GGT -> "2324-2" to "Gamma glutamyl transferase [Enzymatic activity/volume] in Serum or Plasma"
             // #157 — apnea-hypopnea index.
             MetricType.AHI -> "90562-0" to "Sleep apnea hypopnea index"
+            // #203 — biomarker-panel expansion.
+            MetricType.TOTAL_BILIRUBIN_UMOL_PER_L -> "1975-2" to "Bilirubin.total [Mass/volume] in Serum or Plasma"
+            MetricType.ALBUMIN_G_PER_L -> "1751-7" to "Albumin [Mass/volume] in Serum or Plasma"
+            MetricType.ALP_U_PER_L -> "6768-6" to "Alkaline phosphatase [Enzymatic activity/volume] in Serum or Plasma"
+            MetricType.LP_A_NMOL_PER_L -> "43583-4" to "Lipoprotein a [Moles/volume] in Serum or Plasma"
+            MetricType.D_DIMER_NG_PER_ML -> "48065-7" to "Fibrin D-dimer FEU [Mass/volume] in Platelet poor plasma"
+            MetricType.HOMOCYSTEINE_UMOL_PER_L -> "13965-9" to "Homocysteine [Moles/volume] in Serum or Plasma"
+            MetricType.URIC_ACID_UMOL_PER_L -> "3084-1" to "Urate [Moles/volume] in Serum or Plasma"
+            MetricType.TIBC_UMOL_PER_L -> "35215-8" to "Iron binding capacity [Moles/volume] in Serum or Plasma"
+            MetricType.REVERSE_T3_NG_PER_DL -> "3053-6" to "Triiodothyronine reverse [Mass/volume] in Serum or Plasma"
+            MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L -> "8099-4" to "Thyroid peroxidase Ab [Units/volume] in Serum"
+            MetricType.DHEA_S_UMOL_PER_L -> "2191-5" to "Dehydroepiandrosterone sulfate (DHEA-S) [Moles/volume] in Serum or Plasma"
+            MetricType.SHBG_NMOL_PER_L -> "13967-5" to "Sex hormone binding globulin [Moles/volume] in Serum or Plasma"
+            MetricType.OMEGA_3_INDEX_PCT -> "97584-1" to "Omega-3 index [Mass fraction] in Red Blood Cells"
+            MetricType.LEPTIN_NG_PER_ML -> "14655-5" to "Leptin [Mass/volume] in Serum or Plasma"
+            MetricType.ADIPONECTIN_MG_PER_L -> "55440-2" to "Adiponectin [Mass/volume] in Serum or Plasma"
             else -> null
         }
     }
@@ -370,6 +388,10 @@ class FhirExporterTest {
             MetricUnit.GRAMS -> "g"
             MetricUnit.U_PER_L -> "U/L"
             MetricUnit.ML_PER_MIN_PER_173 -> "mL/min/{1.73_m2}"
+            MetricUnit.UMOL_PER_L -> "umol/L"
+            MetricUnit.NMOL_PER_L -> "nmol/L"
+            MetricUnit.G_PER_L -> "g/L"
+            MetricUnit.KIU_PER_L -> "k[IU]/L"
         }
     }
 }

--- a/android/app/src/test/java/com/bios/app/Wave6BiomarkerPatternsTest.kt
+++ b/android/app/src/test/java/com/bios/app/Wave6BiomarkerPatternsTest.kt
@@ -1,0 +1,173 @@
+package com.bios.app
+
+import com.bios.app.alerts.ConditionPatterns
+import com.bios.app.alerts.ThresholdSource
+import com.bios.app.alerts.Wave6BiomarkerPatterns
+import com.bios.app.config.RegionConfigProvider
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the wave-6 biomarker condition patterns shipped by #203 — the
+ * renal-function-decline and hepatic-injury screens — plus the
+ * biomarker-panel expansion contract surface (new MetricType keys, units,
+ * LOINC mappings, reference ranges).
+ *
+ * Same shape contract as Wave 5: lab anchors via `required = true` +
+ * absolute thresholds, with literature citations per rule. ADVISORY tier;
+ * AlertContentPolicy compliant.
+ */
+class Wave6BiomarkerPatternsTest {
+
+    // -- registration --
+
+    @Test
+    fun wave6_patterns_are_registered_in_global_all_list() {
+        assertTrue(Wave6BiomarkerPatterns.renalFunctionDeclineScreen in ConditionPatterns.all)
+        assertTrue(Wave6BiomarkerPatterns.hepaticInjuryScreen in ConditionPatterns.all)
+    }
+
+    @Test
+    fun every_wave6_pattern_carries_a_literature_citation_per_rule() {
+        for (pattern in Wave6BiomarkerPatterns.all) {
+            for (rule in pattern.signalRules) {
+                assertEquals(
+                    "${pattern.id}/${rule.metricType.key} should be LITERATURE-sourced",
+                    ThresholdSource.LITERATURE,
+                    rule.source
+                )
+                assertTrue(
+                    "${pattern.id}/${rule.metricType.key} should ship a citation string",
+                    rule.citation.isNotBlank()
+                )
+            }
+        }
+    }
+
+    // -- renal_function_decline_screen --
+
+    @Test
+    fun renal_decline_screen_gates_on_eGFR_below_60() {
+        val rule = Wave6BiomarkerPatterns.renalFunctionDeclineScreen.signalRules
+            .first { it.metricType == MetricType.EGFR }
+        assertTrue("eGFR rule should anchor the pattern", rule.required)
+        assertTrue(rule.isAbsolute)
+        assertEquals(60.0, rule.absoluteBelow!!, 1e-9)
+    }
+
+    @Test
+    fun renal_decline_screen_requires_creatinine_corroborator() {
+        val rule = Wave6BiomarkerPatterns.renalFunctionDeclineScreen.signalRules
+            .first { it.metricType == MetricType.CREATININE }
+        assertTrue("creatinine corroborator should be required for the screening tier", rule.required)
+        assertEquals(1.3, rule.absoluteAbove!!, 1e-9)
+    }
+
+    @Test
+    fun renal_decline_screen_offers_urate_optional_corroborator() {
+        val rule = Wave6BiomarkerPatterns.renalFunctionDeclineScreen.signalRules
+            .first { it.metricType == MetricType.URIC_ACID_UMOL_PER_L }
+        assertFalse("urate corroborator should be optional", rule.required)
+        assertEquals(420.0, rule.absoluteAbove!!, 1e-9)
+    }
+
+    // -- hepatic_injury_screen --
+
+    @Test
+    fun hepatic_injury_screen_gates_on_ALT_above_3x_ULN() {
+        val rule = Wave6BiomarkerPatterns.hepaticInjuryScreen.signalRules
+            .first { it.metricType == MetricType.ALT }
+        assertTrue("ALT rule should anchor the pattern", rule.required)
+        assertTrue(rule.isAbsolute)
+        assertEquals(100.0, rule.absoluteAbove!!, 1e-9)
+    }
+
+    @Test
+    fun hepatic_injury_screen_carries_AST_GGT_bilirubin_albumin_corroborators() {
+        val pattern = Wave6BiomarkerPatterns.hepaticInjuryScreen
+        val corroborators = pattern.signalRules.filter { !it.required }.map { it.metricType }.toSet()
+        assertTrue(MetricType.AST in corroborators)
+        assertTrue(MetricType.GGT in corroborators)
+        assertTrue(MetricType.TOTAL_BILIRUBIN_UMOL_PER_L in corroborators)
+        assertTrue(MetricType.ALBUMIN_G_PER_L in corroborators)
+    }
+
+    // -- biomarker-panel expansion contract surface --
+
+    @Test
+    fun new_biomarkers_resolve_via_MetricType_entries() {
+        val newKeys = listOf(
+            "total_bilirubin_umol_per_l",
+            "albumin_g_per_l",
+            "alp_u_per_l",
+            "lp_a_nmol_per_l",
+            "d_dimer_ng_per_ml",
+            "homocysteine_umol_per_l",
+            "uric_acid_umol_per_l",
+            "tibc_umol_per_l",
+            "reverse_t3_ng_per_dl",
+            "thyroid_peroxidase_ab_kiu_per_l",
+            "dhea_s_umol_per_l",
+            "shbg_nmol_per_l",
+            "omega_3_index_pct",
+            "leptin_ng_per_ml",
+            "adiponectin_mg_per_l",
+        )
+        for (key in newKeys) {
+            val type = MetricType.fromKey(key)
+            assertNotNull("MetricType.fromKey('$key') should resolve", type)
+            assertEquals("$key should live in the BIOMARKER domain", MetricDomain.BIOMARKER, type!!.domain)
+            assertTrue("$key should allow manual entry (lab-drawn)", type.allowsManualEntry)
+        }
+    }
+
+    @Test
+    fun new_biomarker_units_match_clinically_conventional_units() {
+        assertEquals(MetricUnit.UMOL_PER_L, MetricType.TOTAL_BILIRUBIN_UMOL_PER_L.unit)
+        assertEquals(MetricUnit.G_PER_L, MetricType.ALBUMIN_G_PER_L.unit)
+        assertEquals(MetricUnit.U_PER_L, MetricType.ALP_U_PER_L.unit)
+        assertEquals(MetricUnit.NMOL_PER_L, MetricType.LP_A_NMOL_PER_L.unit)
+        assertEquals(MetricUnit.NG_PER_ML, MetricType.D_DIMER_NG_PER_ML.unit)
+        assertEquals(MetricUnit.UMOL_PER_L, MetricType.HOMOCYSTEINE_UMOL_PER_L.unit)
+        assertEquals(MetricUnit.UMOL_PER_L, MetricType.URIC_ACID_UMOL_PER_L.unit)
+        assertEquals(MetricUnit.UMOL_PER_L, MetricType.TIBC_UMOL_PER_L.unit)
+        assertEquals(MetricUnit.NG_PER_DL, MetricType.REVERSE_T3_NG_PER_DL.unit)
+        assertEquals(MetricUnit.KIU_PER_L, MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L.unit)
+        assertEquals(MetricUnit.UMOL_PER_L, MetricType.DHEA_S_UMOL_PER_L.unit)
+        assertEquals(MetricUnit.NMOL_PER_L, MetricType.SHBG_NMOL_PER_L.unit)
+        assertEquals(MetricUnit.PERCENT, MetricType.OMEGA_3_INDEX_PCT.unit)
+        assertEquals(MetricUnit.NG_PER_ML, MetricType.LEPTIN_NG_PER_ML.unit)
+        assertEquals(MetricUnit.MG_PER_L, MetricType.ADIPONECTIN_MG_PER_L.unit)
+    }
+
+    @Test
+    fun new_biomarker_bands_populated_for_default_region() {
+        // Each pattern-anchored or universally-banded biomarker must have a
+        // BiomarkerBands entry in the default region config so the dashboard
+        // colours readings correctly. DHEA-S, SHBG, leptin, adiponectin, TIBC
+        // are deliberately absent (sex/age-dependent or population-dependent
+        // — see RegionConfigProvider comments).
+        val bands = RegionConfigProvider.forRegion("EU").clinicalThresholds.biomarkerBands
+        val mustHaveBands = listOf(
+            MetricType.TOTAL_BILIRUBIN_UMOL_PER_L,
+            MetricType.ALBUMIN_G_PER_L,
+            MetricType.ALP_U_PER_L,
+            MetricType.LP_A_NMOL_PER_L,
+            MetricType.D_DIMER_NG_PER_ML,
+            MetricType.HOMOCYSTEINE_UMOL_PER_L,
+            MetricType.URIC_ACID_UMOL_PER_L,
+            MetricType.THYROID_PEROXIDASE_AB_KIU_PER_L,
+            MetricType.REVERSE_T3_NG_PER_DL,
+            MetricType.OMEGA_3_INDEX_PCT,
+        )
+        for (type in mustHaveBands) {
+            assertNotNull("${type.key} should have a clinical band defined", bands[type])
+        }
+    }
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -226,6 +226,88 @@ enum class MetricType(
     AST("ast", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
     GGT("ggt", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
 
+    // Biomarker-panel expansion (#203, audit gap convergence across
+    // MEDICAL_PROFESSIONAL_POV §2.8, ONCOLOGY_POV §2.3, CARDIOLOGY_POV §2.11,
+    // MODERN_NON_ALLOPATHIC_POV §2.3, GERIATRICS_PALLIATIVE_POV). The
+    // expansion fills four gaps the audits identified:
+    //  - Hepatic panel completion (ALP / total bilirubin / albumin) — silent
+    //    cholestatic disease, hepatocellular injury staging, and synthetic
+    //    function. Pairs with the existing ALT/AST/GGT trio.
+    //  - Cardiometabolic risk amplifiers — Lp(a) is the single most important
+    //    inherited atherogenic factor (EAS/AHA 2022 consensus) and the only
+    //    one with a once-in-a-lifetime measurement use-case.
+    //  - Functional-medicine / preventive markers — homocysteine,
+    //    uric acid, TIBC, reverse T3, TPO antibodies, DHEA-S, SHBG, omega-3
+    //    index, leptin, adiponectin. The IFM matrix groups these as
+    //    methylation, autoimmune-thyroid, adrenal, and metabolic-hormone
+    //    axes. Bios stores raw values; evaluation belongs to the owner.
+    //  - Thrombosis / coagulation — D-dimer (VTE workup; cardio-oncology
+    //    surveillance adjunct to troponin / NT-proBNP).
+    //
+    // Cross-references: cardio-oncology troponin / NT-proBNP / absolute
+    // neutrophil count are owned by PR #230 (feat/cardio-oncology-
+    // surveillance) and intentionally not added here to avoid contract
+    // collisions; this PR composes against #230's keys via the
+    // BiomarkerConditionPatterns once both ship.
+    //
+    // Hepatic-panel completion (AASLD 2017 — Practice Guidance on
+    // evaluation of abnormal liver chemistries).
+    TOTAL_BILIRUBIN_UMOL_PER_L("total_bilirubin_umol_per_l", MetricUnit.UMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ALBUMIN_G_PER_L("albumin_g_per_l", MetricUnit.G_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ALP_U_PER_L("alp_u_per_l", MetricUnit.U_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
+    // Cardiovascular risk amplifiers.
+    // Lp(a) — EAS 2022 consensus statement / Reyes-Soffer AHA 2022:
+    // measured once in a lifetime; nmol/L is the recommended SI unit
+    // (mg/dL is convertible but is not particle-mass-equivalent across
+    // assays). Audit gap: primary care + cardiology §2.11.
+    LP_A_NMOL_PER_L("lp_a_nmol_per_l", MetricUnit.NMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // D-dimer — Wells / PERC adjunct; cardio-oncology adjunct to
+    // troponin / NT-proBNP. Reported as ng/mL FEU (fibrinogen equivalent
+    // units); the FEU qualifier is universal in clinical practice.
+    D_DIMER_NG_PER_ML("d_dimer_ng_per_ml", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
+    // Functional-medicine / methylation + inflammation panel.
+    // Homocysteine — methylation-cycle marker; elevated values associate
+    // with cardiovascular risk and B12/folate insufficiency (AHA 2009
+    // scientific statement; Smith Refsum 2018).
+    HOMOCYSTEINE_UMOL_PER_L("homocysteine_umol_per_l", MetricUnit.UMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // Uric acid — metabolic-syndrome marker; gout / kidney-stone risk.
+    // SI unit µmol/L; US labs report mg/dL via UnitDisplay.
+    URIC_ACID_UMOL_PER_L("uric_acid_umol_per_l", MetricUnit.UMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // TIBC — total iron-binding capacity. Pairs with FERRITIN above to
+    // disambiguate iron-deficiency from anemia of chronic disease
+    // (Williams Hematology 10th ed.).
+    TIBC_UMOL_PER_L("tibc_umol_per_l", MetricUnit.UMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
+    // Thyroid (functional-medicine extension to TSH/FT4/FT3 above).
+    // Reverse T3 — IFM matrix marker for euthyroid sick syndrome and
+    // peripheral T4-to-T3 conversion impairment. Not part of the standard
+    // ATA workup but used in functional-medicine practice.
+    REVERSE_T3_NG_PER_DL("reverse_t3_ng_per_dl", MetricUnit.NG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // TPO antibody — Hashimoto's autoimmune-thyroid screen (ATA 2014).
+    // Assay-specific unit kIU/L is the WHO international-reference
+    // standard.
+    THYROID_PEROXIDASE_AB_KIU_PER_L("thyroid_peroxidase_ab_kiu_per_l", MetricUnit.KIU_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
+    // Endocrine (functional-medicine extension — adrenal + sex-hormone
+    // binding capacity).
+    // DHEA-S — adrenal-androgen reserve; declines linearly with age and
+    // is a functional-medicine adrenal-axis marker (Endocrine Society
+    // 2014). SI unit µmol/L; US labs report µg/dL.
+    DHEA_S_UMOL_PER_L("dhea_s_umol_per_l", MetricUnit.UMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    // SHBG — sex-hormone-binding globulin; required to compute free
+    // androgen index. PCOS workup, low-testosterone evaluation, and
+    // hyperinsulinemia screen (Endocrine Society 2018).
+    SHBG_NMOL_PER_L("shbg_nmol_per_l", MetricUnit.NMOL_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
+    // Cardiometabolic — leptin, adiponectin, omega-3 index. Each is a
+    // functional-medicine matrix marker for metabolic-syndrome staging
+    // beyond HOMA-IR / HbA1c.
+    OMEGA_3_INDEX_PCT("omega_3_index_pct", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    LEPTIN_NG_PER_ML("leptin_ng_per_ml", MetricUnit.NG_PER_ML, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    ADIPONECTIN_MG_PER_L("adiponectin_mg_per_l", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+
     // Epigenetic age clocks (user-imported from TruDiagnostic / other labs).
     // Slow-rolling: quarterly at best. Treated as biomarkers — the owner sees
     // them alongside HBA1C, ApoB, etc. Bios never derives a composite "age
@@ -328,7 +410,15 @@ enum class MetricUnit(val symbol: String) {
     /** Enzyme activity per litre — ALT, AST, GGT, etc. */
     U_PER_L("U/L"),
     /** eGFR normalized to body surface area — KDIGO 2024 standard. */
-    ML_PER_MIN_PER_173("mL/min/1.73m²")
+    ML_PER_MIN_PER_173("mL/min/1.73m²"),
+    /** SI micromolar — homocysteine, uric acid, TIBC, total bilirubin. */
+    UMOL_PER_L("µmol/L"),
+    /** SI nanomolar — Lp(a) (EAS 2022), SHBG. */
+    NMOL_PER_L("nmol/L"),
+    /** Albumin SI — g/L (US uses g/dL via UnitDisplay). */
+    G_PER_L("g/L"),
+    /** Thyroid antibodies — WHO international-reference assay units. */
+    KIU_PER_L("kIU/L")
 }
 
 enum class MetricDomain {


### PR DESCRIPTION
## Summary

Audit-gap convergence for issue #203 — expands the biomarker panel by 15 lab markers across 5 clinical axes, with literature-anchored thresholds, LOINC codes, clinical bands, reference ranges, and two new sustained-decline condition patterns.

Audits drawn from MEDICAL_PROFESSIONAL_POV §2.8, ONCOLOGY_POV §2.3, CARDIOLOGY_POV §2.11, MODERN_NON_ALLOPATHIC_POV §2.3, and GERIATRICS_PALLIATIVE_POV.

### New biomarkers (15)
| Axis | Markers | Source |
|---|---|---|
| Hepatic completion | total bilirubin, albumin, ALP | AASLD 2017/2021 |
| Cardiovascular amplifiers | Lp(a), D-dimer | EAS 2022 / Reyes-Soffer AHA 2022 |
| Functional / methylation | homocysteine, urate, TIBC | AHA 2009, Smith-Refsum 2018, IFM |
| Thyroid extension | reverse T3, TPO antibodies | ATA 2014, IFM |
| Endocrine | DHEA-S, SHBG | Endocrine Society 2014/2018 |
| Cardiometabolic | omega-3 index, leptin, adiponectin | Harris 2008, IFM |

### New condition patterns (Wave 6, ADVISORY tier)
- `renalFunctionDeclineScreen` — KDIGO 2024 eGFR <60 mL/min/1.73m² with required creatinine corroboration + optional urate corroborator
- `hepaticInjuryScreen` — AASLD 2021 ALT >3× ULN anchor with AST / GGT / bilirubin / albumin corroborators

Same shape as Wave 5: literature-sourced, required-anchor + corroborator rules, AlertContentPolicy compliant.

### Infrastructure additions
- 4 new `MetricUnit` entries (µmol/L, nmol/L, g/L, kIU/L) with matching UCUM codes
- LOINC codes for all 15 new biomarkers in `FhirExporter`
- Clinical bands in `RegionConfigProvider` (sex/age-dependent markers deliberately omitted — surfaced un-coloured rather than misclassified)
- Reference ranges in `BiomarkerReferenceRanges`
- Wired into 5 existing `BiomarkerPanels` (cardiovascular, inflammation, thyroid, hepatic, hormones)

### Non-goals / cross-PR coordination
Cardio-oncology troponin / NT-proBNP / ANC intentionally **not** added here — owned by PR #230 (cardio-oncology surveillance). This PR composes against #230's keys via `BiomarkerConditionPatterns` once both ship.

### Provenance note
This branch was rescued from an abandoned agent worktree whose owning process died before commit. Code builds clean, all 1208 tests pass, and the rescue commit was reviewed before push.

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest` passes (1208 tests, 0 failures)
- [x] `./gradlew :app:assembleStandaloneDebug` builds clean
- [x] `Wave6BiomarkerPatternsTest` guards pattern registration, citation discipline, anchor rules, new-key contract surface, unit assignments, and band coverage
- [x] `FhirExporterTest` LOINC count assertion bumped from 38 → 53
- [x] `BiomarkerEntrySelectorsTest` updated to include all 15 new keys
- [ ] Manual: open Biomarker panel UI, confirm new markers render with reference-range coloring where banded; un-coloured for sex/age-dependent markers
- [ ] Manual: trigger condition pattern with sample eGFR <60 + creatinine >1.3 readings, confirm `renalFunctionDeclineScreen` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)