### PR TITLE
fix(perms): contextual POST_NOTIFICATIONS request + Self banner

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -79,6 +79,7 @@ fun BiosRoot(viewModel: AppViewModel = viewModel()) {
     }
 
     MaybeRequestActivityRecognition(hasPermissions)
+    MaybeRequestPostNotifications(hasPermissions)
 
     // Check permissions on first composition
     LaunchedEffect(Unit) {

--- a/android/app/src/main/java/com/bios/app/ui/NotificationPermissionGate.kt
+++ b/android/app/src/main/java/com/bios/app/ui/NotificationPermissionGate.kt
@@ -1,0 +1,110 @@
+package com.bios.app.ui
+
+import android.Manifest
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * One-shot `POST_NOTIFICATIONS` opt-in shown immediately after the owner
+ * clears Health Connect onboarding.
+ *
+ * Without this permission every alert path on API 33+ silently no-ops
+ * (`AlertManager`, `FollowUpWorker`, `DailyDigestWorker`,
+ * `UrgentAckTimeoutWorker`, `PushMessageHandler`, `DisconnectNotifier`
+ * all check the permission and `return` if it is missing). The previous
+ * code path let Android's first-post auto-prompt show with no context, and
+ * an owner who declined had no way back — alerts would simply never
+ * arrive. This gate shows a manifesto-aligned rationale first ("Bios
+ * speaks when something matters") so the OS prompt that follows is
+ * contextualised.
+ *
+ * The rationale dialog is shown at most once per install (tracked via
+ * SharedPreferences). If the owner declines, [SettingsNotificationsCard]
+ * surfaces a persistent banner with a re-request action so the decision
+ * can be revisited from the Self tab.
+ *
+ * No-op on API < 33 (the permission is install-time granted on older
+ * Android versions).
+ */
+@Composable
+fun MaybeRequestPostNotifications(hasPermissions: Boolean) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+    val context = LocalContext.current
+    var showRationale by remember { mutableStateOf(false) }
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { /* Decline path surfaces in SettingsNotificationsCard as a banner. */ }
+
+    LaunchedEffect(hasPermissions) {
+        if (!hasPermissions) return@LaunchedEffect
+        val alreadyGranted = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (alreadyGranted) return@LaunchedEffect
+        if (NotificationPermissionPrefs.rationaleShown(context)) return@LaunchedEffect
+        showRationale = true
+    }
+
+    if (showRationale) {
+        AlertDialog(
+            onDismissRequest = {
+                showRationale = false
+                NotificationPermissionPrefs.markRationaleShown(context)
+            },
+            title = { Text("Let Bios speak when it matters") },
+            text = {
+                Text(
+                    "Bios stays silent until something deviates from your baseline " +
+                        "or a sensor drops out. Notifications are how it reaches you " +
+                        "when the app isn't open.\n\n" +
+                        "Without this, alerts only appear inside the app.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showRationale = false
+                    NotificationPermissionPrefs.markRationaleShown(context)
+                    launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }) { Text("Continue") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showRationale = false
+                    NotificationPermissionPrefs.markRationaleShown(context)
+                }) { Text("Not now") }
+            },
+        )
+    }
+}
+
+/** Backing store for the "rationale already shown" flag. Lives in a dedicated
+ *  SharedPreferences file so it doesn't collide with feature-toggle prefs. */
+internal object NotificationPermissionPrefs {
+    private const val PREFS_NAME = "bios_notification_perm"
+    private const val KEY_RATIONALE_SHOWN = "rationale_shown_v1"
+
+    fun rationaleShown(context: Context): Boolean = prefs(context).getBoolean(KEY_RATIONALE_SHOWN, false)
+
+    fun markRationaleShown(context: Context) {
+        prefs(context).edit().putBoolean(KEY_RATIONALE_SHOWN, true).apply()
+    }
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsNotificationsCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsNotificationsCard.kt
@@ -1,5 +1,12 @@
 package com.bios.app.ui.settings
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,16 +18,23 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.bios.app.alerts.DailyDigestWorker
 import com.bios.app.push.PushRegistrationManager
 
@@ -37,6 +51,8 @@ internal fun SettingsNotificationsCard() {
         Column(modifier = Modifier.padding(16.dp)) {
             Text("Notifications", style = MaterialTheme.typography.titleSmall)
             Spacer(Modifier.height(8.dp))
+
+            NotificationsPermissionBanner()
 
             var digestEnabled by remember { mutableStateOf(DailyDigestWorker.isEnabled(context)) }
             Row(
@@ -97,4 +113,98 @@ internal fun SettingsNotificationsCard() {
             }
         }
     }
+}
+
+/**
+ * Banner shown at the top of the Notifications card when
+ * `POST_NOTIFICATIONS` is missing — without it the alert pipeline silently
+ * no-ops on API 33+ and the toggles below appear active while delivering
+ * nothing. Surfaced here (rather than left as the OS-managed pref) so the
+ * owner discovers the gap inside Bios when they come looking for alert
+ * controls.
+ *
+ * Recomposes when the host lifecycle resumes, so a permission granted via
+ * the system settings deep-link clears the banner without restarting the
+ * app. No-op on API < 33 where the permission is install-time granted.
+ */
+@Composable
+private fun NotificationsPermissionBanner() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+    val context = LocalContext.current
+    var granted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                granted = ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.POST_NOTIFICATIONS,
+                ) == PackageManager.PERMISSION_GRANTED
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { result -> granted = result }
+
+    if (granted) return
+
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                "Notifications are off — alerts won't reach you outside Bios.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(onClick = {
+                // Direct OS prompt first; if Android remembered a "Don't ask
+                // again" the launcher returns immediately with false and we
+                // bounce to the system settings page where the owner can
+                // still flip the switch.
+                if (NotificationPermissionLastResult.shouldDeepLinkInstead(context)) {
+                    context.startActivity(
+                        Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                            .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    )
+                } else {
+                    launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }) {
+                Text("Turn on notifications")
+            }
+        }
+    }
+    Spacer(Modifier.height(12.dp))
+
+    LaunchedEffect(granted) {
+        NotificationPermissionLastResult.markAttempt(context, granted)
+    }
+}
+
+/** Tracks whether the last in-app POST_NOTIFICATIONS request was denied so
+ *  the banner button knows to deep-link to system settings rather than
+ *  launching a contract that the OS will silently no-op. */
+private object NotificationPermissionLastResult {
+    private const val PREFS = "bios_notification_perm_attempt"
+    private const val KEY_LAST_DENIED = "last_denied_v1"
+
+    fun markAttempt(context: android.content.Context, granted: Boolean) {
+        context.applicationContext.getSharedPreferences(PREFS, android.content.Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_LAST_DENIED, !granted).apply()
+    }
+
+    fun shouldDeepLinkInstead(context: android.content.Context): Boolean =
+        context.applicationContext.getSharedPreferences(PREFS, android.content.Context.MODE_PRIVATE)
+            .getBoolean(KEY_LAST_DENIED, false)
 }


### PR DESCRIPTION
## Summary
The alert pipeline silently no-opped on API 33+ when the owner hadn't granted `POST_NOTIFICATIONS`. The permission was declared in the manifest and checked by every notification path (`AlertManager`, `FollowUpWorker`, `DailyDigestWorker`, `UrgentAckTimeoutWorker`, `PushMessageHandler`, `DisconnectNotifier`) but no UI flow ever requested it. Android's first-post auto-prompt would fire with zero context, and an owner who declined had no way back from inside the app — Bios would simply never speak.

Two pieces fix this:

**`MaybeRequestPostNotifications` gate** — same shape as `MaybeRequestActivityRecognition`. On API 33+, once Health Connect onboarding is cleared, it shows a one-shot manifesto-aligned rationale dialog (*“Bios stays silent until something deviates from your baseline…”*) and then launches the OS prompt. The “rationale shown” flag persists in `SharedPreferences` so it never re-asks. No-op on API < 33.

**Settings notifications banner** — `SettingsNotificationsCard` surfaces a red banner when the permission is missing (*“Notifications are off — alerts won't reach you outside Bios.”*) with a *Turn on notifications* action. First press relaunches the runtime request; if Android remembered “Don't ask again” (tracked via a small per-attempt SharedPref) the action deep-links to system app notification settings instead. Banner clears on `ON_RESUME` so a grant from the deep-link path takes effect without restarting.

## Test plan
- [x] Compiles, all unit tests pass
- [x] `scripts/code-quality-check.sh` clean (all files within 500-line cap)
- [x] On-device (Pixel 9a, Android 16): with `POST_NOTIFICATIONS` revoked and the rationale-shown flag cleared, the manifesto-aligned dialog appears once. After dismissal, Self → Notifications card shows the red banner with working *Turn on notifications* action.
- [x] No-op on API < 33 (install-time grant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)