### PR TITLE
fix(import): CRP unit + standard-vs-hs ambiguity (#354)

### DIFF
--- a/android/app/src/main/java/com/bios/app/config/UniversalBiomarkerBands.kt
+++ b/android/app/src/main/java/com/bios/app/config/UniversalBiomarkerBands.kt
@@ -16,6 +16,14 @@ internal val universalBiomarkerBands: Map<MetricType, BiomarkerBands> = mapOf(
     // hsCRP (mg/L): <1.0 low, 1.0–3.0 moderate, ≥3.0 high
     // (Ridker 2003; Pearson AHA/CDC 2003)
     MetricType.HSCRP to BiomarkerBands(normalCeiling = 1.0, borderlineCeiling = 3.0),
+    // Standard-sensitivity CRP (#354), mg/L. Distinct assay from hsCRP —
+    // tracks acute inflammation / infection, not low-grade cardiovascular
+    // risk. Bands: <10 normal-ish, 10–50 inflammation notice, ≥50 marked
+    // inflammation (Pepys & Hirschfield 2003; Sproston & Ashworth 2018).
+    MetricType.CRP to BiomarkerBands(
+        normalCeiling = 10.0, borderlineCeiling = 50.0,
+        concerningDirection = BandDirection.ABOVE,
+    ),
     // HbA1c (%): <5.7 normal, 5.7–6.5 prediabetic, ≥6.5 diabetic (ADA 2024)
     MetricType.HBA1C to BiomarkerBands(normalCeiling = 5.7, borderlineCeiling = 6.5),
     // Total cholesterol (mg/dL): <200 desirable, 200–239 borderline, ≥240 high

--- a/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
@@ -155,10 +155,21 @@ object FhirImporter {
                 SkippedObservation("valueQuantity missing numeric value", loincCode = loinc)
             )
         }
-        val value = valueQuantity.optDouble("value", Double.NaN)
-        if (value.isNaN() || value <= 0.0) {
+        val rawValue = valueQuantity.optDouble("value", Double.NaN)
+        if (rawValue.isNaN() || rawValue <= 0.0) {
             return ParseOutcome.Skipped(
                 SkippedObservation("Non-positive or non-numeric value", loincCode = loinc)
+            )
+        }
+
+        val value = when (val conversion = normaliseUnit(metric, valueQuantity, rawValue)) {
+            is UnitConversion.Same -> conversion.value
+            is UnitConversion.Converted -> conversion.value
+            is UnitConversion.Mismatch -> return ParseOutcome.Skipped(
+                SkippedObservation(
+                    "Unit ${conversion.incoming} cannot be converted to ${conversion.target} for ${metric.key}",
+                    loincCode = loinc,
+                )
             )
         }
 
@@ -330,6 +341,57 @@ object FhirImporter {
     private sealed class ParseOutcome {
         data class Accepted(val reading: AcceptedReading) : ParseOutcome()
         data class Skipped(val skipped: SkippedObservation) : ParseOutcome()
+    }
+
+    /**
+     * Reconciles the FHIR `valueQuantity.unit` / `valueQuantity.code` with
+     * the canonical Bios unit for [metric]. Returns:
+     *  - [UnitConversion.Same] if the incoming unit matches (or the unit
+     *    field is absent — trust the LOINC mapping in that case).
+     *  - [UnitConversion.Converted] if a registered conversion factor applies.
+     *  - [UnitConversion.Mismatch] when no conversion is known. The caller
+     *    fails closed: better to skip than to store a value in the wrong unit.
+     *
+     * Issue #354 — added because hospital labs report standard CRP in
+     * mg/dL while Bios stores in mg/L; a naive import would underestimate
+     * by 10×. Conversions are intentionally small and explicit — Bios is
+     * not a general unit-conversion service.
+     */
+    private fun normaliseUnit(
+        metric: MetricType,
+        valueQuantity: JSONObject,
+        value: Double,
+    ): UnitConversion {
+        val targetUcum = ucumCode(metric)
+        val incoming = valueQuantity.optString("code").takeIf { it.isNotBlank() }
+            ?: valueQuantity.optString("unit").takeIf { it.isNotBlank() }
+            ?: return UnitConversion.Same(value)
+        if (incoming == targetUcum || incoming == metric.unit.symbol) {
+            return UnitConversion.Same(value)
+        }
+        val factor = conversionFactor(incoming, targetUcum)
+            ?: return UnitConversion.Mismatch(incoming, targetUcum)
+        return UnitConversion.Converted(value * factor)
+    }
+
+    /**
+     * Returns the multiplicative factor to convert [from] to [to], or null
+     * when no conversion is registered. Kept minimal on purpose: every
+     * entry here represents a unit pair Bios has seen in real FHIR imports.
+     */
+    private fun conversionFactor(from: String, to: String): Double? {
+        if (from == to) return 1.0
+        // mg/dL ↔ mg/L. UCUM canonical codes plus the `unit` text fallbacks
+        // that real labs emit. mg/dL × 10 = mg/L.
+        if ((from == "mg/dL" || from == "mg/dl") && to == "mg/L") return 10.0
+        if (from == "mg/L" && (to == "mg/dL" || to == "mg/dl")) return 0.1
+        return null
+    }
+
+    private sealed class UnitConversion {
+        data class Same(val value: Double) : UnitConversion()
+        data class Converted(val value: Double) : UnitConversion()
+        data class Mismatch(val incoming: String, val target: String) : UnitConversion()
     }
 }
 

--- a/android/app/src/main/java/com/bios/app/export/FhirMetricCodings.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirMetricCodings.kt
@@ -35,6 +35,7 @@ internal fun loincCode(metricType: MetricType): Pair<String, String>? = when (me
     MetricType.VO2_MAX -> "97090-9" to "Maximum oxygen consumption per unit time per unit body mass"
     MetricType.HBA1C -> "4548-4" to "Hemoglobin A1c/Hemoglobin.total in Blood"
     MetricType.HSCRP -> "30522-7" to "C reactive protein.high sensitivity [Mass/volume] in Serum or Plasma"
+    MetricType.CRP -> "1988-5" to "C reactive protein [Mass/volume] in Serum or Plasma"
     MetricType.TOTAL_CHOLESTEROL -> "2093-3" to "Cholesterol [Mass/volume] in Serum or Plasma"
     MetricType.LDL_CHOLESTEROL -> "2089-1" to "Cholesterol in LDL [Mass/volume] in Serum or Plasma"
     MetricType.HDL_CHOLESTEROL -> "2085-9" to "Cholesterol in HDL [Mass/volume] in Serum or Plasma"

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerPanel.kt
@@ -55,6 +55,7 @@ object BiomarkerPanels {
         title = "Inflammation & Iron",
         metrics = listOf(
             MetricType.HSCRP,
+            MetricType.CRP,
             MetricType.FERRITIN,
             MetricType.IRON_SERUM,
             MetricType.IRON_SATURATION_PCT,

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerReferenceRanges.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerReferenceRanges.kt
@@ -54,6 +54,8 @@ object BiomarkerReferenceRanges {
 
         // Inflammation — Ridker / AHA cardiovascular-risk bands.
         MetricType.HSCRP to ReferenceRange(low = null, high = 1.0, units = "mg/L"),
+        // Standard-sensitivity CRP (#354) — acute inflammation, not hsCRP cardiovascular risk.
+        MetricType.CRP to ReferenceRange(low = null, high = 10.0, units = "mg/L"),
         // Iron — sex-averaged adult range; the dashboard treats the
         // single number as descriptive only.
         MetricType.FERRITIN to ReferenceRange(low = 30.0, high = 300.0, units = "ng/mL"),

--- a/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerBandsTest.kt
@@ -198,6 +198,7 @@ class BiomarkerBandsTest {
             MetricType.INR,
             MetricType.ABSOLUTE_LYMPHOCYTE_COUNT,
             MetricType.ABSOLUTE_EOSINOPHIL_COUNT,
+            MetricType.CRP,
         )
         for (regionCode in RegionConfigProvider.supportedRegions()) {
             val bands = RegionConfigProvider.forRegion(regionCode).clinicalThresholds.biomarkerBands

--- a/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
+++ b/android/app/src/test/java/com/bios/app/BiomarkerEntrySelectorsTest.kt
@@ -84,6 +84,8 @@ class BiomarkerEntrySelectorsTest {
             MetricType.ABSOLUTE_MONOCYTE_COUNT,
             MetricType.ABSOLUTE_EOSINOPHIL_COUNT,
             MetricType.ABSOLUTE_BASOPHIL_COUNT,
+            // Standard CRP (#354) — distinct from HSCRP.
+            MetricType.CRP,
             // Epigenetic age clocks (slow-rolling, lab-imported).
             MetricType.EPIGENETIC_AGE_DUNEDIN_PACE,
             MetricType.EPIGENETIC_AGE_GRIM,

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -116,11 +116,11 @@ class FhirExporterTest {
         // 32 base + 5 wave-5 biomarkers (#158) + AHI (#157) + 47 Wave-1
         // (audit §3.1) + 8 Wave-2 (audit §3.2 — telomere/bone-T/vit K2
         // intentionally unmapped) + 5 coagulation (#352) + 4 absolute
-        // leukocyte differential (#353) = 102. The count assertion is
-        // maintained alongside the loincCode() table so any unmapped new
-        // MetricType is caught.
+        // leukocyte differential (#353) + 1 standard CRP (#354) = 103.
+        // The count assertion is maintained alongside the loincCode() table
+        // so any unmapped new MetricType is caught.
         val mapped = MetricType.entries.count { loincCode(it) != null }
-        assertEquals(102, mapped)
+        assertEquals(103, mapped)
     }
 
     @Test
@@ -133,6 +133,20 @@ class FhirExporterTest {
     fun `hsCRP maps to LOINC 30522-7`() {
         val (code, _) = loincCode(MetricType.HSCRP)!!
         assertEquals("30522-7", code)
+    }
+
+    @Test
+    fun `CRP maps to LOINC 1988-5 distinct from hsCRP`() {
+        // Issue #354. Standard CRP and high-sensitivity CRP are different
+        // assays with different LOINCs — Bios stores them as separate keys
+        // so a routine ER CRP doesn't masquerade as a cardiovascular-risk
+        // hsCRP.
+        val (code, _) = loincCode(MetricType.CRP)!!
+        assertEquals("1988-5", code)
+        assertNotEquals(
+            loincCode(MetricType.HSCRP)!!.first,
+            loincCode(MetricType.CRP)!!.first,
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirImporterTest.kt
@@ -278,6 +278,97 @@ class FhirImporterTest {
         assertNull(summary.accepted.single().labName)
     }
 
+    // -- Unit normalisation (#354) --
+
+    @Test
+    fun `CRP reported in mg per dL is scaled to mg per L`() {
+        // Sagrat Cor discharge: standard CRP reported as 0.1 mg/dL.
+        // Canonical Bios unit is mg/L; 0.1 mg/dL × 10 = 1.0 mg/L.
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "1988-5" }]
+              },
+              "effectiveDateTime": "2026-04-21T11:49:00Z",
+              "valueQuantity": { "value": 0.1, "unit": "mg/dL", "code": "mg/dL" }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(1.0, summary.accepted.single().value, 0.0001)
+    }
+
+    @Test
+    fun `CRP reported in mg per L passes through unchanged`() {
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "1988-5" }]
+              },
+              "effectiveDateTime": "2026-04-21T11:49:00Z",
+              "valueQuantity": { "value": 5.0, "unit": "mg/L", "code": "mg/L" }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(5.0, summary.accepted.single().value, 0.0001)
+    }
+
+    @Test
+    fun `observation with no unit field trusts the LOINC mapping`() {
+        // A FHIR producer that omits valueQuantity.unit is implicitly using
+        // the LOINC-canonical unit. We accept the value as-is rather than
+        // dropping the import — defensive but pragmatic.
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "1988-5" }]
+              },
+              "effectiveDateTime": "2026-04-21T11:49:00Z",
+              "valueQuantity": { "value": 5.0 }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(1, summary.acceptedCount)
+        assertEquals(5.0, summary.accepted.single().value, 0.0001)
+    }
+
+    @Test
+    fun `unknown unit fails closed rather than storing the wrong value`() {
+        // If the lab sends an unrecognised unit (e.g. someone misconfigures
+        // mg/mL — three orders of magnitude off), we'd rather drop the
+        // observation than silently land the wrong number.
+        val json = """
+            {
+              "resourceType": "Observation",
+              "status": "final",
+              "code": {
+                "coding": [{ "system": "http://loinc.org", "code": "1988-5" }]
+              },
+              "effectiveDateTime": "2026-04-21T11:49:00Z",
+              "valueQuantity": { "value": 0.001, "unit": "mg/mL", "code": "mg/mL" }
+            }
+        """.trimIndent()
+        val summary = FhirImporter.parse(json)
+        assertEquals(0, summary.acceptedCount)
+        assertEquals(1, summary.skippedCount)
+        assertTrue(summary.skipped.single().reason.contains("mg/mL"))
+    }
+
+    @Test
+    fun `CRP and HSCRP route to distinct MetricTypes on import`() {
+        // Bios stores CRP and high-sensitivity CRP separately. Two
+        // observations with the two LOINCs should land on the right keys.
+        assertEquals(MetricType.CRP, FhirImporter.loincToMetricType["1988-5"])
+        assertEquals(MetricType.HSCRP, FhirImporter.loincToMetricType["30522-7"])
+    }
+
     // -- Fixture helpers --
 
     private fun observation(loinc: String, value: Double, instant: String) = """

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -275,7 +275,7 @@ enum class MetricType(
     // alerts/BiomarkerReference.kt — direct readings displace the wearable
     // proxies when an owner imports labs.
     HBA1C("hba1c", MetricUnit.PERCENT, MetricDomain.BIOMARKER, allowsManualEntry = true),
-    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true),
+    HSCRP("hscrp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true), CRP("crp", MetricUnit.MG_PER_L, MetricDomain.BIOMARKER, allowsManualEntry = true), // #354: standard-sensitivity CRP (acute inflammation / infection) distinct from HSCRP (cardiovascular risk); different LOINCs, same canonical UCUM
     TOTAL_CHOLESTEROL("total_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
     LDL_CHOLESTEROL("ldl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),
     HDL_CHOLESTEROL("hdl_cholesterol", MetricUnit.MG_PER_DL, MetricDomain.BIOMARKER, allowsManualEntry = true),


### PR DESCRIPTION
## Summary

Closes #354. Two intertwined CRP fixes — adds standard-sensitivity CRP as a distinct key, and normalises units on FHIR import so mg/dL ↔ mg/L can no longer silently mis-store by 10×.

**Stacked on #360** (abs leukocyte differential) → #359 (coagulation panel). Retarget to base as those merge.

## Changes

### Standard CRP key

- New `MetricType.CRP` (mg/L canonical), distinct from existing `HSCRP`. Both LOINC-mapped (1988-5 / 30522-7) and bands-defined; both surfaced on the existing Inflammation panel.
- Bands for `CRP`: <10 mg/L NORMAL, 10–50 BORDERLINE inflammation, ≥50 CONCERNING (Pepys & Hirschfield 2003 / Sproston & Ashworth 2018). HSCRP bands unchanged.

### Unit normalisation on import

- New private `normaliseUnit` in `FhirImporter.parseObservation`. Reads `valueQuantity.unit` / `valueQuantity.code`, compares against `ucumCode(metric)`, and applies a registered conversion factor or fails closed.
- Conversion table: mg/dL ↔ mg/L (×10) — the only conversion the existing biomarker set needs today. Conversions are intentionally explicit and small; not a general unit-conversion service.
- Missing unit field → trusts the LOINC mapping (defensive). Unknown unit → drops the observation with a clear `SkippedObservation.reason`.

### Why fix-prefixed

The silent unit-mismatch failure mode (mg/dL imported as mg/L) is the load-bearing concern. The new `CRP` key is the enabling condition: without it, a lab reporting 1988-5 CRP would have routed to the unmapped-LOINC skip path. Now both halves of the fix land together.

## Test plan

- [x] `./gradlew :app:testStandaloneDebugUnitTest` — all tests pass
- [x] `./scripts/check-file-length.sh 500` — all files under limit
- [x] New importer tests: mg/dL → mg/L conversion (the Sagrat Cor case), mg/L passthrough, missing-unit-field trusts-LOINC, unknown-unit fail-closed, CRP/HSCRP route distinctly
- [x] New exporter test: CRP maps to LOINC 1988-5 distinct from HSCRP

🤖 Generated with [Claude Code](https://claude.com/claude-code)