### PR TITLE
fix(ingest): stable HC IDs for sleep_stage and sleep_duration (#312)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -258,10 +258,12 @@ class HealthConnectAdapter(private val context: Context) {
                     stage.startTime, stage.endTime
                 ).seconds.toInt()
 
+                val stageStartMs = stage.startTime.toEpochMilli()
                 MetricReading(
+                    id = HealthConnectStableIds.forSubRecord("sleep-stage", sourceId, session.metadata.id, stageStartMs),
                     metricType = MetricType.SLEEP_STAGE.key,
                     value = biosStage.value.toDouble(),
-                    timestamp = stage.startTime.toEpochMilli(),
+                    timestamp = stageStartMs,
                     durationSec = durationSec,
                     sourceId = sourceId,
                     confidence = ConfidenceTier.MEDIUM.level
@@ -279,6 +281,7 @@ class HealthConnectAdapter(private val context: Context) {
             val asleepSec = (sessionSec - awakeSec).coerceAtLeast(0)
 
             val durationReading = MetricReading(
+                id = HealthConnectStableIds.forRecord("sleep-duration", sourceId, session.metadata.id),
                 metricType = MetricType.SLEEP_DURATION.key,
                 value = asleepSec.toDouble(),
                 timestamp = session.endTime.toEpochMilli(),

--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectStableIds.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectStableIds.kt
@@ -1,0 +1,49 @@
+package com.bios.app.ingest
+
+/**
+ * Stable [com.bios.app.model.MetricReading] IDs derived from Health Connect's
+ * own record identifiers (#312).
+ *
+ * Default `MetricReading.id` is `UUID.randomUUID()` — a brand-new value on
+ * every fetch. Re-syncing the same HC record then inserts a parallel row
+ * instead of updating in place, because:
+ *  - the primary-key conflict path needs the *id* to repeat, but UUIDs do not;
+ *  - the unique index on `(sourceId, metricType, timestamp)` only fires when
+ *    the timestamp is identical, and HC silently shifts a session's
+ *    `endTime` when the upstream wearable finalises a session retroactively
+ *    or HC re-derives the boundary.
+ *
+ * Anchoring the row's primary key on the HC record id + a fixed kind prefix
+ * (and the Bios `sourceId` so the same upstream record under two ingest
+ * sources keeps separate rows) gives `OnConflictStrategy.REPLACE` a stable
+ * key to update against — the row's timestamp and value can correct
+ * themselves without leaving phantom rows.
+ *
+ * Scope today: the sleep paths in [HealthConnectAdapter.fetchSleep]
+ * (sleep_stage rows and the sleep_duration session summary). Other HC
+ * record paths (HR, steps, SpO2, etc.) are vulnerable to the same drift
+ * pattern but have not surfaced an owner-visible symptom yet; they get
+ * the same treatment in a follow-up PR keeping the per-path blast radius
+ * small.
+ */
+internal object HealthConnectStableIds {
+
+    /**
+     * Stable ID for a 1:1 mapping (one HC record → one [MetricReading]).
+     * Form: `hc-{kind}-{sourceId}-{hcRecordId}`.
+     */
+    fun forRecord(kind: String, sourceId: String, hcRecordId: String): String =
+        "hc-$kind-$sourceId-$hcRecordId"
+
+    /**
+     * Stable ID for a sub-record mapping (one HC record → many
+     * [MetricReading]s, e.g. sleep stages within a session, deltas within
+     * a skin-temperature record). [subKey] disambiguates the sub-record;
+     * the natural choice is the sub-record's own timestamp in ms because
+     * it survives reordering and is stable across HC re-emissions of the
+     * same physical sub-record.
+     * Form: `hc-{kind}-{sourceId}-{hcRecordId}-{subKey}`.
+     */
+    fun forSubRecord(kind: String, sourceId: String, hcRecordId: String, subKey: Long): String =
+        "hc-$kind-$sourceId-$hcRecordId-$subKey"
+}

--- a/android/app/src/test/java/com/bios/app/HealthConnectStableIdsTest.kt
+++ b/android/app/src/test/java/com/bios/app/HealthConnectStableIdsTest.kt
@@ -1,0 +1,73 @@
+package com.bios.app
+
+import com.bios.app.ingest.HealthConnectStableIds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [HealthConnectStableIds] (#312). Pins the
+ * record-id-anchored primary-key contract that keeps re-syncs of the
+ * same HC record from producing phantom rows when HC mutates the
+ * record's timestamps.
+ */
+class HealthConnectStableIdsTest {
+
+    @Test
+    fun `forRecord returns the same id for the same inputs`() {
+        val a = HealthConnectStableIds.forRecord("sleep-duration", "hc-src", "session-abc")
+        val b = HealthConnectStableIds.forRecord("sleep-duration", "hc-src", "session-abc")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `forRecord disambiguates by kind`() {
+        val duration = HealthConnectStableIds.forRecord("sleep-duration", "hc-src", "session-abc")
+        val stage = HealthConnectStableIds.forRecord("sleep-stage", "hc-src", "session-abc")
+        assertNotEquals(
+            "different kinds with the same HC record id must not collide",
+            duration, stage,
+        )
+    }
+
+    @Test
+    fun `forRecord disambiguates by sourceId`() {
+        val srcA = HealthConnectStableIds.forRecord("sleep-duration", "src-a", "session-abc")
+        val srcB = HealthConnectStableIds.forRecord("sleep-duration", "src-b", "session-abc")
+        assertNotEquals("same HC record under two sources keeps separate rows", srcA, srcB)
+    }
+
+    @Test
+    fun `forRecord disambiguates by HC record id`() {
+        val a = HealthConnectStableIds.forRecord("sleep-duration", "hc-src", "session-a")
+        val b = HealthConnectStableIds.forRecord("sleep-duration", "hc-src", "session-b")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `forSubRecord returns the same id for the same inputs`() {
+        val a = HealthConnectStableIds.forSubRecord("sleep-stage", "hc-src", "session-abc", 1_700_000_000_000L)
+        val b = HealthConnectStableIds.forSubRecord("sleep-stage", "hc-src", "session-abc", 1_700_000_000_000L)
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `forSubRecord disambiguates by subKey`() {
+        val first = HealthConnectStableIds.forSubRecord("sleep-stage", "hc-src", "session-abc", 1000L)
+        val second = HealthConnectStableIds.forSubRecord("sleep-stage", "hc-src", "session-abc", 2000L)
+        assertNotEquals(
+            "two sub-records inside the same HC record must keep separate rows",
+            first, second,
+        )
+    }
+
+    @Test
+    fun `forRecord and forSubRecord do not collide`() {
+        // A record-level id should never collide with a sub-record id from
+        // the same HC record — sleep-duration row vs sleep-stage rows live
+        // alongside each other.
+        val parent = HealthConnectStableIds.forRecord("sleep-stage", "hc-src", "session-abc")
+        val child = HealthConnectStableIds.forSubRecord("sleep-stage", "hc-src", "session-abc", 0L)
+        assertNotEquals(parent, child)
+    }
+}


### PR DESCRIPTION
Closes #312.

## Summary

- New [HealthConnectStableIds](android/app/src/main/java/com/bios/app/ingest/HealthConnectStableIds.kt) helper produces deterministic `MetricReading.id` values from HC record metadata. `forRecord` for 1:1 mappings (sleep_duration → session) and `forSubRecord` for 1:N mappings (sleep_stage → stage within session).
- [HealthConnectAdapter.fetchSleep](android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt#L246) now passes stable IDs to both the per-stage `MetricReading` and the session-summary `sleep_duration`. Same HC `session.metadata.id` on re-sync ⇒ same primary key ⇒ `OnConflictStrategy.REPLACE` updates in place. Phantom row vanishes.
- Pure-JVM coverage in [HealthConnectStableIdsTest](android/app/src/test/java/com/bios/app/HealthConnectStableIdsTest.kt): stability for same inputs, disambiguation by kind / sourceId / HC record id / sub-key, and no record-vs-sub-record collision.

## Scope

Tight on purpose. The issue's owner-visible symptom is sleep_duration; that's what's fixed here. The issue body notes that the same pattern should apply to every HC record path (HR, steps, SpO2, skin temp, etc.) — those are mechanically identical but haven't surfaced a user-visible bug yet. I'll send a follow-up PR for the rest so the blast radius per merge stays small.

## Test plan

- [x] Unit tests for the helper (7 tests, all green).
- [x] `./scripts/code-quality-check.sh` clean.
- [ ] Manual: re-sync a sleep session, confirm the row's `metric_readings.id` survives across syncs (value can update; row count for that session stays = 1). Best done on an HC source whose backing wearable retroactively finalises sessions (Fitbit / Whoop / Oura).
- [ ] Manual: shift HC `endTime` (e.g. wait for Fitbit to revise a previous night's session) and re-sync — confirm the row's `timestamp` updates rather than a new row appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)