### PR TITLE
feat(model): ImagingStudy entity + storage (#356)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -46,8 +46,9 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         GrowthMeasurement::class,
         SourceMetricToggle::class,
         AllergyRecord::class,
+        ImagingStudy::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -85,6 +86,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun growthMeasurementDao(): GrowthMeasurementDao
     abstract fun sourceMetricToggleDao(): SourceMetricToggleDao
     abstract fun allergyRecordDao(): com.bios.app.data.dao.AllergyRecordDao
+    abstract fun imagingStudyDao(): com.bios.app.data.dao.ImagingStudyDao
 
     companion object {
         @Volatile
@@ -107,7 +109,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MetricReadingMigrations.MIGRATION_30_31, SourceMetricToggleMigrations.MIGRATION_31_32, BiosDatabaseMigrationsExtras.MIGRATION_32_33, BiosDatabaseMigrationsExtras.MIGRATION_33_34)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MetricReadingMigrations.MIGRATION_30_31, SourceMetricToggleMigrations.MIGRATION_31_32, BiosDatabaseMigrationsExtras.MIGRATION_32_33, BiosDatabaseMigrationsExtras.MIGRATION_33_34, BiosDatabaseMigrationsExtras.MIGRATION_34_35)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabaseMigrationsExtras.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabaseMigrationsExtras.kt
@@ -87,4 +87,36 @@ internal object BiosDatabaseMigrationsExtras {
             db.execSQL("CREATE INDEX IF NOT EXISTS index_allergy_records_verifiedByClinician ON allergy_records(verifiedByClinician)")
         }
     }
+
+    /**
+     * Owner-recorded imaging studies (#356). Stores radiology-report text
+     * (technique / findings / conclusion) plus modality and body region.
+     * DICOM blob storage is explicitly out of scope; this table is
+     * text-report-only. Hard-delete allowed.
+     */
+    val MIGRATION_34_35: Migration = object : Migration(34, 35) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS imaging_studies (
+                    uuid TEXT PRIMARY KEY NOT NULL,
+                    modality TEXT NOT NULL,
+                    bodyRegion TEXT NOT NULL,
+                    studyDate INTEGER NOT NULL,
+                    indication TEXT,
+                    facility TEXT,
+                    reportTechnique TEXT,
+                    reportFindings TEXT,
+                    reportConclusion TEXT,
+                    reportLanguage TEXT,
+                    ownerNote TEXT,
+                    createdAt INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_imaging_studies_studyDate ON imaging_studies(studyDate)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_imaging_studies_modality ON imaging_studies(modality)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_imaging_studies_bodyRegion ON imaging_studies(bodyRegion)")
+        }
+    }
 }

--- a/android/app/src/main/java/com/bios/app/data/dao/ImagingStudyDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/ImagingStudyDao.kt
@@ -1,0 +1,40 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.bios.app.model.ImagingStudy
+
+/**
+ * Persistence layer for owner-recorded imaging studies (#356).
+ *
+ * Plain CRUD plus a fetch-most-recent query for the medical-history
+ * surface. No pattern-engine joins — Bios doesn't interpret imaging.
+ */
+@Dao
+interface ImagingStudyDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(study: ImagingStudy)
+
+    @Update
+    suspend fun update(study: ImagingStudy)
+
+    @Delete
+    suspend fun delete(study: ImagingStudy)
+
+    @Query("SELECT * FROM imaging_studies WHERE uuid = :uuid")
+    suspend fun fetchByUuid(uuid: String): ImagingStudy?
+
+    @Query("SELECT * FROM imaging_studies ORDER BY studyDate DESC")
+    suspend fun fetchAll(): List<ImagingStudy>
+
+    @Query("SELECT * FROM imaging_studies ORDER BY studyDate DESC LIMIT :limit")
+    suspend fun fetchRecent(limit: Int = 50): List<ImagingStudy>
+
+    @Query("SELECT COUNT(*) FROM imaging_studies")
+    suspend fun count(): Int
+}

--- a/android/app/src/main/java/com/bios/app/model/ImagingStudy.kt
+++ b/android/app/src/main/java/com/bios/app/model/ImagingStudy.kt
@@ -1,0 +1,71 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+/**
+ * Owner-recorded imaging study (#356). Audit gap surfaced by the Sagrat
+ * Cor discharge — a CT head report had no place to live. EcgStrip is the
+ * design precedent (storage-only, no on-device classification); this is
+ * the textual-report analogue.
+ *
+ * **Scope of this entity:**
+ *  - Stores the radiology report **text**: technique, findings,
+ *    conclusion, plus modality and body region for indexing.
+ *  - Does **not** store DICOM blobs. Pixel data lives elsewhere — either
+ *    on the imaging centre's PACS or as a separate binary store the
+ *    owner explicitly opts into in a future PR.
+ *  - Does **not** interpret. The clinician's words are stored verbatim;
+ *    Bios never extracts findings or scores severity. Matches the
+ *    manifesto: instrument, not coach.
+ *
+ * **Erasure by design.** Hard delete is allowed; there is no soft-delete
+ * history. Incidental findings on imaging are a real source of anxiety,
+ * and the owner decides when to revisit.
+ */
+@Entity(
+    tableName = "imaging_studies",
+    indices = [Index("studyDate"), Index("modality"), Index("bodyRegion")],
+)
+data class ImagingStudy(
+    @PrimaryKey val uuid: String = UUID.randomUUID().toString(),
+    val modality: ImagingModality,
+    val bodyRegion: ImagingBodyRegion,
+    /** Date the imaging was performed (epoch millis). */
+    val studyDate: Long,
+    /** Owner / clinician chief-complaint or routine-screening reason. */
+    val indication: String? = null,
+    /** Facility that performed the study, free-text. */
+    val facility: String? = null,
+    /** Verbatim radiology-report sections. All optional — some imports
+     *  ship only a conclusion line, others ship the full report. */
+    val reportTechnique: String? = null,
+    val reportFindings: String? = null,
+    val reportConclusion: String? = null,
+    /** ISO 639-1 language tag for the report text ("es", "en", "ca"). */
+    val reportLanguage: String? = null,
+    /** Free-text owner note. */
+    val ownerNote: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Imaging modalities Bios accepts. Mirrors the FHIR ImagingStudy
+ * `modality` value-set (DICOM modality codes) at the granularity owners
+ * actually distinguish. Vendor-specific subtypes (CT vs. CTA, MRI vs.
+ * fMRI) collapse into the parent — refine later if a clinical pattern
+ * needs the distinction.
+ */
+enum class ImagingModality { CT, MRI, XRAY, ULTRASOUND, PET, DEXA, MAMMOGRAM, ENDOSCOPY, OTHER }
+
+/**
+ * Anatomical region. Pragmatic taxonomy chosen for the way owners
+ * describe what was scanned, not the radiologic gold-standard
+ * BodySite. The free-text `indication` and `reportFindings` carry the
+ * precise anatomy where it matters.
+ */
+enum class ImagingBodyRegion {
+    HEAD, NECK, CHEST, ABDOMEN, PELVIS, SPINE, EXTREMITY, WHOLE_BODY, OTHER
+}

--- a/android/app/src/test/java/com/bios/app/ImagingStudyTest.kt
+++ b/android/app/src/test/java/com/bios/app/ImagingStudyTest.kt
@@ -1,0 +1,106 @@
+package com.bios.app
+
+import com.bios.app.data.BiosDatabaseMigrationsExtras
+import com.bios.app.model.ImagingBodyRegion
+import com.bios.app.model.ImagingModality
+import com.bios.app.model.ImagingStudy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Spec test for the ImagingStudy entity shape and its v34 -> v35
+ * migration. Issue #356.
+ */
+class ImagingStudyTest {
+
+    @Test
+    fun `imaging study generates a stable uuid and createdAt`() {
+        val s = ImagingStudy(
+            modality = ImagingModality.CT,
+            bodyRegion = ImagingBodyRegion.HEAD,
+            studyDate = 1714000000000L,
+        )
+        assertNotNull(s.uuid)
+        assertEquals(36, s.uuid.length) // UUID standard length
+        assertNotNull(s.createdAt)
+    }
+
+    @Test
+    fun `imaging study report fields default to null`() {
+        val s = ImagingStudy(
+            modality = ImagingModality.MRI,
+            bodyRegion = ImagingBodyRegion.SPINE,
+            studyDate = 0L,
+        )
+        // All report sections optional — some imports ship only a conclusion.
+        assertNull(s.indication)
+        assertNull(s.facility)
+        assertNull(s.reportTechnique)
+        assertNull(s.reportFindings)
+        assertNull(s.reportConclusion)
+        assertNull(s.reportLanguage)
+        assertNull(s.ownerNote)
+    }
+
+    @Test
+    fun `imaging study round-trips a Sagrat Cor CT head report verbatim`() {
+        // Issue #356. The Sagrat Cor discharge contained a non-contrast
+        // head CT with full technique / findings / conclusion sections in
+        // Spanish. Bios stores them as the clinician wrote them, no
+        // translation, no summarisation.
+        val s = ImagingStudy(
+            modality = ImagingModality.CT,
+            bodyRegion = ImagingBodyRegion.HEAD,
+            studyDate = 1714000000000L,
+            indication = "Cefalea holocraneal de 10 días, sospecha de patología orgánica",
+            facility = "Hospital Universitari Sagrat Cor",
+            reportTechnique = "Cortes axiales desde base de cráneo a la convexidad en fase simple",
+            reportFindings = "Densidad parénquima cerebral y cerebeloso normal y homogénea, sin lesiones focales",
+            reportConclusion = "TC cráneo sin evidencia de patología aguda al momento del estudio",
+            reportLanguage = "es",
+        )
+        assertEquals(ImagingModality.CT, s.modality)
+        assertEquals(ImagingBodyRegion.HEAD, s.bodyRegion)
+        assertEquals("es", s.reportLanguage)
+        assertEquals("Hospital Universitari Sagrat Cor", s.facility)
+    }
+
+    @Test
+    fun `two imaging studies have unique uuids by default`() {
+        val a = ImagingStudy(
+            modality = ImagingModality.CT,
+            bodyRegion = ImagingBodyRegion.HEAD,
+            studyDate = 0L,
+        )
+        val b = ImagingStudy(
+            modality = ImagingModality.CT,
+            bodyRegion = ImagingBodyRegion.HEAD,
+            studyDate = 0L,
+        )
+        assertNotEquals(a.uuid, b.uuid)
+    }
+
+    @Test
+    fun `MIGRATION_34_35 covers the right schema versions`() {
+        val m = BiosDatabaseMigrationsExtras.MIGRATION_34_35
+        assertEquals(34, m.startVersion)
+        assertEquals(35, m.endVersion)
+    }
+
+    @Test
+    fun `modality and body region enums cover the expected vocabulary`() {
+        // Room persists enum entries by name; renaming would invalidate
+        // existing rows. Pin the value-set.
+        assertEquals(
+            setOf("CT", "MRI", "XRAY", "ULTRASOUND", "PET", "DEXA", "MAMMOGRAM", "ENDOSCOPY", "OTHER"),
+            ImagingModality.entries.map { it.name }.toSet(),
+        )
+        assertEquals(
+            setOf("HEAD", "NECK", "CHEST", "ABDOMEN", "PELVIS", "SPINE", "EXTREMITY", "WHOLE_BODY", "OTHER"),
+            ImagingBodyRegion.entries.map { it.name }.toSet(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #356 — minimal scope. Adds the data-layer for owner-recorded imaging studies (CT, MRI, X-ray, ultrasound, etc.) with verbatim radiology-report text. Surfaced by the Sagrat Cor discharge audit, which included a non-contrast head CT.

**Stacked on #363** (#355 allergy record) → #362 (#357 diagnosis coding). Retarget as those merge.

## Changes

- **`ImagingStudy` entity** ([model/ImagingStudy.kt](android/app/src/main/java/com/bios/app/model/ImagingStudy.kt)):
  - `uuid` (stable cross-system id), `modality` (9 values), `bodyRegion` (9 values), `studyDate`
  - Optional `indication`, `facility`
  - Optional report sections: `reportTechnique`, `reportFindings`, `reportConclusion`, `reportLanguage` (ISO 639-1)
  - Optional `ownerNote`
- **`ImagingStudyDao`** — plain CRUD plus `fetchRecent(limit)` for the medical-history surface.
- **Room migration 34 → 35** in `BiosDatabaseMigrationsExtras.kt`: `CREATE TABLE imaging_studies` with indexes on `studyDate`, `modality`, `bodyRegion`.
- **`BiosDatabase`**: entity + DAO registration, schema version bump 34 → 35.

## Design precedent

`EcgStrip` is the model: storage-only, verbatim, no on-device classification. Bios stores the clinician's words; it never extracts findings, scores severity, or surfaces a "second opinion". Matches the manifesto: instrument, not coach.

## Out of scope (deferred per the #356 issue body)

- **DICOM blob ingest + viewer.** Text-report-only in v1.
- **Manual-entry UI** (Settings → Medical History → Imaging).
- **FHIR `DiagnosticReport` + `ImagingStudy` mapping** (export and import).
- **Cross-study longitudinal radiology surface.**
- **Screening-cadence reminders** (mammogram, MRI surveillance). Clinician owns recall; Bios is not a recall system.

## Manifesto guards

- **Verbatim storage.** No on-device LLM "simplification" of medical narrative — that's evaluation, and evaluation belongs to the owner and their clinician.
- **Owner controls visibility.** Incidental findings on imaging are a real source of anxiety; the UI (future PR) will let the owner collapse / hide the conclusion by default.
- **Erasure by design.** Hard delete is allowed.

## Test plan

- [x] `./gradlew :app:testStandaloneDebugUnitTest` — all tests pass
- [x] `./scripts/check-file-length.sh 500` — all under limit
- [x] New tests: uuid + createdAt generation, all report fields default to null, Sagrat Cor CT head report round-trip (Spanish verbatim), uuid uniqueness, migration version bounds, enum value-set stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)