### PR TITLE
chore: gitignore owner raw lab-result dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ db-backups/
 
 # Claude Code session artifacts
 .claude/worktrees/
+
+# Owner personal lab/medical records — health data stays on-device, never
+# pushed to the (public) remote. Generic owner-subject docs (PROFILE,
+# VESSEL_WATCH, LAB_PANEL_ORDER) remain tracked; raw result dumps do not.
+docs/subjects/owner/LAB_RESULTS_*.md


### PR DESCRIPTION
## Why
`thdelmas/Bios` is a **public** repo. Owner-subject lab-result dumps (e.g. the 2026-04-21 ER panel) contain a real CatSalut health-card number (CIP) and a named clinician's collegiate license number. Per the manifesto ("health data stays on-device"), those must never reach the remote.

## What
Adds `docs/subjects/owner/LAB_RESULTS_*.md` to `.gitignore` so raw medical-record dumps can't be staged accidentally. Generic owner-subject docs (`PROFILE.md`, `VESSEL_WATCH.md`, `LAB_PANEL_ORDER.md`) remain tracked.

The corresponding local lab-results file and related owner-doc edits are intentionally kept as working-tree-only changes and are **not** part of any PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)