### PR TITLE
feat(model): ClinicalEncounter + FollowUpReferral entities (#358)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabase.kt
@@ -47,8 +47,10 @@ import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
         SourceMetricToggle::class,
         AllergyRecord::class,
         ImagingStudy::class,
+        ClinicalEncounter::class,
+        FollowUpReferral::class,
     ],
-    version = 35,
+    version = 36,
     exportSchema = false
 )
 @androidx.room.TypeConverters(MigraineTriggerConverter::class)
@@ -87,6 +89,7 @@ abstract class BiosDatabase : RoomDatabase() {
     abstract fun sourceMetricToggleDao(): SourceMetricToggleDao
     abstract fun allergyRecordDao(): com.bios.app.data.dao.AllergyRecordDao
     abstract fun imagingStudyDao(): com.bios.app.data.dao.ImagingStudyDao
+    abstract fun clinicalEncounterDao(): com.bios.app.data.dao.ClinicalEncounterDao
 
     companion object {
         @Volatile
@@ -109,7 +112,7 @@ abstract class BiosDatabase : RoomDatabase() {
                 "bios.db"
             )
                 .openHelperFactory(factory)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MetricReadingMigrations.MIGRATION_30_31, SourceMetricToggleMigrations.MIGRATION_31_32, BiosDatabaseMigrationsExtras.MIGRATION_32_33, BiosDatabaseMigrationsExtras.MIGRATION_33_34, BiosDatabaseMigrationsExtras.MIGRATION_34_35)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10, MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MedicationVocabularyMigration.MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, BiosDatabaseMigrationsExtras.MIGRATION_23_24, BiosDatabaseMigrations.MIGRATION_24_25, MigrationsAnthropometry.MIGRATION_25_26, EcgStripMigrations.MIGRATION_26_27, PerioperativeMigrations.MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30, MetricReadingMigrations.MIGRATION_30_31, SourceMetricToggleMigrations.MIGRATION_31_32, BiosDatabaseMigrationsExtras.MIGRATION_32_33, BiosDatabaseMigrationsExtras.MIGRATION_33_34, BiosDatabaseMigrationsExtras.MIGRATION_34_35, BiosDatabaseMigrationsExtras.MIGRATION_35_36)
                 // Downgrades happen when the owner installs a build whose
                 // DB schema is older than the one already on disk —
                 // typical when bouncing between a dev build and a tagged

--- a/android/app/src/main/java/com/bios/app/data/BiosDatabaseMigrationsExtras.kt
+++ b/android/app/src/main/java/com/bios/app/data/BiosDatabaseMigrationsExtras.kt
@@ -119,4 +119,53 @@ internal object BiosDatabaseMigrationsExtras {
             db.execSQL("CREATE INDEX IF NOT EXISTS index_imaging_studies_bodyRegion ON imaging_studies(bodyRegion)")
         }
     }
+
+    /**
+     * Clinical encounters + follow-up referrals (#358). Joins a visit's
+     * vitals / labs / diagnoses / prescriptions into one bundle so the
+     * owner can pull up "everything from this visit" as a unit. v1
+     * creates the two new tables; adding the cross-cutting encounterId
+     * column to existing entities (MetricReading, HealthEvent,
+     * MedicationAnnotation, etc.) is intentionally deferred to a
+     * separate migration so this PR stays focused.
+     */
+    val MIGRATION_35_36: Migration = object : Migration(35, 36) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS clinical_encounters (
+                    uuid TEXT PRIMARY KEY NOT NULL,
+                    facility TEXT,
+                    facilityKind TEXT NOT NULL,
+                    admissionAt INTEGER NOT NULL,
+                    dischargeAt INTEGER,
+                    reasonForVisit TEXT,
+                    dischargeSummaryText TEXT,
+                    dischargeSummaryLanguage TEXT,
+                    followUpInstructions TEXT,
+                    ownerNote TEXT,
+                    createdAt INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_clinical_encounters_admissionAt ON clinical_encounters(admissionAt)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_clinical_encounters_facilityKind ON clinical_encounters(facilityKind)")
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS follow_up_referrals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    encounterUuid TEXT NOT NULL,
+                    specialty TEXT NOT NULL,
+                    urgency TEXT NOT NULL,
+                    suggestedTimeframe TEXT,
+                    facility TEXT,
+                    reason TEXT,
+                    createdAt INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_follow_up_referrals_encounterUuid ON follow_up_referrals(encounterUuid)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS index_follow_up_referrals_urgency ON follow_up_referrals(urgency)")
+        }
+    }
 }

--- a/android/app/src/main/java/com/bios/app/data/dao/ClinicalEncounterDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/ClinicalEncounterDao.kt
@@ -1,0 +1,61 @@
+package com.bios.app.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.bios.app.model.ClinicalEncounter
+import com.bios.app.model.FollowUpReferral
+
+/**
+ * Persistence layer for clinical encounters and their follow-up
+ * referrals (#358). Plain CRUD; encounter ↔ referral cascade-delete is
+ * handled in the repo layer rather than via Room ForeignKey to keep the
+ * migration shape simple.
+ */
+@Dao
+interface ClinicalEncounterDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(encounter: ClinicalEncounter)
+
+    @Update
+    suspend fun update(encounter: ClinicalEncounter)
+
+    @Delete
+    suspend fun delete(encounter: ClinicalEncounter)
+
+    @Query("DELETE FROM clinical_encounters WHERE uuid = :uuid")
+    suspend fun deleteByUuid(uuid: String)
+
+    @Query("SELECT * FROM clinical_encounters WHERE uuid = :uuid")
+    suspend fun fetchByUuid(uuid: String): ClinicalEncounter?
+
+    @Query("SELECT * FROM clinical_encounters ORDER BY admissionAt DESC")
+    suspend fun fetchAll(): List<ClinicalEncounter>
+
+    @Query("SELECT * FROM clinical_encounters ORDER BY admissionAt DESC LIMIT :limit")
+    suspend fun fetchRecent(limit: Int = 50): List<ClinicalEncounter>
+
+    @Query("SELECT COUNT(*) FROM clinical_encounters")
+    suspend fun count(): Int
+
+    // -- Follow-up referrals --
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertReferral(referral: FollowUpReferral): Long
+
+    @Update
+    suspend fun updateReferral(referral: FollowUpReferral)
+
+    @Delete
+    suspend fun deleteReferral(referral: FollowUpReferral)
+
+    @Query("DELETE FROM follow_up_referrals WHERE encounterUuid = :encounterUuid")
+    suspend fun deleteReferralsForEncounter(encounterUuid: String)
+
+    @Query("SELECT * FROM follow_up_referrals WHERE encounterUuid = :encounterUuid ORDER BY urgency DESC, createdAt ASC")
+    suspend fun fetchReferralsForEncounter(encounterUuid: String): List<FollowUpReferral>
+}

--- a/android/app/src/main/java/com/bios/app/model/ClinicalEncounter.kt
+++ b/android/app/src/main/java/com/bios/app/model/ClinicalEncounter.kt
@@ -1,0 +1,102 @@
+package com.bios.app.model
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+/**
+ * Clinical encounter — an admission/discharge from an ER, hospital, or
+ * clinic visit (#358). Bundles together the records produced by one
+ * visit so the owner can pull up "everything from this visit" as a unit.
+ *
+ * Surfaced by the Sagrat Cor discharge audit. A single ER visit produces
+ * 30+ correlated data points (vitals, labs, diagnoses, imaging,
+ * medications, follow-up referrals) that were previously scattered
+ * across MetricReading / HealthEvent / MedicationAnnotation /
+ * AllergyRecord / ImagingStudy with no join key.
+ *
+ * **Scope of this entity:** the encounter record itself (admission /
+ * discharge times, facility, free-text reason and discharge summary,
+ * language). The cross-cutting `encounterId` column on existing
+ * entities (MetricReading, HealthEvent, etc.) is **not** part of this
+ * PR — that's a separate, larger migration. Today, an encounter is a
+ * descriptive record; the join is added when the existing entities
+ * grow their encounterId columns.
+ *
+ * **Verbatim storage.** Discharge summary text lives untranslated and
+ * unsummarised. No on-device LLM "simplification" of medical narrative
+ * — that's evaluation, and evaluation belongs to the owner and their
+ * clinician.
+ *
+ * **Erasure by design.** Hard delete is allowed (encounter rows + the
+ * dependent FollowUpReferral rows cascade). If a future PR wires
+ * encounterId on child rows, those should *unlink* (set null) rather
+ * than cascade-delete — the lab result and the prescription are still
+ * the owner's data even if the visit record goes away.
+ */
+@Entity(
+    tableName = "clinical_encounters",
+    indices = [Index("admissionAt"), Index("facilityKind")],
+)
+data class ClinicalEncounter(
+    @PrimaryKey val uuid: String = UUID.randomUUID().toString(),
+    /** Facility name as the owner records it ("Hospital Universitari Sagrat Cor"). */
+    val facility: String? = null,
+    val facilityKind: FacilityKind = FacilityKind.OTHER,
+    /** Admission timestamp, epoch millis. */
+    val admissionAt: Long,
+    /** Discharge timestamp; null while admitted as inpatient. */
+    val dischargeAt: Long? = null,
+    /** Owner-recorded or imported chief complaint / reason for visit. */
+    val reasonForVisit: String? = null,
+    /** Verbatim discharge-summary narrative (Spanish, English, etc.). */
+    val dischargeSummaryText: String? = null,
+    /** ISO 639-1 language tag for the summary text. */
+    val dischargeSummaryLanguage: String? = null,
+    /** Verbatim free-text follow-up instructions from the clinician. */
+    val followUpInstructions: String? = null,
+    /** Free-text owner note. */
+    val ownerNote: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Kind of facility the encounter took place at. Pragmatic taxonomy that
+ * matches how owners describe visits, not a regulatory billing code.
+ */
+enum class FacilityKind { ER, INPATIENT, OUTPATIENT, TELEHEALTH, URGENT_CARE, OTHER }
+
+/**
+ * Follow-up referral attached to a [ClinicalEncounter] (#358). Records
+ * what the clinician said the owner should do next ("follow up with
+ * Neurology within 2 weeks"). Zero-or-many per encounter.
+ *
+ * **No appointment scheduling, no calendar integration, no reminders.**
+ * The manifesto explicitly rules these out — clinician owns recall;
+ * Bios records, surfaces, never nags.
+ */
+@Entity(
+    tableName = "follow_up_referrals",
+    indices = [Index("encounterUuid"), Index("urgency")],
+)
+data class FollowUpReferral(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    /** FK to ClinicalEncounter.uuid. Not declared as a Room ForeignKey
+     *  in v1 to keep migration shape simple; the constraint lives in
+     *  the repo layer (delete-encounter also deletes its referrals). */
+    val encounterUuid: String,
+    /** Specialty or service the owner should follow up with
+     *  ("Neurology", "AP / Primary Care", "Cardiology"). Free-text. */
+    val specialty: String,
+    val urgency: ReferralUrgency = ReferralUrgency.ROUTINE,
+    /** "within 2 weeks", "as needed", "before next AFib episode". */
+    val suggestedTimeframe: String? = null,
+    /** Optional named facility the referral targets. */
+    val facility: String? = null,
+    /** Why the clinician issued the referral. */
+    val reason: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+)
+
+enum class ReferralUrgency { ROUTINE, URGENT, EMERGENT }

--- a/android/app/src/test/java/com/bios/app/ClinicalEncounterTest.kt
+++ b/android/app/src/test/java/com/bios/app/ClinicalEncounterTest.kt
@@ -1,0 +1,106 @@
+package com.bios.app
+
+import com.bios.app.data.BiosDatabaseMigrationsExtras
+import com.bios.app.model.ClinicalEncounter
+import com.bios.app.model.FacilityKind
+import com.bios.app.model.FollowUpReferral
+import com.bios.app.model.ReferralUrgency
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Spec test for ClinicalEncounter / FollowUpReferral entities and the
+ * v35 -> v36 migration. Issue #358.
+ */
+class ClinicalEncounterTest {
+
+    @Test
+    fun `encounter generates stable uuid and createdAt`() {
+        val e = ClinicalEncounter(admissionAt = 1714000000000L)
+        assertNotNull(e.uuid)
+        assertEquals(36, e.uuid.length)
+        assertNotNull(e.createdAt)
+        // Discharge is null while still admitted.
+        assertNull(e.dischargeAt)
+        assertEquals(FacilityKind.OTHER, e.facilityKind)
+    }
+
+    @Test
+    fun `encounter round-trips a Sagrat Cor ER visit verbatim`() {
+        // The Sagrat Cor case: admitted 06:17, discharged 11:49 same day,
+        // facility = ER, reason = headache 6/10 + tunnel-vision episodes.
+        // The narrative is Spanish; Bios stores it as-is.
+        val e = ClinicalEncounter(
+            facility = "Hospital Universitari Sagrat Cor",
+            facilityKind = FacilityKind.ER,
+            admissionAt = 1713680220000L,
+            dischargeAt = 1713700140000L,
+            reasonForVisit = "Cefalea holocraneal de 10 días",
+            dischargeSummaryText = "Dada ausencia de signos de alarma se da alta a domicilio aconsejando seguimiento por médico de AP y Neurología de zona.",
+            dischargeSummaryLanguage = "es",
+            followUpInstructions = "Control por medico de AP y especialista en Neurologia de zona.",
+        )
+        assertEquals(FacilityKind.ER, e.facilityKind)
+        assertEquals("es", e.dischargeSummaryLanguage)
+        assertNotNull(e.dischargeAt)
+    }
+
+    @Test
+    fun `two encounters have unique uuids by default`() {
+        val a = ClinicalEncounter(admissionAt = 0L)
+        val b = ClinicalEncounter(admissionAt = 0L)
+        assertNotEquals(a.uuid, b.uuid)
+    }
+
+    @Test
+    fun `follow-up referral defaults to ROUTINE urgency and carries clinician guidance`() {
+        // Sagrat Cor follow-up: "Control by AP doctor and Neurology zone
+        // specialist." No timeframe specified — defaults to ROUTINE.
+        val r = FollowUpReferral(
+            encounterUuid = "enc-1",
+            specialty = "Neurology",
+        )
+        assertEquals(ReferralUrgency.ROUTINE, r.urgency)
+        assertNull(r.suggestedTimeframe)
+        assertNull(r.facility)
+        assertNull(r.reason)
+    }
+
+    @Test
+    fun `follow-up referral can encode urgency and full clinician guidance`() {
+        val r = FollowUpReferral(
+            encounterUuid = "enc-1",
+            specialty = "Cardiology",
+            urgency = ReferralUrgency.URGENT,
+            suggestedTimeframe = "within 2 weeks",
+            facility = "ESC outpatient",
+            reason = "Suspected paroxysmal AFib — Holter requested",
+        )
+        assertEquals(ReferralUrgency.URGENT, r.urgency)
+        assertEquals("within 2 weeks", r.suggestedTimeframe)
+    }
+
+    @Test
+    fun `MIGRATION_35_36 covers the right schema versions`() {
+        val m = BiosDatabaseMigrationsExtras.MIGRATION_35_36
+        assertEquals(35, m.startVersion)
+        assertEquals(36, m.endVersion)
+    }
+
+    @Test
+    fun `facility kind and urgency enums cover the expected vocabulary`() {
+        // Room persists enum entries by name; renaming would invalidate
+        // existing rows. Pin the value-set.
+        assertEquals(
+            setOf("ER", "INPATIENT", "OUTPATIENT", "TELEHEALTH", "URGENT_CARE", "OTHER"),
+            FacilityKind.entries.map { it.name }.toSet(),
+        )
+        assertEquals(
+            setOf("ROUTINE", "URGENT", "EMERGENT"),
+            ReferralUrgency.entries.map { it.name }.toSet(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #358 — minimal scope. Adds the data layer for clinical encounters (ER / inpatient / outpatient / telehealth / urgent care visits) and their follow-up referrals. Completes the seven-issue audit follow-up arc surfaced by the Sagrat Cor discharge.

**Stacked on #364** (#356 imaging study) → #363 (#355 allergies) → #362 (#357 diagnosis coding). Retarget to `main` as those merge.

## Changes

- **`ClinicalEncounter` entity** ([model/ClinicalEncounter.kt](android/app/src/main/java/com/bios/app/model/ClinicalEncounter.kt)):
  - `uuid` (stable cross-system id), `facility`, `facilityKind` (ER / INPATIENT / OUTPATIENT / TELEHEALTH / URGENT_CARE / OTHER)
  - `admissionAt`, optional `dischargeAt` (null while inpatient)
  - Optional `reasonForVisit`, `dischargeSummaryText`, `dischargeSummaryLanguage` (ISO 639-1), `followUpInstructions`, `ownerNote`
- **`FollowUpReferral` entity** (zero-or-many per encounter):
  - `encounterUuid` (FK in repo layer, not Room ForeignKey — keeps migration shape simple)
  - `specialty` (free-text), `urgency` (ROUTINE / URGENT / EMERGENT)
  - Optional `suggestedTimeframe`, `facility`, `reason`
- **`ClinicalEncounterDao`** — CRUD for both entities, plus `fetchReferralsForEncounter` and `deleteReferralsForEncounter` so the repo layer can cascade encounter deletion.
- **Room migration 35 → 36** in `BiosDatabaseMigrationsExtras.kt`: two `CREATE TABLE` statements with indexes on the obvious lookup columns.
- **`BiosDatabase`**: entity + DAO registration, schema version bump 35 → 36.

## Out of scope (deferred per the #358 issue body)

- **Cross-cutting `encounterId` column on existing entities** (`MetricReading`, `HealthEvent`, `MedicationAnnotation`, `AllergyRecord`, `ImagingStudy`). This is the larger half of #358 — it requires editing each entity and adding a 5-table migration. v1 is the encounter record itself; the join is added in a follow-up.
- **Manual-entry UI** (Settings → Medical History → Visits).
- **FHIR `Encounter` + `Composition`** (discharge-summary) export/import. Bios currently emits Observations / Devices / DetectedIssues only.
- **Appointment booking, calendar integration, follow-up reminders.** The manifesto rules these out.
- **Auto-extraction of vitals/labs from pasted discharge text.** Verbatim only.

## Manifesto guards (encoded in the entity)

- **Verbatim storage.** Discharge text lives untranslated and unsummarised. No on-device LLM "simplification".
- **Owner controls share-out.** The (future) FHIR export honours per-encounter share decisions — Bios never sends a clinical encounter externally without explicit owner action.
- **No nudging on follow-up.** `FollowUpReferral` records the clinician's recommendation; Bios does not pester the owner about booking appointments.

## Test plan

- [x] `./gradlew :app:testStandaloneDebugUnitTest` — all tests pass
- [x] `./scripts/check-file-length.sh 500` — all under limit
- [x] New tests: encounter uuid + createdAt generation, Sagrat Cor ER visit round-trip (Spanish verbatim narrative), encounter uuid uniqueness, referral ROUTINE-default + full-clinician-guidance round-trip, migration version bounds, enum value-set stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)