### PR TITLE
chore(ci): wire :bios-contracts:test into code-quality-check.sh

### DIFF
--- a/scripts/code-quality-check.sh
+++ b/scripts/code-quality-check.sh
@@ -46,6 +46,15 @@ if [ -f "$PROJECT_ROOT/android/gradlew" ]; then
         if ! (cd "$PROJECT_ROOT/android" && ./gradlew testStandaloneDebugUnitTest 2>&1); then
             FAILED=1
         fi
+
+        # bios-contracts is a published artifact that out-of-tree companions
+        # pin to; its frozen MetricType-key snapshot guards against
+        # accidental removals. The :app test target does not exercise it,
+        # so we run it explicitly here whenever Kotlin changes are staged.
+        step "Running bios-contracts tests (MetricType snapshot guard)"
+        if ! (cd "$PROJECT_ROOT/android" && ./gradlew :bios-contracts:test 2>&1); then
+            FAILED=1
+        fi
     else
         step "Skipping Android tests (no Kotlin files staged)"
     fi


### PR DESCRIPTION
Follow-up to #375 — closes the gap that let the MetricType-key snapshot drift.

## Problem

[code-quality-check.sh](scripts/code-quality-check.sh) runs `:app:testStandaloneDebugUnitTest` but never invokes the `:bios-contracts` module's test target. The [MetricTypeKeysSnapshotTest](android/bios-contracts/src/test/kotlin/com/bios/contracts/MetricTypeKeysSnapshotTest.kt) — the guard that catches accidental key removals breaking out-of-tree companion artifact pins — therefore never fired pre-commit. Across at least 4 prior PRs (#352, #353, #354, #339) keys landed without being added to the snapshot. #375 back-filled the 20 missing entries; this PR prevents the recurrence.

## Change

Adds a single new step to [code-quality-check.sh](scripts/code-quality-check.sh) that runs `:bios-contracts:test` whenever Kotlin/Kts changes are staged — same gate as the existing app-tests step.

```bash
step "Running bios-contracts tests (MetricType snapshot guard)"
if ! (cd "$PROJECT_ROOT/android" && ./gradlew :bios-contracts:test 2>&1); then
    FAILED=1
fi
```

## Test plan

- [x] `./scripts/code-quality-check.sh` on this PR — Kotlin-not-staged path correctly skips the test block, "ALL CHECKS PASSED".
- [x] `./gradlew :bios-contracts:test` directly — green (45 tests, including MetricTypeKeysSnapshotTest).
- [ ] Manual verify: any future PR that adds a `MetricType` key without updating the snapshot will now fail locally before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)