### PR TITLE
feat(ingest): manual blood pressure entry preset (#390)

### DIFF
--- a/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/bios/app/ui/MainActivity.kt
@@ -233,6 +233,7 @@ fun BiosApp(viewModel: AppViewModel) {
                     onNavigateToPpgCapture = { navController.navigate("ppg_capture") },
                     onNavigateToBiomarkerEntry = { navController.navigate("biomarker_entry") },
                     onNavigateToClinicalEntry = { navController.navigate("clinical_entry") },
+                    onNavigateToBloodPressureEntry = { navController.navigate("blood_pressure_entry") },
                     onNavigateToSleepEntry = { navController.navigate("sleep_entry") },
                     onNavigateToBbtEntry = { navController.navigate("bbt_entry") },
                     onNavigateToPeriodEntry = { navController.navigate("period_entry") },
@@ -363,6 +364,13 @@ fun BiosApp(viewModel: AppViewModel) {
                 com.bios.app.ui.clinical.ClinicalReadingEntryScreen(
                     viewModel = viewModel,
                     onBack = { navController.popBackStack() }
+                )
+            }
+            composable("blood_pressure_entry") {
+                com.bios.app.ui.clinical.ClinicalReadingEntryScreen(
+                    viewModel = viewModel,
+                    onBack = { navController.popBackStack() },
+                    initialPreset = com.bios.app.ui.clinical.MeasurementPreset.BLOOD_PRESSURE,
                 )
             }
             composable(

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingEntryScreen.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -205,7 +206,10 @@ fun ClinicalReadingEntryScreen(
                 fontWeight = FontWeight.Bold,
             )
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 FilterChip(
                     selected = preset == MeasurementPreset.TRIAGE,
                     onClick = {
@@ -227,6 +231,17 @@ fun ClinicalReadingEntryScreen(
                         }
                     },
                     label = { Text("Body composition") },
+                )
+                FilterChip(
+                    selected = preset == MeasurementPreset.BLOOD_PRESSURE,
+                    onClick = {
+                        if (preset != MeasurementPreset.BLOOD_PRESSURE) {
+                            preset = MeasurementPreset.BLOOD_PRESSURE
+                            rows.clear()
+                            defaultRowsFor(MeasurementPreset.BLOOD_PRESSURE).forEach { rows.add(it) }
+                        }
+                    },
+                    label = { Text("Blood pressure") },
                 )
             }
 

--- a/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
+++ b/android/app/src/main/java/com/bios/app/ui/clinical/ClinicalReadingRows.kt
@@ -210,8 +210,12 @@ internal data class ReadingRowState(
  *  - [BODY_COMPOSITION] is the pharmacy / scale shape (weight, height, BMI,
  *    body fat %, lean + fat mass, blood pressure) — the bundle a body-
  *    composition station prints at a weekly weigh-in.
+ *  - [BLOOD_PRESSURE] is the home-cuff shape (systolic / diastolic / pulse) a
+ *    consumer monitor reports in one measurement. It is the Vessel Watch's
+ *    top missing dial (#390); the dedicated `blood_pressure_entry` route lands
+ *    the owner here so logging a cuff reading is one tap, not a triage form.
  */
-enum class MeasurementPreset { TRIAGE, BODY_COMPOSITION }
+enum class MeasurementPreset { TRIAGE, BODY_COMPOSITION, BLOOD_PRESSURE }
 
 internal fun defaultRowsFor(preset: MeasurementPreset): List<ReadingRowState> = when (preset) {
     MeasurementPreset.TRIAGE -> listOf(
@@ -234,6 +238,11 @@ internal fun defaultRowsFor(preset: MeasurementPreset): List<ReadingRowState> = 
         ReadingRowState(metric = MetricType.FAT_MASS_KG),
         ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
         ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+    )
+    MeasurementPreset.BLOOD_PRESSURE -> listOf(
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_SYSTOLIC),
+        ReadingRowState(metric = MetricType.BLOOD_PRESSURE_DIASTOLIC),
+        ReadingRowState(metric = MetricType.HEART_RATE),
     )
 }
 

--- a/android/app/src/main/java/com/bios/app/ui/log/LogScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/log/LogScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.MedicalServices
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material3.Button
@@ -52,6 +53,7 @@ fun LogScreen(
     onNavigateToPpgCapture: () -> Unit,
     onNavigateToBiomarkerEntry: () -> Unit,
     onNavigateToClinicalEntry: () -> Unit,
+    onNavigateToBloodPressureEntry: () -> Unit,
     onNavigateToSleepEntry: () -> Unit,
     onNavigateToBbtEntry: () -> Unit,
     onNavigateToPeriodEntry: () -> Unit,
@@ -83,10 +85,46 @@ fun LogScreen(
         })
 
         Spacer(Modifier.height(4.dp))
+        TakeAReadingSection(
+            onNavigateToPpgCapture = onNavigateToPpgCapture,
+            onNavigateToBiomarkerEntry = onNavigateToBiomarkerEntry,
+            onNavigateToClinicalEntry = onNavigateToClinicalEntry,
+            onNavigateToBloodPressureEntry = onNavigateToBloodPressureEntry,
+        )
+
+        Spacer(Modifier.height(4.dp))
+        TrackOverTimeSection(
+            onNavigateToSleepEntry = onNavigateToSleepEntry,
+            onNavigateToBbtEntry = onNavigateToBbtEntry,
+            onNavigateToPeriodEntry = onNavigateToPeriodEntry,
+        )
+    }
+}
+
+/**
+ * One-shot readings the owner takes when prompted — vitals captured in the
+ * moment. Blood pressure leads: it is the Vessel Watch's top missing dial
+ * (#390) and the cheapest clinical check, so it sits above the camera/bundle
+ * surfaces.
+ */
+@Composable
+private fun TakeAReadingSection(
+    onNavigateToPpgCapture: () -> Unit,
+    onNavigateToBiomarkerEntry: () -> Unit,
+    onNavigateToClinicalEntry: () -> Unit,
+    onNavigateToBloodPressureEntry: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
             "Take a reading",
             style = MaterialTheme.typography.titleSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        HomeEntryCard(
+            icon = Icons.Default.MonitorHeart,
+            title = "Blood pressure",
+            subtitle = "Systolic, diastolic & pulse from a home cuff",
+            onClick = onNavigateToBloodPressureEntry,
         )
         HomeEntryCard(
             icon = Icons.Default.CameraAlt,
@@ -106,8 +144,20 @@ fun LogScreen(
             subtitle = "Biomarker panels from blood work",
             onClick = onNavigateToBiomarkerEntry,
         )
+    }
+}
 
-        Spacer(Modifier.height(4.dp))
+/**
+ * Recurring trackers the owner enters on a cadence rather than on demand —
+ * each writes the same SELF_REPORTED shape through its dedicated screen.
+ */
+@Composable
+private fun TrackOverTimeSection(
+    onNavigateToSleepEntry: () -> Unit,
+    onNavigateToBbtEntry: () -> Unit,
+    onNavigateToPeriodEntry: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Text(
             "Track over time",
             style = MaterialTheme.typography.titleSmall,

--- a/android/app/src/test/java/com/bios/app/BloodPressureEntryTest.kt
+++ b/android/app/src/test/java/com/bios/app/BloodPressureEntryTest.kt
@@ -1,0 +1,85 @@
+package com.bios.app
+
+import com.bios.app.ui.clinical.MeasurementPreset
+import com.bios.app.ui.clinical.defaultRowsFor
+import com.bios.contracts.MetricType
+import com.bios.contracts.MetricUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the home-cuff blood-pressure entry preset (#390). Blood pressure is
+ * the Vessel Watch's top missing dial; the dedicated `blood_pressure_entry`
+ * route lands the owner on this preset so a cuff reading is one tap rather
+ * than a full triage form.
+ *
+ * The rows route through the same [com.bios.app.data.ManualReadingRepo.addBundle]
+ * path as every other clinical reading → SELF_REPORTED → engine-isolated, so a
+ * manually-typed cuff value never poisons a sensor baseline.
+ */
+class BloodPressureEntryTest {
+
+    @Test
+    fun blood_pressure_preset_is_systolic_diastolic_pulse() {
+        // A home cuff reports exactly these three numbers in one measurement.
+        // Order matches how a monitor displays them (SYS over DIA, pulse last).
+        val expected = listOf(
+            MetricType.BLOOD_PRESSURE_SYSTOLIC,
+            MetricType.BLOOD_PRESSURE_DIASTOLIC,
+            MetricType.HEART_RATE,
+        )
+        val actual = defaultRowsFor(MeasurementPreset.BLOOD_PRESSURE).map { it.metric }
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun blood_pressure_preset_metrics_allow_manual_entry() {
+        // ManualReadingRepo.add require()s allowsManualEntry; if any preset row
+        // lost the flag the save would throw at runtime instead of failing here.
+        for (row in defaultRowsFor(MeasurementPreset.BLOOD_PRESSURE)) {
+            assertTrue(
+                "${row.metric.key} must allow manual entry — blood pressure preset row",
+                row.metric.allowsManualEntry,
+            )
+        }
+    }
+
+    @Test
+    fun blood_pressure_units_are_mmhg_and_pulse_is_bpm() {
+        // The entry field shows the unit suffix; drift here mislabels the cuff
+        // numbers the owner reads back in trends and FHIR export.
+        assertEquals(MetricUnit.MMHG, MetricType.BLOOD_PRESSURE_SYSTOLIC.unit)
+        assertEquals(MetricUnit.MMHG, MetricType.BLOOD_PRESSURE_DIASTOLIC.unit)
+        assertEquals(MetricUnit.BPM, MetricType.HEART_RATE.unit)
+    }
+
+    @Test
+    fun filled_pressure_rows_convert_to_bundle_readings() {
+        // The screen maps rows to BundleReadings before addBundle. A typed
+        // 128/82 @ 70 must survive that conversion as three plain numeric
+        // readings (no original-scale provenance — that's GCS-only).
+        val rows = defaultRowsFor(MeasurementPreset.BLOOD_PRESSURE).mapIndexed { i, row ->
+            row.copy(valueText = listOf("128", "82", "70")[i])
+        }
+        val bundle = rows.mapNotNull { it.toBundleReading() }
+        assertEquals(3, bundle.size)
+        assertEquals(128.0, bundle[0].value, 0.0)
+        assertEquals(82.0, bundle[1].value, 0.0)
+        assertEquals(70.0, bundle[2].value, 0.0)
+        for (b in bundle) {
+            assertNull("BP rows carry no original scale", b.originalScale)
+            assertNull("BP rows carry no original value", b.originalValue)
+        }
+    }
+
+    @Test
+    fun empty_pressure_rows_drop_out_of_the_bundle() {
+        // Default (untouched) rows have blank valueText and must not produce a
+        // zero-valued reading; only filled rows convert.
+        val bundle = defaultRowsFor(MeasurementPreset.BLOOD_PRESSURE)
+            .mapNotNull { it.toBundleReading() }
+        assertTrue("Untouched preset rows must not save", bundle.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
Implements **manual blood pressure entry** (#390) — the Vessel Watch's top missing dial. Adds a one-tap path to log a home-cuff reading (systolic / diastolic / pulse) without filling out a full triage form.

## What changed
- **`MeasurementPreset.BLOOD_PRESSURE`** — a focused 3-row preset (SYS / DIA / pulse), the shape a consumer cuff reports in one measurement.
- **Dedicated `blood_pressure_entry` route** + a **"Blood pressure" card** at the top of the Log screen's "Take a reading" group (it leads — #1 dial, cheapest clinical check).
- **"Blood pressure" preset chip** added to the existing clinical-reading entry screen; the chip row is now horizontally scrollable so three chips don't clip on narrow screens.
- `LogScreen`'s two card groups extracted into `TakeAReadingSection` / `TrackOverTimeSection` to stay under the detekt `LongMethod` limit.

## Data path (unchanged, reused)
Rows write through `ManualReadingRepo.addBundle` → **SELF_REPORTED** → engine-isolated (docs/SELF_REPORTED_DATA_HOME.md decision 3). A manually-typed cuff value shows in trends and FHIR export but never poisons a sensor baseline. Maps to the existing `blood_pressure_systolic` / `blood_pressure_diastolic` keys; pulse maps to `heart_rate`.

## Scope
- [x] Manual cuff entry (SYS / DIA / optional pulse) with timestamp
- [x] Maps to existing `MetricType` keys
- [x] Surfaces as a dedicated entry surface (Vessel Watch dial wiring tracked separately in #389)
- [ ] *(Stretch, deferred per issue)* Omron / Withings BPM adapter

## Tests
`BloodPressureEntryTest` (5 cases): preset shape, manual-entry gating, units (mmHg / bpm), row→bundle conversion, and that untouched rows don't save. All green; full `code-quality-check.sh` passes.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)