### PR TITLE
fix(privacy): wipeRecentData now actually wipes recent data (#313)

### DIFF
--- a/android/app/src/main/java/com/bios/app/data/dao/AnomalyDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/AnomalyDao.kt
@@ -54,4 +54,7 @@ interface AnomalyDao {
 
     @Query("DELETE FROM anomalies")
     suspend fun deleteAll()
+
+    @Query("DELETE FROM anomalies WHERE detectedAt >= :afterMillis")
+    suspend fun deleteAfter(afterMillis: Long): Int
 }

--- a/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
+++ b/android/app/src/main/java/com/bios/app/data/dao/MetricReadingDao.kt
@@ -189,6 +189,9 @@ interface MetricReadingDao {
     @Query("DELETE FROM metric_readings WHERE timestamp < :beforeMillis")
     suspend fun deleteBefore(beforeMillis: Long): Int
 
+    @Query("DELETE FROM metric_readings WHERE timestamp >= :afterMillis")
+    suspend fun deleteAfter(afterMillis: Long): Int
+
     /**
      * Delete a single reading by id. Used by the headache / migraine
      * entry repos (#283 Cut 2) so an entity-table delete also clears

--- a/android/app/src/main/java/com/bios/app/platform/ForensicRiskMonitor.kt
+++ b/android/app/src/main/java/com/bios/app/platform/ForensicRiskMonitor.kt
@@ -3,6 +3,8 @@ package com.bios.app.platform
 import android.content.Context
 import com.bios.app.data.BiosDatabase
 import com.bios.app.data.ReproductiveDatabase
+import com.bios.app.data.dao.AnomalyDao
+import com.bios.app.data.dao.MetricReadingDao
 import com.bios.app.ingest.SyncWorker
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -58,32 +60,32 @@ class ForensicRiskMonitor(
     }
 
     /**
-     * Delete readings newer than the given cutoff, keeping baselines intact.
-     * This lets the owner reduce their footprint without losing long-term trends.
+     * Delete readings (and anomalies) from the last [days] days, keeping
+     * older data so baselines and long-term trends survive. Inverse of
+     * retention pruning: it removes the newest window, not the oldest.
      */
-    suspend fun wipeRecentData(days: Int) {
-        val cutoff = Instant.now().minus(days.toLong(), ChronoUnit.DAYS).toEpochMilli()
-        // Delete readings from the recent period (keep older data for baselines)
-        // This is the inverse of retention pruning: it removes the newest N days
-        val now = System.currentTimeMillis()
-        db.metricReadingDao().deleteBefore(now) // This deletes everything
-        // Re-approach: we need readings BEFORE cutoff to survive
-        // The DAO only has deleteBefore, so we use it differently
-    }
+    suspend fun wipeRecentData(days: Int) =
+        wipeRecentWindow(days, db.metricReadingDao(), db.anomalyDao())
 
-    /**
-     * Delete all readings from the last N days.
-     */
-    suspend fun quickWipe(days: Int) {
-        val cutoffMillis = System.currentTimeMillis() - (days.toLong() * 24 * 3600 * 1000)
-        // We need a "deleteAfter" query — add to DAO
-        // For now, this is a selective delete using the reading DAO
-        val allReadings = db.metricReadingDao().countAll()
-        if (allReadings > 0) {
-            // Delete anomalies from the wipe period too
-            db.anomalyDao().deleteAll() // Simplified — in production, filter by date
-        }
-    }
+    /** Owner-facing alias retained for the privacy-dashboard call site. */
+    suspend fun quickWipe(days: Int) = wipeRecentData(days)
+}
+
+/**
+ * DAO-only wipe so the seed/wipe/survive contract from #313 can be exercised
+ * without spinning up Room. Tests inject fake DAOs and a fixed [nowMillis].
+ */
+internal suspend fun wipeRecentWindow(
+    days: Int,
+    readings: MetricReadingDao,
+    anomalies: AnomalyDao,
+    nowMillis: Long = Instant.now().toEpochMilli(),
+) {
+    val cutoff = Instant.ofEpochMilli(nowMillis)
+        .minus(days.toLong(), ChronoUnit.DAYS)
+        .toEpochMilli()
+    readings.deleteAfter(cutoff)
+    anomalies.deleteAfter(cutoff)
 }
 
 data class DataFootprint(

--- a/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/CircadianEngineTest.kt
@@ -225,6 +225,7 @@ private class FakeMetricReadingDao(
     override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteAfter(afterMillis: Long): Int = notUsed()
     override suspend fun deleteById(readingId: String): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()
 

--- a/android/app/src/test/java/com/bios/app/ForensicWipeRecentDataTest.kt
+++ b/android/app/src/test/java/com/bios/app/ForensicWipeRecentDataTest.kt
@@ -1,0 +1,171 @@
+package com.bios.app
+
+import com.bios.app.data.dao.AnomalyDao
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.model.Anomaly
+import com.bios.app.model.MetricReading
+import com.bios.app.platform.wipeRecentWindow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for issue #313. Before the fix, `wipeRecentData(days)`
+ * called `deleteBefore(now)` and removed virtually every row in the DB —
+ * the opposite of its contract. This test pins the corrected behavior:
+ * given 30 days of seeded data, `wipeRecentData(7)` removes the newest
+ * 7 days and leaves the older 23 untouched.
+ *
+ * The fakes implement only the methods used by [wipeRecentWindow] —
+ * `deleteAfter` on both DAOs — and throw on any other call.
+ */
+class ForensicWipeRecentDataTest {
+
+    private companion object {
+        const val DAY_MS = 24L * 60 * 60 * 1000
+        const val NOW = 30L * DAY_MS
+    }
+
+    @Test
+    fun wipeRecentData_7days_removes_newest_7_keeps_oldest_23() = runBlocking {
+        val readings = WipeFakeMetricReadingDao()
+        val anomalies = WipeFakeAnomalyDao()
+        repeat(30) { day ->
+            readings.seed(reading(timestamp = day * DAY_MS))
+            anomalies.seed(anomaly(detectedAt = day * DAY_MS))
+        }
+
+        wipeRecentWindow(days = 7, readings = readings, anomalies = anomalies, nowMillis = NOW)
+
+        assertEquals(23, readings.rows.size)
+        assertEquals(23, anomalies.rows.size)
+        assertTrue(
+            "all surviving readings must be older than the 7-day cutoff",
+            readings.rows.all { it.timestamp < 23 * DAY_MS },
+        )
+        assertTrue(
+            "all surviving anomalies must be older than the 7-day cutoff",
+            anomalies.rows.all { it.detectedAt < 23 * DAY_MS },
+        )
+    }
+
+    @Test
+    fun wipeRecentData_zero_days_removes_only_the_now_row() = runBlocking {
+        val readings = WipeFakeMetricReadingDao()
+        val anomalies = WipeFakeAnomalyDao()
+        readings.seed(reading(timestamp = NOW - DAY_MS))
+        readings.seed(reading(timestamp = NOW))
+        anomalies.seed(anomaly(detectedAt = NOW - DAY_MS))
+        anomalies.seed(anomaly(detectedAt = NOW))
+
+        wipeRecentWindow(days = 0, readings = readings, anomalies = anomalies, nowMillis = NOW)
+
+        assertEquals(1, readings.rows.size)
+        assertEquals(NOW - DAY_MS, readings.rows.single().timestamp)
+        assertEquals(1, anomalies.rows.size)
+        assertEquals(NOW - DAY_MS, anomalies.rows.single().detectedAt)
+    }
+
+    @Test
+    fun wipeRecentData_window_larger_than_seed_removes_everything() = runBlocking {
+        val readings = WipeFakeMetricReadingDao()
+        val anomalies = WipeFakeAnomalyDao()
+        repeat(5) { day ->
+            readings.seed(reading(timestamp = day * DAY_MS))
+            anomalies.seed(anomaly(detectedAt = day * DAY_MS))
+        }
+
+        wipeRecentWindow(days = 365, readings = readings, anomalies = anomalies, nowMillis = NOW)
+
+        assertEquals(0, readings.rows.size)
+        assertEquals(0, anomalies.rows.size)
+    }
+
+    private fun reading(timestamp: Long) = MetricReading(
+        metricType = "HEART_RATE",
+        value = 72.0,
+        timestamp = timestamp,
+        sourceId = "test-source",
+        confidence = 3,
+    )
+
+    private fun anomaly(detectedAt: Long) = Anomaly(
+        detectedAt = detectedAt,
+        metricTypes = "[\"HEART_RATE\"]",
+        deviationScores = "{}",
+        combinedScore = 0.0,
+        severity = 1,
+        title = "t",
+        explanation = "e",
+    )
+}
+
+private class WipeFakeMetricReadingDao : MetricReadingDao {
+    val rows = mutableListOf<MetricReading>()
+    fun seed(r: MetricReading) {
+        rows += r
+    }
+
+    override suspend fun deleteAfter(afterMillis: Long): Int {
+        val before = rows.size
+        rows.removeAll { it.timestamp >= afterMillis }
+        return before - rows.size
+    }
+
+    override suspend fun insertAll(readings: List<MetricReading>): Unit = notUsed()
+    override suspend fun insert(reading: MetricReading): Unit = notUsed()
+    override suspend fun fetch(metricType: String, startMillis: Long, endMillis: Long): List<MetricReading> = notUsed()
+    override suspend fun fetchValues(
+        metricType: String, startMillis: Long, endMillis: Long, readingKind: String?
+    ): List<Double> = notUsed()
+    override suspend fun fetchLatest(metricType: String, limit: Int): List<MetricReading> = notUsed()
+    override suspend fun count(metricType: String): Int = notUsed()
+    override suspend fun countAll(): Int = notUsed()
+    override suspend fun countInRange(
+        metricType: String, startMillis: Long, endMillis: Long, readingKind: String?
+    ): Int = notUsed()
+    override suspend fun lastTimestampFor(metricType: String): Long? = notUsed()
+    override suspend fun fetchBucketedMeans(
+        metricType: String, startMillis: Long, endMillis: Long, bucketMillis: Long, readingKind: String?
+    ): List<Double> = notUsed()
+    override suspend fun oldestTimestamp(): Long? = notUsed()
+    override suspend fun sourceFreshness(): List<MetricReadingDao.SourceFreshnessRow> = notUsed()
+    override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
+    override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
+    override suspend fun metricTypeCounts(): List<MetricReadingDao.MetricTypeCountRow> = notUsed()
+    override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
+    override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteById(readingId: String): Int = notUsed()
+    override suspend fun deleteAll(): Unit = notUsed()
+
+    private fun <T> notUsed(): T = error("WipeFakeMetricReadingDao: only deleteAfter is exercised")
+}
+
+private class WipeFakeAnomalyDao : AnomalyDao {
+    val rows = mutableListOf<Anomaly>()
+    fun seed(a: Anomaly) {
+        rows += a
+    }
+
+    override suspend fun deleteAfter(afterMillis: Long): Int {
+        val before = rows.size
+        rows.removeAll { it.detectedAt >= afterMillis }
+        return before - rows.size
+    }
+
+    override suspend fun insert(anomaly: Anomaly): Unit = notUsed()
+    override suspend fun fetchRecent(limit: Int): List<Anomaly> = notUsed()
+    override suspend fun fetchUnacknowledged(): List<Anomaly> = notUsed()
+    override suspend fun acknowledge(id: String, now: Long): Unit = notUsed()
+    override suspend fun saveFeedback(
+        id: String, feedbackAt: Long, feltSick: Boolean?, visitedDoctor: Boolean?,
+        diagnosis: String?, symptoms: String?, notes: String?, outcomeAccurate: Boolean?
+    ): Unit = notUsed()
+    override suspend fun fetchWithFeedback(limit: Int): List<Anomaly> = notUsed()
+    override suspend fun fetchCreatedAfter(sinceMillis: Long): List<Anomaly> = notUsed()
+    override suspend fun fetchAll(): List<Anomaly> = notUsed()
+    override suspend fun deleteAll(): Unit = notUsed()
+
+    private fun <T> notUsed(): T = error("WipeFakeAnomalyDao: only deleteAfter is exercised")
+}

--- a/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrRecoveryPersisterTest.kt
@@ -170,6 +170,7 @@ private class FakeReadingDao(
     override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
     override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
     override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteAfter(afterMillis: Long): Int = notUsed()
     override suspend fun deleteById(readingId: String): Int = notUsed()
     override suspend fun deleteAll(): Unit = notUsed()
 


### PR DESCRIPTION
## Summary
- `ForensicRiskMonitor.wipeRecentData(days)` and `quickWipe(days)` were the wrong shape: the first called `deleteBefore(now)` (wipes virtually the whole DB — comment in body even said *"This deletes everything"*), the second dropped every anomaly via `deleteAll()` and never touched the readings. The latter is the one wired from `PrivacyDashboardScreen`, so the owner's "last N days" privacy control silently did the wrong thing.
- Adds `deleteAfter(afterMillis)` to `MetricReadingDao` and `AnomalyDao`, rewrites `wipeRecentData` to use the cutoff it computes, and collapses `quickWipe` into a thin alias so the dashboard call site keeps working.
- Extracts the wipe to a top-level `wipeRecentWindow(days, readings, anomalies, nowMillis)` so it's exercisable from JVM tests without spinning up Room.

## Test plan
- [x] New `ForensicWipeRecentDataTest` — seed/wipe/survive contract from the issue: 30 days of seeded readings + anomalies, `wipeRecentData(7)` removes the newest 7 days, the older 23 survive. Plus boundary cases (0-day window touches only `now`, oversized window removes everything).
- [x] `./scripts/code-quality-check.sh` passes (file-length, secrets, lint, `assembleDebug`, unit tests).
- [x] Existing fake DAOs in `CircadianEngineTest` / `HrRecoveryPersisterTest` updated to stub the new `deleteAfter` method.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)