### PR TITLE
feat(ecosystem): HRBS — heart rate before sleep metric (#309)

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/HrbsEngine.kt
+++ b/android/app/src/main/java/com/bios/app/engine/HrbsEngine.kt
@@ -1,0 +1,101 @@
+package com.bios.app.engine
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Heart rate before sleep (#309). Reads recent `SLEEP_DURATION` rows + the
+ * heart-rate stream surrounding each night's bedtime, and emits one
+ * `HEART_RATE_BEFORE_SLEEP` reading per night via the median of the HR
+ * samples in the [PRE_SLEEP_WINDOW_MIN]-minute window preceding bedtime.
+ *
+ * Bedtime is derived from `SLEEP_DURATION`: `timestamp` is the wake instant
+ * and `durationSec` is total time-in-bed, so `bedtime = timestamp − durationSec`.
+ * Sleep latency is not factored in (we want HR while the owner is in bed
+ * preparing to sleep, which is what the source essay calls out — moving from
+ * "lying still" to "asleep" is exactly the transition this metric captures).
+ *
+ * Pipeline:
+ *  1. Locate the most-recent SLEEP_DURATION row (one HRBS per night, keyed on
+ *     wake timestamp so re-syncs collapse).
+ *  2. Fetch HEART_RATE samples in `[bedtime − PRE_SLEEP_WINDOW_MIN, bedtime]`.
+ *  3. Require [MIN_HR_SAMPLES_REQUIRED] samples; below that the median is
+ *     too noisy to anchor a single nightly value.
+ *  4. Emit the median bpm as a HEART_RATE_BEFORE_SLEEP reading timestamped
+ *     at `bedtime`, inheriting the sleep row's confidence + sourceId.
+ *
+ * Idempotency mirrors [CircadianEngine] — skip emission when a HRBS reading
+ * already exists at or after the current night's bedtime.
+ */
+class HrbsEngine(
+    private val readingDao: MetricReadingDao,
+    private val zoneId: ZoneId = ZoneId.systemDefault(),
+) {
+
+    suspend fun derive(now: Instant = Instant.now()): MetricReading? {
+        val sleepRows = readingDao.fetch(
+            metricType = MetricType.SLEEP_DURATION.key,
+            startMillis = now.minus(LOOKBACK_DAYS.toLong(), ChronoUnit.DAYS).toEpochMilli(),
+            endMillis = now.toEpochMilli(),
+        ).filter { (it.durationSec ?: 0) > 0 }
+        if (sleepRows.isEmpty()) return null
+
+        // Pick the highest-confidence row per local wake-date so a watch
+        // session beats a manual entry, matching CircadianEngine semantics.
+        val byDate = sleepRows.groupBy {
+            Instant.ofEpochMilli(it.timestamp).atZone(zoneId).toLocalDate()
+        }
+        val mostRecentDate = byDate.keys.maxOrNull() ?: return null
+        val best = byDate.getValue(mostRecentDate).maxBy { it.confidence }
+
+        val bedtimeMs = best.timestamp - best.durationSec!!.toLong() * 1000L
+        val windowStartMs = bedtimeMs - PRE_SLEEP_WINDOW_MIN * 60L * 1000L
+
+        val lastEmitted = readingDao.lastTimestampFor(MetricType.HEART_RATE_BEFORE_SLEEP.key)
+        if (lastEmitted != null && lastEmitted >= bedtimeMs) return null
+
+        val hrSamples = readingDao.fetch(
+            metricType = MetricType.HEART_RATE.key,
+            startMillis = windowStartMs,
+            endMillis = bedtimeMs,
+        )
+        if (hrSamples.size < MIN_HR_SAMPLES_REQUIRED) return null
+
+        val median = medianOf(hrSamples.map { it.value })
+
+        return MetricReading(
+            metricType = MetricType.HEART_RATE_BEFORE_SLEEP.key,
+            value = median,
+            timestamp = bedtimeMs,
+            sourceId = best.sourceId,
+            confidence = best.confidence,
+        )
+    }
+
+    companion object {
+        private const val LOOKBACK_DAYS = 2
+
+        /** Pre-sleep window the median is taken over, in minutes. 15 mirrors
+         *  the 15s × 4 owner-pulse-count method described in the source
+         *  essay (Bryan Johnson, May 2026) — a steady "lying quietly"
+         *  interval long enough for HR to settle, short enough to predate
+         *  sleep onset on most schedules. */
+        internal const val PRE_SLEEP_WINDOW_MIN = 15
+
+        /** Minimum HR samples in the window before the median is trusted.
+         *  At 1 sample/min (the Health Connect spot-write cadence on most
+         *  wearables) this is a third of the window; at 1 sample/5s
+         *  (continuous wearable streams) it's a few seconds. */
+        internal const val MIN_HR_SAMPLES_REQUIRED = 5
+
+        internal fun medianOf(values: List<Double>): Double {
+            val sorted = values.sorted()
+            val n = sorted.size
+            return if (n % 2 == 0) (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0 else sorted[n / 2]
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
+++ b/android/app/src/main/java/com/bios/app/ingest/IngestManager.kt
@@ -2,6 +2,7 @@ package com.bios.app.ingest
 
 import com.bios.app.data.BiosDatabase
 import com.bios.app.engine.CircadianEngine
+import com.bios.app.engine.HrbsEngine
 import com.bios.app.engine.DetectionLatencyTracker
 import com.bios.app.engine.GlucoseVariability
 import com.bios.app.engine.HrRecoveryPersister
@@ -53,7 +54,7 @@ class IngestManager(
     private val sourceDao = db.dataSourceDao()
     private val payloadDao = db.eventPayloadFieldDao()
     private val toggleDao = db.sourceMetricToggleDao()
-    private val circadianEngine = CircadianEngine(readingDao)
+    private val circadianEngine = CircadianEngine(readingDao); private val hrbsEngine = HrbsEngine(readingDao)
 
     private val _lastSyncTime = MutableStateFlow<Long?>(null)
     val lastSyncTime: StateFlow<Long?> = _lastSyncTime
@@ -247,6 +248,7 @@ class IngestManager(
             }
 
             circadianEngine.derive()?.let { readingDao.insert(it) }
+            hrbsEngine.derive()?.let { readingDao.insert(it) }
             HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 14)
             RestingHeartRateBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 14)
             _lastSyncTime.value = System.currentTimeMillis()
@@ -311,6 +313,7 @@ class IngestManager(
             // preconditions aren't met (e.g. <4 days of sleep history),
             // so this block is safe to call on every sync.
             circadianEngine.derive()?.let { readingDao.insert(it) }
+            hrbsEngine.derive()?.let { readingDao.insert(it) }
             HrGapTibBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)
             SleepDerivationsBackfill(readingDao).runForLookback(lookbackDays = 30)
             RestingHeartRateBackfill(readingDao, sourceDao).runForLookback(lookbackDays = 30)

--- a/android/app/src/main/java/com/bios/app/ui/components/MetricExplanation.kt
+++ b/android/app/src/main/java/com/bios/app/ui/components/MetricExplanation.kt
@@ -65,5 +65,11 @@ object MetricExplanations {
             whyItVaries = "Schedule, stress, caffeine, alcohol, light exposure, and screen use shift it. Adult guidance is 7–9 hours but personal need varies.",
             howBiosUsesIt = "Bios reports what you slept — not what you should sleep. The Sleep dashboard (tap the card) shows regularity, latency, and efficiency separately.",
         ),
+        MetricType.HEART_RATE_BEFORE_SLEEP to MetricExplanation(
+            title = "Heart rate before sleep",
+            whatItMeasures = "Median beats per minute in the quarter-hour you spent lying quietly before sleep onset. Bios computes it from your continuous heart-rate stream; you can also enter it manually by counting your pulse for 15 seconds and multiplying by four.",
+            whyItVaries = "Alcohol pushes it +5–10 bpm; nicotine +10; a large meal close to bed +10; late caffeine +2–5; stress, anxiety, or rumination +5–25 — the largest single modifier. Fitness, evening room temperature, and how long ago you exercised also shift it.",
+            howBiosUsesIt = "Bios learns your personal nightly range. The number is most informative read alongside the modifiers above — the reading is the instrument, the interpretation is yours.",
+        ),
     )
 }

--- a/android/app/src/test/java/com/bios/app/HrbsEngineTest.kt
+++ b/android/app/src/test/java/com/bios/app/HrbsEngineTest.kt
@@ -1,0 +1,204 @@
+package com.bios.app
+
+import com.bios.app.data.dao.MetricReadingDao
+import com.bios.app.engine.HrbsEngine
+import com.bios.app.model.ConfidenceTier
+import com.bios.app.model.MetricReading
+import com.bios.contracts.MetricType
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Tests the orchestration around the HRBS derivation (#309): the engine
+ * picks the most-recent SLEEP_DURATION row, scopes HR samples to the
+ * pre-sleep window, computes the median, and emits one HRBS reading at
+ * the derived bedtime.
+ */
+class HrbsEngineTest {
+
+    private val utc = ZoneOffset.UTC
+
+    @Test
+    fun `no SLEEP_DURATION rows returns null`() = runBlocking {
+        val dao = FakeHrbsDao(rows = emptyList())
+        val engine = HrbsEngine(dao, zoneId = utc)
+        assertNull(engine.derive(now = "2026-04-10T12:00:00Z".asInstant()))
+    }
+
+    @Test
+    fun `too few HR samples in window returns null`() = runBlocking {
+        // Bedtime = 22:30; pre-sleep window = 22:15..22:30. Only 3 samples
+        // present — below MIN_HR_SAMPLES_REQUIRED=5, so the engine stays silent.
+        val wake = "2026-04-10T06:00:00Z".asInstant()
+        val rows = mutableListOf(sleepRow(wake = wake, inBedHours = 7.5))
+        rows += listOf(60.0, 62.0, 61.0).mapIndexed { i, bpm ->
+            hrSample("2026-04-09T22:%02d:00Z".format(20 + i * 3).asInstant(), bpm)
+        }
+        val dao = FakeHrbsDao(rows = rows)
+        assertNull(HrbsEngine(dao, zoneId = utc).derive(now = "2026-04-10T08:00:00Z".asInstant()))
+    }
+
+    @Test
+    fun `enough HR samples emits the median bpm at bedtime`() = runBlocking {
+        val wake = "2026-04-10T06:00:00Z".asInstant()
+        val sleep = sleepRow(wake = wake, inBedHours = 7.5, sourceId = "watch", confidence = ConfidenceTier.HIGH.level)
+        val bpms = listOf(58.0, 60.0, 62.0, 64.0, 66.0, 68.0, 70.0)
+        val samples = bpms.mapIndexed { i, bpm ->
+            // 7 samples spread across the 15-minute pre-sleep window 22:15-22:30.
+            hrSample("2026-04-09T22:%02d:00Z".format(17 + i * 2).asInstant(), bpm)
+        }
+        val dao = FakeHrbsDao(rows = listOf(sleep) + samples)
+
+        val emitted = HrbsEngine(dao, zoneId = utc).derive(now = "2026-04-10T08:00:00Z".asInstant())
+
+        assertNotNull(emitted)
+        assertEquals(MetricType.HEART_RATE_BEFORE_SLEEP.key, emitted!!.metricType)
+        // Median of 58,60,62,64,66,68,70 = 64.
+        assertEquals(64.0, emitted.value, 1e-9)
+        // Bedtime = wake (06:00) − 7.5h = 22:30 previous day.
+        assertEquals("2026-04-09T22:30:00Z".asInstant().toEpochMilli(), emitted.timestamp)
+        assertEquals("watch", emitted.sourceId)
+        assertEquals(ConfidenceTier.HIGH.level, emitted.confidence)
+    }
+
+    @Test
+    fun `HR samples outside the pre-sleep window are ignored`() = runBlocking {
+        val wake = "2026-04-10T06:00:00Z".asInstant()
+        val sleep = sleepRow(wake = wake, inBedHours = 7.5)
+        // 5 in-window low samples (avg ~60), plus 5 out-of-window high samples
+        // (90s) hours earlier. Median must come only from the in-window set.
+        val inWindow = listOf(58.0, 59.0, 60.0, 61.0, 62.0).mapIndexed { i, bpm ->
+            hrSample("2026-04-09T22:%02d:00Z".format(20 + i * 2).asInstant(), bpm)
+        }
+        val outOfWindow = listOf(90.0, 92.0, 88.0, 94.0, 89.0).mapIndexed { i, bpm ->
+            hrSample("2026-04-09T18:%02d:00Z".format(i).asInstant(), bpm)
+        }
+        val dao = FakeHrbsDao(rows = listOf(sleep) + inWindow + outOfWindow)
+
+        val emitted = HrbsEngine(dao, zoneId = utc).derive(now = "2026-04-10T08:00:00Z".asInstant())
+        assertNotNull(emitted)
+        assertEquals(60.0, emitted!!.value, 1e-9)
+    }
+
+    @Test
+    fun `re-emission for the same night is suppressed`() = runBlocking {
+        val wake = "2026-04-10T06:00:00Z".asInstant()
+        val sleep = sleepRow(wake = wake, inBedHours = 7.5)
+        val samples = (0..6).map {
+            hrSample("2026-04-09T22:%02d:00Z".format(17 + it * 2).asInstant(), 60.0 + it)
+        }
+        val dao = FakeHrbsDao(rows = listOf(sleep) + samples)
+        // Pretend HRBS was already emitted at bedtime — engine must stay silent.
+        dao.recordLastHrbs("2026-04-09T22:30:00Z".asInstant().toEpochMilli())
+
+        assertNull(HrbsEngine(dao, zoneId = utc).derive(now = "2026-04-10T08:00:00Z".asInstant()))
+    }
+
+    @Test
+    fun `highest-confidence sleep row wins when same night has multiple adapters`() = runBlocking {
+        val wake = "2026-04-10T06:00:00Z".asInstant()
+        // Two sleep rows for the same night: a manual entry (LOW) and a
+        // watch session (HIGH). The HRBS reading must inherit watch confidence.
+        val manualSleep = sleepRow(wake = wake, inBedHours = 7.5, sourceId = "manual", confidence = ConfidenceTier.LOW.level)
+        val watchSleep = sleepRow(wake = wake, inBedHours = 7.5, sourceId = "watch", confidence = ConfidenceTier.HIGH.level)
+        val samples = (0..6).map {
+            hrSample("2026-04-09T22:%02d:00Z".format(17 + it * 2).asInstant(), 60.0 + it)
+        }
+        val dao = FakeHrbsDao(rows = listOf(manualSleep, watchSleep) + samples)
+
+        val emitted = HrbsEngine(dao, zoneId = utc).derive(now = "2026-04-10T08:00:00Z".asInstant())
+        assertNotNull(emitted)
+        assertEquals("watch", emitted!!.sourceId)
+        assertEquals(ConfidenceTier.HIGH.level, emitted.confidence)
+    }
+
+    @Test
+    fun `medianOf is correct for odd and even sample counts`() {
+        // Odd: middle element.
+        assertEquals(60.0, HrbsEngine.medianOf(listOf(58.0, 60.0, 62.0)), 1e-9)
+        // Even: mean of the two middle elements.
+        assertEquals(61.0, HrbsEngine.medianOf(listOf(58.0, 60.0, 62.0, 64.0)), 1e-9)
+        // Out-of-order input.
+        assertEquals(60.0, HrbsEngine.medianOf(listOf(62.0, 58.0, 60.0)), 1e-9)
+    }
+
+    // -- helpers --
+
+    private fun sleepRow(
+        wake: Instant,
+        inBedHours: Double,
+        sourceId: String = "source1",
+        confidence: Int = ConfidenceTier.MEDIUM.level,
+    ): MetricReading {
+        val inBedSec = (inBedHours * 3600).toInt()
+        return MetricReading(
+            metricType = MetricType.SLEEP_DURATION.key,
+            value = inBedSec.toDouble(),
+            timestamp = wake.toEpochMilli(),
+            durationSec = inBedSec,
+            sourceId = sourceId,
+            confidence = confidence,
+        )
+    }
+
+    private fun hrSample(
+        at: Instant, bpm: Double, sourceId: String = "watch",
+    ): MetricReading = MetricReading(
+        metricType = MetricType.HEART_RATE.key,
+        value = bpm,
+        timestamp = at.toEpochMilli(),
+        sourceId = sourceId,
+        confidence = ConfidenceTier.MEDIUM.level,
+    )
+
+    private fun String.asInstant(): Instant = Instant.parse(this)
+}
+
+/**
+ * Minimal in-memory MetricReadingDao for [HrbsEngineTest]. Implements only
+ * the `fetch` and `lastTimestampFor` paths the engine exercises.
+ */
+private class FakeHrbsDao(
+    private val rows: List<MetricReading>,
+) : MetricReadingDao {
+
+    private var lastHrbsTimestamp: Long? = null
+
+    fun recordLastHrbs(timestamp: Long) {
+        lastHrbsTimestamp = timestamp
+    }
+
+    override suspend fun fetch(metricType: String, startMillis: Long, endMillis: Long): List<MetricReading> =
+        rows.filter {
+            it.metricType == metricType && it.timestamp in startMillis..endMillis
+        }
+
+    override suspend fun lastTimestampFor(metricType: String): Long? =
+        if (metricType == MetricType.HEART_RATE_BEFORE_SLEEP.key) lastHrbsTimestamp else null
+
+    override suspend fun insertAll(readings: List<MetricReading>): Unit = notUsed()
+    override suspend fun insert(reading: MetricReading): Unit = notUsed()
+    override suspend fun fetchValues(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun fetchLatest(metricType: String, limit: Int): List<MetricReading> = notUsed()
+    override suspend fun count(metricType: String): Int = notUsed()
+    override suspend fun countAll(): Int = notUsed()
+    override suspend fun countInRange(metricType: String, startMillis: Long, endMillis: Long, readingKind: String?): Int = notUsed()
+    override suspend fun fetchBucketedMeans(metricType: String, startMillis: Long, endMillis: Long, bucketMillis: Long, readingKind: String?): List<Double> = notUsed()
+    override suspend fun oldestTimestamp(): Long? = notUsed()
+    override suspend fun statusSummary(since24h: Long): List<MetricReadingDao.MetricStatusRow> = notUsed()
+    override suspend fun sourceFreshness(): List<MetricReadingDao.SourceFreshnessRow> = notUsed()
+    override suspend fun metricTypeCounts(): List<MetricReadingDao.MetricTypeCountRow> = notUsed()
+    override suspend fun sourceCountsForMetric(metricType: String): List<MetricReadingDao.SourceCountRow> = notUsed()
+    override suspend fun fetchCreatedAfter(sinceMillis: Long): List<MetricReading> = notUsed()
+    override suspend fun deleteBefore(beforeMillis: Long): Int = notUsed()
+    override suspend fun deleteAfter(afterMillis: Long): Int = notUsed()
+    override suspend fun deleteById(readingId: String): Int = notUsed()
+    override suspend fun deleteAll(): Unit = notUsed()
+
+    private fun <T> notUsed(): T = error("FakeHrbsDao: method not exercised by HrbsEngineTest")
+}

--- a/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
+++ b/android/bios-contracts/src/main/kotlin/com/bios/contracts/MetricType.kt
@@ -43,7 +43,7 @@ enum class MetricType(
     HRV_LF_POWER("hrv_lf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     HRV_HF_POWER("hrv_hf_power", MetricUnit.MS_SQUARED, MetricDomain.CARDIOVASCULAR),
     VO2_MAX("vo2_max", MetricUnit.ML_PER_KG_MIN, MetricDomain.CARDIOVASCULAR),
-    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
+    RESTING_HEART_RATE("resting_heart_rate", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true), HEART_RATE_BEFORE_SLEEP("heart_rate_before_sleep", MetricUnit.BPM, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true), // #309 HRBS — median bpm in the N-min window preceding sleep onset; Bios-owned, companion-read
     BLOOD_PRESSURE_SYSTOLIC("blood_pressure_systolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
     BLOOD_PRESSURE_DIASTOLIC("blood_pressure_diastolic", MetricUnit.MMHG, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),
     BLOOD_OXYGEN("blood_oxygen", MetricUnit.PERCENT, MetricDomain.CARDIOVASCULAR, allowsManualEntry = true),

--- a/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
+++ b/android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt
@@ -266,6 +266,34 @@ class MetricTypeKeysSnapshotTest {
         "cough_frequency_self_rating",
         "sputum_self_rating",
         "breath_ease_self_rating",
+        // HRBS (#309)
+        "heart_rate_before_sleep",
+        // Snapshot back-fill for keys that landed without updating the
+        // snapshot in their original PR — the bios-contracts test target
+        // is not invoked by the project's code-quality script, so the
+        // drift accumulated silently. These are all already shipped via
+        // their landing PRs.
+        "rbd_event_flag",
+        "rem_movement_index",
+        "tremor_amplitude_g",
+        "tremor_frequency_hz",
+        "crp",                          // #354
+        "d_dimer",                      // #339
+        "reverse_t3",                   // #339
+        "omega_3_index",                // #339
+        "leptin",                       // #339
+        "adiponectin",                  // #339
+        "prothrombin_time",             // #352
+        "inr",                          // #352
+        "quick_index",                  // #352
+        "aptt",                         // #352
+        "aptt_ratio",                   // #352
+        "absolute_lymphocyte_count",    // #353
+        "absolute_monocyte_count",      // #353
+        "absolute_eosinophil_count",    // #353
+        "absolute_basophil_count",      // #353
+        "gait_variability_cov",
+        "typing_speed_char_per_min",
     )
 
     @Test

--- a/docs/CONSUMER_API.md
+++ b/docs/CONSUMER_API.md
@@ -192,7 +192,8 @@ The canonical string keys Bios stores and accepts. All are lowercase with
 underscores, case-sensitive.
 
 **Cardiovascular**: `heart_rate`, `heart_rate_variability`, `resting_heart_rate`,
-`blood_pressure_systolic`, `blood_pressure_diastolic`, `blood_oxygen`
+`heart_rate_before_sleep`, `blood_pressure_systolic`, `blood_pressure_diastolic`,
+`blood_oxygen`
 
 **Respiratory**: `respiratory_rate`
 

--- a/docs/ECOSYSTEM_BOUNDARIES.md
+++ b/docs/ECOSYSTEM_BOUNDARIES.md
@@ -40,6 +40,7 @@ Applied:
 | `tobacco_use`, `fall_event`, etc. | discrete user actions | **companion** | requires tap-to-log / fall-detection surface |
 | `reaction_time_ms` | active test result | **Fil / W2F** | requires active-test surface |
 | `circadian_phase_shift` | sleep-onset times | **Bios** | inputs are canonical (sleep timing from 9 adapters); no companion-specific surface |
+| `heart_rate_before_sleep` | HR stream + sleep onset | **Bios** | inputs are canonical; consumed read-only by Smokeless (substance modifiers), W2F (stress correlate), SoulRadio (parasympathetic before/after), Fil (autonomic surveillance) — see #309 |
 | `sleep_duration` from screen-off | long quiet screen-off windows | **W2F** (LOW confidence) | UsageStatsTracker / screen-off is W2F's unique surface; Bios accepts the write via companion URI |
 | `sleep_duration` from phone sensors | accel + screen-off + charging + ambient-light fusion | **Bios** (MEDIUM confidence) | universal-infrastructure: every phone has these sensors; not domain-specific |
 | `cognitive_speed` (planned) | TBD | **decide at landing** | if active test output → Fil; if composite over canonical inputs → Bios |


### PR DESCRIPTION
Closes #309.

## Summary

Lands `HEART_RATE_BEFORE_SLEEP` as a first-class, Bios-owned, derived metric. Median bpm in the 15-min window preceding detected bedtime — derived from existing HR + sleep-onset signals, consumed read-only by companions through the existing provider surface.

### Pipeline

[HrbsEngine](android/app/src/main/java/com/bios/app/engine/HrbsEngine.kt) mirrors the [CircadianEngine](android/app/src/main/java/com/bios/app/engine/CircadianEngine.kt) shape:

1. Locate the most-recent `SLEEP_DURATION` row; derive `bedtime = wake - durationSec`.
2. Pick the highest-confidence sleep row when adapters disagree on the same night (watch session beats manual entry).
3. Fetch `HEART_RATE` samples in `[bedtime - 15min, bedtime]`. Require ≥ 5 samples (covers continuous-stream wearables and HC's 1-sample-per-minute spot-write cadence).
4. Emit one HRBS reading at the bedtime instant inheriting the sleep row's confidence + sourceId.
5. Idempotent on `lastTimestampFor(HEART_RATE_BEFORE_SLEEP)` — re-syncs of the same night collapse.

Wired into [IngestManager](android/app/src/main/java/com/bios/app/ingest/IngestManager.kt) alongside `circadianEngine.derive()` so both incremental and 30-day historical syncs cover it.

### Consumer surface

Read-only consumption already works through the existing [`/readings/{metric_type}` provider URI](docs/CONSUMER_API.md#read-uris) — companion implementations don't need new provider code. HRBS is now listed in:
- [docs/CONSUMER_API.md](docs/CONSUMER_API.md) cardiovascular metric keys
- [docs/ECOSYSTEM_BOUNDARIES.md](docs/ECOSYSTEM_BOUNDARIES.md) Bios-owned signals table

### Owner-facing copy

[MetricExplanations](android/app/src/main/java/com/bios/app/ui/components/MetricExplanation.kt) gets a HRBS card documenting the modifiers the source essay cites (alcohol +5–10, nicotine +10, stress +5–25, late caffeine +2–5, etc.) in the existing instrument-not-coach voice. `allowsManualEntry = true` preserves the owner-pulse-count fallback (15s × 4) for owners without a wearable.

### Snapshot drift fix

[MetricTypeKeysSnapshotTest](android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt) needed back-filling — `:bios-contracts:test` isn't invoked by `code-quality-check.sh`, so 20 keys landed across earlier PRs (#352 coag panel, #353 abs leukocyte differential, #354 standard CRP, #339 Wave-6 expansion, plus a few others) without updating the snapshot. Picked up the back-fill here since the HRBS addition triggered the same test path. Worth filing a separate follow-up to wire `:bios-contracts:test` into the code-quality script so this can't drift again.

## Out of scope (per issue)

- Companion overlays / surfaces (Smokeless substance-vs-HRBS chart, W2F evening-state, SoulRadio before/after delta, Fil autonomic input) ride in companion repos once Bios ships the metric.
- iOS HealthKit adapter (`HKQuantityTypeIdentifierHeartRate` + `HKCategoryTypeIdentifierSleepAnalysis`) lands with iOS-side work.
- BaselineEngine / AnomalyDetector wiring — those subscribe to any MetricType automatically; no per-key code needed.

## Test plan

- [x] `./gradlew :app:testStandaloneDebugUnitTest` — 2178 tests green (7 new HRBS tests).
- [x] `./gradlew :bios-contracts:test` — snapshot test green after back-fill.
- [x] `./scripts/code-quality-check.sh` clean.
- [ ] Manual smoke: sync a wearable that streams continuous HR overnight, confirm HRBS appears the next sync with a plausible bpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)