### PR TITLE
docs: rewrite monetization around the consent rail; add B2B partner model

### DIFF
--- a/docs/B2B_PARTNER_MODEL.md
+++ b/docs/B2B_PARTNER_MODEL.md
@@ -1,0 +1,117 @@
+# Bios B2B Partner Model — instrument, not data broker
+
+> How institutions (trials, clinics, research cohorts) become paying partners **without** buying
+> user data and **without** forcing one-app-per-partner. This is the operational detail behind
+> [MONETIZATION_PLAN.md](MONETIZATION_PLAN.md) (Stream A + the consent rail) and is governed by
+> [PRIVACY_ARCHITECTURE.md](PRIVACY_ARCHITECTURE.md). Worked 2026-06-08.
+
+## The core principle
+
+**You sell the privacy-preserving measurement instrument + the consent/compliance rail. You never
+sell user data.** The owner's device is the single point of capture *and* the single fan-out hub.
+Every partner is a scoped, siloed, independently-billed *recipient* hanging off the owner — never a
+fork of the app, never a buyer of a data pool.
+
+Two things wearing the word "data revenue", kept strictly distinct:
+- **Selling user data** (taking what users gave you, reselling it): **never.** Architecturally impossible — you don't hold it.
+- **Licensing a measurement instrument to an institution that collects its *own* consented data from its *own* enrolled patients**: a clean, proven, multi-billion-dollar business (eCOA / decentralized-trial / digital-biomarker platforms — Medable, Castor, Cambridge Cognition, ActiGraph). Data flows patient → *their* trial/clinic (already consented), never patient → you → buyer.
+
+## What a partner buys / doesn't buy
+
+| Buys | Does NOT buy |
+|---|---|
+| A license to use Bios as a remote-measurement instrument for *their* cohort | User data (you don't sell it; you don't hold it centrally) |
+| Reduced data-compliance burden (on-device, consented, scoped — shrinks their GDPR/HIPAA/IRB risk) | A custom app / a fork |
+| An integration (API/export) to pipe **consented** results into their data system (EDC) | Visibility into any user outside their own consented cohort |
+
+The privacy architecture is the **selling point**, not an obstacle: data-governance is one of the
+biggest costs/risks in a trial, and "stays on the patient's device, shared only by explicit per-study
+consent" makes the sponsor's burden smaller.
+
+## The consent rail IS the multi-tenancy (no fork, ever)
+
+A partner is **a named recipient + a config + an API key** — not a codebase.
+
+- **One instrument app per *domain*** (Bios-generic; Fil neuro; W2F mood). Never one per partner.
+- A new partner onboards as: a recipient registered in the partner console, a config (which metrics,
+  cadence, study ID), an API/export to their system, optional branding badge. **A new partner is a
+  database row, not a sprint.**
+- Where partner-specific needs go: **configuration** (metrics/schedule/thresholds), **theming/white-label**
+  (one codebase, N skins), **integration** (a stable API). Genuinely-custom asks → a bounded, separately-paid
+  integration — **never a maintained fork.**
+- For partners who already have their own app: **license the measurement engine as an SDK** — they embed
+  it, you build zero apps. Maximum picks-and-shovels.
+
+> Discipline: the pressure to fork "for one big paying client" is how a product company quietly becomes
+> a consultancy. Build the config/API layer early so "yes" to a partner means *configure*, not *fork*.
+> For a solo founder with no medical background, the product architecture is the *only* survivable version.
+
+## Worked example — one study
+
+**NorthTrial**, a CRO running a Phase 2 metabolic-drug study, needs continuous **sleep, resting HR, HRV,
+activity** from at-home participants (safety + secondary endpoints). Generic physiology = Bios's
+domain-neutral backbone, no specialty required.
+
+1. **They buy:** a per-study license + per-active-participant/month fee + a one-time EDC integration.
+   *(Illustrative: study license low-five-figures, per-participant-month in the tens of dollars — directional, not a quote.)*
+2. **Participant experience:** installs **the same free Bios** everyone uses (full private hub, theirs
+   forever). At enrollment, a code; in the consent rail: *"Share {sleep, RHR, HRV, activity} with
+   NorthTrial Study #NT-204 for the study duration?"* — neutral, explicit, scoped, revocable. Using Bios
+   never requires enrolling.
+3. **Data flow:** device → (consented, scoped) → NorthTrial's EDC. Never device → Bios server → sold.
+   The trial owns its trial data under its own IRB consent. Bios is the ruler and the pipe.
+4. **No fork:** NT-204 is a recipient + config + API export in the partner console. SouthTrial is the next row.
+5. **Money + free hub intact:** NorthTrial pays; the participant pays nothing and gets the same full Bios;
+   the non-millionaire who never enrolls gets the identical free hub. No feature gate, no data sale.
+
+## Worked example — the same user in TWO studies at once
+
+Add **SouthTrial #ST-110** wanting {HRV, sleep, temperature}, concurrent with NT-204. This isn't an edge
+case to handle — it's the model proving it was right.
+
+- **Two independent grants, one owner.** Grant A → NT-204 {sleep, RHR, HRV, activity}; Grant B → ST-110
+  {HRV, sleep, temperature}. Independent scopes/windows/recipients; revoking A never touches B. N studies = N rows.
+- **Overlapping metrics don't collide — data isn't "spent".** The device **captures HRV once** (from the
+  wearable) and **fans it out per grant** to both pipes, because the owner authorized both. No contention,
+  no double-sampling.
+- **Partners stay siloed.** NorthTrial sees only NT-204; SouthTrial sees only ST-110. **Neither knows the
+  user is in the other.** The two grants assemble in exactly one place: the **owner's consent dashboard.**
+  Cross-study linkage exists only at the owner — never on your server, never between partners.
+- **Billing is per-grant.** One user, two studies = two participant-month line items, one per sponsor.
+  Revenue scales with *grants*, not users.
+
+**Why this is the whole point** — the test the other architectures fail:
+- *One-app-per-partner:* two studies = two apps = HRV captured twice, fragmented, batteries doubled.
+- *Central data lake (surveillance model):* you hold all data and "share" it = you're the broker between
+  two sponsors and a user = the data-sale risk you refuse.
+- *Owner-as-hub (this model):* capture once on device, fan out per independent consent, you broker nothing.
+  Concurrency is trivial **and** ethical. The thing that made it private is the thing that made it scale.
+
+## Boundaries & rules
+
+- **Clinical-protocol / co-enrollment conflicts are the *trials'* job, not Bios's.** Some trials forbid
+  co-enrollment via their own eligibility rules. Bios is the neutral instrument — it measures and shares
+  what the owner consents to; it does not police trial protocols.
+- **Optional owner-facing co-enrollment notice** (not a block): *"You're already sharing with another study;
+  some trials restrict this — check with your investigators."* Factual, owner-facing, no judgment — consistent
+  with "instrument, not coach." Owner decides.
+- **Server design rule (bake in early):** the partner console learns the *minimum per grant* (e.g. "U active
+  in NT-204" for billing) and **never correlates grants across partners.** This is the line that keeps you an
+  instrument vendor and not, accidentally, a data broker.
+
+## Why Bios-generic is likely the *first* B2B door
+
+Bios-direct has a **lower validation bar than the specialists.** For background physiology it mostly
+**aggregates already-validated wearable data** (Oura HRV, Garmin sleep, Health Connect activity) — leaning
+on the device-makers' validation rather than inventing a biomarker. Fil's novel gait algorithm needs its own
+clinical validation before a trial trusts it; Bios orchestrating Garmin HRV does not. So the sequencing is
+likely: **Bios-generic remote-physiology monitoring first** (lower validation, no specialty, it's the substrate
+you're building anyway) → specialist digital-biomarker plays (Fil, W2F) after a clinical champion + validation exist.
+
+## Why this fits a non-medical solo founder
+
+You are the **instrument/tech vendor**, not the data-interpreter. You provide the validated measurement +
+privacy rail + integration (your skill). The partner brings the clinical interpretation, the patient
+relationship, and the regulatory wrapper (their skill). Picks and shovels: you make the shovel; you don't
+mine the gold or own the claim. *(Regulatory note: confirm the instrument-vs-medical-device line with a
+regulatory consult before any clinical-care sale — not now, but before money changes hands.)*

--- a/docs/MONETIZATION_PLAN.md
+++ b/docs/MONETIZATION_PLAN.md
@@ -1,224 +1,218 @@
-# Bios Monetization Plan
+# Bios Ecosystem Monetization Plan
 
-## Guiding Constraints
+> Rewritten 2026-06-08. Supersedes the prior consumer-tiered "reciprocity" plan
+> (see [§ What changed](#what-changed-and-why-2026-06-08)). This is an **ecosystem-wide**
+> plan — Bios the backbone plus its companions — not a single-app pricing sheet.
 
-Any monetization model must respect the core principles from the Bios Manifesto:
+## The two problems this plan solves
 
-- **Full health intelligence for everyone** -- no feature gates, no detection limits, no "upgrade to unlock." Every user gets the same product.
-- **Reciprocity** -- free users contribute anonymized, aggregated data back to the commons. This is the deal, stated plainly.
-- **Privacy as a choice** -- users who prefer not to contribute can pay instead. Both tiers receive identical functionality.
-- **Science-grounded** -- premium add-ons must deliver real value, not artificial scarcity.
+Bios has two structurally linked problems, and naming them precisely is half the answer:
 
----
+1. **Data learning** — how do we improve detection algorithms when raw data never leaves the device?
+2. **Revenue** — how do we fund the ecosystem when the manifesto forbids the cloud, data sale, ads, and engagement loops?
 
-## The Model: Reciprocity-Based Access
+**They are the same wall.** Both are blocked by one rule: *data can't leave the device.* You can't
+aggregate it to train, and you can't aggregate it to sell.
 
-### How It Works
-
-Bios is not freemium. There is no degraded free tier. Every user gets full health intelligence. The question is how you give back:
-
-| | Community (free) | Private ($9/mo or $79/yr) |
-|---|---|---|
-| **Health features** | All of them | All of them |
-| **Device sync** | Unlimited | Unlimited |
-| **Condition detection** | Full matrix | Full matrix |
-| **Trend history** | Unlimited | Unlimited |
-| **Personalized baselines** | Yes | Yes |
-| **Doctor-ready reports** | Yes | Yes |
-| **Alert customization** | Yes | Yes |
-| **Data contribution** | Anonymized, aggregated patterns shared to improve detection for all users | Nothing. Zero data leaves your device. |
-
-**That's it.** Same app, same intelligence, same chance to catch something early. The difference is whether your anonymized experience helps improve the system for everyone else.
-
-### What "Data Contribution" Actually Means
-
-Community tier users contribute:
-
-- **Anonymized aggregate patterns** -- statistical distributions (e.g., "users in age range X with baseline HRV of Y showed pattern Z"), never individual readings
-- **Detection feedback** -- when a user confirms or dismisses an alert, that signal improves the model for everyone
-- **Condition pattern training** -- anonymized data helps refine detection algorithms across demographics and device types
-
-Community tier users never contribute:
-
-- Raw sensor readings
-- Anything tied to an identity, device ID, or account
-- Location, behavioral, or demographic data beyond what the user explicitly provides
-- Data to advertisers. Ever.
-
-All aggregation happens **on-device** before anything is transmitted. The server receives pre-aggregated, differentially private statistical summaries -- not data that is anonymized after collection, but data that is anonymous by construction.
-
-### Why Not Just Make It All Free?
-
-Bios costs money to build and run. The Private tier funds development. Community data contributions fund improvement of the detection engine. Both are necessary. Neither is charity -- both are fair exchange.
+**And that wall is the moat, not just the cost.** The architecture that makes surveillance-monetization
+impossible is the same architecture that makes *consented, owner-driven sharing* uniquely valuable and
+ethical. The answer to both problems is one piece of infrastructure: **the consent rail** — the owner
+owns their data and explicitly chooses to share a scoped slice of it, with a named recipient, for a
+named purpose (their clinician, a trial they enrolled in, research-to-improve, or no one). That single
+rail is the learning model, the revenue model, and the dignity position at once.
 
 ---
 
-## Revenue Streams
+## Guiding constraints (from the manifesto + ECOSYSTEM_BOUNDARIES)
 
-### Stream 1 -- Consumer (Community + Private)
+Any model must hold these — they are not negotiable, they are the product:
 
-#### Community Tier (free)
-- Full Bios experience
-- Anonymized data contribution to the commons
-- Target: the vast majority of users
-
-#### Private Tier -- $9/month or $79/year
-- Full Bios experience
-- Zero data contribution -- complete zero-knowledge privacy
-- For users who want the product without any data leaving their device
-
-#### Family Plan -- $16/month or $139/year
-- Private tier for up to 5 members
-- Caregiver dashboard (monitor children, aging parents)
-- Shared alerts -- notify a family member or caregiver when anomalies are detected
-- Per-member baselines and independent trend tracking
-
-Note: Family members can individually choose Community or Private. The Family Plan provides Private as the default, but any member can switch to Community if they prefer.
-
-#### Condition Packs (Add-ons) -- $4/month each
-Available to all users (Community and Private):
-
-- **Cardiac Health Pack** -- deep ECG analysis, HRV trends, cardiovascular risk scoring, exercise recovery insights
-- **Metabolic Health Pack** -- CGM integration, glucose pattern analysis, metabolic syndrome indicators
-- **Women's Health Pack** -- cycle tracking, perimenopause pattern detection, fertility window insights
-- **Mental Wellness Pack** -- stress trend analysis, burnout scoring, sleep-mood correlation, voice biomarker tracking
-- **Bundle all packs** -- $12/month (save vs. individual)
-
-These packs represent genuinely deeper analysis requiring specialized models -- not features stripped out of the free tier to force upgrades.
-
-### Stream 2 -- Research Partnerships
-
-The anonymized, aggregated data contributed by Community users creates a uniquely valuable research asset:
-
-- Partner with universities and medical research institutions
-- Population-level health pattern studies (e.g., sleep trend shifts during flu season, regional HRV patterns)
-- All partnerships reviewed by an independent ethics board
-- Research findings published openly where possible
-- Revenue from research partnerships funds further development
-
-This is not selling data. This is enabling science with consented, anonymized, aggregated patterns that no individual can be identified from.
-
-### Stream 3 -- B2B / Enterprise
-
-#### Employer Wellness Programs
-- Per-seat licensing ($3-6/employee/month)
-- Aggregated, anonymized workforce health dashboards for HR and benefits teams
-- Integration with existing corporate wellness platforms
-- ROI metrics: reduced sick days, earlier intervention, lower insurance claims
-- Target: companies with 500+ employees, self-insured employers
-- Employees choose their own tier (Community or Private) -- employer cannot mandate data contribution
-
-#### Insurance Partnerships
-- Insurers subsidize Bios Private tier for policyholders
-- In exchange: opt-in, anonymized, aggregate risk trend data (never individual-level)
-- Value proposition for insurers: earlier detection = lower claim costs
-- User must explicitly consent -- no silent data sharing
-
-#### Telehealth Platform Integration
-- License Bios detection engine to telehealth providers
-- Passive monitoring between appointments
-- API access for partner platforms to embed Bios insights into their care workflows
-- Revenue model: per-active-patient monthly fee or revenue share
-
-### Stream 4 -- Wearable Partnerships & Affiliates
-
-#### Device Referrals
-- In-app recommendations for compatible wearables based on the user's health goals
-- Affiliate commission on purchases (typically 3-8% from wearable manufacturers)
-- "Works best with Bios" curated device lists
-
-#### OEM Partnerships
-- Co-marketing with wearable manufacturers ("Works with Bios" certification)
-- Pre-installed app agreements with Android OEMs and wearable makers
-- Joint launch campaigns around new device releases
-
-#### Data Integration Partnerships
-- Partner with CGM companies (Dexcom Stelo, Abbott Lingo) for seamless onboarding
-- Cross-promotion: their hardware + our intelligence layer
-
-### Stream 5 -- Platform / API Licensing (Phase 3)
-
-Once the detection engine is mature and validated:
-
-- **Bios Detection API** -- license the anomaly detection and cross-sensor correlation engine to:
-  - Other health apps lacking multi-sensor intelligence
-  - EHR (Electronic Health Record) systems wanting passive monitoring
-  - Research institutions running population health studies
-- Pricing: per-API-call or monthly active user fee
-- This becomes a long-term moat -- Bios as the intelligence layer for health data
+- **On-device by default. Nothing leaves the device unless the owner explicitly sends it.**
+- **No data sale. No ads. No third-party tracking SDKs.**
+- **Instrument, not coach.** No push-side evaluation, no engagement loops, no streaks/goals/nudges.
+  ([MANIFESTO.md](MANIFESTO.md) P7; [ECOSYSTEM_BOUNDARIES.md](ECOSYSTEM_BOUNDARIES.md) pull-side design rule.)
+- **Full intelligence for everyone.** No feature gates on detection; a paywall never hides a health signal.
+- **Bios does not ask for data.** It works with whatever the owner gives.
+- **Free protection tiers stay free** (Virgil's safety net is never paywalled).
 
 ---
 
-## Rollout Phases
+## What changed and why (2026-06-08)
 
-### Phase 1 -- Foundation (Months 1-6)
-**Goal:** Validate the reciprocity model, build user base
+The prior plan was a conventional health-app plan that no longer fits. Three things were retired:
 
-- Launch Community tier with full features (phone + wearable sensors)
-- Launch Private tier alongside from day one
-- Implement clear, honest onboarding explaining the Community/Private choice
-- Target: 10,000 Community users, 500-1,000 Private users
-- **Estimated MRR at end of Phase 1:** $4,500 - $9,000
-
-### Phase 2 -- Expand & Monetize (Months 7-12)
-**Goal:** Broaden device support, introduce B2B, launch research partnerships
-
-- Add Phase 2 device integrations (Oura, WHOOP, Garmin, Withings)
-- Launch Family Plan
-- Launch first Condition Packs (Cardiac + Mental Wellness)
-- First research partnership pilot with 1-2 institutions
-- Begin pilot conversations with 2-3 employer wellness prospects
-- Introduce wearable affiliate partnerships
-- Target: 50,000 Community users, 5-7% Private conversion
-- **Estimated MRR at end of Phase 2:** $25,000 - $35,000
-
-### Phase 3 -- Scale (Months 13-24)
-**Goal:** B2B revenue, platform play, research at scale
-
-- Launch remaining Condition Packs (Metabolic, Women's Health)
-- Add CGM integrations (Dexcom, Abbott)
-- Close first enterprise wellness contracts
-- Begin insurance partnership pilots
-- Alpha release of Bios Detection API for partner integrations
-- Scale research partnerships -- the Community data commons becomes a competitive moat
-- Target: 200,000+ Community users, 7-10% Private conversion, 2-3 enterprise contracts
-- **Estimated MRR at end of Phase 3:** $150,000 - $250,000+
-
----
-
-## Key Metrics to Track
-
-| Metric | Why It Matters |
+| Retired | Why |
 |---|---|
-| Community-to-Private conversion rate | Revenue health (but high Community is also good -- it feeds the data commons) |
-| Monthly churn rate (Private) | Retention = product-market fit |
-| Community data contribution rate | How much usable signal the commons generates |
-| Detection accuracy improvement over time | Proves the reciprocity model works -- Community data makes the product better |
-| Devices connected per user | More devices = better detection for everyone |
-| Alert accuracy rate | Trust drives retention and word-of-mouth |
-| Time-to-first-insight | Faster value = higher retention |
-| B2B pipeline / seats sold | Tracks enterprise revenue growth |
-| Research partnerships active | Validates the data commons as an asset |
-| NPS (Net Promoter Score) | Overall user satisfaction |
+| **The "reciprocity" model** (free users pay with anonymized aggregated data; private users pay €/mo to opt out) | Contradicts the hardened stance. Even on-device-aggregated, differentially-private contribution is a *default-on* outbound data flow — and "Bios does not ask for data" + "owner decides" can't support default-on. Replaced by **opt-in consent only**. Corollary: when privacy is *total and default*, there is nothing to sell people to "keep private" — so the "pay for privacy" consumer tier loses its rationale entirely. |
+| **Insurer / employer-wellness streams** | Aggregated workforce/risk dashboards for insurers and employers are the surveillance-adjacent model the manifesto exists to refuse, even "anonymized." Off-brand. Removed. |
+| **In-Bios "Condition Packs"** (Cardiac/Metabolic/Women's/Mental as paid add-ons inside Bios) | These *are* the specialist companions in the real architecture (mood → W2F, etc.). Feature-gating them inside Bios also violates "no feature gates." Folded into the per-app map below. |
+
+Preserved from the old plan: radical transparency, pricing discipline, the risk-table format, and the
+instinct that "privacy is a choice" — sharpened into the consent rail.
 
 ---
 
-## Pricing Rationale
+## Architecture context: backbone + specialists
 
-- **$9/month Private** sits below premium health apps (WHOOP $30/mo, Oura $6/mo) while offering broader cross-device intelligence. Positioned as a privacy choice, not a feature unlock.
-- **Family Plan at $16/month** is an aggressive discount vs. individual plans to encourage household adoption -- the caregiver use case (monitoring parents/kids) is a strong emotional driver.
-- **$4/month Condition Packs** are available to ALL users -- these represent genuinely specialized analysis, not feature gates. A Community user can buy a Cardiac Pack. A Private user can too.
-- **Community tier is genuinely free** -- no trial period, no feature degradation, no "upgrade to unlock" prompts. The deal is clear from day one.
+Monetization follows the boundary in [ECOSYSTEM_BOUNDARIES.md](ECOSYSTEM_BOUNDARIES.md):
+
+- **Bios** is the domain-neutral backbone — ingestion (9 adapters), encrypted storage, personal
+  baselines, the 12 generic condition patterns, the ContentProvider. It is **not** a vertical and
+  **not** a consumer cash cow. It is free, full, private-by-default infrastructure.
+- **Companions** are the apps people install for a domain. Some are clinical-grade instruments
+  (Fil, W2F); some are consumer/lifestyle (SoulRadio, Idun, Smokeless); some are safety (Virgil).
+  They monetize differently — see the per-app map.
+
+The revenue does not come from the backbone. It comes from (a) the **clinical specialists** sold to
+institutions and (b) **grants** funding the backbone as public-health infrastructure, with consumer
+apps as a validating, funnel-building base.
 
 ---
 
-## Risks & Mitigations
+## Problem 1 — Data learning, without raw data leaving the device
+
+Three layers, in priority order. None requires betraying on-device privacy.
+
+1. **Public research datasets for the global cold-start.** Validated open corpora exist for exactly the
+   hard problems — gait (PhysioNet, GaitRec), fall detection (SisFall, UMAFall), PPG/HR, accelerometry.
+   Calibrate the *shipped baseline* on these. This is the answer to the recurring calibration gap
+   (e.g. Virgil's fall thresholds): you do not need *your users'* events if the physiology is covered
+   by public data. **Highest-leverage, lowest-friction, do this first.**
+2. **On-device n=1 personalization.** Already the pattern — Bios personal baselines/z-scores, Fil's
+   drift engine, Virgil's `ActivityBaseline` EWMA. The model adapts to the individual, on their device,
+   sharing nothing. Real learning; just not global.
+3. **The consent rail — opt-in, owner-driven contribution** for population-level gains. Explicit,
+   per-purpose, revocable. Two forms:
+   - **Donate-to-improve:** owner chooses to send a scoped, de-identified slice to improve the shared
+     model (Virgil's `FalseAlarmSnapshot` opt-in is already this shape).
+   - **Federated updates** (optional, manifesto call): model weight-deltas sync, raw data never does.
+     Stretches the no-cloud reading — *flagged as an explicit decision for the owner of the project,
+     not assumed.*
+
+**Hard line:** no default-on contribution of any kind. Population learning is opt-in or it doesn't happen.
+We trade the silent, total data advantage of surveillance competitors for the dignity position — and
+substitute public datasets + n=1 + consented donation for it.
+
+---
+
+## Problem 2 — Revenue: monetize institutions and missions, not the sovereign user
+
+Per-app consumer pricing is **pocket money and fights the values** (one-time €3 → ~€2 net → needs
+~900 sales/mo, decaying). So the engine is elsewhere.
+
+### Stream A — Clinical B2B (the primary engine)
+
+The clinical specialists are the real revenue.
+
+- **Fil** (MS / neurology) and **W2F** (mood / bipolar) are clinical-grade instruments: gait/drift/fall,
+  typing-cadence/ADA-1/HDA-1, active micro-tests.
+- The buyer is **not the patient** paying €3 — it's **neurology & psychiatry clinics, academic
+  researchers, and pharma running decentralized clinical trials (DCTs)**, who pay substantially for
+  *compliant, privacy-preserving remote measurement* that runs on the patient's own phone.
+- The patient app stays **free**; the patient **consents** to share their data stream with *their*
+  clinician or *their* enrolled trial — pull-side, owner-decides. The consent rail is the delivery mechanism.
+- **Pricing shapes:** per-active-patient/month, per-trial site license, or per-study data-collection
+  contract.
+- **Prerequisite & moat:** clinical validation against gold standards. This is the gating investment
+  (cost + 6–18mo timeline) — and once done, it's a deep moat few indie health apps can cross.
+
+> Why this is manifesto-clean: nobody's data is sold. The patient owns it and chooses to share it with
+> the institution already in their care. Bios/Fil/W2F are paid as the *instrument*, not as a data broker.
+
+### Stream B — Grants fund the backbone
+
+Bios-the-backbone can't (and shouldn't) monetize consumers. Fund it as **public-health infrastructure**:
+
+- SDG 3 (health) + privacy/digital-sovereignty grant programs (EU Horizon/EIC, privacy-tech, digital-
+  health-equity). The existing SDG-alignment map is the framing asset.
+- Non-dilutive, mission-aligned, and it funds the substrate that enables Stream A.
+
+### Stream C — Paid consumer apps (the base layer)
+
+Honest paid apps — pocket money individually, but real, and they validate + build a funnel:
+
+- One-time / honest pricing (the **SoulRadio €3.99** model — bought, not extracted).
+- Optional **ecosystem "supporter" license / bundle** — pay once to support the family of apps; unlocks
+  nothing gated (there are no health gates), purely voluntary patronage of the mission.
+
+### Stream D — explicitly NOT doing (the guardrail list)
+
+- ❌ Selling data, aggregated or otherwise.
+- ❌ Insurer risk-data or employer workforce-health dashboards.
+- ❌ Ads, affiliate-surveillance, "works best with" kickback funnels as a core model.
+- ❌ Default-on data contribution dressed as "community."
+- ❌ Feature-gating any health signal behind a paywall.
+
+---
+
+## Per-app monetization map
+
+Archetypes (col. 2) follow the portfolio-wide taxonomy in
+[KB monetization-doctrine.md](../../Miam/miam-knowledge-base/docs/monetization-doctrine.md): **1**=instrument/B2B,
+**2**=consumer, **3**=free commons. The values are universal; the mechanism follows each app's nature.
+
+| App | Archetype | Role | Model | Notes |
+|---|---|---|---|---|
+| **Bios** | **1 + 3** | Backbone / hub | **Free, full, private-by-default.** Funded by grants (Stream B) + as the substrate enabling Stream A. Optional voluntary supporter / one-time "Pro" for power-user *export* extras only (never gating health signal). | No "pay for privacy" tier — privacy is total, nothing to sell. |
+| **Fil** | **1** (free patient app) | Clinical specialist (neurology/MS) | **Clinical B2B (Stream A).** Patient app free; clinics/MS-research/DCTs license the instrument. | Gated on clinical validation. Primary engine. |
+| **W2F** | **1** (free patient app) | Clinical specialist (mood/bipolar) | **Clinical B2B (Stream A).** Patient app free; psychiatry/mood-research/DCTs license it. | Gated on clinical validation. Primary engine. |
+| **Virgil** | **3** (+ optional 2) | Safety (standalone) | **Protection tier free, always.** Optional low-cost *convenience* tier (family dashboard, check-in history). Possible secondary B2B: elder-care / assisted-living licensing. | Never paywall the safety net. |
+| **SoulRadio** | **2** | Ambient (standalone) | **One-time €3.99** (shipped decision). Subscription as library grows, later. | Base layer. Wellness-audio category. Pure consumer — no data bus, no B2B. |
+| **Idun** | **2** | Lifestyle (longevity meals) | **Paid consumer**, subscription the eventual engine (Open Roots brand). | Base layer + content brand. Needs commercial-clearance first. |
+| **Smokeless** | **2** (+ minor 1) | Substance ledger (standalone) | Free or low one-time **when ready** (not release-ready per 2026-06-08). Optional opt-in research contribution. | Base layer. |
+| **Anastasis / Carnet** | **2** | Lifestyle specialists | TBD — likely free or low one-time. | Base layer. |
+
+---
+
+## Honest economics & sequencing
+
+Tie to reality (see the income-pipeline frame):
+
+- **Consumer apps (base) = pocket money + validation, now.** They do **not** replace salary. Don't bank
+  near-term runway on them.
+- **Clinical B2B + grants = the real money, 6–18-month horizon.** This is where the ecosystem becomes a
+  business — and it requires the upfront investment in clinical validation + the consent rail + grant applications.
+- **Net:** "monetizing the ecosystem" is a multi-year build that funds the long-term endgame, not the
+  next quarter. Sequenced:
+
+| Window | Move |
+|---|---|
+| **Now** | Ship SoulRadio (€3.99, done) + Idun (after clearance) — base validation + funnel. Build the **consent rail** in Bios (serves learning *and* B2B). |
+| **Mid (6–12 mo)** | Clinical validation for Fil / W2F. First grant applications for Bios (SDG/privacy-tech). First clinic/research pilots. |
+| **Long (12–24 mo)** | Clinical B2B contracts + DCT data-collection deals. Research-grade consent rail at scale. Ecosystem supporter license. |
+
+---
+
+## The consent rail — build once, serves everything
+
+The single highest-leverage build in this whole plan. A Bios-side capability where the owner can:
+
+- select a **scoped slice** of their data (metrics, time window),
+- choose a **named recipient** (their clinician, a specific enrolled trial, "research-to-improve", export-to-self),
+- with **explicit, revocable, per-purpose consent**, logged and inspectable.
+
+This one rail is simultaneously: the **data-learning** mechanism (Problem 1, layer 3), the **clinical-B2B**
+delivery mechanism (Stream A), and the concrete expression of the **dignity** principle (owner decides).
+It is the place where the constraint becomes the moat. Prioritize it.
+
+**Operational detail — how partners plug into the rail without buying data or forking the app (worked
+examples incl. concurrent multi-study enrollment): [B2B_PARTNER_MODEL.md](B2B_PARTNER_MODEL.md).**
+
+---
+
+## Risks & guardrails
 
 | Risk | Mitigation |
 |---|---|
-| "You're selling health data" accusation | Be radically transparent: publish exactly what is aggregated, how differential privacy works, and what partners receive. Open-source the aggregation pipeline. Publish regular transparency reports. |
-| Most users choose Community, Private revenue is low | This is actually fine -- Community data improves the product and enables research revenue. Private is one revenue stream, not the only one. |
-| Regulatory risk (medical claims) | Maintain "inform, not diagnose" positioning. Work with legal counsel on health claim language. Pursue FDA clearance where applicable. |
-| Wearable APIs change or restrict access | Diversify integrations broadly. Prioritize Health Connect (Android) and HealthKit (iOS) as platform-level data sources rather than relying solely on individual device APIs. |
-| Users don't understand the Community model | Invest heavily in onboarding UX. Show exactly what is shared (statistical patterns) vs. what is not (raw data, identity). Make it tangible, not abstract. |
-| Ethics board becomes rubber stamp | Independent board with published members, public meeting notes, and veto power over partnerships. |
+| Drift back toward surveillance-monetization (the gravitational pull of "just aggregate a little") | This doc's Stream D no-list is a standing guardrail. Any proposed stream gets tested against "does data leave the owner's control without per-purpose consent?" If yes, it's out. |
+| "You're selling health data" accusation | We don't. Publish the consent rail's exact mechanics; open-source it. The patient is the sharer, the institution the recipient, always per-consent. |
+| Clinical B2B never closes (validation cost sinks it) | Validation is staged and partly grant-fundable (Stream B can fund the work that unlocks Stream A). Public datasets de-risk the algorithmic side. |
+| Consumer apps mistaken for the business | Stated plainly above: base layer, pocket money, not salary. The business is B2B + grants. |
+| Regulatory (medical claims) | "Instrument, not coach / inform not diagnose" positioning holds. Clinical-grade claims (Fil/W2F B2B) require the validation + appropriate regulatory path (e.g. CE/FDA SaMD) — budget for it as part of Stream A. |
+| Federated-learning / weight-sync stretches no-cloud vow | Flagged as an explicit owner decision, not assumed. Default plan ships without it (public datasets + n=1 + opt-in donation suffice for v1). |
+
+---
+
+*This plan turns the ecosystem's defining constraint — data sovereignty — from a monetization handicap
+into its moat. We don't monetize the user; we let the user choose to share, and we charge the institutions
+and missions that benefit from privacy-preserving, consented measurement.*


### PR DESCRIPTION
## What
Replaces the prior consumer-tiered *reciprocity* monetization plan with an **ecosystem-wide** model aligned to the manifesto, and adds the operational B2B detail behind it.

### `MONETIZATION_PLAN.md` (rewritten)
- **Retires:** the reciprocity model (default-on anonymized contribution), insurer/employer-wellness streams, and in-Bios feature-gated *Condition Packs* — all flagged as off-manifesto.
- **Reframes** the data-learning and revenue problems as one wall (data can't leave the device) and answers both with the **consent rail**: opt-in, per-purpose, revocable owner-driven sharing.
- **Revenue** moves to clinical B2B (privacy-preserving remote measurement licensed to trials/clinics) + grants funding the free backbone; population learning is **opt-in only**.

### `B2B_PARTNER_MODEL.md` (new)
- Instrument-not-broker principle: partners license the measurement instrument + consent/compliance rail; user data is never sold and never centrally held.
- Consent rail **is** the multi-tenancy — a partner is "a named recipient + config + API key," never a fork. Worked examples incl. one user in two concurrent studies (capture once, fan out per consent).

## Notes
- Docs only. Branches from `main`.
- Owner-subject personal lab data is **intentionally excluded** from version control and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)