### PR TITLE
feat(screening): WHO coverage expansion + preventive-care audit fixes

### DIFF
--- a/android/app/src/main/java/com/bios/app/screening/AnatomyProfile.kt
+++ b/android/app/src/main/java/com/bios/app/screening/AnatomyProfile.kt
@@ -28,9 +28,9 @@ data class AnatomyProfile(
     val hasBreastTissue: Boolean? = null,
     /** Owner has a cervix (drives cervical-cancer screening cadence). */
     val hasCervix: Boolean? = null,
-    /** Owner has a uterus (drives endometrial-cancer surveillance discussions). */
+    /** Owner has a uterus (the closest anatomy proxy for DEXA routing). */
     val hasUterus: Boolean? = null,
-    /** Owner has a prostate (drives PSA-discussion cadence). */
+    /** Owner has a prostate (drives the AAA one-time-ultrasound gate). */
     val hasProstate: Boolean? = null,
     /**
      * Owner has had gender-affirming surgery affecting screened anatomy.
@@ -69,7 +69,6 @@ data class AnatomyProfile(
         return when (screeningKey) {
             "mammogram" -> resolve(hasBreastTissue)
             "cervical_cancer" -> resolve(hasCervix)
-            "endometrial_cancer" -> resolve(hasUterus)
             "dexa_bone_density" -> {
                 // DEXA in the USPSTF schedule pins to postmenopausal
                 // owners with uterine / ovarian history; we route on
@@ -78,7 +77,7 @@ data class AnatomyProfile(
                 // can still record it — [Unset] keeps it elective.
                 resolve(hasUterus)
             }
-            "aaa_one_time", "psa_discussion" -> resolve(hasProstate)
+            "aaa_one_time" -> resolve(hasProstate)
             else -> ApplicabilityResolution.Match
         }
     }

--- a/android/app/src/main/java/com/bios/app/screening/OwnerDemographicsStore.kt
+++ b/android/app/src/main/java/com/bios/app/screening/OwnerDemographicsStore.kt
@@ -1,25 +1,47 @@
 package com.bios.app.screening
 
 import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 
 /**
  * Owner-set demographics needed by the cadence engine (#155). Stored in
- * encrypted shared-prefs — these aren't health readings, but birth year
- * and anatomy-presentation are dignity-class data and shouldn't be
- * sniffable by other apps with shared-prefs read.
+ * [EncryptedSharedPreferences] backed by the Android Keystore — these
+ * aren't health readings, but birth year and anatomy answers (breast
+ * tissue, cervix, uterus, prostate, gender-affirming-surgery history) are
+ * dignity-class data and must not sit in cleartext at rest, where a device
+ * backup, root, or forensic extraction could read them. Same protection
+ * the credential stores use (see `OuraTokenStore`).
  *
- * Tiny surface: birth year (more stable than age) and an
- * [Applicability]-domain anatomy presentation flag. The engine derives
- * current age from birth year against the system clock. Owner can clear
- * either to opt out of demographic gating — when both are null, the
- * cadence screen renders a one-time prompt asking the owner to set them
- * (no push, just the in-screen surface).
+ * Tiny surface: birth year (more stable than age) and the per-organ
+ * [AnatomyProfile]. The engine derives current age from birth year against
+ * the system clock. Owner can clear either to opt out of demographic
+ * gating — when both are null, the cadence screen renders a one-time
+ * prompt asking the owner to set them (no push, just the in-screen
+ * surface).
+ *
+ * Migration: an earlier build wrote these to a plaintext `MODE_PRIVATE`
+ * file. On first construction we copy any values out of that legacy file
+ * into the encrypted store and delete the plaintext one, so existing
+ * owners keep their answers without re-entering dignity-class data.
  */
 class OwnerDemographicsStore(context: Context) {
 
-    private val prefs = context.applicationContext.getSharedPreferences(
-        "bios_screening_demographics", Context.MODE_PRIVATE,
+    private val appContext = context.applicationContext
+
+    private val prefs = EncryptedSharedPreferences.create(
+        appContext,
+        ENCRYPTED_PREFS_NAME,
+        MasterKey.Builder(appContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
     )
+
+    init {
+        migrateLegacyPlaintextPrefs()
+    }
 
     fun setBirthYear(year: Int?) {
         prefs.edit().apply {
@@ -100,7 +122,29 @@ class OwnerDemographicsStore(context: Context) {
         prefs.edit().clear().apply()
     }
 
+    /**
+     * One-time copy of values written by the pre-encryption build into the
+     * encrypted store, then deletes the plaintext file. No-op once the
+     * legacy file is gone (the common case after the first run, and for
+     * fresh installs that never had one).
+     */
+    private fun migrateLegacyPlaintextPrefs() {
+        val legacy = appContext.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE)
+        if (legacy.all.isEmpty()) return
+        prefs.edit().apply {
+            if (legacy.contains(KEY_BIRTH_YEAR)) putInt(KEY_BIRTH_YEAR, legacy.getInt(KEY_BIRTH_YEAR, -1))
+            legacy.getString(KEY_PRESENTS_AS, null)?.let { putString(KEY_PRESENTS_AS, it) }
+            for (key in listOf(KEY_BREAST_TISSUE, KEY_CERVIX, KEY_UTERUS, KEY_PROSTATE, KEY_SURGERY)) {
+                if (legacy.contains(key)) putBoolean(key, legacy.getBoolean(key, false))
+            }
+            apply()
+        }
+        legacy.edit().clear().apply()
+    }
+
     private companion object {
+        const val ENCRYPTED_PREFS_NAME = "bios_screening_demographics_enc"
+        const val LEGACY_PREFS_NAME = "bios_screening_demographics"
         const val KEY_BIRTH_YEAR = "birth_year"
         const val KEY_PRESENTS_AS = "presents_as"
         const val KEY_BREAST_TISSUE = "anatomy_breast_tissue"

--- a/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
+++ b/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
@@ -166,7 +166,10 @@ object ScreeningCatalog {
             displayName = "Colorectal cancer (colonoscopy or FIT)",
             minAge = 45, maxAge = 75, cadenceMonths = 12,
             applicability = Applicability.UNIVERSAL,
-            citation = "USPSTF 2021 (A recommendation) — colorectal cancer screening 45–75; annual FIT or 10-yr colonoscopy. Cadence here is the annual-FIT pace; the engine treats long-interval modalities (colonoscopy) as still-current when within 10 years.",
+            citation = "USPSTF 2021 (A recommendation) — colorectal cancer screening 45–75; annual " +
+                "FIT or 10-yr colonoscopy. The 12-mo cadence here is the annual-FIT pace. Bios doesn't " +
+                "know which modality you used, so if you had a colonoscopy record its date and read the " +
+                "next-due as the 10-yr interval your provider set — the displayed cadence assumes FIT.",
         ),
         ScreeningCatalogEntry(
             key = "mammogram",

--- a/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
+++ b/android/app/src/main/java/com/bios/app/screening/ScreeningCatalog.kt
@@ -264,11 +264,20 @@ object ScreeningCatalog {
     val checkups: List<ScreeningCatalogEntry> = CheckupCatalog.entries
 
     /**
+     * WHO globally-scoped recommendations (maximum-coverage follow-up) —
+     * total cardiovascular-risk assessment (WHO PEN / HEARTS) and the
+     * at-least-once infectious-disease tests (HIV, HBsAg, anti-HCV). Adds
+     * coverage the USPSTF-anchored set lacks without duplicating entries
+     * WHO merely restates at a different threshold. See [WhoScreeningCatalog].
+     */
+    val who: List<ScreeningCatalogEntry> = WhoScreeningCatalog.entries
+
+    /**
      * Everything the engine should evaluate in the default cadence
      * screen. The UI iterates this list; each entry's [riskGate] +
      * [applicability] + age-band decide whether it actually renders for
      * the active owner.
      */
     val combined: List<ScreeningCatalogEntry> =
-        uspstf + hereditary + obGynSociety + cardiology + ihsPaho + checkups
+        uspstf + hereditary + obGynSociety + cardiology + ihsPaho + checkups + who
 }

--- a/android/app/src/main/java/com/bios/app/screening/WhoScreeningCatalog.kt
+++ b/android/app/src/main/java/com/bios/app/screening/WhoScreeningCatalog.kt
@@ -1,0 +1,84 @@
+package com.bios.app.screening
+
+/**
+ * World Health Organization screening / periodic-check recommendations
+ * (maximum-coverage follow-up). Where the rest of the catalog anchors on
+ * the USPSTF (a US body), this set carries WHO's globally-scoped guidance
+ * so the cadence screen isn't silently US-centric — fitting the catalog's
+ * region-agnostic design.
+ *
+ * Only entries that add *new* coverage live here. WHO recommendations that
+ * merely restate something already in the catalog with a different
+ * threshold are deliberately omitted to avoid duplicate rows:
+ *
+ *  - Cervical (WHO: HPV-primary from 30, q5–10y; q3–5y from 25 for women
+ *    living with HIV), breast (WHO: 50–69 biennial), colorectal (WHO/IARC:
+ *    FIT biennial 50–74), diabetes/HbA1c, lipids, blood-pressure, and
+ *    depression are all already represented by their USPSTF/society entries.
+ *
+ * **Honest sourcing.** WHO frames most of these as setting-dependent (the
+ * infectious-disease tests gate on local prevalence) or as a *composite*
+ * assessment rather than a single lab. Each citation states that posture so
+ * the owner reads cadence as WHO public-health guidance, not a Bios verdict.
+ * Bios points; the clinic reads.
+ *
+ * **Deferred (need infrastructure this PR doesn't add):**
+ *  - WHO systematic TB screening — risk-gated to PLHIV, contacts, prisons,
+ *    high-burden settings; needs new [RiskProfile] flags + a RegionConfig
+ *    prevalence hook before it can surface without false universality.
+ *  - Antenatal syphilis / HBsAg / HIV ("at least once per pregnancy") —
+ *    belong to the reproductive module's pregnancy timeline, not the adult
+ *    cadence screen.
+ *  - Tobacco / harmful-alcohol screening — WHO frames these as opportunistic
+ *    at every visit with no fixed interval; tobacco load is already the
+ *    Smokeless companion's domain (see ECOSYSTEM_BOUNDARIES).
+ */
+internal object WhoScreeningCatalog {
+
+    val entries: List<ScreeningCatalogEntry> = listOf(
+        ScreeningCatalogEntry(
+            key = "who_cvd_risk_assessment",
+            displayName = "Cardiovascular risk assessment (WHO total-risk)",
+            minAge = 40, maxAge = null, cadenceMonths = 12,
+            applicability = Applicability.UNIVERSAL,
+            citation = "WHO PEN 2020 / HEARTS 2020 — total cardiovascular risk assessment using the " +
+                "WHO/ISH risk charts for adults >40 (or at any age with current smoking, raised waist, " +
+                "known hypertension or diabetes, or premature-CVD family history). Low-risk reassessment " +
+                "~yearly; higher-risk bands sooner, set by your clinician. A composite risk check, not a " +
+                "single test.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+        ScreeningCatalogEntry(
+            key = "hiv_test",
+            displayName = "HIV test",
+            minAge = 18, maxAge = null, cadenceMonths = Int.MAX_VALUE,
+            applicability = Applicability.UNIVERSAL,
+            citation = "WHO Consolidated Guidelines on HIV Testing Services (2019; updated 2024) — at " +
+                "least one HIV test for adults, with broad general-population testing offered in " +
+                "higher-prevalence settings. Higher-risk / key populations retest at least yearly (every " +
+                "3–6 mo with ongoing exposure) — record again if so. Self-testing is an accepted option.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+        ScreeningCatalogEntry(
+            key = "hepatitis_b_test",
+            displayName = "Hepatitis B test (HBsAg)",
+            minAge = 18, maxAge = null, cadenceMonths = Int.MAX_VALUE,
+            applicability = Applicability.UNIVERSAL,
+            citation = "WHO Guidelines on Hepatitis B and C Testing (2017) — at least one HBsAg test; " +
+                "general-population testing where HBsAg seroprevalence is ≥2%, otherwise focused on " +
+                "higher-risk groups. Often offered opportunistically through antenatal, HIV or TB " +
+                "services. No repeat needed once negative and risk is low.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+        ScreeningCatalogEntry(
+            key = "hepatitis_c_test",
+            displayName = "Hepatitis C test (anti-HCV)",
+            minAge = 18, maxAge = null, cadenceMonths = Int.MAX_VALUE,
+            applicability = Applicability.UNIVERSAL,
+            citation = "WHO Guidelines on Hepatitis B and C Testing (2017) — a one-time anti-HCV test for " +
+                "the general adult population in settings with ≥2% seroprevalence (or by birth cohort), " +
+                "and for higher-risk groups regardless of setting. Repeat only with ongoing exposure.",
+            cadenceKind = CadenceKind.RECURRING,
+        ),
+    )
+}

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
@@ -281,11 +281,18 @@ private fun ScreeningRow(
     status: ScreeningStatus,
     onRecord: () -> Unit,
 ) {
+    // One-time tests (Lp(a), HIV / hepatitis serology, AAA) carry a
+    // sentinel Int.MAX_VALUE cadence; once recorded they're "current"
+    // effectively forever, so we render that plainly instead of leaking
+    // the astronomically large "next in N mo" the cadence math produces.
+    val oneTime = entry.cadenceMonths == Int.MAX_VALUE
     val statusText = when (status) {
         is ScreeningStatus.NotEligible -> status.reason
-        ScreeningStatus.NoRecord -> "No record yet"
+        ScreeningStatus.NoRecord ->
+            if (oneTime) "Recommended once — no record yet" else "No record yet"
         is ScreeningStatus.Current ->
-            "Last ${status.monthsSinceLast} mo ago — next in ${status.monthsUntilDue} mo"
+            if (oneTime) "Recorded ${status.monthsSinceLast} mo ago — one-time, no repeat needed"
+            else "Last ${status.monthsSinceLast} mo ago — next in ${status.monthsUntilDue} mo"
         is ScreeningStatus.DueNow ->
             if (status.monthsOverdue > 0)
                 "Overdue by ${status.monthsOverdue} mo"

--- a/android/app/src/test/java/com/bios/app/WhoScreeningCatalogTest.kt
+++ b/android/app/src/test/java/com/bios/app/WhoScreeningCatalogTest.kt
@@ -1,0 +1,129 @@
+package com.bios.app
+
+import com.bios.app.model.ScreeningEntry
+import com.bios.app.screening.CadenceKind
+import com.bios.app.screening.OwnerDemographics
+import com.bios.app.screening.ScreeningCadenceEngine
+import com.bios.app.screening.ScreeningCatalog
+import com.bios.app.screening.ScreeningStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the WHO globally-scoped catalog (maximum-coverage follow-up) and
+ * its interaction with [ScreeningCadenceEngine]. Time is pinned the same
+ * way as the sibling screening suites: `now` is a concrete epoch and the
+ * engine takes it as a parameter.
+ */
+class WhoScreeningCatalogTest {
+
+    // 2026-05-21 → 1747824000000 (matches ScreeningCadenceEngineTest).
+    private val now: Long = 1_747_824_000_000L
+    private val day = 86_400_000L
+    private val daysPerMonth = 30.4375  // matches the engine's constant
+
+    private fun monthsAgo(months: Int): Long =
+        (now - (months * daysPerMonth * day).toLong()).toLong()
+
+    @Test
+    fun who_keys_surface_in_combined_catalog() {
+        val keys = ScreeningCatalog.combined.map { it.key }.toSet()
+        for (key in listOf(
+            "who_cvd_risk_assessment", "hiv_test", "hepatitis_b_test", "hepatitis_c_test",
+        )) {
+            assertTrue("$key should be in combined catalog", key in keys)
+        }
+    }
+
+    @Test
+    fun every_who_entry_carries_a_citation() {
+        for (entry in ScreeningCatalog.who) {
+            assertTrue("${entry.key} should ship a citation", entry.citation.isNotBlank())
+        }
+    }
+
+    @Test
+    fun cvd_risk_assessment_below_min_age_is_NotEligible() {
+        // WHO total-risk assessment is gated to adults >40; a 28-yo is
+        // below the band and the engine must exclude it.
+        val cvd = ScreeningCatalog.who.first { it.key == "who_cvd_risk_assessment" }
+        assertEquals(40, cvd.minAge)
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = cvd,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = null,
+            now = now,
+        )
+        assertTrue("28yo should be NotEligible for a 40+ check, got $status", status is ScreeningStatus.NotEligible)
+    }
+
+    @Test
+    fun cvd_risk_assessment_eligible_with_no_record_is_NoRecord() {
+        val cvd = ScreeningCatalog.who.first { it.key == "who_cvd_risk_assessment" }
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = cvd,
+            demographics = OwnerDemographics(ageYears = 45),
+            latest = null,
+            now = now,
+        )
+        assertEquals(ScreeningStatus.NoRecord, status)
+    }
+
+    @Test
+    fun cvd_risk_assessment_recurring_reads_DueNow_when_overdue() {
+        // It's RECURRING at 12mo, so a 24-mo-old record reads as overdue.
+        val cvd = ScreeningCatalog.who.first { it.key == "who_cvd_risk_assessment" }
+        assertEquals(CadenceKind.RECURRING, cvd.cadenceKind)
+        val latest = ScreeningEntry(screeningKey = cvd.key, performedDate = monthsAgo(24))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = cvd,
+            demographics = OwnerDemographics(ageYears = 45),
+            latest = latest,
+            now = now,
+        )
+        assertTrue("expected DueNow, got $status", status is ScreeningStatus.DueNow)
+    }
+
+    @Test
+    fun infectious_disease_tests_are_modelled_one_time() {
+        // HIV / HBsAg / anti-HCV are "at least once" — the engine models
+        // that as a sentinel Int.MAX_VALUE cadence (matching lpa_one_time).
+        for (key in listOf("hiv_test", "hepatitis_b_test", "hepatitis_c_test")) {
+            val entry = ScreeningCatalog.who.first { it.key == key }
+            assertEquals("$key should be one-time", Int.MAX_VALUE, entry.cadenceMonths)
+        }
+    }
+
+    @Test
+    fun hiv_test_with_no_record_is_NoRecord_and_never_nags() {
+        // A fresh install shows "no record yet", not an overdue nag — so it
+        // never contributes to the passive due badge (DueNow only).
+        val hiv = ScreeningCatalog.who.first { it.key == "hiv_test" }
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = hiv,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = null,
+            now = now,
+        )
+        assertEquals(ScreeningStatus.NoRecord, status)
+        assertFalse("one-time test with no record must never read DueNow", status is ScreeningStatus.DueNow)
+    }
+
+    @Test
+    fun hiv_test_with_a_record_reads_Current_indefinitely_not_DueNow() {
+        // Once recorded, a one-time test stays current forever — it must
+        // never escalate to the overdue DueNow state.
+        val hiv = ScreeningCatalog.who.first { it.key == "hiv_test" }
+        val latest = ScreeningEntry(screeningKey = hiv.key, performedDate = monthsAgo(60))
+        val status = ScreeningCadenceEngine.evaluate(
+            entry = hiv,
+            demographics = OwnerDemographics(ageYears = 28),
+            latest = latest,
+            now = now,
+        )
+        assertTrue("expected Current, got $status", status is ScreeningStatus.Current)
+        assertFalse("one-time test must never read DueNow", status is ScreeningStatus.DueNow)
+    }
+}


### PR DESCRIPTION
Two related pieces of work on the medical check-ups / Preventive Care feature.

## Part 1 — Audit fixes

Reviewed the screening/checkup engine, catalogs, data layer, Compose UI, the #400 health-data link, and the #401 due badge. Three issues found and fixed:

- **🔴 Dignity-class data stored in plaintext.** `OwnerDemographicsStore` claimed encrypted storage in its docstring but used a plain `MODE_PRIVATE` file — birth year + the full anatomy profile (breast tissue, cervix, uterus, prostate, gender-affirming-surgery flag) sat in cleartext, readable via backup/root/forensics. Switched to `EncryptedSharedPreferences` (Keystore-backed, matching `OuraTokenStore`) with a one-time migration so existing owners keep their answers.
- **🟠 Colorectal could falsely read "Overdue."** The citation claimed engine modality logic that doesn't exist, so a logged colonoscopy was flagged overdue (~13mo) and counted in the due badge. Reworded honestly (cadence assumes annual FIT).
- **🟡 Dead anatomy-routing branches** (`endometrial_cancer` / `psa_discussion`) removed, stale field docs fixed.

## Part 2 — WHO global coverage expansion

The catalog was USPSTF-anchored (a US body). Added WHO's globally-scoped guidance ([WhoScreeningCatalog.kt](android/app/src/main/java/com/bios/app/screening/WhoScreeningCatalog.kt)) so the cadence screen isn't silently US-centric — fitting the region-agnostic design. New, non-duplicative entries, each WHO-cited:

| Entry | WHO source | Population | Cadence |
|-------|-----------|-----------|---------|
| Cardiovascular risk assessment | WHO PEN 2020 / HEARTS 2020 | 40+ | ~yearly (recurring) |
| HIV test | WHO HTS Guidelines 2019/2024 | 18+ | at least once |
| Hepatitis B (HBsAg) | WHO HBV/HCV Testing 2017 | 18+ | at least once |
| Hepatitis C (anti-HCV) | WHO HBV/HCV Testing 2017 | 18+ | at least once |

WHO recommendations that merely restate an existing entry at a different threshold (cervical, breast, colorectal, diabetes, lipids, BP, depression) are intentionally omitted to avoid duplicate rows. TB systematic screening, antenatal serology, and tobacco/alcohol screening are **deferred with documented rationale** (need new risk-profile flags / a region-prevalence hook / belong to other modules).

The one-time serology entries are modelled with the existing `Int.MAX_VALUE` sentinel (like `lpa_one_time`): no record → "no record yet" (never nags, never counts in the due badge); once recorded → current indefinitely. Because these are now universal (18+, unlike `lpa`/`aaa` at 50+/65+), a latent display issue surfaced and is fixed: one-time rows now read *"Recorded N mo ago — one-time, no repeat needed"* instead of leaking the huge "next in N mo" from the cadence math.

## Testing
`./scripts/code-quality-check.sh` passes (build + detekt + unit tests). New `WhoScreeningCatalogTest`; existing `CheckupCadenceTest` / `ScreeningCadenceEngineTest` / `PaediatricVaccineCadenceEngineTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)