### PR TITLE
fix(ui): SpO2 card showed 9900% instead of 99%

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricCard.kt
@@ -222,7 +222,7 @@ internal fun formatValue(value: Double, metricType: MetricType): String {
         MetricType.HEART_RATE_VARIABILITY ->
             "${value.toInt()} ms"
         MetricType.BLOOD_OXYGEN ->
-            "${(value * 100).toInt()}%"
+            "${value.toInt()}%"
         MetricType.STEPS ->
             "${value.toInt()}"
         MetricType.SKIN_TEMPERATURE_DEVIATION -> {

--- a/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
+++ b/android/app/src/test/java/com/bios/app/MetricCardFormatTest.kt
@@ -41,6 +41,15 @@ class MetricCardFormatTest {
     }
 
     @Test
+    fun `blood oxygen formats stored percentage value without rescaling`() {
+        // Canonical storage is percent (e.g. 99.0 = 99%), not fraction —
+        // see SignalQualityFilter bounds 70-100 and HealthConnect's
+        // record.percentage.value mapping.
+        assertEquals("99%", formatValue(99.0, MetricType.BLOOD_OXYGEN))
+        assertEquals("95%", formatValue(95.4, MetricType.BLOOD_OXYGEN))
+    }
+
+    @Test
     fun `relative time under 60 seconds is just now`() {
         assertEquals("just now", formatRelativeTime(0))
         assertEquals("just now", formatRelativeTime(30_000))


### PR DESCRIPTION
## Summary
- `formatValue` for `BLOOD_OXYGEN` multiplied the stored value by 100, but the canonical unit is already percent (e.g. 99.0 → \"99%\"), so the card rendered \"9900%\".
- Removed the rescale and added a regression test (`MetricCardFormatTest`).

Canonical storage confirmed by:
- `SignalQualityFilter` bounds 70.0–100.0 for `blood_oxygen`
- `HealthConnectAdapter` ingests `record.percentage.value` (already a percent)
- `AcuteWindowDetector` compares directly against 92.0
- `CommunityAggregator` SD comment marks the unit as `%`

## Test plan
- [x] `./gradlew :app:testStandaloneDebugUnitTest --tests com.bios.app.MetricCardFormatTest` passes (new SpO2 assertions included)
- [x] `./scripts/code-quality-check.sh` passes
- [ ] Visually verify on-device that the SpO2 metric card renders \"99%\" (not \"9900%\") with a recent reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)