### PR TITLE
feat(screening): chronological timeline for Preventive Care

### DIFF
--- a/android/app/src/main/java/com/bios/app/screening/PreventiveCareTimeline.kt
+++ b/android/app/src/main/java/com/bios/app/screening/PreventiveCareTimeline.kt
@@ -1,0 +1,102 @@
+package com.bios.app.screening
+
+/**
+ * Turns the cadence engine's per-entry [ScreeningStatus] results into a
+ * single chronological timeline the Preventive Care screen renders against
+ * one shared time axis: what's coming up (above TODAY), what's done and
+ * current (below it), what hasn't been recorded, and what doesn't apply.
+ *
+ * Pure function, no Android dependency — placement and ordering are
+ * unit-testable without a device, the same way [ScreeningCadenceEngine]
+ * stays pure. The screen supplies the engine results, the owner's
+ * latest-performed dates, and `now`; this returns the ordered [Item] list.
+ *
+ * Manifesto guard: this only *arranges* what the engine already decided.
+ * Minimum-interval checkups that came due read as the neutral
+ * [ScreeningStatus.IntervalElapsed] and stay out of the overdue treatment —
+ * the no-shame rule is preserved by carrying the status through untouched.
+ */
+object PreventiveCareTimeline {
+
+    /** Where an item sits relative to the TODAY anchor. */
+    enum class Section {
+        /** Due, overdue, or eligible-again — sits above TODAY, soonest first. */
+        UPCOMING,
+        /** Recorded and current — sits below TODAY, most-recent first. */
+        PAST,
+        /** Eligible but no date on file — recommended, owner can record. */
+        NOT_RECORDED,
+        /** Filtered out by age / anatomy / risk gate — shown last, with reason. */
+        NOT_APPLICABLE,
+    }
+
+    data class Item(
+        val entry: ScreeningCatalogEntry,
+        val status: ScreeningStatus,
+        val section: Section,
+        /**
+         * Epoch millis this item anchors at on the axis: next-due for
+         * [Section.UPCOMING], last-performed for [Section.PAST]. Null for the
+         * undated sections.
+         */
+        val anchorDate: Long?,
+        /**
+         * Next-due epoch for dated [Section.PAST] items (rendered as a
+         * subtitle). Null for one-time tests (no repeat) and undated sections.
+         */
+        val nextDue: Long?,
+    )
+
+    private const val DAYS_PER_MONTH = 30.4375  // matches ScreeningCadenceEngine
+    private const val MILLIS_PER_DAY = 86_400_000L
+
+    /**
+     * Build the ordered timeline. [results] is the engine's output (already
+     * filtered for hidden hereditary gates by the caller); [lastPerformedByKey]
+     * maps screening key → most-recent performed date (manual ledger merged
+     * with health-derived dates). Returns items grouped by section in render
+     * order: upcoming (soonest first), past (newest first), not-recorded,
+     * not-applicable (both alphabetical).
+     */
+    fun build(
+        results: List<Pair<ScreeningCatalogEntry, ScreeningStatus>>,
+        lastPerformedByKey: Map<String, Long?>,
+        now: Long,
+    ): List<Item> {
+        val items = results.map { (entry, status) ->
+            val last = lastPerformedByKey[entry.key]
+            val cadence = cadenceMillis(entry)
+            val nextDue = if (last != null && cadence != null) last + cadence else null
+            when (status) {
+                is ScreeningStatus.NotEligible ->
+                    Item(entry, status, Section.NOT_APPLICABLE, anchorDate = null, nextDue = null)
+                ScreeningStatus.NoRecord ->
+                    Item(entry, status, Section.NOT_RECORDED, anchorDate = null, nextDue = null)
+                is ScreeningStatus.DueNow ->
+                    Item(entry, status, Section.UPCOMING, anchorDate = nextDue ?: now, nextDue = nextDue)
+                is ScreeningStatus.IntervalElapsed ->
+                    Item(entry, status, Section.UPCOMING, anchorDate = nextDue ?: now, nextDue = nextDue)
+                is ScreeningStatus.Current ->
+                    Item(entry, status, Section.PAST, anchorDate = last, nextDue = nextDue)
+                is ScreeningStatus.WithinInterval ->
+                    Item(entry, status, Section.PAST, anchorDate = last, nextDue = nextDue)
+            }
+        }
+
+        val upcoming = items.filter { it.section == Section.UPCOMING }
+            .sortedBy { it.anchorDate ?: now }
+        val past = items.filter { it.section == Section.PAST }
+            .sortedByDescending { it.anchorDate ?: 0L }
+        val notRecorded = items.filter { it.section == Section.NOT_RECORDED }
+            .sortedBy { it.entry.displayName }
+        val notApplicable = items.filter { it.section == Section.NOT_APPLICABLE }
+            .sortedBy { it.entry.displayName }
+
+        return upcoming + past + notRecorded + notApplicable
+    }
+
+    /** Recommended-interval window in millis, or null for one-time tests. */
+    private fun cadenceMillis(entry: ScreeningCatalogEntry): Long? =
+        if (entry.cadenceMonths == Int.MAX_VALUE) null
+        else (entry.cadenceMonths * DAYS_PER_MONTH * MILLIS_PER_DAY).toLong()
+}

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -43,7 +42,6 @@ import com.bios.app.data.RiskProfileRepo
 import com.bios.app.data.ScreeningEntryRepo
 import com.bios.app.model.RiskProfile
 import com.bios.app.screening.AnatomyProfile
-import com.bios.app.screening.CadenceKind
 import com.bios.app.screening.OwnerDemographicsStore
 import com.bios.app.screening.ScreeningCadenceEngine
 import com.bios.app.screening.ScreeningCatalog
@@ -82,8 +80,10 @@ fun PreventiveCareScreen(onBack: () -> Unit) {
     var riskProfile by remember { mutableStateOf<RiskProfile?>(null) }
     var showRecordDialog by remember { mutableStateOf<ScreeningCatalogEntry?>(null) }
     var showDemographicsDialog by remember { mutableStateOf(false) }
+    var notApplicableExpanded by remember { mutableStateOf(false) }
 
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+    val now = remember { System.currentTimeMillis() }
 
     suspend fun refresh() {
         // Most-recent-per-key, merging the manual ledger with dates Bios can
@@ -107,6 +107,30 @@ fun PreventiveCareScreen(onBack: () -> Unit) {
         )
     }
 
+    // Build the chronological timeline once per recomposition from the
+    // engine's per-entry statuses. Risk-gated hereditary entries the owner
+    // doesn't qualify for are dropped first — showing the whole NCCN list to
+    // every non-carrier would be noise; they reappear once the owner sets the
+    // matching flag on the risk-profile screen.
+    val timeline = demographics?.let { demo ->
+        val statuses = ScreeningCadenceEngine.evaluateAll(
+            catalog = ScreeningCatalog.combined,
+            demographics = demo,
+            latestByKey = { key ->
+                entries[key]?.let { date ->
+                    com.bios.app.model.ScreeningEntry(screeningKey = key, performedDate = date)
+                }
+            },
+            riskProfile = riskProfile,
+            now = now,
+        )
+        val visible = statuses.filterNot { (_, status) ->
+            status is ScreeningStatus.NotEligible &&
+                status.reason.startsWith("Requires owner-recorded")
+        }
+        com.bios.app.screening.PreventiveCareTimeline.build(visible, entries, now)
+    } ?: emptyList()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -119,63 +143,38 @@ fun PreventiveCareScreen(onBack: () -> Unit) {
             )
         }
     ) { padding ->
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(padding)
-                .padding(16.dp),
+                .padding(padding),
+            contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            DemographicsCard(
-                birthYear = birthYear,
-                anatomy = anatomy,
-                onEdit = { showDemographicsDialog = true },
-            )
-            ManifestoCard()
+            item(key = "demographics") {
+                DemographicsCard(
+                    birthYear = birthYear,
+                    anatomy = anatomy,
+                    onEdit = { showDemographicsDialog = true },
+                )
+            }
+            item(key = "manifesto") { ManifestoCard() }
 
             if (demographics == null) {
-                Text(
-                    "Set your birth year above to see what's recommended for your age.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                item(key = "prompt") {
+                    Text(
+                        "Set your birth year above to see what's recommended for your age.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             } else {
-                val statuses = ScreeningCadenceEngine.evaluateAll(
-                    catalog = ScreeningCatalog.combined,
-                    demographics = demographics,
-                    latestByKey = { key ->
-                        entries[key]?.let { date ->
-                            com.bios.app.model.ScreeningEntry(
-                                screeningKey = key,
-                                performedDate = date,
-                            )
-                        }
-                    },
-                    riskProfile = riskProfile,
+                preventiveCareTimeline(
+                    items = timeline,
+                    now = now,
+                    notApplicableExpanded = notApplicableExpanded,
+                    onToggleNotApplicable = { notApplicableExpanded = !notApplicableExpanded },
+                    onRecord = { showRecordDialog = it },
                 )
-                // Hide risk-gated entries the owner doesn't qualify for —
-                // showing the entire NCCN hereditary list to every
-                // non-carrier owner would be noise. The owner's
-                // risk-profile screen is the entry point to surface
-                // these; once a syndrome flag is set, the engine
-                // returns a non-`Requires owner-recorded ...` status
-                // and the row appears here.
-                val visible = statuses.filterNot { (_, status) ->
-                    status is ScreeningStatus.NotEligible &&
-                        status.reason.startsWith("Requires owner-recorded")
-                }
-                LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    contentPadding = PaddingValues(vertical = 4.dp)
-                ) {
-                    items(visible, key = { it.first.key }) { (entry, status) ->
-                        ScreeningRow(
-                            entry = entry,
-                            status = status,
-                            onRecord = { showRecordDialog = entry },
-                        )
-                    }
-                }
             }
         }
     }
@@ -219,14 +218,15 @@ private fun ManifestoCard() {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("How Bios uses this", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
             Text(
-                "Bios reads the USPSTF adult screening schedule, routine " +
-                    "checkup intervals (dental, eye, periodic exam), and your " +
-                    "own history to answer one question: what are you due for? " +
-                    "Routine checkups show a recommended delay since your last " +
-                    "visit — never an 'overdue', because that's advice, not a " +
-                    "deadline. Nothing here pushes a notification; the screen " +
-                    "waits until you ask. Cadence math is just math — your " +
-                    "provider applies the local guideline for diagnosis.",
+                "Bios reads the USPSTF and WHO adult screening schedules, " +
+                    "routine checkup intervals (dental, eye, periodic exam), and " +
+                    "your own history, then lays them on one timeline: what's " +
+                    "coming up sits above today, what you've done and are current " +
+                    "on sits below. Routine checkups show a recommended delay " +
+                    "since your last visit — never an 'overdue', because that's " +
+                    "advice, not a deadline. Nothing here pushes a notification; " +
+                    "the screen waits until you ask. Cadence math is just math — " +
+                    "your provider applies the local guideline for diagnosis.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -273,66 +273,6 @@ private fun anatomySummary(anatomy: AnatomyProfile): String {
     if (anatomy.hasProstate == true) parts += "prostate"
     if (parts.isEmpty()) return "anatomy noted"
     return parts.joinToString(", ")
-}
-
-@Composable
-private fun ScreeningRow(
-    entry: ScreeningCatalogEntry,
-    status: ScreeningStatus,
-    onRecord: () -> Unit,
-) {
-    // One-time tests (Lp(a), HIV / hepatitis serology, AAA) carry a
-    // sentinel Int.MAX_VALUE cadence; once recorded they're "current"
-    // effectively forever, so we render that plainly instead of leaking
-    // the astronomically large "next in N mo" the cadence math produces.
-    val oneTime = entry.cadenceMonths == Int.MAX_VALUE
-    val statusText = when (status) {
-        is ScreeningStatus.NotEligible -> status.reason
-        ScreeningStatus.NoRecord ->
-            if (oneTime) "Recommended once — no record yet" else "No record yet"
-        is ScreeningStatus.Current ->
-            if (oneTime) "Recorded ${status.monthsSinceLast} mo ago — one-time, no repeat needed"
-            else "Last ${status.monthsSinceLast} mo ago — next in ${status.monthsUntilDue} mo"
-        is ScreeningStatus.DueNow ->
-            if (status.monthsOverdue > 0)
-                "Overdue by ${status.monthsOverdue} mo"
-            else "Due now (last ${status.monthsSinceLast} mo ago)"
-        // Minimum-interval (routine checkup) states — neutral wording, no
-        // "overdue". A recommended delay you can't be late for.
-        is ScreeningStatus.WithinInterval ->
-            "Recommended again in ${status.monthsUntilEligible} mo (last ${status.monthsSinceLast} mo ago)"
-        is ScreeningStatus.IntervalElapsed ->
-            "Eligible again (last ${status.monthsSinceLast} mo ago)"
-    }
-    val statusColor = when (status) {
-        is ScreeningStatus.DueNow -> MaterialTheme.colorScheme.error
-        ScreeningStatus.NoRecord -> MaterialTheme.colorScheme.secondary
-        is ScreeningStatus.Current -> MaterialTheme.colorScheme.primary
-        is ScreeningStatus.WithinInterval -> MaterialTheme.colorScheme.primary
-        is ScreeningStatus.IntervalElapsed -> MaterialTheme.colorScheme.secondary
-        is ScreeningStatus.NotEligible -> MaterialTheme.colorScheme.onSurfaceVariant
-    }
-
-    Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text(entry.displayName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-            Text(statusText, style = MaterialTheme.typography.bodySmall, color = statusColor)
-            Text(
-                "${cadenceDescriptor(entry)} • ${ageLabel(entry)}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            if (status !is ScreeningStatus.NotEligible) {
-                OutlinedButton(
-                    onClick = onRecord,
-                    modifier = Modifier.fillMaxWidth(),
-                ) { Text("Record date") }
-            }
-        }
-    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -386,28 +326,6 @@ private fun RecordScreeningDialog(
         ) { DatePicker(state = state) }
     }
 }
-
-private fun cadenceLabel(months: Int): String = when {
-    months == Int.MAX_VALUE -> "one-time"
-    months % 12 == 0 -> "${months / 12} yr"
-    else -> "$months mo"
-}
-
-/**
- * Cadence wording by [CadenceKind]. Recurring entries read "every X";
- * minimum-interval checkups read "recommended delay: X" so the owner sees
- * a delay-since-last advice, not a clock to fail.
- */
-private fun cadenceDescriptor(entry: ScreeningCatalogEntry): String =
-    when (entry.cadenceKind) {
-        CadenceKind.RECURRING -> "Cadence: every ${cadenceLabel(entry.cadenceMonths)}"
-        CadenceKind.MIN_INTERVAL_SINCE_LAST ->
-            "Recommended delay: ${cadenceLabel(entry.cadenceMonths)} since last"
-    }
-
-private fun ageLabel(entry: ScreeningCatalogEntry): String =
-    if (entry.maxAge != null) "ages ${entry.minAge}–${entry.maxAge}"
-    else "from age ${entry.minAge}"
 
 private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.US)
 private fun formatDate(millis: Long): String = dateFormat.format(Date(millis))

--- a/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareTimelineView.kt
+++ b/android/app/src/main/java/com/bios/app/ui/screening/PreventiveCareTimelineView.kt
@@ -1,0 +1,335 @@
+package com.bios.app.ui.screening
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.bios.app.screening.CadenceKind
+import com.bios.app.screening.PreventiveCareTimeline
+import com.bios.app.screening.PreventiveCareTimeline.Section
+import com.bios.app.screening.ScreeningCatalogEntry
+import com.bios.app.screening.ScreeningStatus
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Renders a [PreventiveCareTimeline] result as a single chronological axis:
+ * upcoming items above a TODAY anchor, done-and-current items below it, then
+ * the undated "not yet recorded" and (collapsed) "not applicable" sections.
+ *
+ * A `LazyListScope` extension rather than its own `LazyColumn` so the
+ * Preventive Care screen owns one scroll container (demographics + manifesto
+ * cards scroll with the timeline). Pure presentation — every placement
+ * decision was already made by [PreventiveCareTimeline]; this only draws it.
+ */
+fun LazyListScope.preventiveCareTimeline(
+    items: List<PreventiveCareTimeline.Item>,
+    now: Long,
+    notApplicableExpanded: Boolean,
+    onToggleNotApplicable: () -> Unit,
+    onRecord: (ScreeningCatalogEntry) -> Unit,
+) {
+    val upcoming = items.filter { it.section == Section.UPCOMING }
+    val past = items.filter { it.section == Section.PAST }
+    val notRecorded = items.filter { it.section == Section.NOT_RECORDED }
+    val notApplicable = items.filter { it.section == Section.NOT_APPLICABLE }
+
+    if (upcoming.isNotEmpty()) {
+        item(key = "header_upcoming") { SectionLabel("Upcoming") }
+        items(upcoming, key = { it.entry.key }) { item ->
+            TimelineNode(status = item.status) {
+                ScreeningCard(item = item, now = now, onRecord = { onRecord(item.entry) })
+            }
+        }
+    }
+
+    item(key = "today_anchor") { TodayAnchor(now) }
+
+    if (past.isNotEmpty()) {
+        item(key = "header_past") { SectionLabel("Done & current") }
+        items(past, key = { it.entry.key }) { item ->
+            TimelineNode(status = item.status) {
+                ScreeningCard(item = item, now = now, onRecord = { onRecord(item.entry) })
+            }
+        }
+    }
+
+    if (notRecorded.isNotEmpty()) {
+        item(key = "header_not_recorded") { SectionLabel("Not yet recorded · ${notRecorded.size}") }
+        items(notRecorded, key = { it.entry.key }) { item ->
+            TimelineNode(status = item.status) {
+                ScreeningCard(item = item, now = now, onRecord = { onRecord(item.entry) })
+            }
+        }
+    }
+
+    if (notApplicable.isNotEmpty()) {
+        item(key = "header_not_applicable") {
+            NotApplicableHeader(
+                count = notApplicable.size,
+                expanded = notApplicableExpanded,
+                onToggle = onToggleNotApplicable,
+            )
+        }
+        if (notApplicableExpanded) {
+            items(notApplicable, key = { it.entry.key }) { item ->
+                NotApplicableRow(item)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text.uppercase(Locale.US),
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = 4.dp, top = 8.dp, bottom = 2.dp),
+    )
+}
+
+@Composable
+private fun TodayAnchor(now: Long) {
+    val accent = MaterialTheme.colorScheme.tertiary
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .width(28.dp)
+                .height(16.dp)
+                .drawBehind {
+                    drawCircle(accent, radius = 7.dp.toPx(), center = Offset(size.width / 2, size.height / 2))
+                },
+        )
+        Text(
+            "TODAY · ${monthYear(now)}",
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+        )
+        Spacer(Modifier.width(8.dp))
+        HorizontalDivider(color = accent, modifier = Modifier.weight(1f))
+    }
+}
+
+/**
+ * Leading timeline gutter: a vertical connector line through the row with a
+ * dot whose colour/fill reflects the screening's status. Filled = needs or
+ * has attention; outlined = neutral / not yet started.
+ */
+@Composable
+private fun TimelineNode(
+    status: ScreeningStatus,
+    content: @Composable () -> Unit,
+) {
+    val color = statusColor(status)
+    val filled = when (status) {
+        is ScreeningStatus.DueNow, is ScreeningStatus.IntervalElapsed, is ScreeningStatus.Current -> true
+        else -> false
+    }
+    val line = MaterialTheme.colorScheme.outlineVariant
+    val surface = MaterialTheme.colorScheme.surface
+    Row(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+        Box(
+            modifier = Modifier
+                .width(28.dp)
+                .fillMaxHeight()
+                .drawBehind {
+                    val cx = size.width / 2
+                    val cy = 18.dp.toPx()
+                    val r = 6.dp.toPx()
+                    drawLine(line, Offset(cx, 0f), Offset(cx, size.height), strokeWidth = 2.dp.toPx())
+                    if (filled) {
+                        drawCircle(color, r, Offset(cx, cy))
+                    } else {
+                        drawCircle(surface, r, Offset(cx, cy))
+                        drawCircle(color, r, Offset(cx, cy), style = Stroke(width = 2.dp.toPx()))
+                    }
+                },
+        )
+        Box(modifier = Modifier.weight(1f).padding(start = 4.dp, bottom = 10.dp)) { content() }
+    }
+}
+
+@Composable
+private fun ScreeningCard(
+    item: PreventiveCareTimeline.Item,
+    now: Long,
+    onRecord: () -> Unit,
+) {
+    val entry = item.entry
+    val status = item.status
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            dateLabel(item, now)?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = statusColor(status),
+                )
+            }
+            Text(entry.displayName, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+            Text(statusText(entry, status), style = MaterialTheme.typography.bodySmall, color = statusColor(status))
+            Text(
+                "${cadenceDescriptor(entry)} • ${ageLabel(entry)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedButton(onClick = onRecord, modifier = Modifier.fillMaxWidth()) { Text("Record date") }
+        }
+    }
+}
+
+@Composable
+private fun NotApplicableHeader(count: Int, expanded: Boolean, onToggle: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(start = 4.dp, top = 12.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "NOT APPLICABLE · $count",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.width(4.dp))
+        Icon(
+            if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+            contentDescription = if (expanded) "Collapse" else "Expand",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun NotApplicableRow(item: PreventiveCareTimeline.Item) {
+    val reason = (item.status as? ScreeningStatus.NotEligible)?.reason ?: ""
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = Modifier.fillMaxWidth().padding(start = 28.dp),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                item.entry.displayName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (reason.isNotBlank()) {
+                Text(
+                    "Doesn't apply: $reason",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/** Date chip above the card: when it's next due (upcoming) or was done (past). */
+private fun dateLabel(item: PreventiveCareTimeline.Item, now: Long): String? {
+    val date = item.anchorDate ?: return null
+    return when (item.section) {
+        Section.UPCOMING ->
+            if (date <= now) "Was due ${monthYear(date)}" else "Due ${monthYear(date)}"
+        Section.PAST -> "Done ${monthYear(date)}"
+        else -> null
+    }
+}
+
+private fun statusText(entry: ScreeningCatalogEntry, status: ScreeningStatus): String {
+    // One-time tests (Lp(a), HIV / hepatitis serology, AAA) carry a sentinel
+    // Int.MAX_VALUE cadence; once recorded they're current effectively forever.
+    val oneTime = entry.cadenceMonths == Int.MAX_VALUE
+    return when (status) {
+        is ScreeningStatus.NotEligible -> status.reason
+        ScreeningStatus.NoRecord ->
+            if (oneTime) "Recommended once — no record yet" else "No record yet"
+        is ScreeningStatus.Current ->
+            if (oneTime) "Recorded ${status.monthsSinceLast} mo ago — one-time, no repeat needed"
+            else "Last ${status.monthsSinceLast} mo ago — next in ${status.monthsUntilDue} mo"
+        is ScreeningStatus.DueNow ->
+            if (status.monthsOverdue > 0) "Overdue by ${status.monthsOverdue} mo"
+            else "Due now (last ${status.monthsSinceLast} mo ago)"
+        // Minimum-interval (routine checkup) states — neutral, never "overdue".
+        is ScreeningStatus.WithinInterval ->
+            "Recommended again in ${status.monthsUntilEligible} mo (last ${status.monthsSinceLast} mo ago)"
+        is ScreeningStatus.IntervalElapsed ->
+            "Eligible again (last ${status.monthsSinceLast} mo ago)"
+    }
+}
+
+@Composable
+private fun statusColor(status: ScreeningStatus): Color = when (status) {
+    is ScreeningStatus.DueNow -> MaterialTheme.colorScheme.error
+    ScreeningStatus.NoRecord -> MaterialTheme.colorScheme.secondary
+    is ScreeningStatus.Current -> MaterialTheme.colorScheme.primary
+    is ScreeningStatus.WithinInterval -> MaterialTheme.colorScheme.primary
+    is ScreeningStatus.IntervalElapsed -> MaterialTheme.colorScheme.secondary
+    is ScreeningStatus.NotEligible -> MaterialTheme.colorScheme.onSurfaceVariant
+}
+
+private fun cadenceLabel(months: Int): String = when {
+    months == Int.MAX_VALUE -> "one-time"
+    months % 12 == 0 -> "${months / 12} yr"
+    else -> "$months mo"
+}
+
+/**
+ * Cadence wording by [CadenceKind]. Recurring entries read "every X";
+ * minimum-interval checkups read "recommended delay: X" so the owner sees
+ * delay-since-last advice, not a clock to fail.
+ */
+private fun cadenceDescriptor(entry: ScreeningCatalogEntry): String =
+    when (entry.cadenceKind) {
+        CadenceKind.RECURRING -> "Cadence: every ${cadenceLabel(entry.cadenceMonths)}"
+        CadenceKind.MIN_INTERVAL_SINCE_LAST ->
+            "Recommended delay: ${cadenceLabel(entry.cadenceMonths)} since last"
+    }
+
+private fun ageLabel(entry: ScreeningCatalogEntry): String =
+    if (entry.maxAge != null) "ages ${entry.minAge}–${entry.maxAge}"
+    else "from age ${entry.minAge}"
+
+private val monthYearFormat = SimpleDateFormat("MMM yyyy", Locale.US)
+private fun monthYear(millis: Long): String = monthYearFormat.format(Date(millis))

--- a/android/app/src/test/java/com/bios/app/PreventiveCareTimelineTest.kt
+++ b/android/app/src/test/java/com/bios/app/PreventiveCareTimelineTest.kt
@@ -1,0 +1,133 @@
+package com.bios.app
+
+import com.bios.app.model.ScreeningEntry
+import com.bios.app.screening.OwnerDemographics
+import com.bios.app.screening.PreventiveCareTimeline
+import com.bios.app.screening.PreventiveCareTimeline.Section
+import com.bios.app.screening.ScreeningCadenceEngine
+import com.bios.app.screening.ScreeningCatalog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [PreventiveCareTimeline]'s placement and ordering. Time is pinned
+ * (`now` is a concrete epoch) the same way as the sibling screening suites,
+ * and the engine output is produced through the real catalog so the test
+ * exercises the same data the screen sees.
+ */
+class PreventiveCareTimelineTest {
+
+    // 2026-05-21 → 1747824000000 (matches ScreeningCadenceEngineTest).
+    private val now: Long = 1_747_824_000_000L
+    private val day = 86_400_000L
+    private val daysPerMonth = 30.4375
+
+    private fun monthsAgo(months: Int): Long =
+        (now - (months * daysPerMonth * day).toLong()).toLong()
+
+    private fun timelineFor(
+        ageYears: Int,
+        latestByKey: Map<String, Long?>,
+    ): List<PreventiveCareTimeline.Item> {
+        val results = ScreeningCadenceEngine.evaluateAll(
+            catalog = ScreeningCatalog.combined,
+            demographics = OwnerDemographics(ageYears = ageYears),
+            latestByKey = { key ->
+                latestByKey[key]?.let { ScreeningEntry(screeningKey = key, performedDate = it) }
+            },
+            now = now,
+        )
+        return PreventiveCareTimeline.build(results, latestByKey, now)
+    }
+
+    @Test
+    fun overdue_recurring_screening_lands_in_upcoming() {
+        // periodic_health_exam is RECURRING 36mo; performed 48mo ago → overdue.
+        val items = timelineFor(ageYears = 30, mapOf("periodic_health_exam" to monthsAgo(48)))
+        val exam = items.first { it.entry.key == "periodic_health_exam" }
+        assertEquals(Section.UPCOMING, exam.section)
+        assertTrue("overdue item should anchor at/around now", exam.anchorDate != null)
+    }
+
+    @Test
+    fun current_screening_lands_in_past_with_next_due() {
+        // periodic_health_exam performed 12mo ago is well inside the 36mo window.
+        val last = monthsAgo(12)
+        val items = timelineFor(ageYears = 30, mapOf("periodic_health_exam" to last))
+        val exam = items.first { it.entry.key == "periodic_health_exam" }
+        assertEquals(Section.PAST, exam.section)
+        assertEquals(last, exam.anchorDate)
+        assertTrue("current recurring item carries a next-due date", exam.nextDue != null)
+        assertTrue("next-due is in the future", exam.nextDue!! > now)
+    }
+
+    @Test
+    fun unrecorded_eligible_screening_lands_in_not_recorded() {
+        val items = timelineFor(ageYears = 30, emptyMap())
+        val depression = items.first { it.entry.key == "depression_screen" }
+        assertEquals(Section.NOT_RECORDED, depression.section)
+    }
+
+    @Test
+    fun age_gated_screening_lands_in_not_applicable() {
+        // hearing_test is 50+; a 30-yo is below the band.
+        val items = timelineFor(ageYears = 30, emptyMap())
+        val hearing = items.first { it.entry.key == "hearing_test" }
+        assertEquals(Section.NOT_APPLICABLE, hearing.section)
+    }
+
+    @Test
+    fun one_time_test_with_record_is_past_with_no_next_due() {
+        // hiv_test is one-time (Int.MAX_VALUE) — once recorded, no repeat.
+        val items = timelineFor(ageYears = 30, mapOf("hiv_test" to monthsAgo(20)))
+        val hiv = items.first { it.entry.key == "hiv_test" }
+        assertEquals(Section.PAST, hiv.section)
+        assertEquals(null, hiv.nextDue)
+    }
+
+    @Test
+    fun upcoming_is_sorted_soonest_first_past_is_newest_first() {
+        val items = timelineFor(
+            ageYears = 30,
+            mapOf(
+                // Two overdue recurring items with different last-done → different next-due.
+                "periodic_health_exam" to monthsAgo(48),   // 36mo cadence → due ~12mo ago
+                "blood_pressure_check" to monthsAgo(30),    // 12mo cadence → due ~18mo ago
+                // Two current items → PAST, ordered newest-first by last-done.
+                "depression_screen" to monthsAgo(2),        // 12mo cadence, current
+                "lipid_panel" to monthsAgo(6),              // not eligible <40, ignore if so
+            ),
+        )
+        val upcoming = items.filter { it.section == Section.UPCOMING }
+        if (upcoming.size >= 2) {
+            val anchors = upcoming.map { it.anchorDate ?: now }
+            assertEquals("upcoming sorted ascending", anchors.sorted(), anchors)
+        }
+        val past = items.filter { it.section == Section.PAST }
+        if (past.size >= 2) {
+            val anchors = past.map { it.anchorDate ?: 0L }
+            assertEquals("past sorted descending", anchors.sortedDescending(), anchors)
+        }
+    }
+
+    @Test
+    fun render_order_is_upcoming_then_past_then_not_recorded_then_not_applicable() {
+        val items = timelineFor(
+            ageYears = 30,
+            mapOf(
+                "periodic_health_exam" to monthsAgo(48),  // upcoming
+                "depression_screen" to monthsAgo(2),      // past
+            ),
+        )
+        val sections = items.map { it.section }
+        // Each section appears as a contiguous block in this fixed order.
+        val order = listOf(
+            Section.UPCOMING, Section.PAST, Section.NOT_RECORDED, Section.NOT_APPLICABLE,
+        )
+        val firstIndexOf = order.associateWith { sec -> sections.indexOfFirst { it == sec } }
+            .filterValues { it >= 0 }
+        val indices = order.mapNotNull { firstIndexOf[it] }
+        assertEquals("sections appear in render order", indices.sorted(), indices)
+    }
+}


### PR DESCRIPTION
Redesigns the Preventive Care screen from a flat status list into a single chronological **timeline** — what you asked for ("a true timeline", more user-friendly).

## Layout
One shared time axis with a **TODAY** anchor:

```
── UPCOMING ──────────────────
 ●  DUE NOW · Blood pressure check
 ●  Due Sep 2026 · Dental exam
─◆─ TODAY · Jun 2026 ──────────
 ○  Done Apr 2026 · Lipid panel (from labs)
 ○  Done Jan 2026 · HbA1c (from labs)
── NOT YET RECORDED · 6 ───────
   HIV test, Skin check, …
── NOT APPLICABLE · 4  ⌄ ──────
   Hearing test — Doesn't apply: Recommended from age 50
```

- **Upcoming** (above TODAY): due / overdue / eligible-again, soonest first.
- **TODAY** anchor.
- **Done & current** (below): newest first, with the next-due month.
- **Not yet recorded**: eligible but undated — actionable, tap to record.
- **Not applicable** (collapsed at the very bottom, per your follow-up): each item shows *why* it doesn't apply, using the engine's gate reason (age band / anatomy).

## Implementation
- New **pure** `PreventiveCareTimeline` builder (screening package, no Android dep) does all placement + ordering — unit-tested for section assignment and sort order.
- Rendering is a `LazyListScope` extension (`PreventiveCareTimelineView`) so the screen keeps one scroll container; both UI files stay under the 500-line cap.
- **No-shame preserved**: minimum-interval checkups (dental, eye) carry the neutral `IntervalElapsed` status through and never render in the overdue/error treatment. Still pull-only — no notifications.
- Also surfaces the earlier one-time-display fix on the axis (one-time tests read "one-time, no repeat needed", never a huge "next in N mo").

## Testing
`./scripts/code-quality-check.sh` passes (build + detekt + unit tests). New `PreventiveCareTimelineTest`; existing screening suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)