### PR TITLE
feat(screening): link HbA1c, lipid panel, Lp(a) to health data

### DIFF
--- a/android/app/src/main/java/com/bios/app/screening/CheckupHealthDataLink.kt
+++ b/android/app/src/main/java/com/bios/app/screening/CheckupHealthDataLink.kt
@@ -11,11 +11,24 @@ import com.bios.contracts.MetricType
  * an imported ER vital) *is* a blood-pressure check. Without this link the
  * Preventive Care screen would show "No record yet" for `blood_pressure_check`
  * while a fresh systolic/diastolic reading sits in the metric store one
- * screen over. The UI merges the most-recent derived date with any manual
+ * screen over. The same holds for the lab-backed screenings: a FHIR lab
+ * import (#396) or a manual biomarker entry for HbA1c, a lipid component, or
+ * Lp(a) *is* the corresponding screening, drawn on the reading's date. The
+ * UI merges the most-recent derived date with any manual
  * [com.bios.app.model.ScreeningEntry]; most-recent wins.
  *
+ * Only screenings a single reading can actually satisfy are linked. Imaging
+ * / cytology / endoscopy screenings (mammogram, cervical, colorectal, DEXA)
+ * and the composite WHO cardiovascular-risk assessment have no one metric
+ * that stands in for "the test was done", so they stay owner-entered.
+ *
+ * A lipid panel is satisfied by *any* of its component analytes — labs vary
+ * in which they report — so the merge in `PreventiveCareData` takes the
+ * most-recent across the listed keys.
+ *
  * Pure data, no Android dependency — the lookup + merge live in
- * `PreventiveCareData` so the engine stays a pure function. Closes #400.
+ * `PreventiveCareData` so the engine stays a pure function. Closes #400;
+ * lab-backed links extend it.
  */
 object CheckupHealthDataLink {
 
@@ -24,6 +37,18 @@ object CheckupHealthDataLink {
         "blood_pressure_check" to listOf(
             MetricType.BLOOD_PRESSURE_SYSTOLIC.key,
             MetricType.BLOOD_PRESSURE_DIASTOLIC.key,
+        ),
+        "hba1c" to listOf(
+            MetricType.HBA1C.key,
+        ),
+        "lipid_panel" to listOf(
+            MetricType.TOTAL_CHOLESTEROL.key,
+            MetricType.LDL_CHOLESTEROL.key,
+            MetricType.HDL_CHOLESTEROL.key,
+            MetricType.TRIGLYCERIDES.key,
+        ),
+        "lpa_one_time" to listOf(
+            MetricType.LIPOPROTEIN_A.key,
         ),
     )
 }

--- a/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
+++ b/android/app/src/test/java/com/bios/app/CheckupCadenceTest.kt
@@ -149,4 +149,31 @@ class CheckupCadenceTest {
         assertTrue("blood_pressure_check should link to the diastolic metric key",
             linked?.contains(MetricType.BLOOD_PRESSURE_DIASTOLIC.key) == true)
     }
+
+    @Test
+    fun lab_backed_screenings_link_to_their_biomarker_metric_keys() {
+        // An imported / manually-entered biomarker reading is the screening,
+        // so the owner never re-logs a lab Bios already holds.
+        val links = CheckupHealthDataLink.metricKeysByScreeningKey
+        assertEquals(listOf(MetricType.HBA1C.key), links["hba1c"])
+        assertEquals(listOf(MetricType.LIPOPROTEIN_A.key), links["lpa_one_time"])
+        // A lipid panel is satisfied by any of its component analytes.
+        val lipid = links["lipid_panel"].orEmpty()
+        for (component in listOf(
+            MetricType.TOTAL_CHOLESTEROL.key, MetricType.LDL_CHOLESTEROL.key,
+            MetricType.HDL_CHOLESTEROL.key, MetricType.TRIGLYCERIDES.key,
+        )) {
+            assertTrue("lipid_panel should link to $component", component in lipid)
+        }
+    }
+
+    @Test
+    fun every_linked_screening_key_exists_in_the_catalog() {
+        // A link to a key no catalog defines would silently never fire;
+        // guard against that drift.
+        val catalogKeys = ScreeningCatalog.combined.map { it.key }.toSet()
+        for (screeningKey in CheckupHealthDataLink.metricKeysByScreeningKey.keys) {
+            assertTrue("$screeningKey is linked but not in the catalog", screeningKey in catalogKeys)
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #404. Extends the #400 health-data link beyond blood pressure.

## Problem
`CheckupHealthDataLink` mapped exactly one screening key (`blood_pressure_check` ← BP readings). Every other screening showed "No record yet" even when the satisfying reading already sat in the metric store — so the manifesto rule the link exists for ("the owner never re-logs data Bios already holds") was kept for 1 screening out of ~25.

## Change
Linked the lab-backed screenings to their biomarker metric keys:

| Screening | Metric key(s) |
|-----------|---------------|
| `hba1c` | `HBA1C` |
| `lipid_panel` | total / LDL / HDL cholesterol, triglycerides (any one satisfies) |
| `lpa_one_time` | `LIPOPROTEIN_A` |

A FHIR lab import (#396) or a manual biomarker entry now keeps these screenings current automatically. The merge logic in `PreventiveCareData` already handles multi-key (most-recent across components wins), so no engine change was needed — this is pure data plus tests.

**Deliberately not linked:** imaging / cytology / endoscopy screenings (mammogram, cervical, colorectal, DEXA) and the composite WHO CVD-risk assessment — no single reading stands in for "the test was done", so they stay owner-entered.

## Testing
`./scripts/code-quality-check.sh` passes. New tests cover the lab links plus a drift guard that every linked key exists in the catalog (a link to a phantom key would silently never fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)