### PR TITLE
refactor(settings): extract Data & sources into its own screen

### DIFF
--- a/android/app/detekt-baseline.xml
+++ b/android/app/detekt-baseline.xml
@@ -19,7 +19,6 @@
     <ID>CyclomaticComplexMethod:PdfReportExporter.kt$private fun renderPage( canvas: Canvas, focalMetric: MetricType, focalReadings: List&lt;MetricReading&gt;, focalBaseline: PersonalBaseline?, biomarkerLatest: List&lt;Pair&lt;MetricType, MetricReading&gt;&gt;, bands: Map&lt;MetricType, BiomarkerBands&gt;, startMillis: Long, endMillis: Long, ownerNote: String?, versionName: String, generatedAtMillis: Long, )</ID>
     <ID>CyclomaticComplexMethod:PpgSignalProcessor.kt$PpgSignalProcessor$internal fun computeWaveformFeatures( smoothed: DoubleArray, peakIndices: List&lt;Int&gt;, samplingRateHz: Double, peakAmpCov: Double ): PulseWaveformFeatures?</ID>
     <ID>CyclomaticComplexMethod:PrivacyDashboardScreen.kt$@Composable fun PrivacyDashboardScreen(viewModel: AppViewModel)</ID>
-    <ID>CyclomaticComplexMethod:SettingsScreen.kt$@Composable fun SettingsScreen( viewModel: AppViewModel, onNavigate: (route: String) -&gt; Unit = {}, )</ID>
     <ID>CyclomaticComplexMethod:Spectral.kt$Spectral$fun lfHfPowers(ibisMs: List&lt;Double&gt;): LfHfPowers</ID>
     <ID>CyclomaticComplexMethod:SyncManager.kt$SyncManager$suspend fun pull(serverUrl: String, accountId: String)</ID>
     <ID>CyclomaticComplexMethod:SyncSerializationTest.kt$SyncSerializationTest$@Test fun `Anomaly with nullable fields round-trips through JSON`()</ID>
@@ -809,7 +808,6 @@
     <ID>MaxLineLength:SettingsHelperText.kt$SettingsHelperText$const val WITHINGS = "Paste a Withings API access token. Obtain one through a Withings developer-account OAuth exchange against developer.withings.com — Bios does not perform the OAuth dance itself yet."</ID>
     <ID>MaxLineLength:SettingsScreen.kt$PrivacyTier.COMMUNITY -&gt; "Send anonymous aggregates. Off by default. Aggregation happens on-device before transmission — raw data never leaves."</ID>
     <ID>MaxLineLength:SettingsScreen.kt$text = { Text("This will permanently delete all your health data, baselines, and alerts from Bios. This action cannot be undone.") }</ID>
-    <ID>MaxLineLength:SettingsScreen.kt$viewModel.apiTokenStore.saveToken(WithingsApiAdapter.PROVIDER_KEY, token); isWithingsConnected = true; showWithingsDialog = false</ID>
     <ID>MaxLineLength:SleepApneaPattern.kt$SleepApneaPattern$"AASM scoring manual (Berry et al. 2020) — AHI ≥5 events/h is the mild-OSA threshold; severity tiers 5–15 mild, 15–30 moderate, ≥30 severe"</ID>
     <ID>MaxLineLength:SleepApneaPattern.kt$SleepApneaPattern$"Berry et al. 2020 — sustained nocturnal SpO2 desaturation is the canonical wearable signature of sleep-disordered breathing"</ID>
     <ID>MaxLineLength:SleepApneaPattern.kt$SleepApneaPattern$"Bonzini et al. 2020 — apnea-driven micro-arousals raise the post-onset awakening count even when total sleep time appears normal"</ID>

--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -305,6 +305,13 @@ fun BiosApp(viewModel: AppViewModel) {
                     onLongPressVersion = { navController.navigate("metric_readings_debug") },
                 )
             }
+            composable("data_sources") {
+                com.bios.app.ui.settings.DataSourcesScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
+                    onNavigate = { route -> navController.navigate(route) },
+                )
+            }
             composable("metric_sources") {
                 com.bios.app.ui.settings.MetricSourcesScreen(
                     viewModel = viewModel,

--- a/android/app/src/main/java/com/bios/app/ui/settings/DataSourcesScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/DataSourcesScreen.kt
@@ -1,0 +1,301 @@
+package com.bios.app.ui.settings
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
+import com.bios.app.engine.BaselineEngine
+import com.bios.app.export.DataExporter
+import com.bios.app.export.FhirExporter
+import com.bios.app.ingest.GarminApiAdapter
+import com.bios.app.ingest.PolarApiAdapter
+import com.bios.app.ingest.WhoopApiAdapter
+import com.bios.app.ingest.WithingsApiAdapter
+import com.bios.app.ui.AppViewModel
+import kotlinx.coroutines.launch
+import java.io.File
+
+/**
+ * Data & sources — where the owner's data comes from (wearable/API
+ * connections, Health Connect) and where it can go (export). Extracted
+ * from [SettingsScreen] so the "Self" tab stays a short hub focused on
+ * identity and privacy; this screen carries the connection/dialog/export
+ * state that made the Self tab a 500-line scroll.
+ *
+ * [onNavigate] forwards the few sub-routes this screen links to
+ * (data_coverage, metric_sources, ble_pair).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DataSourcesScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit = {},
+    onNavigate: (route: String) -> Unit = {},
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Data & sources") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            DataSourcesCard(viewModel = viewModel, onNavigate = onNavigate)
+            YourDataCard(viewModel = viewModel)
+        }
+    }
+}
+
+/**
+ * A token-backed wearable/API connection: the connect/disconnect row plus
+ * its paste-token dialog. Storage differs per provider (Oura has its own
+ * store; the rest share apiTokenStore keyed by PROVIDER_KEY), so the
+ * save/clear/initial-state are passed in as plain lambdas.
+ */
+private class TokenSource(
+    val rowName: String,
+    val dialogName: String,
+    val helperText: String,
+    val initialConnected: Boolean,
+    val onSave: (String) -> Unit,
+    val onClear: () -> Unit,
+)
+
+@Composable
+private fun DataSourcesCard(
+    viewModel: AppViewModel,
+    onNavigate: (route: String) -> Unit,
+) {
+    val hasPermissions by viewModel.hasPermissions.collectAsState()
+    val tokenSources = listOf(
+        TokenSource(
+            "Oura Ring", "Oura", SettingsHelperText.OURA,
+            viewModel.ouraTokenStore.hasToken(),
+            { viewModel.ouraTokenStore.saveToken(it) },
+            { viewModel.ouraTokenStore.clearToken() },
+        ),
+        apiTokenSource(viewModel, "Withings", SettingsHelperText.WITHINGS, WithingsApiAdapter.PROVIDER_KEY),
+        apiTokenSource(viewModel, "WHOOP", SettingsHelperText.WHOOP, WhoopApiAdapter.PROVIDER_KEY),
+        apiTokenSource(viewModel, "Garmin", SettingsHelperText.GARMIN, GarminApiAdapter.PROVIDER_KEY),
+        apiTokenSource(viewModel, "Polar", SettingsHelperText.POLAR, PolarApiAdapter.PROVIDER_KEY),
+    )
+
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Data Sources", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Health Connect")
+                Text(
+                    if (hasPermissions) "Connected" else "Not Connected",
+                    color = if (hasPermissions) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.error
+                )
+            }
+            tokenSources.forEach { source ->
+                Spacer(Modifier.height(4.dp))
+                ApiTokenSourceRow(source)
+            }
+
+            Spacer(Modifier.height(4.dp))
+            ConnectableSourceRow(
+                name = "Air-quality sensor (BLE)",
+                isConnected = viewModel.bleAirQualityAdapter.isPaired,
+                // Both routes go to the pair screen — unpair lives there.
+                onConnect = { onNavigate("ble_pair") },
+                onDisconnect = { onNavigate("ble_pair") },
+            )
+
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(onClick = { onNavigate("data_coverage") }, modifier = Modifier.fillMaxWidth()) {
+                Text("Data coverage")
+            }
+            Spacer(Modifier.height(4.dp))
+            OutlinedButton(onClick = { onNavigate("metric_sources") }, modifier = Modifier.fillMaxWidth()) {
+                Text("Per-metric sources")
+            }
+        }
+    }
+}
+
+private fun apiTokenSource(
+    viewModel: AppViewModel,
+    name: String,
+    helperText: String,
+    providerKey: String,
+) = TokenSource(
+    rowName = name,
+    dialogName = name,
+    helperText = helperText,
+    initialConnected = viewModel.apiTokenStore.hasToken(providerKey),
+    onSave = { viewModel.apiTokenStore.saveToken(providerKey, it) },
+    onClear = { viewModel.apiTokenStore.clearToken(providerKey) },
+)
+
+@Composable
+private fun ApiTokenSourceRow(source: TokenSource) {
+    var connected by remember { mutableStateOf(source.initialConnected) }
+    var showDialog by remember { mutableStateOf(false) }
+    ConnectableSourceRow(
+        name = source.rowName,
+        isConnected = connected,
+        onConnect = { showDialog = true },
+        onDisconnect = { source.onClear(); connected = false },
+    )
+    if (showDialog) {
+        PasteTokenDialog(
+            providerName = source.dialogName,
+            helperText = source.helperText,
+            onConnect = { token -> source.onSave(token); connected = true; showDialog = false },
+            onDismiss = { showDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun YourDataCard(viewModel: AppViewModel) {
+    val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
+    var totalReadings by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        totalReadings = viewModel.db.metricReadingDao().countAll()
+    }
+
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Your Data", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(8.dp))
+
+            SettingsRow("Data Age", "$dataAge days")
+            SettingsRow("Total Readings", "$totalReadings")
+            SettingsRow(
+                "Baseline Status",
+                if (dataAge >= BaselineEngine.MINIMUM_DATA_DAYS) "Active"
+                else "${BaselineEngine.MINIMUM_DATA_DAYS - dataAge} days remaining"
+            )
+
+            Spacer(Modifier.height(8.dp))
+            ExportButton(
+                label = "Export as JSON",
+                enabled = totalReadings > 0,
+                mimeType = "application/json",
+                chooserTitle = "Export Bios Data",
+            ) { DataExporter(it, viewModel.db).exportToFile() }
+            Spacer(Modifier.height(4.dp))
+            ExportButton(
+                label = "Export as CSV",
+                enabled = totalReadings > 0,
+                mimeType = "application/zip",
+                chooserTitle = "Export Bios Data (CSV)",
+            ) { DataExporter(it, viewModel.db).exportToCsvZip() }
+            Spacer(Modifier.height(4.dp))
+            ExportButton(
+                label = "Export as FHIR Bundle (for doctors)",
+                enabled = totalReadings > 0,
+                mimeType = "application/fhir+json",
+                chooserTitle = "Share FHIR Bundle with your doctor",
+            ) { FhirExporter(it, viewModel.db).exportToFhirBundle() }
+            Spacer(Modifier.height(4.dp))
+            PdfSummaryButton(viewModel = viewModel, enabled = totalReadings > 0)
+        }
+    }
+}
+
+/**
+ * Shared export-and-share button: runs [produceFile] off the main thread,
+ * wraps the result in a FileProvider URI, and fires a share chooser.
+ * Manages its own in-flight state so each export is independent.
+ */
+@Composable
+private fun ExportButton(
+    label: String,
+    enabled: Boolean,
+    mimeType: String,
+    chooserTitle: String,
+    produceFile: suspend (android.content.Context) -> File,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var isExporting by remember { mutableStateOf(false) }
+    OutlinedButton(
+        onClick = {
+            isExporting = true
+            scope.launch {
+                try {
+                    val file = produceFile(context)
+                    val uri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file
+                    )
+                    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                        type = mimeType
+                        putExtra(Intent.EXTRA_STREAM, uri)
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+                    context.startActivity(Intent.createChooser(shareIntent, chooserTitle))
+                } finally {
+                    isExporting = false
+                }
+            }
+        },
+        enabled = enabled && !isExporting,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        if (isExporting) {
+            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(if (isExporting) "Exporting..." else label)
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.bios.app.ui.settings
 
 import android.content.Context
-import android.content.Intent
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -13,21 +12,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.content.FileProvider
-import com.bios.app.engine.BaselineEngine
-import com.bios.app.export.DataExporter
-import com.bios.app.export.FhirExporter
-import com.bios.app.ingest.GarminApiAdapter
-import com.bios.app.ingest.PolarApiAdapter
-import com.bios.app.ingest.WhoopApiAdapter
-import com.bios.app.ingest.WithingsApiAdapter
 import com.bios.app.model.CompanionGrant
 import com.bios.app.model.PrivacyTier
-import com.bios.app.alerts.DailyDigestWorker
 import com.bios.app.privacy.ContributionWorker
-import com.bios.app.push.PushRegistrationManager
 import com.bios.app.ui.AppViewModel
-import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(
@@ -35,22 +23,7 @@ fun SettingsScreen(
     onNavigate: (route: String) -> Unit = {},
 ) {
     val context = LocalContext.current
-    val dataAge by viewModel.ingestManager.dataAgeDays.collectAsState()
-    val hasPermissions by viewModel.hasPermissions.collectAsState()
-    val scope = rememberCoroutineScope()
-    var totalReadings by remember { mutableIntStateOf(0) }
     var showDeleteDialog by remember { mutableStateOf(false) }
-    var isExporting by remember { mutableStateOf(false) }
-    var showOuraDialog by remember { mutableStateOf(false) }
-    var isOuraConnected by remember { mutableStateOf(viewModel.ouraTokenStore.hasToken()) }
-    var showWithingsDialog by remember { mutableStateOf(false) }
-    var isWithingsConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(WithingsApiAdapter.PROVIDER_KEY)) }
-    var showWhoopDialog by remember { mutableStateOf(false) }
-    var isWhoopConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(WhoopApiAdapter.PROVIDER_KEY)) }
-    var showGarminDialog by remember { mutableStateOf(false) }
-    var isGarminConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(GarminApiAdapter.PROVIDER_KEY)) }
-    var showPolarDialog by remember { mutableStateOf(false) }
-    var isPolarConnected by remember { mutableStateOf(viewModel.apiTokenStore.hasToken(PolarApiAdapter.PROVIDER_KEY)) }
     val companionGrants by viewModel.db.companionGrantDao()
         .observeAll()
         .collectAsState(initial = emptyList())
@@ -60,10 +33,6 @@ fun SettingsScreen(
         val prefs = context.getSharedPreferences("bios_settings", Context.MODE_PRIVATE)
         val tier = prefs.getString("privacy_tier", PrivacyTier.PRIVATE.name)
         mutableStateOf(PrivacyTier.valueOf(tier ?: PrivacyTier.PRIVATE.name))
-    }
-
-    LaunchedEffect(Unit) {
-        totalReadings = viewModel.db.metricReadingDao().countAll()
     }
 
     Column(
@@ -153,207 +122,13 @@ fun SettingsScreen(
             }
         }
 
-        // Data Sources
+        // Data & sources — wearable/API connections and export — live behind
+        // their own screen so the Self tab stays a short, scannable hub.
         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
             Column(modifier = Modifier.padding(16.dp)) {
-                Text("Data Sources", style = MaterialTheme.typography.titleSmall)
+                Text("Data", style = MaterialTheme.typography.titleSmall)
                 Spacer(Modifier.height(8.dp))
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Text("Health Connect")
-                    Text(
-                        if (hasPermissions) "Connected" else "Not Connected",
-                        color = if (hasPermissions) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.error
-                    )
-                }
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "Oura Ring",
-                    isConnected = isOuraConnected,
-                    onConnect = { showOuraDialog = true },
-                    onDisconnect = {
-                        viewModel.ouraTokenStore.clearToken()
-                        isOuraConnected = false
-                    },
-                )
-
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "Withings",
-                    isConnected = isWithingsConnected,
-                    onConnect = { showWithingsDialog = true },
-                    onDisconnect = {
-                        viewModel.apiTokenStore.clearToken(
-                            WithingsApiAdapter.PROVIDER_KEY
-                        )
-                        isWithingsConnected = false
-                    },
-                )
-
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "WHOOP",
-                    isConnected = isWhoopConnected,
-                    onConnect = { showWhoopDialog = true },
-                    onDisconnect = {
-                        viewModel.apiTokenStore.clearToken(WhoopApiAdapter.PROVIDER_KEY)
-                        isWhoopConnected = false
-                    },
-                )
-
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "Garmin",
-                    isConnected = isGarminConnected,
-                    onConnect = { showGarminDialog = true },
-                    onDisconnect = {
-                        viewModel.apiTokenStore.clearToken(GarminApiAdapter.PROVIDER_KEY)
-                        isGarminConnected = false
-                    },
-                )
-
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "Polar",
-                    isConnected = isPolarConnected,
-                    onConnect = { showPolarDialog = true },
-                    onDisconnect = {
-                        viewModel.apiTokenStore.clearToken(PolarApiAdapter.PROVIDER_KEY)
-                        isPolarConnected = false
-                    },
-                )
-
-                Spacer(Modifier.height(4.dp))
-                ConnectableSourceRow(
-                    name = "Air-quality sensor (BLE)",
-                    isConnected = viewModel.bleAirQualityAdapter.isPaired,
-                    // Both routes go to the pair screen — unpair lives there.
-                    onConnect = { onNavigate("ble_pair") },
-                    onDisconnect = { onNavigate("ble_pair") },
-                )
-
-                Spacer(Modifier.height(8.dp))
-                SettingsActionButton("Data coverage") { onNavigate("data_coverage") }
-                Spacer(Modifier.height(4.dp))
-                SettingsActionButton("Per-metric sources") { onNavigate("metric_sources") }
-            }
-        }
-
-        // Your Data
-        Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text("Your Data", style = MaterialTheme.typography.titleSmall)
-                Spacer(Modifier.height(8.dp))
-
-                SettingsRow("Data Age", "$dataAge days")
-                SettingsRow("Total Readings", "$totalReadings")
-                SettingsRow("Baseline Status",
-                    if (dataAge >= BaselineEngine.MINIMUM_DATA_DAYS) "Active"
-                    else "${BaselineEngine.MINIMUM_DATA_DAYS - dataAge} days remaining"
-                )
-
-                Spacer(Modifier.height(8.dp))
-                OutlinedButton(
-                    onClick = {
-                        isExporting = true
-                        scope.launch {
-                            try {
-                                val exporter = DataExporter(context, viewModel.db)
-                                val file = exporter.exportToFile()
-                                val uri = FileProvider.getUriForFile(
-                                    context,
-                                    "${context.packageName}.fileprovider",
-                                    file
-                                )
-                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                                    type = "application/json"
-                                    putExtra(Intent.EXTRA_STREAM, uri)
-                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                }
-                                context.startActivity(
-                                    Intent.createChooser(shareIntent, "Export Bios Data")
-                                )
-                            } finally {
-                                isExporting = false
-                            }
-                        }
-                    },
-                    enabled = !isExporting && totalReadings > 0,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    if (isExporting) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp
-                        )
-                        Spacer(Modifier.width(8.dp))
-                    }
-                    Text(if (isExporting) "Exporting..." else "Export as JSON")
-                }
-                Spacer(Modifier.height(4.dp))
-                OutlinedButton(
-                    onClick = {
-                        isExporting = true
-                        scope.launch {
-                            try {
-                                val exporter = DataExporter(context, viewModel.db)
-                                val file = exporter.exportToCsvZip()
-                                val uri = FileProvider.getUriForFile(
-                                    context,
-                                    "${context.packageName}.fileprovider",
-                                    file
-                                )
-                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                                    type = "application/zip"
-                                    putExtra(Intent.EXTRA_STREAM, uri)
-                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                }
-                                context.startActivity(
-                                    Intent.createChooser(shareIntent, "Export Bios Data (CSV)")
-                                )
-                            } finally {
-                                isExporting = false
-                            }
-                        }
-                    },
-                    enabled = !isExporting && totalReadings > 0,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Export as CSV")
-                }
-                Spacer(Modifier.height(4.dp))
-                OutlinedButton(
-                    onClick = {
-                        isExporting = true
-                        scope.launch {
-                            try {
-                                val exporter = FhirExporter(context, viewModel.db)
-                                val file = exporter.exportToFhirBundle()
-                                val uri = FileProvider.getUriForFile(
-                                    context,
-                                    "${context.packageName}.fileprovider",
-                                    file
-                                )
-                                val shareIntent = Intent(Intent.ACTION_SEND).apply {
-                                    type = "application/fhir+json"
-                                    putExtra(Intent.EXTRA_STREAM, uri)
-                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                }
-                                context.startActivity(
-                                    Intent.createChooser(shareIntent, "Share FHIR Bundle with your doctor")
-                                )
-                            } finally {
-                                isExporting = false
-                            }
-                        }
-                    },
-                    enabled = !isExporting && totalReadings > 0,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Export as FHIR Bundle (for doctors)")
-                }
-                Spacer(Modifier.height(4.dp))
-                PdfSummaryButton(viewModel = viewModel, enabled = totalReadings > 0)
+                SettingsActionButton("Data & sources") { onNavigate("data_sources") }
             }
         }
 
@@ -378,7 +153,6 @@ fun SettingsScreen(
                 TextButton(
                     onClick = {
                         com.bios.app.platform.DataDestroyer.destroyAll(context)
-                        totalReadings = 0
                         showDeleteDialog = false
                     },
                     colors = ButtonDefaults.textButtonColors(
@@ -389,57 +163,6 @@ fun SettingsScreen(
             dismissButton = {
                 TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
             }
-        )
-    }
-
-    if (showOuraDialog) {
-        PasteTokenDialog(
-            providerName = "Oura",
-            helperText = SettingsHelperText.OURA,
-            onConnect = { token ->
-                viewModel.ouraTokenStore.saveToken(token); isOuraConnected = true; showOuraDialog = false
-            },
-            onDismiss = { showOuraDialog = false }
-        )
-    }
-    if (showWithingsDialog) {
-        PasteTokenDialog(
-            providerName = "Withings",
-            helperText = SettingsHelperText.WITHINGS,
-            onConnect = { token ->
-                viewModel.apiTokenStore.saveToken(WithingsApiAdapter.PROVIDER_KEY, token); isWithingsConnected = true; showWithingsDialog = false
-            },
-            onDismiss = { showWithingsDialog = false }
-        )
-    }
-    if (showWhoopDialog) {
-        PasteTokenDialog(
-            providerName = "WHOOP",
-            helperText = SettingsHelperText.WHOOP,
-            onConnect = { token ->
-                viewModel.apiTokenStore.saveToken(WhoopApiAdapter.PROVIDER_KEY, token); isWhoopConnected = true; showWhoopDialog = false
-            },
-            onDismiss = { showWhoopDialog = false }
-        )
-    }
-    if (showGarminDialog) {
-        PasteTokenDialog(
-            providerName = "Garmin",
-            helperText = SettingsHelperText.GARMIN,
-            onConnect = { token ->
-                viewModel.apiTokenStore.saveToken(GarminApiAdapter.PROVIDER_KEY, token); isGarminConnected = true; showGarminDialog = false
-            },
-            onDismiss = { showGarminDialog = false }
-        )
-    }
-    if (showPolarDialog) {
-        PasteTokenDialog(
-            providerName = "Polar",
-            helperText = SettingsHelperText.POLAR,
-            onConnect = { token ->
-                viewModel.apiTokenStore.saveToken(PolarApiAdapter.PROVIDER_KEY, token); isPolarConnected = true; showPolarDialog = false
-            },
-            onDismiss = { showPolarDialog = false }
         )
     }
 }


### PR DESCRIPTION
Extracts the Data & sources section of Settings into its own `DataSourcesScreen`.

Recreated from #395, which GitHub auto-closed when its base branch (`refactor/identity-card-grouping`, #394) was deleted on merge and could not be reopened. Same single commit (`aa599f0`), now targeting `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)