### PR TITLE
feat(screening): add routine periodic medical checkups

### DIFF
--- a/android/app/src/main/java/com/bios/app/engine/AnomalyExplanation.kt
+++ b/android/app/src/main/java/com/bios/app/engine/AnomalyExplanation.kt
@@ -1,6 +1,7 @@
 package com.bios.app.engine
 
 import com.bios.contracts.MetricType
+import java.util.Locale
 import kotlin.math.abs
 
 /**
@@ -26,7 +27,7 @@ internal fun buildAnomalyExplanation(
         .sortedByDescending { abs(it.value) }
         .map { (metric, zScore) ->
             val direction = if (zScore > 0) "above" else "below"
-            val sigmas = String.format("%.1f", abs(zScore))
+            val sigmas = String.format(Locale.ROOT, "%.1f", abs(zScore))
             "Your ${metric.readableName.lowercase()} is $sigmas standard deviations $direction your personal baseline."
         }
         .toMutableList()

--- a/android/app/src/main/java/com/bios/app/screening/CheckupCatalog.kt
+++ b/android/app/src/main/java/com/bios/app/screening/CheckupCatalog.kt
@@ -1,0 +1,99 @@
+package com.bios.app.screening
+
+/**
+ * Routine periodic medical checkups — the recurring clinical *encounters*
+ * that aren't disease-specific screenings (those live in
+ * [ScreeningCatalog.uspstf]) or vaccines (those live in the immunisations
+ * screen). The cadence screen's own doc comment named "eye, dental" as
+ * universal examples long before any entry existed; this catalog closes
+ * that gap.
+ *
+ * Two timing semantics, both surfaced by [ScreeningCadenceEngine]:
+ *
+ *  - **[CadenceKind.RECURRING]** — a target interval that reads "due" /
+ *    "overdue" once passed (e.g. the periodic wellness visit).
+ *  - **[CadenceKind.MIN_INTERVAL_SINCE_LAST]** — a *recommended delay
+ *    since the last occurrence*; doing it sooner adds little and being
+ *    "late" is not a failure, so it never renders as overdue (dental
+ *    recall, eye exam, skin / hearing checks). This is the manifesto's
+ *    no-shame rule expressed in the data model.
+ *
+ * **Honest sourcing.** Unlike the USPSTF screening set, several routine
+ * checkups have no A/B grade — the periodic physical and average-risk
+ * skin exam are explicitly *not* USPSTF-recommended. Each entry's
+ * citation states the actual evidence posture so the owner reads cadence
+ * as professional-society convention, not a Bios diagnosis. Bios points;
+ * the clinic reads.
+ *
+ * Region-agnostic by design, like the rest of the catalog — a future
+ * RegionConfig hook can substitute local recall intervals (NHS dental
+ * NICE recall, etc.) without touching the engine.
+ */
+internal object CheckupCatalog {
+
+    val entries: List<ScreeningCatalogEntry> = listOf(
+        ScreeningCatalogEntry(
+            key = "periodic_health_exam",
+            displayName = "Periodic health exam (wellness visit)",
+            minAge = 18, maxAge = null, cadenceMonths = 36,
+            applicability = Applicability.UNIVERSAL,
+            citation = "No USPSTF A/B grade for the annual physical (the routine yearly exam in " +
+                "asymptomatic adults shows no mortality benefit). Framed here as a periodic check-in to " +
+                "keep a clinician relationship live; a 3-yr default for younger adults is a common " +
+                "primary-care convention, not a mandate. Your provider sets the real interval.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+        ScreeningCatalogEntry(
+            key = "blood_pressure_check",
+            displayName = "Blood pressure check",
+            minAge = 18, maxAge = null, cadenceMonths = 12,
+            applicability = Applicability.UNIVERSAL,
+            citation = "USPSTF 2021 (A recommendation) — BP screening in adults ≥18. Annual for adults " +
+                "≥40 or at higher risk; every 3–5 yr for 18–39 with normal BP. The 12-mo cadence here is " +
+                "the higher-risk pace; an in-range reading just means the recommended re-check is further out.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+        ScreeningCatalogEntry(
+            key = "dental_checkup",
+            displayName = "Dental exam + cleaning",
+            minAge = 18, maxAge = null, cadenceMonths = 6,
+            applicability = Applicability.UNIVERSAL,
+            citation = "ADA: recall interval set individually by risk; ~6 mo is the common default for " +
+                "average-risk adults (NICE recall can extend to 24 mo for low-risk). A recommended delay " +
+                "since your last visit, not a deadline.",
+            cadenceKind = CadenceKind.MIN_INTERVAL_SINCE_LAST,
+        ),
+        ScreeningCatalogEntry(
+            key = "eye_exam",
+            displayName = "Comprehensive eye exam",
+            minAge = 18, maxAge = null, cadenceMonths = 24,
+            applicability = Applicability.UNIVERSAL,
+            citation = "AAO / AOA: comprehensive eye exam every 1–2 yr for low-risk adults (annual from " +
+                "~65). New or changing vision symptoms route to an eye-care professional regardless of " +
+                "where this interval sits — Bios has no vision-acuity metric.",
+            cadenceKind = CadenceKind.MIN_INTERVAL_SINCE_LAST,
+        ),
+        ScreeningCatalogEntry(
+            key = "skin_exam",
+            displayName = "Full-body skin check",
+            minAge = 18, maxAge = null, cadenceMonths = 12,
+            applicability = Applicability.UNIVERSAL,
+            citation = "USPSTF 2023: I-statement — insufficient evidence to recommend routine whole-body " +
+                "skin exams in average-risk asymptomatic adults. Surfaced as an elective annual recall; " +
+                "higher-risk owners (personal/family melanoma history) follow a dermatologist's shorter " +
+                "interval. A new or changing lesion routes to a clinician now, not at the next recall.",
+            cadenceKind = CadenceKind.MIN_INTERVAL_SINCE_LAST,
+        ),
+        ScreeningCatalogEntry(
+            key = "hearing_test",
+            displayName = "Hearing check (audiometry)",
+            minAge = 50, maxAge = null, cadenceMonths = 36,
+            applicability = Applicability.UNIVERSAL,
+            citation = "USPSTF 2021: I-statement — insufficient evidence to screen for hearing loss in " +
+                "asymptomatic older adults; ASHA suggests periodic audiometry from ~50. Surfaced as a " +
+                "recommended delay since your last test, never overdue. Noticeable hearing change routes " +
+                "to a clinician regardless.",
+            cadenceKind = CadenceKind.MIN_INTERVAL_SINCE_LAST,
+        ),
+    )
+}

--- a/android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt
+++ b/android/app/src/main/java/com/bios/app/screening/ScreeningCadenceEngine.kt
@@ -39,6 +39,22 @@ sealed class ScreeningStatus {
     data class DueNow(val monthsSinceLast: Int, val monthsOverdue: Int) : ScreeningStatus()
     /** Eligible, on record, current; next due in [monthsUntilDue] months. */
     data class Current(val monthsSinceLast: Int, val monthsUntilDue: Int) : ScreeningStatus()
+
+    /**
+     * [CadenceKind.MIN_INTERVAL_SINCE_LAST] only: on record, but the
+     * recommended delay since the last occurrence hasn't elapsed yet.
+     * Neutral — "recommended again in [monthsUntilEligible] months". This
+     * is *not* an overdue state and callers must never render it as one.
+     */
+    data class WithinInterval(val monthsSinceLast: Int, val monthsUntilEligible: Int) : ScreeningStatus()
+
+    /**
+     * [CadenceKind.MIN_INTERVAL_SINCE_LAST] only: on record and the
+     * recommended delay has elapsed — eligible to repeat. Still neutral:
+     * a recommended delay you can't be "late" for (manifesto no-shame
+     * rule). Distinct from [DueNow], which carries overdue urgency.
+     */
+    data class IntervalElapsed(val monthsSinceLast: Int) : ScreeningStatus()
 }
 
 /**
@@ -144,6 +160,20 @@ object ScreeningCadenceEngine {
         val monthsSinceLast = (daysSinceLast / DAYS_PER_MONTH).toInt()
         val cadenceDays = (entry.cadenceMonths * DAYS_PER_MONTH).toInt()
         val daysUntilDue = cadenceDays - daysSinceLast
+
+        // Minimum-interval entries (routine checkups) never read as
+        // overdue: before the recommended delay elapses they're
+        // WithinInterval, after it they're IntervalElapsed — both neutral.
+        if (entry.cadenceKind == CadenceKind.MIN_INTERVAL_SINCE_LAST) {
+            return if (daysUntilDue > 0) {
+                ScreeningStatus.WithinInterval(
+                    monthsSinceLast = monthsSinceLast,
+                    monthsUntilEligible = (daysUntilDue / DAYS_PER_MONTH).toInt(),
+                )
+            } else {
+                ScreeningStatus.IntervalElapsed(monthsSinceLast = monthsSinceLast)
+            }
+        }
 
         return if (daysUntilDue <= DUE_NOW_GRACE_DAYS) {
             val monthsOverdue = if (daysUntilDue >= 0) 0 else (-daysUntilDue / DAYS_PER_MONTH).toInt()

--- a/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
+++ b/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
@@ -69,6 +69,38 @@ enum class RiskGate {
 }
 
 /**
+ * How a catalog entry's recommended interval should be read.
+ *
+ * The distinction matters for owner-facing framing, not just arithmetic
+ * (audit follow-up: periodic checkups). Disease screenings recur on a
+ * target cadence and read "overdue" once you pass it; routine checkups
+ * are often phrased as a *minimum recommended delay since the last one*,
+ * where doing it sooner adds little and being "late" is not a failure.
+ *
+ * Manifesto guard: the no-shame rule means a delay you can't fail must
+ * never render in the error / overdue treatment. The engine honours that
+ * by returning distinct statuses per kind.
+ */
+enum class CadenceKind {
+    /**
+     * Recurring periodic screening. `cadenceMonths` is a *target* — once
+     * the owner passes it (plus the grace window) the entry reads as due
+     * / overdue. The default so every pre-existing entry is unchanged.
+     */
+    RECURRING,
+
+    /**
+     * Recommended *delay since the last occurrence*. `cadenceMonths` is a
+     * minimum recommended interval, not a target to chase. Before it
+     * elapses the entry reads "recommended again after …"; once it does,
+     * "eligible again" — neutral either way, never overdue. Used for
+     * routine checkups (dental recall, eye exam, periodic wellness visit)
+     * whose interval is advice, not a clock you fail.
+     */
+    MIN_INTERVAL_SINCE_LAST,
+}
+
+/**
  * One screening recommendation. Pinned to the USPSTF adult schedule v1
  * (#155, audit gap §2.2), with hereditary-syndrome / cardiology
  * one-time / Ob/Gyn-society / IHS extensions added in #191.
@@ -105,6 +137,13 @@ data class ScreeningCatalogEntry(
      * [com.bios.app.model.RiskProfile] flag is set.
      */
     val riskGate: RiskGate = RiskGate.NONE,
+    /**
+     * How [cadenceMonths] should be interpreted. Defaults to
+     * [CadenceKind.RECURRING] so every existing entry keeps its current
+     * due/overdue behaviour; routine checkups opt into
+     * [CadenceKind.MIN_INTERVAL_SINCE_LAST].
+     */
+    val cadenceKind: CadenceKind = CadenceKind.RECURRING,
 )
 
 /**
@@ -212,11 +251,21 @@ object ScreeningCatalog {
     val ihsPaho: List<ScreeningCatalogEntry> = IhsPahoCatalog.entries
 
     /**
+     * Routine periodic medical checkups (periodic-checkup follow-up) —
+     * the recurring clinical encounters that aren't disease-specific
+     * screenings or vaccines: periodic wellness visit, BP check, dental,
+     * eye, skin, hearing. Several use
+     * [CadenceKind.MIN_INTERVAL_SINCE_LAST] so they read as a recommended
+     * delay, never as overdue.
+     */
+    val checkups: List<ScreeningCatalogEntry> = CheckupCatalog.entries
+
+    /**
      * Everything the engine should evaluate in the default cadence
      * screen. The UI iterates this list; each entry's [riskGate] +
      * [applicability] + age-band decide whether it actually renders for
      * the active owner.
      */
     val combined: List<ScreeningCatalogEntry> =
-        uspstf + hereditary + obGynSociety + cardiology + ihsPaho
+        uspstf + hereditary + obGynSociety + cardiology + ihsPaho + checkups
 }

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareDemographicsDialog.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareDemographicsDialog.kt
@@ -1,0 +1,138 @@
+package com.bios.app.ui.screening
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.screening.AnatomyProfile
+import java.util.Calendar
+
+/**
+ * Demographics + anatomy editor for [PreventiveCareScreen]. Split into its
+ * own file so the screen stays under the 500-line cap. Same package, so
+ * these stay `internal` rather than `public`.
+ *
+ * The anatomy-direct flow (#209) asks per-organ rather than a binary
+ * sex/gender question — each screening pins to an organ, so the owner
+ * answers what applies and leaves the rest unset.
+ */
+@Composable
+internal fun DemographicsDialog(
+    initialBirthYear: Int?,
+    initialAnatomy: AnatomyProfile,
+    onDismiss: () -> Unit,
+    onSave: (Int?, AnatomyProfile) -> Unit,
+) {
+    var yearText by remember { mutableStateOf(initialBirthYear?.toString() ?: "") }
+    var anatomy by remember { mutableStateOf(initialAnatomy) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Demographics") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = yearText,
+                    onValueChange = { v -> yearText = v.filter { it.isDigit() }.take(4) },
+                    label = { Text("Birth year (e.g. 1985)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text("Anatomy", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
+                Text(
+                    "Bios asks about anatomy, not gender. Each screening " +
+                        "recommendation pins to an organ: mammograms to breast " +
+                        "tissue, cervical screening to a cervix, PSA discussion " +
+                        "to a prostate. Answer what applies; leave the rest " +
+                        "unset.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                AnatomyQuestion(
+                    label = "Do you have breast tissue?",
+                    answer = anatomy.hasBreastTissue,
+                    onAnswer = { anatomy = anatomy.copy(hasBreastTissue = it) },
+                )
+                AnatomyQuestion(
+                    label = "Do you have a cervix?",
+                    answer = anatomy.hasCervix,
+                    onAnswer = { anatomy = anatomy.copy(hasCervix = it) },
+                )
+                AnatomyQuestion(
+                    label = "Do you have a uterus?",
+                    answer = anatomy.hasUterus,
+                    onAnswer = { anatomy = anatomy.copy(hasUterus = it) },
+                )
+                AnatomyQuestion(
+                    label = "Do you have a prostate?",
+                    answer = anatomy.hasProstate,
+                    onAnswer = { anatomy = anatomy.copy(hasProstate = it) },
+                )
+                AnatomyQuestion(
+                    label = "Have you had bottom or top surgery?",
+                    answer = anatomy.hadGenderAffirmingSurgery,
+                    onAnswer = { anatomy = anatomy.copy(hadGenderAffirmingSurgery = it) },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onSave(
+                    yearText.toIntOrNull()?.takeIf {
+                        it in 1900..Calendar.getInstance().get(Calendar.YEAR)
+                    },
+                    anatomy,
+                )
+            }) { Text("Save") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+@Composable
+private fun AnatomyQuestion(
+    label: String,
+    answer: Boolean?,
+    onAnswer: (Boolean?) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            AnatomyChip("Yes", answer == true) { onAnswer(true) }
+            AnatomyChip("No", answer == false) { onAnswer(false) }
+            AnatomyChip("Unset", answer == null) { onAnswer(null) }
+        }
+    }
+}
+
+@Composable
+private fun AnatomyChip(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        colors = if (selected) {
+            ButtonDefaults.outlinedButtonColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        } else ButtonDefaults.outlinedButtonColors(),
+    ) { Text(label) }
+}

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
@@ -43,6 +43,7 @@ import com.bios.app.data.RiskProfileRepo
 import com.bios.app.data.ScreeningEntryRepo
 import com.bios.app.model.RiskProfile
 import com.bios.app.screening.AnatomyProfile
+import com.bios.app.screening.CadenceKind
 import com.bios.app.screening.OwnerDemographicsStore
 import com.bios.app.screening.ScreeningCadenceEngine
 import com.bios.app.screening.ScreeningCatalog
@@ -217,11 +218,14 @@ private fun ManifestoCard() {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("How Bios uses this", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
             Text(
-                "Bios reads the USPSTF adult screening schedule and your own " +
-                    "history to answer one question: what are you due for? " +
-                    "Nothing here pushes a notification; the screen waits until " +
-                    "you ask. Cadence math is just math — your provider applies " +
-                    "the local guideline for diagnosis.",
+                "Bios reads the USPSTF adult screening schedule, routine " +
+                    "checkup intervals (dental, eye, periodic exam), and your " +
+                    "own history to answer one question: what are you due for? " +
+                    "Routine checkups show a recommended delay since your last " +
+                    "visit — never an 'overdue', because that's advice, not a " +
+                    "deadline. Nothing here pushes a notification; the screen " +
+                    "waits until you ask. Cadence math is just math — your " +
+                    "provider applies the local guideline for diagnosis.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -285,11 +289,19 @@ private fun ScreeningRow(
             if (status.monthsOverdue > 0)
                 "Overdue by ${status.monthsOverdue} mo"
             else "Due now (last ${status.monthsSinceLast} mo ago)"
+        // Minimum-interval (routine checkup) states — neutral wording, no
+        // "overdue". A recommended delay you can't be late for.
+        is ScreeningStatus.WithinInterval ->
+            "Recommended again in ${status.monthsUntilEligible} mo (last ${status.monthsSinceLast} mo ago)"
+        is ScreeningStatus.IntervalElapsed ->
+            "Eligible again (last ${status.monthsSinceLast} mo ago)"
     }
     val statusColor = when (status) {
         is ScreeningStatus.DueNow -> MaterialTheme.colorScheme.error
         ScreeningStatus.NoRecord -> MaterialTheme.colorScheme.secondary
         is ScreeningStatus.Current -> MaterialTheme.colorScheme.primary
+        is ScreeningStatus.WithinInterval -> MaterialTheme.colorScheme.primary
+        is ScreeningStatus.IntervalElapsed -> MaterialTheme.colorScheme.secondary
         is ScreeningStatus.NotEligible -> MaterialTheme.colorScheme.onSurfaceVariant
     }
 
@@ -301,7 +313,7 @@ private fun ScreeningRow(
             Text(entry.displayName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
             Text(statusText, style = MaterialTheme.typography.bodySmall, color = statusColor)
             Text(
-                "Cadence: every ${cadenceLabel(entry.cadenceMonths)} • ${ageLabel(entry)}",
+                "${cadenceDescriptor(entry)} • ${ageLabel(entry)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -367,117 +379,23 @@ private fun RecordScreeningDialog(
     }
 }
 
-@Composable
-private fun DemographicsDialog(
-    initialBirthYear: Int?,
-    initialAnatomy: AnatomyProfile,
-    onDismiss: () -> Unit,
-    onSave: (Int?, AnatomyProfile) -> Unit,
-) {
-    var yearText by remember { mutableStateOf(initialBirthYear?.toString() ?: "") }
-    var anatomy by remember { mutableStateOf(initialAnatomy) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Demographics") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = yearText,
-                    onValueChange = { v -> yearText = v.filter { it.isDigit() }.take(4) },
-                    label = { Text("Birth year (e.g. 1985)") },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Text("Anatomy", style = MaterialTheme.typography.bodySmall, fontWeight = FontWeight.Bold)
-                Text(
-                    "Bios asks about anatomy, not gender. Each screening " +
-                        "recommendation pins to an organ: mammograms to breast " +
-                        "tissue, cervical screening to a cervix, PSA discussion " +
-                        "to a prostate. Answer what applies; leave the rest " +
-                        "unset.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                AnatomyQuestion(
-                    label = "Do you have breast tissue?",
-                    answer = anatomy.hasBreastTissue,
-                    onAnswer = { anatomy = anatomy.copy(hasBreastTissue = it) },
-                )
-                AnatomyQuestion(
-                    label = "Do you have a cervix?",
-                    answer = anatomy.hasCervix,
-                    onAnswer = { anatomy = anatomy.copy(hasCervix = it) },
-                )
-                AnatomyQuestion(
-                    label = "Do you have a uterus?",
-                    answer = anatomy.hasUterus,
-                    onAnswer = { anatomy = anatomy.copy(hasUterus = it) },
-                )
-                AnatomyQuestion(
-                    label = "Do you have a prostate?",
-                    answer = anatomy.hasProstate,
-                    onAnswer = { anatomy = anatomy.copy(hasProstate = it) },
-                )
-                AnatomyQuestion(
-                    label = "Have you had bottom or top surgery?",
-                    answer = anatomy.hadGenderAffirmingSurgery,
-                    onAnswer = { anatomy = anatomy.copy(hadGenderAffirmingSurgery = it) },
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                onSave(
-                    yearText.toIntOrNull()?.takeIf {
-                        it in 1900..Calendar.getInstance().get(Calendar.YEAR)
-                    },
-                    anatomy,
-                )
-            }) { Text("Save") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
-    )
-}
-
-@Composable
-private fun AnatomyQuestion(
-    label: String,
-    answer: Boolean?,
-    onAnswer: (Boolean?) -> Unit,
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(label, style = MaterialTheme.typography.bodyMedium)
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            AnatomyChip("Yes", answer == true) { onAnswer(true) }
-            AnatomyChip("No", answer == false) { onAnswer(false) }
-            AnatomyChip("Unset", answer == null) { onAnswer(null) }
-        }
-    }
-}
-
-@Composable
-private fun AnatomyChip(
-    label: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    OutlinedButton(
-        onClick = onClick,
-        colors = if (selected) {
-            androidx.compose.material3.ButtonDefaults.outlinedButtonColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
-        } else androidx.compose.material3.ButtonDefaults.outlinedButtonColors(),
-    ) { Text(label) }
-}
-
 private fun cadenceLabel(months: Int): String = when {
     months == Int.MAX_VALUE -> "one-time"
     months % 12 == 0 -> "${months / 12} yr"
     else -> "$months mo"
 }
+
+/**
+ * Cadence wording by [CadenceKind]. Recurring entries read "every X";
+ * minimum-interval checkups read "recommended delay: X" so the owner sees
+ * a delay-since-last advice, not a clock to fail.
+ */
+private fun cadenceDescriptor(entry: ScreeningCatalogEntry): String =
+    when (entry.cadenceKind) {
+        CadenceKind.RECURRING -> "Cadence: every ${cadenceLabel(entry.cadenceMonths)}"
+        CadenceKind.MIN_INTERVAL_SINCE_LAST ->
+            "Recommended delay: ${cadenceLabel(entry.cadenceMonths)} since last"
+    }
 
 private fun ageLabel(entry: ScreeningCatalogEntry): String =
     if (entry.maxAge != null) "ages ${entry.minAge}–${entry.maxAge}"

--- a/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
@@ -1,0 +1,108 @@
+package com.bios.app
+
+import com.bios.app.model.ScreeningEntry
+import com.bios.app.screening.CadenceKind
+import com.bios.app.screening.OwnerDemographics
+import com.bios.app.screening.ScreeningCadenceEngine
+import com.bios.app.screening.ScreeningCatalog
+import com.bios.app.screening.ScreeningStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the routine periodic-checkup catalog (periodic-checkup follow-up)
+ * and the [CadenceKind.MIN_INTERVAL_SINCE_LAST] semantics in
+ * [ScreeningCadenceEngine]. Split out of [ScreeningCadenceEngineTest] to
+ * keep both files under the 500-line cap. Time is pinned the same way:
+ * `now` is a concrete epoch, the engine takes it as a parameter.
+ */
+class CheckupCadenceTest {
+
+    // 2026-05-21 → 1747824000000 (matches ScreeningCadenceEngineTest).
+    private val now: Long = 1_747_824_000_000L
+    private val day = 86_400_000L
+    private val daysPerMonth = 30.4375  // matches the engine's constant
+
+    private fun monthsAgo(months: Int): Long =
+        (now - (months * daysPerMonth * day).toLong()).toLong()
+
+    @Test
+    fun checkup_keys_surface_in_combined_catalog() {
+        val keys = ScreeningCatalog.combined.map { it.key }.toSet()
+        for (key in listOf(
+            "periodic_health_exam", "blood_pressure_check", "dental_checkup",
+            "eye_exam", "skin_exam", "hearing_test",
+        )) {
+            assertTrue("$key should be in combined catalog", key in keys)
+        }
+    }
+
+    @Test
+    fun every_checkup_entry_carries_a_citation() {
+        for (entry in ScreeningCatalog.checkups) {
+            assertTrue("${entry.key} should ship a citation", entry.citation.isNotBlank())
+        }
+    }
+
+    @Test
+    fun recurring_checkup_still_reads_DueNow_when_overdue() {
+        // The periodic wellness visit is RECURRING — it keeps the normal
+        // due/overdue behaviour, unlike the min-interval checkups.
+        val exam = ScreeningCatalog.checkups.first { it.key == "periodic_health_exam" }  // 36mo
+        assertEquals(CadenceKind.RECURRING, exam.cadenceKind)
+        val latest = ScreeningEntry(screeningKey = exam.key, performedDate = monthsAgo(48))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = exam,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = latest,
+            now = now,
+        )
+        assertTrue("expected DueNow, got $status", status is ScreeningStatus.DueNow)
+    }
+
+    @Test
+    fun min_interval_checkup_reads_WithinInterval_before_the_delay_elapses() {
+        val dental = ScreeningCatalog.checkups.first { it.key == "dental_checkup" }  // 6mo min-interval
+        assertEquals(CadenceKind.MIN_INTERVAL_SINCE_LAST, dental.cadenceKind)
+        val latest = ScreeningEntry(screeningKey = dental.key, performedDate = monthsAgo(2))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = dental,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = latest,
+            now = now,
+        )
+        assertTrue("expected WithinInterval, got $status", status is ScreeningStatus.WithinInterval)
+        status as ScreeningStatus.WithinInterval
+        assertTrue("monthsUntilEligible ~4, got ${status.monthsUntilEligible}", status.monthsUntilEligible in 3..4)
+    }
+
+    @Test
+    fun min_interval_checkup_reads_IntervalElapsed_after_the_delay_but_never_DueNow() {
+        val dental = ScreeningCatalog.checkups.first { it.key == "dental_checkup" }  // 6mo min-interval
+        val latest = ScreeningEntry(screeningKey = dental.key, performedDate = monthsAgo(10))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = dental,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = latest,
+            now = now,
+        )
+        // Manifesto no-shame rule: a recommended delay you can't be "late"
+        // for never escalates to the overdue DueNow state.
+        assertFalse("min-interval checkup must never read DueNow", status is ScreeningStatus.DueNow)
+        assertTrue("expected IntervalElapsed, got $status", status is ScreeningStatus.IntervalElapsed)
+    }
+
+    @Test
+    fun min_interval_checkup_with_no_record_is_NoRecord() {
+        val eye = ScreeningCatalog.checkups.first { it.key == "eye_exam" }
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = eye,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = null,
+            now = now,
+        )
+        assertEquals(ScreeningStatus.NoRecord, status)
+    }
+}


### PR DESCRIPTION
## What

Adds the **routine periodic medical checkup encounters** to the existing screening-cadence feature. Until now Bios tracked disease-specific screenings (colorectal, mammogram, lipid, HbA1c, DEXA…) and vaccines (immunisations screen) — but the recurring clinical *encounters* (periodic exam, dental, eye, skin, hearing, BP) were missing. The cadence catalog's own doc comment even named "eye, dental" as universal examples that were never added.

Everything reuses the existing pull-side `PreventiveCareScreen` + `ScreeningCadenceEngine` — **no new DAO, no new screen, no notifications.** Silence stays a feature.

## Two timing semantics (`CadenceKind`)

Per reviewer request, checkups distinguish a fixed cadence from a *recommended delay since the last occurrence*:

- **`RECURRING`** — existing target-cadence behaviour; reads due / overdue once passed (default, so every prior entry is unchanged). Used for the periodic wellness visit and BP check.
- **`MIN_INTERVAL_SINCE_LAST`** — a recommended delay. Reads **"recommended again after X"** before it elapses and **"eligible again"** after — *never* "overdue", honouring the manifesto's no-shame rule (a delay you can't fail). New neutral `WithinInterval` / `IntervalElapsed` engine statuses; the screen renders them in neutral colours and reframes the cadence line as a delay. Used for dental / eye / skin / hearing.

## Honest citations

Several routine checkups have **no USPSTF A/B grade** (annual physical, average-risk skin/hearing exams are I-statements). Each entry states its actual evidence posture so cadence reads as professional-society convention, not a Bios recommendation. *Bios points; the clinic reads.*

## Manifesto compliance

- Pull-only — surfaced on a screen the owner navigates into; no notifications.
- No composite score; each checkup stands alone.
- No-shame: min-interval items can never render as overdue/red.

## Files

- `CheckupCatalog.kt` (new) — 6 checkups, folded into `ScreeningCatalog.combined`
- `ScreeningCatalog.kt` — `CadenceKind` enum + `cadenceKind` field (defaults `RECURRING`)
- `ScreeningCadenceEngine.kt` — `WithinInterval` / `IntervalElapsed` statuses + min-interval branch
- `PreventiveCareScreen.kt` — neutral rendering + delay-aware cadence label
- `PreventiveCareDemographicsDialog.kt` (new) — extracted to keep the screen <500 lines
- `CheckupCadenceTest.kt` (new) — min-interval transitions + catalog contracts

## Notes

- First commit (`fix(detekt)`) is an **unrelated pre-existing** fix: `AnomalyExplanation.kt` tripped detekt's `ImplicitDefaultLocale`, which was leaving the pre-commit gate red on the branch independent of this feature. Pinned `Locale.ROOT` to match the `PpgCalibrationLogger` convention. Split into its own commit so it reviews cleanly.
- All checks pass (`./scripts/code-quality-check.sh` → ALL CHECKS PASSED). The remaining lint error (`CameraPpgAdapter` opt-in) is pre-existing and unrelated; lint is non-blocking in the script.

## Test plan

- [x] `ScreeningCadenceEngineTest` (existing, still green)
- [x] `CheckupCadenceTest` (new): WithinInterval before delay, IntervalElapsed after, never DueNow for min-interval, NoRecord with no history, recurring checkup still overdue
- [x] Full `code-quality-check.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)