### PR TITLE
feat(screening): link checkups to health data + passive due badge

### DIFF
--- a/android/app/src/main/java/com/bios/app/screening/CheckupHealthDataLink.kt
+++ b/android/app/src/main/java/com/bios/app/screening/CheckupHealthDataLink.kt
@@ -1,0 +1,29 @@
+package com.bios.app.screening
+
+import com.bios.contracts.MetricType
+
+/**
+ * Maps a checkup / screening key to the metric readings that, when present,
+ * already count as that checkup having been performed — so the owner is
+ * never asked to re-log data Bios already holds.
+ *
+ * The canonical case: a blood-pressure reading (manual cuff entry, Withings,
+ * an imported ER vital) *is* a blood-pressure check. Without this link the
+ * Preventive Care screen would show "No record yet" for `blood_pressure_check`
+ * while a fresh systolic/diastolic reading sits in the metric store one
+ * screen over. The UI merges the most-recent derived date with any manual
+ * [com.bios.app.model.ScreeningEntry]; most-recent wins.
+ *
+ * Pure data, no Android dependency — the lookup + merge live in
+ * `PreventiveCareData` so the engine stays a pure function. Closes #400.
+ */
+object CheckupHealthDataLink {
+
+    /** screening key → metric keys whose latest reading satisfies it. */
+    val metricKeysByScreeningKey: Map<String, List<String>> = mapOf(
+        "blood_pressure_check" to listOf(
+            MetricType.BLOOD_PRESSURE_SYSTOLIC.key,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC.key,
+        ),
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareData.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareData.kt
@@ -1,0 +1,78 @@
+package com.bios.app.ui.screening
+
+import android.content.Context
+import com.bios.app.data.BiosDatabase
+import com.bios.app.data.RiskProfileRepo
+import com.bios.app.data.ScreeningEntryRepo
+import com.bios.app.model.ScreeningEntry
+import com.bios.app.screening.CheckupHealthDataLink
+import com.bios.app.screening.OwnerDemographicsStore
+import com.bios.app.screening.ScreeningCadenceEngine
+import com.bios.app.screening.ScreeningCatalog
+import com.bios.app.screening.ScreeningStatus
+import java.util.Calendar
+
+/**
+ * Shared pull-side data assembly for Preventive Care. Both the screen and
+ * the passive Settings badge read through here, so "what's due" is computed
+ * exactly one way.
+ *
+ * Nothing here pushes: every caller is owner-initiated (the screen the owner
+ * opened, or the Settings card the owner is already looking at). No
+ * notifications, no background work — the manifesto's pull-side rule holds.
+ */
+object PreventiveCareData {
+
+    /**
+     * Most-recent "performed" date per screening key, merging the owner's
+     * manual screening ledger with dates Bios can *derive* from existing
+     * health data (a blood-pressure reading satisfies `blood_pressure_check`,
+     * etc. — see [CheckupHealthDataLink]). Most-recent wins, so either a
+     * manual entry or a fresh reading keeps the checkup current and the
+     * owner never re-logs data Bios already holds. Closes #400.
+     */
+    suspend fun latestPerformedByKey(context: Context): Map<String, Long?> {
+        val db = BiosDatabase.getInstance(context)
+        val merged = ScreeningEntryRepo(db).fetchAll()
+            .groupBy { it.screeningKey }
+            .mapValues { (_, list) -> list.maxOfOrNull { it.performedDate } }
+            .toMutableMap()
+
+        val readingDao = db.metricReadingDao()
+        for ((screeningKey, metricKeys) in CheckupHealthDataLink.metricKeysByScreeningKey) {
+            val derived = metricKeys
+                .mapNotNull { key -> readingDao.fetchLatest(key, 1).firstOrNull()?.timestamp }
+                .maxOrNull() ?: continue
+            merged[screeningKey] = maxOf(merged[screeningKey] ?: 0L, derived)
+        }
+        return merged
+    }
+
+    /**
+     * Count of entries that read as [ScreeningStatus.DueNow] (recurring and
+     * overdue) for the active owner — the number behind the passive badge on
+     * the Settings "Preventive care" row (#401). Deliberately conservative:
+     *
+     *  - minimum-interval checkups never contribute (they're never "overdue"
+     *    — the no-shame rule), and
+     *  - `NoRecord` doesn't count (not-yet-started ≠ due), so a fresh install
+     *    shows no badge rather than a wall of nags.
+     *
+     * Returns 0 when birth year isn't set (no demographics → nothing to say).
+     */
+    suspend fun dueCount(context: Context, now: Long = System.currentTimeMillis()): Int {
+        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        val demographics = OwnerDemographicsStore(context).load(currentYear) ?: return 0
+        val latest = latestPerformedByKey(context)
+        val riskProfile = RiskProfileRepo(BiosDatabase.getInstance(context)).fetch()
+        return ScreeningCadenceEngine.evaluateAll(
+            catalog = ScreeningCatalog.combined,
+            demographics = demographics,
+            latestByKey = { key ->
+                latest[key]?.let { ScreeningEntry(screeningKey = key, performedDate = it) }
+            },
+            riskProfile = riskProfile,
+            now = now,
+        ).count { (_, status) -> status is ScreeningStatus.DueNow }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
@@ -86,10 +86,11 @@ fun PreventiveCareScreen(onBack: () -> Unit) {
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)
 
     suspend fun refresh() {
-        val all = repo.fetchAll()
-        // Group most-recent per key.
-        entries = all.groupBy { it.screeningKey }
-            .mapValues { (_, list) -> list.maxOfOrNull { it.performedDate } }
+        // Most-recent-per-key, merging the manual ledger with dates Bios can
+        // derive from existing health data (e.g. a BP reading satisfies the
+        // blood-pressure check). Shared with the Settings due badge so both
+        // compute "what's due" the same way (#400).
+        entries = PreventiveCareData.latestPerformedByKey(context)
         riskProfile = riskRepo.fetch()
     }
 

--- a/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/IdentityCard.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -17,6 +19,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,6 +44,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun IdentityCard(
     onNavigate: (route: String) -> Unit = {},
+    dueByRoute: Map<String, Int> = emptyMap(),
 ) {
     val sections = listOf(
         "Body & baseline" to listOf(
@@ -86,7 +90,12 @@ internal fun IdentityCard(
             Text("Identity", style = MaterialTheme.typography.titleSmall)
             sections.forEach { (title, entries) ->
                 Spacer(Modifier.height(8.dp))
-                IdentitySection(title = title, entries = entries, onNavigate = onNavigate)
+                IdentitySection(
+                    title = title,
+                    entries = entries,
+                    onNavigate = onNavigate,
+                    dueByRoute = dueByRoute,
+                )
             }
         }
     }
@@ -101,8 +110,12 @@ private fun IdentitySection(
     title: String,
     entries: List<Pair<String, String>>,
     onNavigate: (route: String) -> Unit,
+    dueByRoute: Map<String, Int> = emptyMap(),
 ) {
     var expanded by remember { mutableStateOf(false) }
+    // Sum the section's row counts so the collapsed header still signals
+    // that something inside is due — the owner sees it without expanding.
+    val sectionDue = entries.sumOf { dueByRoute[it.second] ?: 0 }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -112,17 +125,50 @@ private fun IdentitySection(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(title, style = MaterialTheme.typography.titleMedium)
-        Icon(
-            imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-            contentDescription = if (expanded) "Collapse $title" else "Expand $title",
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (!expanded && sectionDue > 0) {
+                DueBadge(sectionDue)
+                Spacer(Modifier.width(8.dp))
+            }
+            Icon(
+                imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                contentDescription = if (expanded) "Collapse $title" else "Expand $title",
+            )
+        }
     }
     AnimatedVisibility(visible = expanded) {
         Column {
             entries.forEachIndexed { idx, (label, route) ->
                 if (idx > 0) Spacer(Modifier.height(4.dp))
-                OutlinedButton(onClick = { onNavigate(route) }, modifier = Modifier.fillMaxWidth()) { Text(label) }
+                OutlinedButton(onClick = { onNavigate(route) }, modifier = Modifier.fillMaxWidth()) {
+                    Text(label)
+                    val due = dueByRoute[route] ?: 0
+                    if (due > 0) {
+                        Spacer(Modifier.weight(1f))
+                        DueBadge(due)
+                    }
+                }
             }
         }
+    }
+}
+
+/**
+ * Neutral status pill — a passive count, never an alarm. Uses the
+ * secondary container colour (not error); a checkup being due is
+ * information, not a failure. Manifesto: instrument, not coach.
+ */
+@Composable
+private fun DueBadge(count: Int) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = RoundedCornerShape(percent = 50),
+    ) {
+        Text(
+            text = "$count due",
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
     }
 }

--- a/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/settings/SettingsScreen.kt
@@ -34,6 +34,15 @@ fun SettingsScreen(
         val tier = prefs.getString("privacy_tier", PrivacyTier.PRIVATE.name)
         mutableStateOf(PrivacyTier.valueOf(tier ?: PrivacyTier.PRIVATE.name))
     }
+    // Passive, owner-pulled preventive-care due count for the Identity card
+    // badge (#401). Computed only because the owner opened this screen — no
+    // notification, no background work. Recomputed each time the screen is
+    // entered, so recording a checkup elsewhere clears the badge on return.
+    var dueByRoute by remember { mutableStateOf<Map<String, Int>>(emptyMap()) }
+    LaunchedEffect(Unit) {
+        val due = com.bios.app.ui.screening.PreventiveCareData.dueCount(context)
+        dueByRoute = if (due > 0) mapOf("preventive_care" to due) else emptyMap()
+    }
 
     Column(
         modifier = Modifier
@@ -44,7 +53,7 @@ fun SettingsScreen(
     ) {
         Text("Self", style = MaterialTheme.typography.headlineLarge, fontWeight = FontWeight.Bold)
 
-        IdentityCard(onNavigate = onNavigate)
+        IdentityCard(onNavigate = onNavigate, dueByRoute = dueByRoute)
 
         // Privacy — what can leave, and who can access. Highest-stakes surface.
         Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {

--- a/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
@@ -2,10 +2,12 @@ package com.bios.app
 
 import com.bios.app.model.ScreeningEntry
 import com.bios.app.screening.CadenceKind
+import com.bios.app.screening.CheckupHealthDataLink
 import com.bios.app.screening.OwnerDemographics
 import com.bios.app.screening.ScreeningCadenceEngine
 import com.bios.app.screening.ScreeningCatalog
 import com.bios.app.screening.ScreeningStatus
+import com.bios.contracts.MetricType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -104,5 +106,47 @@ class CheckupCadenceTest {
             now = now,
         )
         assertEquals(ScreeningStatus.NoRecord, status)
+    }
+
+    @Test
+    fun checkup_below_min_age_is_NotEligible() {
+        // Hearing check is gated to 50+; a 28-yo is below the band and the
+        // engine must exclude it regardless of record state (#402).
+        val hearing = ScreeningCatalog.checkups.first { it.key == "hearing_test" }
+        assertEquals(50, hearing.minAge)
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = hearing,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = null,
+            now = now,
+        )
+        assertTrue("28yo should be NotEligible for a 50+ check, got $status", status is ScreeningStatus.NotEligible)
+    }
+
+    @Test
+    fun recurring_checkup_within_window_reads_Current() {
+        // Periodic exam is RECURRING at 36mo; performed 12mo ago is well
+        // inside the window, so it reads Current — not DueNow (#402).
+        val exam = ScreeningCatalog.checkups.first { it.key == "periodic_health_exam" }
+        assertEquals(CadenceKind.RECURRING, exam.cadenceKind)
+        val latest = ScreeningEntry(screeningKey = exam.key, performedDate = monthsAgo(12))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = exam,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = latest,
+            now = now,
+        )
+        assertTrue("expected Current, got $status", status is ScreeningStatus.Current)
+    }
+
+    @Test
+    fun blood_pressure_check_links_to_the_bp_metric_keys() {
+        // The health-data link is what stops blood_pressure_check showing
+        // "No record" when Bios already holds a BP reading (#400).
+        val linked = CheckupHealthDataLink.metricKeysByScreeningKey["blood_pressure_check"]
+        assertTrue("blood_pressure_check should link to the systolic metric key",
+            linked?.contains(MetricType.BLOOD_PRESSURE_SYSTOLIC.key) == true)
+        assertTrue("blood_pressure_check should link to the diastolic metric key",
+            linked?.contains(MetricType.BLOOD_PRESSURE_DIASTOLIC.key) == true)
     }
 }


### PR DESCRIPTION
Addresses the three follow-ups from the preventive-care cadence audit.

## #400 — checkups read existing health data (Closes #400)
`blood_pressure_check` no longer shows "No record yet" when Bios already holds a BP reading. New `CheckupHealthDataLink` maps a screening key → the metric keys that satisfy it (`blood_pressure_check` → systolic/diastolic); `PreventiveCareData.latestPerformedByKey` merges the most-recent **derived** date with the manual screening ledger (most-recent wins). The Preventive Care screen now reads through this shared assembly, so manual entry still works and takes precedence when newer. Extensible: add a row to the map to link more checkups.

## #401 — passive due badge (Closes #401)
A neutral **"N due"** badge on the Settings Identity card — shown on the collapsed **Prevention & risk** section header (so it's visible *without* expanding) and on the **Preventive care** row. Counts only `DueNow` (recurring + overdue); min-interval checkups and `NoRecord` never contribute, so a fresh install shows nothing. Styled with `secondaryContainer` (never `error`) — information, not alarm.

**Manifesto-safe:** computed in a `LaunchedEffect` *only because the owner opened Settings*. No notification, no background work, no push. Recomputed on screen entry, so recording a checkup clears the badge on return.

## #402 — test gaps (Closes #402)
Added: age-gate exclusion (28-yo vs the 50+ hearing check → `NotEligible`), RECURRING in-window → `Current` (not `DueNow`), and the BP health-data link mapping.

## Verification
- Pre-commit `code-quality-check.sh` (build + unit tests) passed.
- `:app:testLetheDebugUnitTest --tests CheckupCadenceTest` run explicitly: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)