### PR TITLE
test(ui): pin TrendsScreen header contract for arbitrary metrics (#311)

### DIFF
--- a/android/app/src/test/java/com/bios/app/TrendsScreenTest.kt
+++ b/android/app/src/test/java/com/bios/app/TrendsScreenTest.kt
@@ -107,6 +107,32 @@ class TrendsScreenTest {
         assertNull(MetricType.fromKey("unknown_metric"))
     }
 
+    // -- TrendsScreen header surfaces any metric the search bar can navigate to (#311) --
+    // The original chip-row design hardcoded a small trackableMetrics set; metrics opened
+    // via HomeScreen.MetricSearchBar that were not in that set landed on a dashboard with
+    // an unselected chip row. The clickable header that replaced the chip row reads
+    // `selectedMetric.readableName` directly, so the bug is impossible by construction
+    // *as long as* every MetricType yields a non-empty readableName. These tests pin that.
+
+    @Test
+    fun `every MetricType yields a non-empty readableName so any navigation target renders`() {
+        for (m in MetricType.entries) {
+            assertTrue(
+                "${m.key} produced a blank readableName — TrendsScreen header would be empty",
+                m.readableName.isNotBlank(),
+            )
+        }
+    }
+
+    @Test
+    fun `metrics cited in #311 surface human-readable header text`() {
+        // The issue called out Weight / BMI / Body fat as failure-mode examples.
+        // Each must render a non-key human string in the dashboard header.
+        assertEquals("Body mass", MetricType.BODY_MASS.readableName)
+        assertEquals("Bmi kg per m2", MetricType.BMI_KG_PER_M2.readableName)
+        assertEquals("Body fat pct", MetricType.BODY_FAT_PCT.readableName)
+    }
+
     // -- Baseline list display --
 
     @Test


### PR DESCRIPTION
Closes #311 — the underlying bug was already fixed by a different design and only the regression-prevention test was missing.

## Investigation

#311 described a chip row at the top of `TrendsScreen` that hardcoded an 8-metric `trackableMetrics` set. Metrics opened via the global search bar that weren't in that set landed on a dashboard with no chip selected.

The chip row no longer exists. Commit [`8fff94f`](https://github.com/thdelmas/Bios/commit/8fff94f) (owner entry-flow refactor — the same PR the issue cited as the origin of the bug) replaced it with a clickable header that reads `selectedMetric.readableName` directly and opens [MetricBrowserSheet](android/app/src/main/java/com/bios/app/ui/trends/MetricBrowserSheet.kt) on tap. The "no chip selected for an arbitrary metric" failure mode is structurally impossible — the header always reflects the selection, for any `MetricType`.

`grep -r trackableMetrics android/` returns no matches, and [TrendsScreen.kt:108-125](android/app/src/main/java/com/bios/app/ui/trends/TrendsScreen.kt#L108-L125) is the clickable header that handles every metric uniformly.

## What this PR adds

Two tests that pin the contract the new design relies on:

- `every MetricType yields a non-empty readableName so any navigation target renders` — locks the `MetricType.readableName` invariant so the header never empties out as new metrics are added.
- `metrics cited in #311 surface human-readable header text` — explicit spot-checks for `BODY_MASS`, `BMI_KG_PER_M2`, `BODY_FAT_PCT` (the metrics #311 named as failure-mode examples).

If a future refactor reintroduced a hardcoded allow-list anywhere on the navigation path, the first test would still pass, but a regression would manifest as the per-metric dashboard misbehaving — caught by the manual test step below.

## Test plan

- [x] `./gradlew :app:testStandaloneDebugUnitTest --tests "com.bios.app.TrendsScreenTest"` — 2 new tests green; 17 existing TrendsScreen tests still green.
- [x] `./scripts/code-quality-check.sh` clean.
- [ ] Manual smoke: open Home, type "Body mass" / "BMI" / "Body fat" into the search bar, tap a result, confirm the per-metric dashboard header reads the metric's name and the chart loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)