### PR TITLE
fix(ingest): stable HC IDs for the remaining record paths

### DIFF
--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt
@@ -13,12 +13,10 @@ import com.bios.app.model.ExerciseSession
 import com.bios.app.model.ExerciseSessionFields
 import com.bios.app.model.MetricReading
 import com.bios.contracts.MetricType
-import com.bios.app.model.SleepStage
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import java.time.Instant
-import java.util.UUID
 
 /**
  * Bridges Health Connect data into Bios unified MetricReadings.
@@ -63,281 +61,26 @@ class HealthConnectAdapter(private val context: Context) {
         sourceId: String
     ): List<MetricReading> = coroutineScope {
         val jobs = listOf(
-            async { fetchHeartRate(startTime, endTime, sourceId) },
-            async { fetchHRV(startTime, endTime, sourceId) },
-            async { fetchRestingHR(startTime, endTime, sourceId) },
-            async { fetchSpO2(startTime, endTime, sourceId) },
-            async { fetchRespiratoryRate(startTime, endTime, sourceId) },
-            async { fetchSkinTemp(startTime, endTime, sourceId) },
-            async { fetchSleep(startTime, endTime, sourceId) },
-            async { fetchSteps(startTime, endTime, sourceId) },
-            async { fetchActiveCalories(startTime, endTime, sourceId) },
-            async { fetchVo2Max(startTime, endTime, sourceId) },
+            async { HealthConnectReads.heartRate(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.hrv(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.restingHr(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.spo2(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.respiratoryRate(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.skinTemp(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.sleep(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.steps(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.activeCalories(client, startTime, endTime, sourceId) },
+            async { HealthConnectReads.vo2Max(client, startTime, endTime, sourceId) },
             async { HealthConnectBodyComposition.fetchAll(client, startTime, endTime, sourceId) },
         )
         jobs.awaitAll().flatten()
     }
 
-    // VO2 max is vendor-derived (Garmin / Fitbit / Apple fitness models); not a clinical CPET.
-    private suspend fun fetchVo2Max(start: Instant, end: Instant, sourceId: String): List<MetricReading> =
-        client.readRecords(ReadRecordsRequest(Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end)))
-            .records.map { record -> MetricReading(
-                metricType = MetricType.VO2_MAX.key,
-                value = record.vo2MillilitersPerMinuteKilogram,
-                timestamp = record.time.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.VENDOR_DERIVED.level,
-            ) }
-
-    // MARK: - Individual record types
-
-    private suspend fun fetchHeartRate(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                HeartRateRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.flatMap { record ->
-            record.samples.map { sample ->
-                MetricReading(
-                    metricType = MetricType.HEART_RATE.key,
-                    value = sample.beatsPerMinute.toDouble(),
-                    timestamp = sample.time.toEpochMilli(),
-                    sourceId = sourceId,
-                    confidence = ConfidenceTier.MEDIUM.level
-                )
-            }
-        }
-    }
-
-    private suspend fun fetchHRV(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                HeartRateVariabilityRmssdRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            MetricReading(
-                metricType = MetricType.HEART_RATE_VARIABILITY.key,
-                value = record.heartRateVariabilityMillis,
-                timestamp = record.time.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
-
-    private suspend fun fetchRestingHR(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                RestingHeartRateRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            MetricReading(
-                metricType = MetricType.RESTING_HEART_RATE.key,
-                value = record.beatsPerMinute.toDouble(),
-                timestamp = record.time.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
-
-    private suspend fun fetchSpO2(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                OxygenSaturationRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            MetricReading(
-                metricType = MetricType.BLOOD_OXYGEN.key,
-                value = record.percentage.value,
-                timestamp = record.time.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
-
-    private suspend fun fetchRespiratoryRate(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                RespiratoryRateRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            MetricReading(
-                metricType = MetricType.RESPIRATORY_RATE.key,
-                value = record.rate,
-                timestamp = record.time.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
-
-    private suspend fun fetchSkinTemp(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                SkinTemperatureRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.flatMap { record ->
-            val baselineC = record.baseline?.inCelsius
-            record.deltas.flatMap { delta ->
-                val tMs = delta.time.toEpochMilli()
-                val deviation = MetricReading(
-                    metricType = MetricType.SKIN_TEMPERATURE_DEVIATION.key,
-                    value = delta.delta.inCelsius,
-                    timestamp = tMs,
-                    sourceId = sourceId,
-                    confidence = ConfidenceTier.MEDIUM.level
-                )
-                // Reconstruct raw absolute temp when the record supplies a baseline.
-                // Needed for febrile-range thresholds and menstrual phase detection,
-                // which require absolute °C rather than personal-baseline deltas.
-                if (baselineC != null) {
-                    listOf(
-                        deviation,
-                        MetricReading(
-                            metricType = MetricType.SKIN_TEMPERATURE.key,
-                            value = baselineC + delta.delta.inCelsius,
-                            timestamp = tMs,
-                            sourceId = sourceId,
-                            confidence = ConfidenceTier.MEDIUM.level
-                        )
-                    )
-                } else {
-                    listOf(deviation)
-                }
-            }
-        }
-    }
-
-    private suspend fun fetchSleep(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                SleepSessionRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.flatMap { session ->
-            val stageReadings = session.stages.mapNotNull { stage ->
-                val biosStage = when (stage.stage) {
-                    SleepSessionRecord.STAGE_TYPE_AWAKE,
-                    SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> SleepStage.AWAKE
-                    SleepSessionRecord.STAGE_TYPE_LIGHT -> SleepStage.LIGHT
-                    SleepSessionRecord.STAGE_TYPE_DEEP -> SleepStage.DEEP
-                    SleepSessionRecord.STAGE_TYPE_REM -> SleepStage.REM
-                    else -> null
-                } ?: return@mapNotNull null
-
-                val durationSec = java.time.Duration.between(
-                    stage.startTime, stage.endTime
-                ).seconds.toInt()
-
-                val stageStartMs = stage.startTime.toEpochMilli()
-                MetricReading(
-                    id = HealthConnectStableIds.forSubRecord("sleep-stage", sourceId, session.metadata.id, stageStartMs),
-                    metricType = MetricType.SLEEP_STAGE.key,
-                    value = biosStage.value.toDouble(),
-                    timestamp = stageStartMs,
-                    durationSec = durationSec,
-                    sourceId = sourceId,
-                    confidence = ConfidenceTier.MEDIUM.level
-                )
-            }
-
-            // Asleep time = session total minus AWAKE stages (matches Oura/Whoop semantics).
-            // If the session has no stage breakdown, fall back to the full session length.
-            val awakeSec = stageReadings
-                .filter { it.value.toInt() == SleepStage.AWAKE.value }
-                .sumOf { it.durationSec ?: 0 }
-            val sessionSec = java.time.Duration.between(
-                session.startTime, session.endTime
-            ).seconds.toInt()
-            val asleepSec = (sessionSec - awakeSec).coerceAtLeast(0)
-
-            val durationReading = MetricReading(
-                id = HealthConnectStableIds.forRecord("sleep-duration", sourceId, session.metadata.id),
-                metricType = MetricType.SLEEP_DURATION.key,
-                value = asleepSec.toDouble(),
-                timestamp = session.endTime.toEpochMilli(),
-                durationSec = sessionSec,
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-
-            stageReadings + durationReading
-        }
-    }
-
-    private suspend fun fetchSteps(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                StepsRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            val durationSec = java.time.Duration.between(
-                record.startTime, record.endTime
-            ).seconds.toInt()
-
-            MetricReading(
-                metricType = MetricType.STEPS.key,
-                value = record.count.toDouble(),
-                timestamp = record.startTime.toEpochMilli(),
-                durationSec = durationSec,
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
-
-    private suspend fun fetchActiveCalories(
-        start: Instant, end: Instant, sourceId: String
-    ): List<MetricReading> {
-        val response = client.readRecords(
-            ReadRecordsRequest(
-                ActiveCaloriesBurnedRecord::class,
-                timeRangeFilter = TimeRangeFilter.between(start, end)
-            )
-        )
-        return response.records.map { record ->
-            MetricReading(
-                metricType = MetricType.ACTIVE_CALORIES.key,
-                value = record.energy.inKilocalories,
-                timestamp = record.startTime.toEpochMilli(),
-                sourceId = sourceId,
-                confidence = ConfidenceTier.MEDIUM.level
-            )
-        }
-    }
+    // Per-record reads (1:1 record ⇒ MetricReading, multi-output for HR
+    // samples / skin-temp deltas / sleep stages) live in
+    // [HealthConnectReads] so this file stays under the 500-line ceiling
+    // and each emitted MetricReading carries a stable id derived from the
+    // HC record id — see #312.
 
     // MARK: - Composite event: exercise sessions
 
@@ -379,7 +122,7 @@ class HealthConnectAdapter(private val context: Context) {
             ).seconds.toInt()
 
             val reading = MetricReading(
-                id = UUID.randomUUID().toString(),
+                id = HealthConnectStableIds.forRecord("exercise-session", sourceId, record.metadata.id),
                 metricType = MetricType.EXERCISE_SESSION.key,
                 value = 1.0,
                 timestamp = startMs,

--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectBodyComposition.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectBodyComposition.kt
@@ -57,6 +57,7 @@ internal object HealthConnectBodyComposition {
         ReadRecordsRequest(WeightRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
     ).records.map { record ->
         MetricReading(
+            id = HealthConnectStableIds.forRecord("body-mass", sourceId, record.metadata.id),
             metricType = MetricType.BODY_MASS.key,
             value = record.weight.inKilograms,
             timestamp = record.time.toEpochMilli(),
@@ -71,6 +72,7 @@ internal object HealthConnectBodyComposition {
         ReadRecordsRequest(BodyFatRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
     ).records.map { record ->
         MetricReading(
+            id = HealthConnectStableIds.forRecord("body-fat", sourceId, record.metadata.id),
             metricType = MetricType.BODY_FAT_PCT.key,
             // HC reports body fat as a percentage (0–100), confusingly via
             // a `Percentage` type — `.value` is the 0–100 number, matching
@@ -88,6 +90,7 @@ internal object HealthConnectBodyComposition {
         ReadRecordsRequest(LeanBodyMassRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
     ).records.map { record ->
         MetricReading(
+            id = HealthConnectStableIds.forRecord("lean-mass", sourceId, record.metadata.id),
             metricType = MetricType.LEAN_MASS.key,
             value = record.mass.inKilograms,
             timestamp = record.time.toEpochMilli(),

--- a/android/app/src/main/java/com/bios/app/ingest/HealthConnectReads.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/HealthConnectReads.kt
@@ -1,0 +1,251 @@
+package com.bios.app.ingest
+
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
+import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.HeartRateVariabilityRmssdRecord
+import androidx.health.connect.client.records.OxygenSaturationRecord
+import androidx.health.connect.client.records.RespiratoryRateRecord
+import androidx.health.connect.client.records.RestingHeartRateRecord
+import androidx.health.connect.client.records.SkinTemperatureRecord
+import androidx.health.connect.client.records.SleepSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.Vo2MaxRecord
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.app.model.SleepStage
+import com.bios.contracts.MetricType
+import java.time.Instant
+
+/**
+ * Per-record-type reads from Health Connect. Extracted from
+ * [HealthConnectAdapter] so the adapter stays under the project's 500-line
+ * ceiling and each read carries a stable
+ * [HealthConnectStableIds]-derived `MetricReading.id` (#312 follow-up).
+ *
+ * Every reading's primary key is anchored on the HC record's `metadata.id`,
+ * so `OnConflictStrategy.REPLACE` updates the row in place when HC re-emits
+ * the same record — even after HC silently shifts the record's timestamp.
+ *
+ * Kept as a flat `internal object` rather than a class so callers don't
+ * have to thread a constructor through; the [client] is supplied per call
+ * by [HealthConnectAdapter], which owns it.
+ */
+internal object HealthConnectReads {
+
+    suspend fun heartRate(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(HeartRateRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.flatMap { record ->
+        record.samples.map { sample ->
+            val sampleMs = sample.time.toEpochMilli()
+            MetricReading(
+                id = HealthConnectStableIds.forSubRecord("hr-sample", sourceId, record.metadata.id, sampleMs),
+                metricType = MetricType.HEART_RATE.key,
+                value = sample.beatsPerMinute.toDouble(),
+                timestamp = sampleMs,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+        }
+    }
+
+    suspend fun hrv(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(HeartRateVariabilityRmssdRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("hrv", sourceId, record.metadata.id),
+            metricType = MetricType.HEART_RATE_VARIABILITY.key,
+            value = record.heartRateVariabilityMillis,
+            timestamp = record.time.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    suspend fun restingHr(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(RestingHeartRateRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("resting-hr", sourceId, record.metadata.id),
+            metricType = MetricType.RESTING_HEART_RATE.key,
+            value = record.beatsPerMinute.toDouble(),
+            timestamp = record.time.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    suspend fun spo2(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(OxygenSaturationRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("spo2", sourceId, record.metadata.id),
+            metricType = MetricType.BLOOD_OXYGEN.key,
+            value = record.percentage.value,
+            timestamp = record.time.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    suspend fun respiratoryRate(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(RespiratoryRateRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("respiratory-rate", sourceId, record.metadata.id),
+            metricType = MetricType.RESPIRATORY_RATE.key,
+            value = record.rate,
+            timestamp = record.time.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    suspend fun skinTemp(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(SkinTemperatureRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.flatMap { record ->
+        val baselineC = record.baseline?.inCelsius
+        val recordId = record.metadata.id
+        record.deltas.flatMap { delta ->
+            val tMs = delta.time.toEpochMilli()
+            val deviation = MetricReading(
+                id = HealthConnectStableIds.forSubRecord("skin-temp-deviation", sourceId, recordId, tMs),
+                metricType = MetricType.SKIN_TEMPERATURE_DEVIATION.key,
+                value = delta.delta.inCelsius,
+                timestamp = tMs,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+            // Reconstruct raw absolute temp when the record supplies a baseline.
+            // Needed for febrile-range thresholds and menstrual phase detection,
+            // which require absolute °C rather than personal-baseline deltas.
+            if (baselineC != null) {
+                listOf(
+                    deviation,
+                    MetricReading(
+                        id = HealthConnectStableIds.forSubRecord("skin-temp", sourceId, recordId, tMs),
+                        metricType = MetricType.SKIN_TEMPERATURE.key,
+                        value = baselineC + delta.delta.inCelsius,
+                        timestamp = tMs,
+                        sourceId = sourceId,
+                        confidence = ConfidenceTier.MEDIUM.level,
+                    ),
+                )
+            } else {
+                listOf(deviation)
+            }
+        }
+    }
+
+    suspend fun sleep(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(SleepSessionRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.flatMap { session ->
+        val sessionId = session.metadata.id
+        val stageReadings = session.stages.mapNotNull { stage ->
+            val biosStage = when (stage.stage) {
+                SleepSessionRecord.STAGE_TYPE_AWAKE,
+                SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> SleepStage.AWAKE
+                SleepSessionRecord.STAGE_TYPE_LIGHT -> SleepStage.LIGHT
+                SleepSessionRecord.STAGE_TYPE_DEEP -> SleepStage.DEEP
+                SleepSessionRecord.STAGE_TYPE_REM -> SleepStage.REM
+                else -> null
+            } ?: return@mapNotNull null
+
+            val durationSec = java.time.Duration.between(stage.startTime, stage.endTime).seconds.toInt()
+            val stageStartMs = stage.startTime.toEpochMilli()
+            MetricReading(
+                id = HealthConnectStableIds.forSubRecord("sleep-stage", sourceId, sessionId, stageStartMs),
+                metricType = MetricType.SLEEP_STAGE.key,
+                value = biosStage.value.toDouble(),
+                timestamp = stageStartMs,
+                durationSec = durationSec,
+                sourceId = sourceId,
+                confidence = ConfidenceTier.MEDIUM.level,
+            )
+        }
+
+        // Asleep time = session total minus AWAKE stages (matches Oura/Whoop semantics).
+        // If the session has no stage breakdown, fall back to the full session length.
+        val awakeSec = stageReadings
+            .filter { it.value.toInt() == SleepStage.AWAKE.value }
+            .sumOf { it.durationSec ?: 0 }
+        val sessionSec = java.time.Duration.between(session.startTime, session.endTime).seconds.toInt()
+        val asleepSec = (sessionSec - awakeSec).coerceAtLeast(0)
+
+        val durationReading = MetricReading(
+            id = HealthConnectStableIds.forRecord("sleep-duration", sourceId, sessionId),
+            metricType = MetricType.SLEEP_DURATION.key,
+            value = asleepSec.toDouble(),
+            timestamp = session.endTime.toEpochMilli(),
+            durationSec = sessionSec,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+
+        stageReadings + durationReading
+    }
+
+    suspend fun steps(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(StepsRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        val durationSec = java.time.Duration.between(record.startTime, record.endTime).seconds.toInt()
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("steps", sourceId, record.metadata.id),
+            metricType = MetricType.STEPS.key,
+            value = record.count.toDouble(),
+            timestamp = record.startTime.toEpochMilli(),
+            durationSec = durationSec,
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    suspend fun activeCalories(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(ActiveCaloriesBurnedRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("active-calories", sourceId, record.metadata.id),
+            metricType = MetricType.ACTIVE_CALORIES.key,
+            value = record.energy.inKilocalories,
+            timestamp = record.startTime.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.MEDIUM.level,
+        )
+    }
+
+    // VO2 max is vendor-derived (Garmin / Fitbit / Apple fitness models); not a clinical CPET.
+    suspend fun vo2Max(
+        client: HealthConnectClient, start: Instant, end: Instant, sourceId: String,
+    ): List<MetricReading> = client.readRecords(
+        ReadRecordsRequest(Vo2MaxRecord::class, timeRangeFilter = TimeRangeFilter.between(start, end))
+    ).records.map { record ->
+        MetricReading(
+            id = HealthConnectStableIds.forRecord("vo2-max", sourceId, record.metadata.id),
+            metricType = MetricType.VO2_MAX.key,
+            value = record.vo2MillilitersPerMinuteKilogram,
+            timestamp = record.time.toEpochMilli(),
+            sourceId = sourceId,
+            confidence = ConfidenceTier.VENDOR_DERIVED.level,
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #371 / closes the rest of #312.

## Summary

- Every HC record path previously falling back to `UUID.randomUUID()` now uses [HealthConnectStableIds](android/app/src/main/java/com/bios/app/ingest/HealthConnectStableIds.kt) so re-syncs collapse on the primary key, not on the volatile unique-index path:
  - **1:1**: hrv, resting_hr, blood_oxygen, respiratory_rate, steps, active_calories, vo2_max, body_mass, body_fat_pct, lean_mass, exercise_session.
  - **1:N**: heart_rate (per sample), skin_temperature_deviation + skin_temperature (per delta).
- `exercise_session`'s stable id matters extra — every [EventPayloadField](android/app/src/main/java/com/bios/app/model/EventPayloadField.kt) keys against the parent reading's id, so a UUID-shaped parent left payload rows orphaned on re-sync. Now they update in place.

## Refactor

[HealthConnectAdapter](android/app/src/main/java/com/bios/app/ingest/HealthConnectAdapter.kt) was at the 500-line cap. Moved the 10 private per-record fetch methods to a new [HealthConnectReads](android/app/src/main/java/com/bios/app/ingest/HealthConnectReads.kt) sibling object (mirrors the existing [HealthConnectBodyComposition](android/app/src/main/java/com/bios/app/ingest/HealthConnectBodyComposition.kt) split). The adapter keeps:
- orchestration (`fetchReadings`, `fetchExerciseSessions`)
- permission set + `isAvailable` / `hasAllPermissions`
- the publicly-tested companion helpers (`mapExerciseTypeToModality`, `meanHrInWindow`, `HrSample`) — those existing tests stay green untouched.

Adapter drops from 500 → 243 lines.

## Stable kind strings

The kind string is now part of the persisted primary key, so it must not be renamed once shipped. Inventory:

| Kind | Variant | Notes |
| --- | --- | --- |
| `sleep-duration` | `forRecord` | Shipped in #371 — do not rename |
| `sleep-stage` | `forSubRecord` (stageStartMs) | Shipped in #371 — do not rename |
| `hr-sample` | `forSubRecord` (sample.time) | New |
| `hrv` | `forRecord` | New |
| `resting-hr` | `forRecord` | New |
| `spo2` | `forRecord` | New |
| `respiratory-rate` | `forRecord` | New |
| `skin-temp-deviation` | `forSubRecord` (delta.time) | New |
| `skin-temp` | `forSubRecord` (delta.time) | New |
| `steps` | `forRecord` | New |
| `active-calories` | `forRecord` | New |
| `vo2-max` | `forRecord` | New |
| `body-mass` | `forRecord` | New |
| `body-fat` | `forRecord` | New |
| `lean-mass` | `forRecord` | New |
| `exercise-session` | `forRecord` | New |

## Test plan

- [x] Existing [HealthConnectStableIdsTest](android/app/src/test/java/com/bios/app/HealthConnectStableIdsTest.kt) coverage (7 tests) still validates the stability contract.
- [x] `./gradlew :app:testStandaloneDebugUnitTest` — full suite green.
- [x] `./scripts/code-quality-check.sh` clean.
- [ ] Manual: re-sync HR / steps / body composition rows from an HC source that revises timestamps; confirm row counts stay = 1 per HC record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)