### PR TITLE
feat(labocr): on-device lab-report OCR ingestion (Phase 10)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -149,6 +149,12 @@ dependencies {
     implementation("com.google.ai.edge.litert:litert:1.4.2")
     implementation("com.google.ai.edge.litert:litert-support-api:1.4.2")
 
+    // Tesseract OCR (lab-report ingestion, Phase 10) — tess-two is Apache-2.0
+    // and fully Google-Play-Services-free, so it runs on a degoogled build.
+    // Trained-data models are operator-provisioned, never vendored — see
+    // app/src/main/assets/tessdata/README.md.
+    implementation("com.rmtheis:tess-two:9.1.0")
+
     // Ed25519 signature verification (model updates) — needed for API < 33
     implementation("org.bouncycastle:bcprov-jdk18on:1.80")
 

--- a/android/app/detekt-baseline.xml
+++ b/android/app/detekt-baseline.xml
@@ -6,7 +6,7 @@
     <ID>ComplexCondition:RhythmClassifier.kt$RhythmClassifier$(curr &gt; prev &amp;&amp; curr &gt; next) || (curr &lt; prev &amp;&amp; curr &lt; next)</ID>
     <ID>CyclomaticComplexMethod:AnomalyDetector.kt$AnomalyDetector$private suspend fun evaluatePattern(pattern: ConditionPattern): Anomaly?</ID>
     <ID>CyclomaticComplexMethod:AnomalyDetector.kt$AnomalyDetector$private suspend fun scorePattern(pattern: ConditionPattern): DiagnosticResult</ID>
-    <ID>CyclomaticComplexMethod:BiomarkerEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BiomarkerEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit )</ID>
+    <ID>CyclomaticComplexMethod:BiomarkerEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BiomarkerEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit, onOpenScanReview: () -&gt; Unit = {}, )</ID>
     <ID>CyclomaticComplexMethod:CameraPpgAdapter.kt$CameraPpgAdapter$@OptIn(ExperimentalCamera2Interop::class) suspend fun capture( lifecycleOwner: LifecycleOwner, durationSec: Int, sourceId: String, surfaceProvider: Preview.SurfaceProvider? = null, qualityFlow: MutableStateFlow&lt;CaptureQuality&gt;? = null ): CaptureResult</ID>
     <ID>CyclomaticComplexMethod:ClinicalReadingEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun ClinicalReadingEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit, initialPreset: MeasurementPreset = MeasurementPreset.TRIAGE, )</ID>
     <ID>CyclomaticComplexMethod:ConditionDetailScreen.kt$@Composable private fun SignalDetailRow(signal: SignalStatus)</ID>
@@ -64,7 +64,7 @@
     <ID>LongMethod:AnomalyDetector.kt$AnomalyDetector$private suspend fun scorePattern(pattern: ConditionPattern): DiagnosticResult</ID>
     <ID>LongMethod:AnthropometryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun AnthropometryScreen(onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:BbtEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BbtEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit )</ID>
-    <ID>LongMethod:BiomarkerEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BiomarkerEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit )</ID>
+    <ID>LongMethod:BiomarkerEntryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BiomarkerEntryScreen( viewModel: AppViewModel, onBack: () -&gt; Unit, onOpenScanReview: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:BleAirQualityPairScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun BleAirQualityPairScreen( viewModel: BleAirQualityPairViewModel, onBack: () -&gt; Unit )</ID>
     <ID>LongMethod:CameraPpgAdapter.kt$CameraPpgAdapter$@OptIn(ExperimentalCamera2Interop::class) suspend fun capture( lifecycleOwner: LifecycleOwner, durationSec: Int, sourceId: String, surfaceProvider: Preview.SurfaceProvider? = null, qualityFlow: MutableStateFlow&lt;CaptureQuality&gt;? = null ): CaptureResult</ID>
     <ID>LongMethod:CameraPpgResultMapper.kt$CameraPpgResultMapper$fun toResult( ppg: PpgResult, hrv: HrvAnalyzer.HrvResult?, sourceId: String, timestamp: Long, ): CaptureResult</ID>
@@ -91,13 +91,12 @@
     <ID>LongMethod:HeadacheDiaryScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun HeadacheDiaryScreen( onBack: () -&gt; Unit, onNavigateToClusterPeriodicity: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:HealthEventCard.kt$@Composable fun HealthEventCard( event: HealthEvent, actionItems: List&lt;ActionItem&gt;, childEvents: List&lt;HealthEvent&gt;, onStatusChange: (HealthEventStatus) -&gt; Unit, onAddFollowUp: () -&gt; Unit, onToggleAction: (String, Boolean) -&gt; Unit, onDeleteAction: (String) -&gt; Unit, onAddAction: (String) -&gt; Unit )</ID>
     <ID>LongMethod:HealthEventSheet.kt$@OptIn(ExperimentalLayoutApi::class) @Composable private fun HealthEventForm( onSave: (HealthEventInput) -&gt; Unit, parentEventId: String?, defaultType: HealthEventType? )</ID>
-    <ID>LongMethod:HomeScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun HomeScreen( viewModel: AppViewModel, onNavigateToActiveSubstances: () -&gt; Unit = {}, onNavigateToBodyLevels: () -&gt; Unit = {}, onNavigateToMetric: (MetricType) -&gt; Unit = {} )</ID>
     <ID>LongMethod:IdentityRoutes.kt$internal fun NavGraphBuilder.identityRoutes(navController: NavController)</ID>
     <ID>LongMethod:ImmunisationsScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun ImmunisationsScreen(onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:ImmunisationsScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AddImmunisationDialog( onDismiss: () -&gt; Unit, onSave: ( name: String, cvxCode: String?, date: Long, doseNumber: Int?, lotNumber: String?, note: String? ) -&gt; Unit, )</ID>
     <ID>LongMethod:InterventionEventsScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun InterventionEventsScreen(onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:InterventionEventsScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AddInterventionDialog( availableCourses: List&lt;TreatmentCourse&gt;, onDismiss: () -&gt; Unit, onSave: ( category: InterventionCategory, timestamp: Long, subType: String?, tradition: MedicalTradition?, bodyRegion: String?, notes: String?, courseId: String?, ) -&gt; Unit, )</ID>
-    <ID>LongMethod:LogScreen.kt$@Composable fun LogScreen( viewModel: AppViewModel, onNavigateToPpgCapture: () -&gt; Unit, onNavigateToBiomarkerEntry: () -&gt; Unit, onNavigateToClinicalEntry: () -&gt; Unit, onNavigateToSleepEntry: () -&gt; Unit, onNavigateToBbtEntry: () -&gt; Unit, onNavigateToPeriodEntry: () -&gt; Unit, )</ID>
+    <ID>LongMethod:LabScanReviewScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun LabScanReviewScreen( viewModel: AppViewModel, onBack: () -&gt; Unit, onAddManually: () -&gt; Unit, )</ID>
     <ID>LongMethod:LongevityReferenceScreen.kt$@Composable private fun BiomarkerCard( biomarker: BiomarkerReference, trackedMetrics: Set&lt;MetricType&gt;, latestDirectValue: Double? = null, biomarkerBands: com.bios.app.config.BiomarkerBands? = null )</ID>
     <ID>LongMethod:LongevityReferenceScreen.kt$@Composable private fun CoverageSummaryCard(trackedMetrics: Set&lt;MetricType&gt;)</ID>
     <ID>LongMethod:LongevityReferenceScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun LongevityReferenceScreen( trackedMetrics: Set&lt;MetricType&gt;, latestDirectBiomarkerValues: Map&lt;MetricType, Double&gt; = emptyMap(), onBack: () -&gt; Unit )</ID>
@@ -166,6 +165,7 @@
     <ID>MatchingDeclarationName:AppViewModelEntries.kt$RecentEntry</ID>
     <ID>MatchingDeclarationName:BiosPushReceiver.kt$BiosPushService : PushService</ID>
     <ID>MatchingDeclarationName:HealthEventSheet.kt$HealthEventInput</ID>
+    <ID>MatchingDeclarationName:LabUnitConversion.kt$CanonicalUnit</ID>
     <ID>MatchingDeclarationName:Statistics.kt$Stats</ID>
     <ID>MatchingDeclarationName:TimelineScreen.kt$TimelineItem</ID>
     <ID>MaxLineLength:AcuteWindowPatterns.kt$AcuteWindowPatterns$"ACEP / SCCM consensus — sustained SpO2 ≤88 % is the supplemental-oxygen threshold in adult respiratory depression; pairs with RR ≤8 in opioid / sedative / COPD-exacerbation respiratory failure"</ID>
@@ -212,7 +212,6 @@
     <ID>MaxLineLength:AfibRhythmPattern.kt$AfibRhythmPattern$suggestedAction = "Discuss these readings with a healthcare provider. The standard follow-up is a clinical ECG — single-lead (Apple Watch, KardiaMobile, Withings ScanWatch) or 12-lead in office — to confirm or rule out atrial fibrillation. The burden trend and individual session data can be exported and shared with a cardiologist."</ID>
     <ID>MaxLineLength:AnomalyDetectorReadingKindFilterTest.kt$AnomalyDetectorReadingKindFilterTest$"${metric.key} is WOMENS_HEALTH — readingKindFilterFor must return null so the SELF_REPORTED BBT rows in ReproductiveDatabase resolve"</ID>
     <ID>MaxLineLength:AppViewModel.kt$AppViewModel$codeSystem: String? = null</ID>
-    <ID>MaxLineLength:AppViewModel.kt$AppViewModel$val bleAirQualityAdapter = BleAirQualityAdapter(application, db.metricReadingDao(), com.bios.app.ingest.BlePairedDeviceStore(application))</ID>
     <ID>MaxLineLength:AutonomicPatternShiftPattern.kt$AutonomicPatternShiftPattern$earlyDetection = "Acute autonomic shifts produce a recognisable wearable signature: HRV widens, resting heart rate climbs, and SpO2 may drift mildly downward. The combination is sensitive but non-specific. Bios surfaces this pattern as an observation; the PPG-derived AFib screen (which classifies the RR-interval series itself) is a separate surface."</ID>
     <ID>MaxLineLength:AutonomicPatternShiftPattern.kt$AutonomicPatternShiftPattern$explanation = "Heart-rate variability is showing baseline-relative irregularity alongside a sustained resting-HR elevation. This autonomic pattern is non-specific — infection, dehydration, alcohol withdrawal, thyroid perturbation, and post-vaccination autonomic shifts can all produce it."</ID>
     <ID>MaxLineLength:AutonomicPatternShiftPattern.kt$AutonomicPatternShiftPattern$healing = "Rest, hydration, and watching for symptoms over the next 24–48 hours is the first step. If symptoms develop or persist — palpitations, lightheadedness, breathlessness, chest pain — clinical evaluation is the appropriate next step. The pull-side detail view shows the HRV and resting-HR trends."</ID>
@@ -785,7 +784,6 @@
     <ID>MaxLineLength:ScreeningCatalog.kt$ScreeningCatalog$citation = "USPSTF 2016 (B recommendation) — statin primary prevention assessment with periodic lipid measurement; 5-yr cadence reflects the standard primary-care interval for stable values"</ID>
     <ID>MaxLineLength:ScreeningCatalog.kt$ScreeningCatalog$citation = "USPSTF 2018 (A recommendation) — 5-yr HPV co-testing 30–65; 3-yr cytology 21–29 (cadence pinned to the lighter-burden HPV-era schedule)"</ID>
     <ID>MaxLineLength:ScreeningCatalog.kt$ScreeningCatalog$citation = "USPSTF 2018 (B recommendation) — postmenopausal women ≥65; biennial cadence reflects clinical convention for stable T-scores"</ID>
-    <ID>MaxLineLength:ScreeningCatalog.kt$ScreeningCatalog$citation = "USPSTF 2021 (A recommendation) — colorectal cancer screening 45–75; annual FIT or 10-yr colonoscopy. Cadence here is the annual-FIT pace; the engine treats long-interval modalities (colonoscopy) as still-current when within 10 years."</ID>
     <ID>MaxLineLength:ScreeningCatalog.kt$ScreeningCatalog$citation = "USPSTF 2021 (B recommendation) — prediabetes/T2DM screening 35–70 in overweight/obese adults, 3-yr cadence in normoglycemic owners"</ID>
     <ID>MaxLineLength:SepsisScreenPattern.kt$SepsisScreenPattern$"Evans L et al. (2021) — Surviving Sepsis Campaign: International Guidelines for Management of Sepsis and Septic Shock. Critical Care Medicine"</ID>
     <ID>MaxLineLength:SepsisScreenPattern.kt$SepsisScreenPattern$"Kumar A et al. (2006) — Duration of hypotension before initiation of effective antimicrobial therapy is the critical determinant of survival in human septic shock. Critical Care Medicine"</ID>
@@ -909,6 +907,7 @@
     <ID>ThrowsCount:SyncProtocol.kt$SyncProtocol$fun decryptBlob(blob: ByteArray, syncKey: ByteArray): DecryptedBlob</ID>
     <ID>TooGenericExceptionCaught:AppViewModel.kt$AppViewModel$e: Exception</ID>
     <ID>TooGenericExceptionCaught:AppViewModel.kt$AppViewModel$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:AppViewModelLabScan.kt$AppViewModelLabScan$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CameraPpgAdapter.kt$CameraPpgAdapter$e: Exception</ID>
     <ID>TooGenericExceptionCaught:CommunityApiClient.kt$CommunityApiClient$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ContributionWorker.kt$ContributionWorker$e: Exception</ID>
@@ -917,6 +916,7 @@
     <ID>TooGenericExceptionCaught:HealthApiServer.kt$HealthApiServer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:IpfsClient.kt$IpfsClient$e: Exception</ID>
     <ID>TooGenericExceptionCaught:IrohNode.kt$IrohNode$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:LabScanner.kt$LabScanner$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LetheCompatImpl.kt$LetheCompatImpl$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LocalNetworkTransport.kt$LocalNetworkTransport$e: Exception</ID>
     <ID>TooGenericExceptionCaught:ModelUpdateManager.kt$ModelUpdateManager$e: Exception</ID>
@@ -934,6 +934,7 @@
     <ID>TooGenericExceptionCaught:SleepTileService.kt$SleepTileService$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SyncManager.kt$SyncManager$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SyncWorker.kt$SyncWorker$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:TesseractLabOcrEngine.kt$TesseractLabOcrEngine$e: Exception</ID>
     <ID>TooGenericExceptionCaught:WillowSyncAdapter.kt$WillowSyncAdapter$e: Exception</ID>
     <ID>TooManyFunctions:AppViewModel.kt$AppViewModel : AndroidViewModel</ID>
     <ID>TooManyFunctions:BiosDatabase.kt$BiosDatabase : RoomDatabase</ID>

--- a/android/app/src/main/assets/tessdata/.gitignore
+++ b/android/app/src/main/assets/tessdata/.gitignore
@@ -1,0 +1,3 @@
+# Tesseract language models are operator-provisioned, never committed.
+# See README.md in this folder.
+*.traineddata

--- a/android/app/src/main/assets/tessdata/README.md
+++ b/android/app/src/main/assets/tessdata/README.md
@@ -1,0 +1,30 @@
+# Tesseract trained data (operator-provisioned)
+
+Lab-report OCR (Phase 10, `com.bios.app.labocr`) uses Tesseract via tess-two.
+Tesseract needs one `<lang>.traineddata` model per language. These are
+multi-megabyte binaries and are **deliberately not committed** to this public
+repository — they bloat the repo and the APK and are redistributed under their
+own licence.
+
+At runtime `TesseractLabOcrEngine` copies every `*.traineddata` it finds in
+this `assets/tessdata/` folder into private storage and enables OCR for those
+languages. If none are present, lab-report scanning is unavailable and the
+review screen says so — it never fails silently.
+
+## Adding the models for a build
+
+Drop the language files Bios ships aliases for (Catalan, Spanish, English)
+into this folder before assembling a release:
+
+```
+app/src/main/assets/tessdata/cat.traineddata
+app/src/main/assets/tessdata/spa.traineddata
+app/src/main/assets/tessdata/eng.traineddata
+```
+
+Use the `tessdata_fast` models (smaller, plenty accurate for printed reports):
+https://github.com/tesseract-ocr/tessdata_fast
+
+The `*.traineddata` files are git-ignored (see this folder's `.gitignore`), so
+a local drop never gets committed. For CI/release, fetch them in the build
+pipeline rather than vendoring them here.

--- a/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirImporter.kt
@@ -369,23 +369,12 @@ object FhirImporter {
         if (incoming == targetUcum || incoming == metric.unit.symbol) {
             return UnitConversion.Same(value)
         }
-        val factor = conversionFactor(incoming, targetUcum)
+        // Shared conversion table — the single source of truth used by both
+        // this importer and lab-report OCR ingestion (see LabUnitConversion.kt).
+        // canonicaliseUnitToken folds real-lab spellings (mg/dl → mg/dL) first.
+        val factor = conversionFactor(canonicaliseUnitToken(incoming), targetUcum)
             ?: return UnitConversion.Mismatch(incoming, targetUcum)
         return UnitConversion.Converted(value * factor)
-    }
-
-    /**
-     * Returns the multiplicative factor to convert [from] to [to], or null
-     * when no conversion is registered. Kept minimal on purpose: every
-     * entry here represents a unit pair Bios has seen in real FHIR imports.
-     */
-    private fun conversionFactor(from: String, to: String): Double? {
-        if (from == to) return 1.0
-        // mg/dL ↔ mg/L. UCUM canonical codes plus the `unit` text fallbacks
-        // that real labs emit. mg/dL × 10 = mg/L.
-        if ((from == "mg/dL" || from == "mg/dl") && to == "mg/L") return 10.0
-        if (from == "mg/L" && (to == "mg/dL" || to == "mg/dl")) return 0.1
-        return null
     }
 
     private sealed class UnitConversion {

--- a/android/app/src/main/java/com/bios/app/export/LabUnitConversion.kt
+++ b/android/app/src/main/java/com/bios/app/export/LabUnitConversion.kt
@@ -1,0 +1,155 @@
+package com.bios.app.export
+
+import com.bios.contracts.MetricType
+
+/**
+ * One unit-reconciliation source of truth shared by FHIR import
+ * ([FhirImporter.normaliseUnit]) and lab-report OCR ingestion
+ * (`LabLineExtractor`). Both surfaces read a value plus a free-text unit
+ * token off an external artifact and must reconcile it against the
+ * canonical Bios unit for a [MetricType] before anything is stored — and
+ * they must agree, or the same lab value imports differently depending on
+ * which door it came through.
+ *
+ * The conversion table is intentionally tiny: every entry is a unit pair
+ * Bios has actually seen on a real report. Bios is a health guardian, not a
+ * general unit-conversion service — an unknown pair fails closed (skip and
+ * report) rather than guessing and storing a wrong-by-10× value.
+ */
+
+/** Outcome of reconciling an OCR/FHIR unit token against a metric's canonical unit. */
+sealed class CanonicalUnit {
+    /** Value is in (or was converted to) the canonical unit; safe to store. */
+    data class Ok(val value: Double) : CanonicalUnit()
+
+    /** No known conversion from [incoming] to [target]; caller must skip-and-report. */
+    data class Incompatible(val incoming: String, val target: String) : CanonicalUnit()
+}
+
+/**
+ * Reconcile [rawUnit] (as printed on the report / FHIR `valueQuantity`)
+ * against the canonical unit of [metric] and return [value] in that
+ * canonical unit.
+ *
+ *  - A blank/absent unit returns [CanonicalUnit.Ok] unchanged: the analyte
+ *    was already resolved by name/LOINC, so trust the mapping. (The OCR
+ *    caller separately drops a unit-less line to LOW confidence.)
+ *  - A unit equal to the canonical UCUM code or the human symbol passes through.
+ *  - A registered conversion factor is applied.
+ *  - Anything else is [CanonicalUnit.Incompatible] — fail closed.
+ */
+fun normalizeToCanonicalUnit(metric: MetricType, rawUnit: String?, value: Double): CanonicalUnit {
+    val incoming = rawUnit?.trim().orEmpty()
+    if (incoming.isEmpty()) return CanonicalUnit.Ok(value)
+
+    val target = ucumCode(metric)
+    val canon = canonicaliseUnitToken(incoming)
+    if (canon == target || incoming == metric.unit.symbol || canon == metric.unit.symbol) {
+        return CanonicalUnit.Ok(value)
+    }
+    val factor = conversionFactor(canon, target)
+        ?: return CanonicalUnit.Incompatible(incoming, target)
+    return CanonicalUnit.Ok(value * factor)
+}
+
+/**
+ * Returns the multiplicative factor to convert [from] to [to], or null when
+ * no conversion is registered. Both arguments are expected to already be
+ * canonical UCUM tokens (run [canonicaliseUnitToken] first for free text).
+ *
+ * Issue #354 — hospital labs report standard CRP in mg/dL while Bios stores
+ * mg/L; a naive import underestimates by 10×. Kept deliberately minimal.
+ */
+internal fun conversionFactor(from: String, to: String): Double? {
+    if (from == to) return 1.0
+    // mg/dL ↔ mg/L. mg/dL × 10 = mg/L.
+    if (from == "mg/dL" && to == "mg/L") return 10.0
+    if (from == "mg/L" && to == "mg/dL") return 0.1
+    return null
+}
+
+/**
+ * Folds the many ways a lab or OCR engine spells a unit into the canonical
+ * UCUM token [ucumCode] emits, so the comparison in [normalizeToCanonicalUnit]
+ * is apples-to-apples. Case- and accent-insensitive on the lookup key; the
+ * returned value is the exact UCUM string Bios uses internally.
+ *
+ * Unknown tokens fall through unchanged — they simply won't match a target
+ * and the caller fails closed. This is a gazetteer of real report spellings,
+ * not an attempt at general UCUM parsing.
+ */
+internal fun canonicaliseUnitToken(raw: String): String =
+    UNIT_CANON[unitLookupKey(raw)] ?: raw.trim()
+
+/**
+ * True if [raw] reads as a unit of measure (a known spelling, or carries a
+ * `/` or `%`), as opposed to an abnormal-result flag ("H", "L", "*", "alto")
+ * that can sit in the same column position on a report. The line extractor
+ * uses this so a flag never gets treated as an incompatible unit and wrongly
+ * skips an otherwise-good reading.
+ */
+internal fun isKnownUnitToken(raw: String): Boolean {
+    if (raw.contains('/') || raw.contains('%')) return true
+    return UNIT_CANON.containsKey(unitLookupKey(raw))
+}
+
+private fun unitLookupKey(raw: String): String = raw.lowercase()
+    .replace("µ", "u")
+    .replace("μ", "u")
+    .replace("⁹", "9")
+    .replace("¹²", "12")
+    .replace("^", "")
+    .replace("·", ".")
+    .replace(" ", "")
+
+/** Lowercased real-report unit spelling → canonical UCUM token [ucumCode] emits. */
+private val UNIT_CANON: Map<String, String> = mapOf(
+    "mg/dl" to "mg/dL",
+    "mg/l" to "mg/L",
+    "g/dl" to "g/dL",
+    "g/l" to "g/L",
+    "%" to "%",
+    "pct" to "%",
+    "u/l" to "U/L",
+    "ui/l" to "U/L",
+    "iu/l" to "U/L",
+    "miu/l" to "m[IU]/L",
+    "mui/l" to "m[IU]/L",
+    "mu/l" to "m[IU]/L",
+    "uiu/ml" to "u[IU]/mL",
+    "uui/ml" to "u[IU]/mL",
+    "miu/ml" to "m[IU]/mL",
+    "mui/ml" to "m[IU]/mL",
+    "iu/ml" to "[IU]/mL",
+    "ui/ml" to "[IU]/mL",
+    "ng/ml" to "ng/mL",
+    "ng/dl" to "ng/dL",
+    "ng/l" to "ng/L",
+    "pg/ml" to "pg/mL",
+    "pg" to "pg",
+    "ug/dl" to "ug/dL",
+    "ug/l" to "ug/L",
+    "nmol/l" to "nmol/L",
+    "umol/l" to "umol/L",
+    "mmol/l" to "meq/L",
+    "meq/l" to "meq/L",
+    "fl" to "fL",
+    "10e9/l" to "10*9/L",
+    "109/l" to "10*9/L",
+    "10*9/l" to "10*9/L",
+    "x109/l" to "10*9/L",
+    "10e3/ul" to "10*9/L",
+    "10e12/l" to "10*12/L",
+    "1012/l" to "10*12/L",
+    "10*12/l" to "10*12/L",
+    "x1012/l" to "10*12/L",
+    "10e6/ul" to "10*12/L",
+    "ml/min/1.73m2" to "mL/min/{1.73_m2}",
+    "ml/min/1,73m2" to "mL/min/{1.73_m2}",
+    "ml/min" to "mL/min/{1.73_m2}",
+    "/ul" to "/uL",
+    "ul" to "/uL",
+    "s" to "s",
+    "sec" to "s",
+    "seg" to "s",
+)

--- a/android/app/src/main/java/com/bios/app/labocr/LabAnalyteAliases.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/LabAnalyteAliases.kt
@@ -1,0 +1,236 @@
+package com.bios.app.labocr
+
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import java.text.Normalizer
+
+/**
+ * Multilingual analyte-name → [MetricType] resolution for lab-report OCR.
+ *
+ * **Anti-drift design (critical).** [MetricType] carries no synonyms, and a
+ * biomarker's English `key` (`tsh`, `total_cholesterol`) will never match a
+ * Catalan/Spanish report (`Tirotropina`, `Colesterol total`). So aliases are
+ * the one genuinely new data artifact this feature needs — but the resolver
+ * [aliasToMetricType] is *derived by scanning [MetricType.entries]* through
+ * [biomarkerAliases], exactly as `FhirImporter.loincToMetricType` is built by
+ * scanning entries through `loincCode`. A hand-maintained `Map<String,
+ * MetricType>` kept *parallel* to the enum silently drifts the day a new
+ * biomarker key lands without an alias — the same dual-source drift the LOINC
+ * map was deliberately built to avoid.
+ *
+ * `LabAnalyteAliasesTest` asserts every `BIOMARKER` + `allowsManualEntry`
+ * entry has ≥1 alias, so adding a biomarker key without an alias fails CI.
+ *
+ * Aliases ship for the owner's locales (ES / CA / EN). Broader language
+ * coverage is the eventual home of the `RegionConfigProvider` layer (v0.4).
+ *
+ * See docs/LAB_OCR_INGESTION.md §4.3.
+ */
+object LabAnalyteAliases {
+
+    /** Resolver derived FROM the per-metric alias lists. Built once, lazily. */
+    val aliasToMetricType: Map<String, MetricType> by lazy {
+        buildMap {
+            for (type in MetricType.entries) {
+                for (alias in biomarkerAliases(type).orEmpty()) {
+                    // First writer wins: alias lists are authored collision-free
+                    // (LabAnalyteAliasesTest guards this), so a clash is a bug.
+                    putIfAbsent(normalise(alias), type)
+                }
+            }
+        }
+    }
+
+    /** Resolution of a report line's leading text to a biomarker. */
+    data class AnalyteMatch(val metric: MetricType, val exact: Boolean)
+
+    /**
+     * Resolve [leadingText] (the words before the first numeric token) to a
+     * biomarker. An exact normalised hit is [AnalyteMatch.exact] = true; a
+     * prefix/partial overlap resolves with exact = false so the caller can
+     * drop the row to LOW confidence.
+     */
+    fun resolve(leadingText: String): AnalyteMatch? {
+        val norm = normalise(leadingText)
+        if (norm.length < 2) return null
+        aliasToMetricType[norm]?.let { return AnalyteMatch(it, exact = true) }
+        // Fuzzy: the printed label carries a trailing qualifier OCR kept
+        // ("colesterol total seric"), or a leading code was dropped. Accept
+        // the longest alias the line starts with, min 4 chars to avoid noise.
+        val fuzzy = aliasToMetricType.entries
+            .filter { it.key.length >= 4 && norm.startsWith(it.key) }
+            .maxByOrNull { it.key.length }
+        return fuzzy?.let { AnalyteMatch(it.value, exact = false) }
+    }
+
+    /**
+     * Lowercase, strip diacritics, fold `%` to a `percent` token (the only
+     * differentiator between e.g. `Monòcits %` and absolute `Monòcits`), and
+     * collapse every other non-alphanumeric run to a single space. Used to
+     * key both the alias table and the lookup so they compare apples-to-apples.
+     */
+    fun normalise(s: String): String {
+        val deAccented = Normalizer.normalize(s, Normalizer.Form.NFD)
+            .replace(Regex("\\p{Mn}+"), "")
+        return deAccented.lowercase()
+            .replace("%", " percent ")
+            .replace(Regex("[^a-z0-9]+"), " ")
+            .trim()
+            .replace(Regex("\\s+"), " ")
+    }
+
+    /**
+     * Aliases keyed BY [MetricType]; the resolver is derived FROM this. Only
+     * `BIOMARKER`-domain entries the owner can transcribe off a report need
+     * coverage — everything else returns null. Percentage differential keys
+     * carry a `%` so they don't collide with their absolute-count siblings.
+     */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    fun biomarkerAliases(metric: MetricType): List<String>? {
+        if (metric.domain != MetricDomain.BIOMARKER) return null
+        return when (metric) {
+            // Glycemic
+            MetricType.HBA1C -> listOf("hba1c", "hemoglobina glicada", "hemoglobina glucosilada", "glycated hemoglobin", "a1c")
+            MetricType.FASTING_GLUCOSE -> listOf(
+                "glucosa en dejuni", "glucosa en ayunas", "glucosa basal", "fasting glucose", "glucemia basal",
+            )
+            MetricType.FASTING_INSULIN -> listOf("insulina en dejuni", "insulina basal", "insulina en ayunas", "fasting insulin")
+            MetricType.HOMA_IR -> listOf("homa ir", "homa", "index homa", "indice homa")
+            // Inflammation
+            MetricType.HSCRP -> listOf("pcr ultrasensible", "pcr us", "proteina c reactiva ultrasensible", "high sensitivity crp", "hs crp")
+            MetricType.CRP -> listOf("pcr", "proteina c reactiva", "proteina c reactiva serica", "c reactive protein")
+            // Lipids
+            MetricType.TOTAL_CHOLESTEROL -> listOf("colesterol total", "colesterol", "cholesterol total", "colesterol serico")
+            MetricType.LDL_CHOLESTEROL -> listOf("colesterol ldl", "ldl", "colesterol de ldl", "ldl cholesterol", "colesterol ldl calculat")
+            MetricType.HDL_CHOLESTEROL -> listOf("colesterol hdl", "hdl", "colesterol de hdl", "hdl cholesterol", "colesterol d hdl")
+            MetricType.TRIGLYCERIDES -> listOf("triglicerids", "trigliceridos", "triglycerides", "tg")
+            MetricType.APO_B -> listOf("apolipoproteina b", "apo b", "apob", "apolipoprotein b")
+            MetricType.LIPOPROTEIN_A -> listOf("lipoproteina a", "lp a", "lipoprotein a", "lpa")
+            // Vitamins / micronutrients
+            MetricType.VITAMIN_D_25OH -> listOf("vitamina d", "25 hidroxivitamina d", "25 oh vitamina d", "vitamin d 25 oh", "calcidiol")
+            MetricType.VITAMIN_B12 -> listOf("vitamina b12", "cobalamina", "vitamin b12", "b12")
+            MetricType.FOLATE -> listOf("acid folic", "acido folico", "folat", "folato", "folate")
+            MetricType.VITAMIN_A_RETINOL -> listOf("vitamina a", "retinol", "vitamin a retinol")
+            MetricType.VITAMIN_E_ALPHA_TOCOPHEROL -> listOf("vitamina e", "alfa tocoferol", "tocoferol alfa", "vitamin e")
+            MetricType.VITAMIN_K2 -> listOf("vitamina k2", "menaquinona", "vitamin k2", "mk 7")
+            MetricType.OMEGA_3_INDEX -> listOf("index omega 3", "indice omega 3", "omega 3 index")
+            // Thyroid
+            MetricType.TSH -> listOf("tsh", "tirotropina", "tirotropina tsh", "thyrotropin", "hormona estimulant del tiroide")
+            MetricType.FREE_T4 -> listOf("t4 lliure", "t4 libre", "tiroxina lliure", "tiroxina libre", "free t4", "ft4")
+            MetricType.FREE_T3 -> listOf("t3 lliure", "t3 libre", "triiodotironina lliure", "free t3", "ft3")
+            MetricType.REVERSE_T3 -> listOf("t3 reversa", "t3 invertida", "reverse t3", "rt3")
+            MetricType.THYROID_PEROXIDASE_AB -> listOf(
+                "anticossos antiperoxidasa", "anti tpo", "anticuerpos antiperoxidasa",
+                "tpo ab", "thyroid peroxidase antibody",
+            )
+            MetricType.THYROGLOBULIN_AB -> listOf("anticossos antitiroglobulina", "anti tiroglobulina", "tg ab", "thyroglobulin antibody")
+            // CBC
+            MetricType.HEMOGLOBIN -> listOf("hemoglobina", "hb", "hemoglobin")
+            MetricType.HEMATOCRIT -> listOf("hematocrit", "hematocrito", "hto", "hct")
+            MetricType.WBC -> listOf("leucocits", "leucocitos", "white blood cells", "wbc", "recompte de leucocits")
+            MetricType.RBC -> listOf("hematies", "eritrocits", "eritrocitos", "red blood cells", "rbc", "hematies recompte")
+            MetricType.PLATELETS -> listOf("plaquetes", "plaquetas", "platelets", "plt", "recompte de plaquetes")
+            MetricType.MCV -> listOf("vcm", "volum corpuscular mitja", "volumen corpuscular medio", "mcv")
+            MetricType.MCH -> listOf("hcm", "hemoglobina corpuscular mitjana", "hemoglobina corpuscular media", "mch")
+            MetricType.MCHC -> listOf("chcm", "concentracio hemoglobina corpuscular", "mchc")
+            MetricType.RDW -> listOf("rdw", "amplada de distribucio eritrocitaria", "ancho de distribucion eritrocitaria")
+            MetricType.MPV -> listOf("vpm", "volum plaquetari mitja", "volumen plaquetario medio", "mpv")
+            MetricType.NEUTROPHILS_PCT -> listOf("neutrofils %", "neutrofilos %", "neutrophils %", "segmentats %")
+            MetricType.LYMPHOCYTES_PCT -> listOf("limfocits %", "linfocitos %", "lymphocytes %")
+            MetricType.MONOCYTES_PCT -> listOf("monocits %", "monocitos %", "monocytes %")
+            MetricType.EOSINOPHILS_PCT -> listOf("eosinofils %", "eosinofilos %", "eosinophils %")
+            MetricType.BASOPHILS_PCT -> listOf("basofils %", "basofilos %", "basophils %")
+            MetricType.ABSOLUTE_NEUTROPHIL_COUNT -> listOf(
+                "neutrofils absoluts", "neutrofilos absolutos", "absolute neutrophil count", "anc",
+            )
+            MetricType.ABSOLUTE_LYMPHOCYTE_COUNT -> listOf("limfocits absoluts", "linfocitos absolutos", "absolute lymphocyte count")
+            MetricType.ABSOLUTE_MONOCYTE_COUNT -> listOf("monocits absoluts", "monocitos absolutos", "absolute monocyte count")
+            MetricType.ABSOLUTE_EOSINOPHIL_COUNT -> listOf("eosinofils absoluts", "eosinofilos absolutos", "absolute eosinophil count")
+            MetricType.ABSOLUTE_BASOPHIL_COUNT -> listOf("basofils absoluts", "basofilos absolutos", "absolute basophil count")
+            // Iron
+            MetricType.FERRITIN -> listOf("ferritina", "ferritin")
+            MetricType.IRON_SERUM -> listOf("ferro", "hierro", "ferro seric", "hierro serico", "serum iron", "sideremia")
+            MetricType.IRON_SATURATION_PCT -> listOf(
+                "index de saturacio de transferrina", "indice de saturacion de transferrina",
+                "saturacio de transferrina", "transferrin saturation", "ist",
+            )
+            MetricType.TIBC -> listOf(
+                "capacitat total de fixacio del ferro", "capacidad total de fijacion del hierro",
+                "total iron binding capacity", "tibc",
+            )
+            // Renal / metabolic panel
+            MetricType.EGFR -> listOf("filtrat glomerular", "filtrado glomerular", "fg", "egfr", "tasa de filtracion glomerular", "ckd epi")
+            MetricType.CREATININE -> listOf("creatinina", "creatinine")
+            MetricType.BUN -> listOf("nitrogen ureic", "nitrogeno ureico", "bun", "urea nitrogen")
+            MetricType.URIC_ACID -> listOf("acid uric", "acido urico", "uric acid", "uricemia")
+            MetricType.SODIUM -> listOf("sodi", "sodio", "sodium", "na")
+            MetricType.POTASSIUM -> listOf("potassi", "potasio", "potassium", "k")
+            MetricType.CHLORIDE -> listOf("clor", "cloro", "cloruro", "chloride", "cl")
+            MetricType.CARBON_DIOXIDE -> listOf("bicarbonat", "bicarbonato", "co2 total", "carbon dioxide")
+            MetricType.CALCIUM_SERUM -> listOf("calci", "calcio", "calci seric", "calcium", "calcemia")
+            MetricType.PHOSPHATE -> listOf("fosfat", "fosforo", "fosfor", "phosphate", "fosforo serico")
+            MetricType.MAGNESIUM -> listOf("magnesi", "magnesio", "magnesium", "mg serico")
+            // Liver / pancreas
+            MetricType.ALT -> listOf("alt", "gpt", "alanina aminotransferasa", "alat", "transaminasa gpt")
+            MetricType.AST -> listOf("ast", "got", "aspartat aminotransferasa", "asat", "transaminasa got")
+            MetricType.GGT -> listOf("ggt", "gamma gt", "gamma glutamil transferasa", "gamma glutamyl transferase")
+            MetricType.ALKALINE_PHOSPHATASE -> listOf("fosfatasa alcalina", "fa", "alkaline phosphatase", "alp")
+            MetricType.BILIRUBIN_TOTAL -> listOf("bilirubina total", "bilirrubina total", "total bilirubin")
+            MetricType.ALBUMIN -> listOf("albumina", "albumin", "albumina serica")
+            MetricType.TOTAL_PROTEIN -> listOf("proteines totals", "proteinas totales", "total protein", "proteina total")
+            MetricType.AMYLASE -> listOf("amilasa", "amylase", "amilasemia")
+            MetricType.LIPASE -> listOf("lipasa", "lipase")
+            // Endocrine / reproductive
+            MetricType.TESTOSTERONE_TOTAL -> listOf("testosterona total", "testosterona", "total testosterone")
+            MetricType.TESTOSTERONE_FREE -> listOf("testosterona lliure", "testosterona libre", "free testosterone")
+            MetricType.ESTRADIOL -> listOf("estradiol", "estradiol e2", "17 beta estradiol")
+            MetricType.CORTISOL -> listOf("cortisol", "cortisol seric", "cortisol basal")
+            MetricType.IGF_1 -> listOf("igf 1", "factor de creixement insulinic", "somatomedina c", "insulin like growth factor 1")
+            MetricType.FSH -> listOf("fsh", "hormona fol·liculoestimulant", "foliculoestimulante", "follicle stimulating hormone")
+            MetricType.LH -> listOf("lh", "hormona luteinitzant", "hormona luteinizante", "luteinizing hormone")
+            MetricType.SHBG -> listOf(
+                "shbg", "globulina fixadora hormones sexuals",
+                "globulina transportadora de hormonas sexuales", "sex hormone binding globulin",
+            )
+            MetricType.AMH -> listOf("hormona antimulleriana", "amh", "anti mullerian hormone")
+            MetricType.PROLACTIN -> listOf("prolactina", "prl", "prolactin")
+            MetricType.DHEA_SULFATE -> listOf("dhea sulfat", "sulfat de dhea", "sulfato de dhea", "dhea s", "dhea sulfate")
+            // Cardiac / coag
+            MetricType.TROPONIN_NG_PER_L -> listOf("troponina", "troponina t", "troponina i", "troponin", "hs troponina")
+            MetricType.NT_PRO_BNP_PG_PER_ML -> listOf("nt probnp", "probnp", "nt pro bnp", "pro bnp")
+            MetricType.D_DIMER -> listOf("dimer d", "dimero d", "d dimer", "d dimero")
+            MetricType.HOMOCYSTEINE -> listOf("homocisteina", "homocysteine")
+            MetricType.PROTHROMBIN_TIME -> listOf("temps de protrombina", "tiempo de protrombina", "prothrombin time", "tp")
+            MetricType.INR -> listOf("inr", "ratio internacional normalitzat", "indice internacional normalizado")
+            MetricType.QUICK_INDEX -> listOf("index de quick", "indice de quick", "activitat de protrombina", "quick")
+            MetricType.APTT -> listOf(
+                "ttpa", "temps de tromboplastina parcial activada",
+                "tiempo de tromboplastina parcial activada", "aptt",
+            )
+            MetricType.APTT_RATIO -> listOf("ratio ttpa", "aptt ratio", "ratio de aptt")
+            // Tumor / screening / imaging markers
+            MetricType.PSA_TOTAL -> listOf(
+                "psa total", "psa", "antigen prostatic especific",
+                "antigeno prostatico especifico", "prostate specific antigen",
+            )
+            MetricType.PSA_FREE -> listOf("psa lliure", "psa libre", "free psa", "fpsa")
+            MetricType.CORONARY_CALCIUM_SCORE -> listOf(
+                "calci coronari", "calcio coronario", "coronary calcium score", "agatston", "cac score",
+            )
+            MetricType.BONE_DENSITY_T_SCORE -> listOf(
+                "t score", "puntuacio t", "densitat ossia t score", "bone density t score", "dexa t score",
+            )
+            MetricType.PTAU_217 -> listOf("ptau 217", "tau fosforilada 217", "p tau 217")
+            // Adipokines
+            MetricType.LEPTIN -> listOf("leptina", "leptin")
+            MetricType.ADIPONECTIN -> listOf("adiponectina", "adiponectin")
+            // Epigenetic / proprietary clocks (EN only — vendor-specific reports)
+            MetricType.TELOMERE_LENGTH -> listOf("longitud telomerica", "telomere length", "longitud de telomeros")
+            MetricType.EPIGENETIC_AGE_DUNEDIN_PACE -> listOf("dunedinpace", "dunedin pace", "pace of aging")
+            MetricType.EPIGENETIC_AGE_GRIM -> listOf("grimage", "grim age", "edat epigenetica grim")
+            MetricType.EPIGENETIC_AGE_PHENO -> listOf("phenoage", "pheno age", "edat epigenetica pheno")
+            MetricType.EPIGENETIC_AGE_HORVATH -> listOf("horvath", "horvath age", "rellotge de horvath")
+            else -> null
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/labocr/LabLineExtractor.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/LabLineExtractor.kt
@@ -1,0 +1,167 @@
+package com.bios.app.labocr
+
+import com.bios.app.export.CanonicalUnit
+import com.bios.app.export.isKnownUnitToken
+import com.bios.app.export.normalizeToCanonicalUnit
+
+/**
+ * Turns a single recognised report line into either an [ExtractedReading] or
+ * a [SkippedLine] with a reason — never drops a line silently (docs
+ * LAB_OCR_INGESTION.md §4.2).
+ *
+ * Lab lines share a stable shape across labs and languages:
+ * ```
+ * <analyte name> … <value> <unit> <ref-low> – <ref-high>
+ * ```
+ * The analyte is resolved first (longest leading-token alias), so digits that
+ * are part of the *name* (`Vitamina B12`, `Omega 3 index`, `T4 lliure`) are
+ * not mistaken for the value. The value is the first number after the name;
+ * the unit gates acceptance; the printed reference range, if any, is used
+ * only as a magnitude plausibility check and is never stored.
+ */
+object LabLineExtractor {
+
+    /** Either an accepted reading or a reasoned skip — exhaustive, no third state. */
+    sealed class LineOutcome {
+        data class Reading(val reading: ExtractedReading) : LineOutcome()
+        data class Skipped(val skipped: SkippedLine) : LineOutcome()
+        /** No analyte and no number — structural line (section header, blank). Not surfaced. */
+        object Ignored : LineOutcome()
+    }
+
+    /** Greatest number of leading whitespace tokens we'll try to fold into an analyte name. */
+    private const val MAX_NAME_TOKENS = 6
+
+    /** A number, optionally with a `<`/`>` qualifier or trailing flag char. */
+    private val NUMBER = Regex("[0-9]+(?:[.,][0-9]+)*")
+
+    fun extract(rawLine: String): LineOutcome {
+        val line = rawLine.trim()
+        if (line.isEmpty()) return LineOutcome.Ignored
+        val tokens = line.split(Regex("\\s+"))
+
+        val resolved = resolveLeadingAnalyte(tokens)
+        if (resolved == null) {
+            // No analyte. If the line has no numbers either it's structural;
+            // otherwise it's a real value line we simply can't map — report it.
+            return if (NUMBER.containsMatchIn(line)) {
+                LineOutcome.Skipped(SkippedLine(line, "No analyte name matched"))
+            } else {
+                LineOutcome.Ignored
+            }
+        }
+
+        val (match, remainder) = resolved
+        val metric = match.metric
+
+        val valueIdx = remainder.indexOfFirst { tokenNumber(it) != null }
+        if (valueIdx < 0) {
+            return LineOutcome.Skipped(SkippedLine(line, "${metric.readableName}: no numeric value on line"))
+        }
+        val value = tokenNumber(remainder[valueIdx])!!
+        if (value <= 0.0) {
+            return LineOutcome.Skipped(SkippedLine(line, "${metric.readableName}: non-positive value"))
+        }
+
+        val unit = remainder.drop(valueIdx + 1).firstOrNull { isKnownUnitToken(it) }
+        val range = referenceRange(remainder.drop(valueIdx + 1))
+
+        // Unit guard — the disambiguation gate. Reuses the shared FHIR/OCR
+        // conversion table; an incompatible unit skips-and-reports, never guesses.
+        val canonical = normalizeToCanonicalUnit(metric, unit, value)
+        if (canonical is CanonicalUnit.Incompatible) {
+            val target = metric.unit.symbol.ifEmpty { canonical.target }
+            return LineOutcome.Skipped(
+                SkippedLine(line, "${metric.readableName}: unit ${canonical.incoming} not compatible with $target")
+            )
+        }
+        val storedValue = (canonical as CanonicalUnit.Ok).value
+
+        val confidence = scoreConfidence(match.exact, unit, value, range)
+        return LineOutcome.Reading(ExtractedReading(metric, storedValue, confidence, rawLine.trim()))
+    }
+
+    /**
+     * Folds the longest leading run of tokens that resolves to a biomarker,
+     * preferring an exact alias hit over a fuzzy one and a longer name over a
+     * shorter (so `Colesterol HDL` beats bare `Colesterol`). Returns the match
+     * plus the remaining tokens (where the value lives), or null.
+     */
+    private fun resolveLeadingAnalyte(
+        tokens: List<String>,
+    ): Pair<LabAnalyteAliases.AnalyteMatch, List<String>>? {
+        val maxLen = minOf(MAX_NAME_TOKENS, tokens.size - 1).coerceAtLeast(1)
+        // Exact first, longest prefix wins.
+        for (len in maxLen downTo 1) {
+            val prefix = tokens.take(len).joinToString(" ")
+            val m = LabAnalyteAliases.resolve(prefix)
+            if (m != null && m.exact) return m to tokens.drop(len)
+        }
+        // Then fuzzy, longest prefix wins.
+        for (len in maxLen downTo 1) {
+            val prefix = tokens.take(len).joinToString(" ")
+            val m = LabAnalyteAliases.resolve(prefix)
+            if (m != null) return m to tokens.drop(len)
+        }
+        return null
+    }
+
+    /**
+     * HIGH only when the name was an exact alias hit, a real unit was present,
+     * and the value sits within ~2 orders of magnitude of the printed
+     * reference range. Anything softer is LOW — shown unchecked for the owner
+     * to verify, never silently accepted (docs §4.4).
+     */
+    private fun scoreConfidence(
+        exactName: Boolean,
+        unit: String?,
+        value: Double,
+        range: Pair<Double, Double>?,
+    ): Confidence {
+        if (!exactName) return Confidence.LOW
+        if (unit == null) return Confidence.LOW
+        if (range != null) {
+            val (low, high) = range
+            // The magnitude trap: a value three orders outside the printed
+            // range is a dropped decimal point, not a real result.
+            if (high > 0 && value > high * 100) return Confidence.LOW
+            if (low > 0 && value < low / 100) return Confidence.LOW
+        }
+        return Confidence.HIGH
+    }
+
+    /** First two numbers separated by a dash are the printed low–high reference range. */
+    private fun referenceRange(afterValue: List<String>): Pair<Double, Double>? {
+        val joined = afterValue.joinToString(" ")
+        if (!joined.contains(Regex("[-–—]"))) return null
+        val nums = NUMBER.findAll(joined).mapNotNull { parseNumber(it.value) }.toList()
+        return if (nums.size >= 2) nums[0] to nums[1] else null
+    }
+
+    /** Parse the numeric part of a token ("<5", "5,2*", "190") to a Double, or null. */
+    private fun tokenNumber(token: String): Double? {
+        val m = NUMBER.find(token) ?: return null
+        return parseNumber(m.value)
+    }
+
+    /**
+     * Locale-aware decimal parse. Honours both `.` and `,` as decimal marks
+     * and strips thousands separators — gluing `6.5` + `%` is the classic
+     * strip-non-digits bug, so each printed number is parsed on its own.
+     */
+    private fun parseNumber(raw: String): Double? {
+        val hasDot = raw.contains('.')
+        val hasComma = raw.contains(',')
+        val normalized = when {
+            hasDot && hasComma ->
+                if (raw.lastIndexOf(',') > raw.lastIndexOf('.')) {
+                    raw.replace(".", "").replace(",", ".")
+                } else {
+                    raw.replace(",", "")
+                }
+            hasComma -> raw.replace(",", ".")
+            else -> raw
+        }
+        return normalized.toDoubleOrNull()
+    }
+}

--- a/android/app/src/main/java/com/bios/app/labocr/LabOcrEngine.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/LabOcrEngine.kt
@@ -1,0 +1,35 @@
+package com.bios.app.labocr
+
+import android.graphics.Bitmap
+
+/**
+ * On-device OCR seam. The whole extraction pipeline depends only on this
+ * interface, so the concrete engine (Tesseract today, ML Kit or another
+ * tomorrow) is swappable without touching alias resolution, the line
+ * extractor, or the review UI — the hedge the design called for
+ * (docs LAB_OCR_INGESTION.md §2).
+ *
+ * Implementations MUST be fully on-device and free of Google Play Services so
+ * Bios keeps working on a degoogled build (principle 6). No byte of a lab
+ * report leaves the device.
+ */
+interface LabOcrEngine {
+
+    /**
+     * True when the engine can actually run — e.g. its language data is
+     * installed. When false the scanner reports a clear, actionable file
+     * error instead of silently returning zero readings.
+     */
+    fun isAvailable(): Boolean
+
+    /**
+     * Recognise text lines from one rasterised page, in reading order.
+     * [page] is the 0-based source page index, carried onto each [OcrLine].
+     * Returns an empty list on a blank/garbled page; throws only on a hard
+     * engine failure (the scanner converts that into a file error).
+     */
+    suspend fun recognise(bitmap: Bitmap, page: Int): List<OcrLine>
+
+    /** Release native resources. Safe to call more than once. */
+    fun close()
+}

--- a/android/app/src/main/java/com/bios/app/labocr/LabScanModels.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/LabScanModels.kt
@@ -1,0 +1,103 @@
+package com.bios.app.labocr
+
+import com.bios.app.data.BiomarkerContext
+import com.bios.app.model.Specimen
+import com.bios.contracts.MetricType
+
+/**
+ * Result types for lab-report OCR ingestion (Phase 10). Deliberately shaped
+ * to mirror [com.bios.app.export.FhirImportSummary] / `AcceptedReading` so the
+ * review screen and the existing FHIR summary dialog share one mental model:
+ * a batch of accepted readings, a list of skipped lines with reasons, and an
+ * optional file-level error.
+ *
+ * Nothing here is persisted. These objects feed the owner-facing review
+ * screen; only the rows the owner confirms ever reach
+ * [com.bios.app.data.BiomarkerEntryRepo]. OCR proposes, the owner disposes.
+ *
+ * See docs/LAB_OCR_INGESTION.md.
+ */
+
+/** One physical text line recognised by a [LabOcrEngine], with its page-space bounds. */
+data class OcrLine(
+    val text: String,
+    /** Source page index (0-based) the line came from — multi-page reports. */
+    val page: Int = 0,
+    /** Top edge in page pixels; used only to order lines and locate the header band. */
+    val top: Int = 0,
+)
+
+/**
+ * Confidence in a single extracted reading. Drives the review UX — never
+ * silent acceptance. HIGH rows are pre-checked; LOW rows are shown unchecked
+ * with a flag for the owner to verify before it counts.
+ */
+enum class Confidence { HIGH, LOW }
+
+/**
+ * Panel-level metadata extracted once from the report header and applied to
+ * every row (a report has one specimen date, usually one specimen type and
+ * lab). All fields are editable in the review screen before confirm.
+ *
+ * [collectionDate] is intentionally nullable: OCR must never silently default
+ * a lab's draw date to "today". When null, the review screen forces the owner
+ * to pick a date before confirm is enabled.
+ */
+data class PanelMetadata(
+    val labName: String? = null,
+    val collectionDate: Long? = null,
+    val specimen: Specimen? = null,
+    /** content:// URI of the copied source image/PDF, attached to every row. */
+    val sourceUri: String? = null,
+) {
+    /** Build the shared [BiomarkerContext] for a confirmed row. */
+    fun toContext(): BiomarkerContext = BiomarkerContext(
+        labName = labName?.ifBlank { null },
+        specimen = specimen,
+        sourceUri = sourceUri?.ifBlank { null },
+    )
+}
+
+/**
+ * A biomarker reading parsed off one report line, already unit-normalised to
+ * the metric's canonical unit. [rawLine] is carried (unlike FHIR's
+ * `AcceptedReading`) because the owner is verifying a machine read of fuzzy
+ * pixels and needs to see the source text.
+ */
+data class ExtractedReading(
+    val metricType: MetricType,
+    val value: Double,
+    val confidence: Confidence,
+    val rawLine: String,
+)
+
+/** A line that could not become a reading, with a human-readable reason. */
+data class SkippedLine(
+    val rawLine: String,
+    val reason: String,
+)
+
+/**
+ * Everything the review screen needs. Mirrors `FhirImportSummary`:
+ * [readings] + [skipped] + an optional [fileError] for an unreadable file /
+ * no pages / OCR failure. [panel] carries the editable shared header.
+ */
+data class LabScanSummary(
+    val readings: List<ExtractedReading>,
+    val skipped: List<SkippedLine>,
+    val panel: PanelMetadata,
+    val fileError: String? = null,
+) {
+    val isFileError: Boolean get() = fileError != null
+    val readingCount: Int get() = readings.size
+    val skippedCount: Int get() = skipped.size
+
+    companion object {
+        fun fileError(message: String): LabScanSummary = LabScanSummary(
+            readings = emptyList(),
+            skipped = emptyList(),
+            panel = PanelMetadata(),
+            fileError = message,
+        )
+    }
+}

--- a/android/app/src/main/java/com/bios/app/labocr/LabScanner.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/LabScanner.kt
@@ -1,0 +1,119 @@
+package com.bios.app.labocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Orchestrates one lab-report scan: source URI → page bitmaps → on-device OCR
+ * → panel metadata + per-line extraction → a [LabScanSummary] for the review
+ * screen. Pure funnel, no persistence — nothing is written here. The owner
+ * confirms rows on the review screen; only then do they reach
+ * [com.bios.app.data.BiomarkerEntryRepo] (docs LAB_OCR_INGESTION.md §3).
+ *
+ * The source [Uri] is threaded straight through onto every reading as
+ * provenance ([PanelMetadata.sourceUri]); image picks keep their persistable
+ * content URI (released by `DataDestroyer`), camera captures live under
+ * `cacheDir/labocr` (wiped by `DataDestroyer`).
+ */
+class LabScanner(private val engine: LabOcrEngine) {
+
+    /**
+     * @param uri the report (PDF or image)
+     * @param isPdf whether [uri] points at a PDF (from its MIME type at the call site)
+     */
+    suspend fun scan(context: Context, uri: Uri, isPdf: Boolean): LabScanSummary =
+        withContext(Dispatchers.IO) {
+            if (!engine.isAvailable()) {
+                return@withContext LabScanSummary.fileError(
+                    "OCR language data isn't installed on this build — add it or enter values by hand."
+                )
+            }
+
+            val pages = try {
+                loadPages(context, uri, isPdf)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to load report pages", e)
+                return@withContext LabScanSummary.fileError("Could not open the selected report.")
+            }
+            if (pages.bitmaps.isEmpty()) {
+                return@withContext LabScanSummary.fileError("No readable pages in the report.")
+            }
+
+            val lines = mutableListOf<OcrLine>()
+            try {
+                pages.bitmaps.forEachIndexed { index, bitmap ->
+                    lines += engine.recognise(bitmap, index)
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "OCR failed", e)
+                return@withContext LabScanSummary.fileError("Couldn't read text from the report.")
+            } finally {
+                pages.bitmaps.forEach { it.recycle() }
+            }
+
+            if (lines.isEmpty()) {
+                return@withContext LabScanSummary.fileError("No text found in the report.")
+            }
+
+            val panel = PanelMetadataExtractor.extract(lines).copy(sourceUri = uri.toString())
+            val readings = mutableListOf<ExtractedReading>()
+            val skipped = mutableListOf<SkippedLine>()
+            for (line in lines) {
+                when (val outcome = LabLineExtractor.extract(line.text)) {
+                    is LabLineExtractor.LineOutcome.Reading -> readings += outcome.reading
+                    is LabLineExtractor.LineOutcome.Skipped -> skipped += outcome.skipped
+                    LabLineExtractor.LineOutcome.Ignored -> Unit // structural line
+                }
+            }
+            if (pages.droppedPages > 0) {
+                skipped += SkippedLine(
+                    "(${pages.droppedPages} page(s) beyond the ${PdfPageRasterizer.MAX_PAGES}-page limit)",
+                    "Not scanned — re-scan those pages separately",
+                )
+            }
+            LabScanSummary(readings = dedupe(readings), skipped = skipped, panel = panel)
+        }
+
+    private data class Pages(val bitmaps: List<Bitmap>, val droppedPages: Int)
+
+    private fun loadPages(context: Context, uri: Uri, isPdf: Boolean): Pages {
+        if (isPdf) {
+            val result = PdfPageRasterizer.rasterise(context, uri)
+            return Pages(result.pages, result.droppedPages)
+        }
+        val bitmap = context.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it)
+        } ?: error("Could not decode image")
+        return Pages(listOf(bitmap), droppedPages = 0)
+    }
+
+    /**
+     * A multi-column report can list the same analyte twice (e.g. a value and
+     * its delta). Keep the first, highest-confidence reading per metric so the
+     * owner doesn't see duplicate rows. Order is otherwise preserved.
+     */
+    private fun dedupe(readings: List<ExtractedReading>): List<ExtractedReading> {
+        val byMetric = LinkedHashMap<String, ExtractedReading>()
+        for (r in readings) {
+            val key = r.metricType.key
+            val existing = byMetric[key]
+            if (existing == null || (existing.confidence == Confidence.LOW && r.confidence == Confidence.HIGH)) {
+                byMetric[key] = r
+            }
+        }
+        return byMetric.values.toList()
+    }
+
+    companion object {
+        private const val TAG = "LabScanner"
+
+        /** Build the default (Tesseract) scanner for [context]. */
+        fun default(context: Context): LabScanner =
+            LabScanner(TesseractLabOcrEngine.create(context))
+    }
+}

--- a/android/app/src/main/java/com/bios/app/labocr/PanelMetadataExtractor.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/PanelMetadataExtractor.kt
@@ -1,0 +1,110 @@
+package com.bios.app.labocr
+
+import com.bios.app.model.Specimen
+import java.text.Normalizer
+import java.time.DateTimeException
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Pulls the panel-level header a lab prints once and applies to every analyte
+ * — collection date, specimen type, lab name — out of the recognised lines
+ * (docs LAB_OCR_INGESTION.md §4.1). The values pre-fill the review screen's
+ * editable header; none is binding until the owner confirms.
+ *
+ * [PanelMetadata.collectionDate] is deliberately left null when no date is
+ * found: OCR must never silently stamp a lab draw as "today". The review
+ * screen forces the owner to set a date before confirm is enabled.
+ */
+object PanelMetadataExtractor {
+
+    /** dd/mm/yyyy or dd-mm-yy etc. — the dominant ES/CA/EU report format. */
+    private val DMY = Regex("\\b(\\d{1,2})[/.\\-](\\d{1,2})[/.\\-](\\d{2,4})\\b")
+
+    /** ISO yyyy-mm-dd. */
+    private val ISO = Regex("\\b(\\d{4})-(\\d{2})-(\\d{2})\\b")
+
+    /** Labels that introduce the *collection* date (preferred over print/report date). */
+    private val DATE_LABELS = listOf(
+        "presa de la mostra", "data extraccio", "data d obtencio", "data de la mostra",
+        "fecha de toma", "fecha de extraccion", "fecha de la muestra", "fecha de obtencion",
+        "collected", "collection date", "specimen date", "drawn", "sample date",
+    )
+
+    private val LAB_KEYWORDS = listOf(
+        "laboratori", "laboratorio", "laboratory", "hospital", "clinica", "clinic",
+        "centre", "centro", "synlab", "cerba", "catlab", "labco", "echevarne", "reference lab",
+    )
+
+    fun extract(lines: List<OcrLine>): PanelMetadata = PanelMetadata(
+        labName = findLabName(lines),
+        collectionDate = findCollectionDate(lines),
+        specimen = findSpecimen(lines),
+    )
+
+    private fun findCollectionDate(lines: List<OcrLine>): Long? {
+        // 1) A date on a line that names the collection event wins.
+        for (line in lines) {
+            val norm = deAccent(line.text)
+            if (DATE_LABELS.any { norm.contains(it) }) {
+                parseDate(line.text)?.let { return it }
+            }
+        }
+        // 2) Otherwise the first plausible date in the header band.
+        return lines.take(HEADER_BAND).firstNotNullOfOrNull { parseDate(it.text) }
+    }
+
+    private fun parseDate(text: String): Long? {
+        ISO.find(text)?.let { m ->
+            return toEpochUtc(m.groupValues[1].toInt(), m.groupValues[2].toInt(), m.groupValues[3].toInt())
+        }
+        DMY.find(text)?.let { m ->
+            val day = m.groupValues[1].toInt()
+            val month = m.groupValues[2].toInt()
+            val year = normaliseYear(m.groupValues[3].toInt())
+            return toEpochUtc(year, month, day)
+        }
+        return null
+    }
+
+    /** Two-digit years map into 2000–2099 — lab reports are contemporary. */
+    private fun normaliseYear(raw: Int): Int = if (raw < 100) 2000 + raw else raw
+
+    private fun toEpochUtc(year: Int, month: Int, day: Int): Long? = try {
+        LocalDate.of(year, month, day).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+    } catch (_: DateTimeException) {
+        null // 31/02, month 13, OCR garble — let the owner pick instead.
+    }
+
+    private fun findSpecimen(lines: List<OcrLine>): Specimen? {
+        for (line in lines.take(HEADER_BAND)) {
+            val norm = deAccent(line.text)
+            when {
+                "serum" in norm || "suero" in norm -> return Specimen.SERUM
+                "plasma" in norm -> return Specimen.PLASMA
+                "edta" in norm || "whole blood" in norm || "sang total" in norm ||
+                    "sangre total" in norm -> return Specimen.WHOLE_BLOOD
+            }
+        }
+        return null
+    }
+
+    private fun findLabName(lines: List<OcrLine>): String? {
+        val candidate = lines.take(HEADER_BAND).firstOrNull { line ->
+            val norm = deAccent(line.text)
+            LAB_KEYWORDS.any { norm.contains(it) }
+        } ?: return null
+        return candidate.text.trim().take(MAX_LAB_NAME).ifBlank { null }
+    }
+
+    private fun deAccent(s: String): String =
+        Normalizer.normalize(s, Normalizer.Form.NFD)
+            .replace(Regex("\\p{Mn}+"), "")
+            .lowercase()
+
+    /** How many leading lines count as the report header for name/specimen. */
+    private const val HEADER_BAND = 20
+
+    /** Defensive cap so an OCR-merged header line can't become a giant lab name. */
+    private const val MAX_LAB_NAME = 80
+}

--- a/android/app/src/main/java/com/bios/app/labocr/PdfPageRasterizer.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/PdfPageRasterizer.kt
@@ -1,0 +1,57 @@
+package com.bios.app.labocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+
+/**
+ * Rasterises a PDF lab report to one [Bitmap] per page using the framework
+ * [PdfRenderer] (API 21+, zero dependency, no Google) so the OCR engine can
+ * read it (docs LAB_OCR_INGESTION.md §2). Pages render at a fixed DPI tuned
+ * for printed-table legibility; oversized reports are capped and the caller
+ * is told how many pages were dropped (never a silent truncation).
+ */
+object PdfPageRasterizer {
+
+    /** Target render resolution — high enough for small printed analyte rows. */
+    private const val TARGET_DPI = 200
+    private const val POINTS_PER_INCH = 72f
+
+    /** Hard page cap for a single report; anything beyond is reported, not read. */
+    const val MAX_PAGES = 12
+
+    data class Result(val pages: List<Bitmap>, val droppedPages: Int)
+
+    /**
+     * Render up to [MAX_PAGES] pages of the PDF at [uri]. Throws on an
+     * unreadable file (the scanner converts that into a file error).
+     */
+    fun rasterise(context: Context, uri: Uri): Result {
+        val pfd = context.contentResolver.openFileDescriptor(uri, "r")
+            ?: error("Could not open PDF")
+        pfd.use { descriptor ->
+            PdfRenderer(descriptor).use { renderer ->
+                val total = renderer.pageCount
+                val take = minOf(total, MAX_PAGES)
+                val bitmaps = ArrayList<Bitmap>(take)
+                for (i in 0 until take) {
+                    renderer.openPage(i).use { page ->
+                        val scale = TARGET_DPI / POINTS_PER_INCH
+                        val width = (page.width * scale).toInt().coerceAtLeast(1)
+                        val height = (page.height * scale).toInt().coerceAtLeast(1)
+                        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                        // PDF pages render with a transparent background; OCR
+                        // wants black-on-white, so paint white underneath first.
+                        Canvas(bitmap).drawColor(Color.WHITE)
+                        page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                        bitmaps += bitmap
+                    }
+                }
+                return Result(bitmaps, droppedPages = total - take)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/labocr/TesseractLabOcrEngine.kt
+++ b/android/app/src/main/java/com/bios/app/labocr/TesseractLabOcrEngine.kt
@@ -1,0 +1,141 @@
+package com.bios.app.labocr
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.util.Log
+import com.googlecode.tesseract.android.TessBaseAPI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+
+/**
+ * [LabOcrEngine] backed by Tesseract via tess-two (`com.rmtheis:tess-two`,
+ * Apache-2.0). Fully FOSS and free of Google Play Services — the degoogled-
+ * purist choice for Phase 10 (docs LAB_OCR_INGESTION.md §2).
+ *
+ * **Trained data is operator-provisioned, never committed.** Tesseract needs a
+ * `<lang>.traineddata` model per language. Those are multi-MB binaries that do
+ * not belong in a public source repo, so they are not bundled here. At runtime
+ * [provisionFromAssets] copies any `.traineddata` files shipped in app
+ * assets into private storage; if none are present, [isAvailable] is false and
+ * the scanner reports "OCR language data not installed" rather than failing
+ * silently. See `app/src/main/assets/tessdata/README` for how to add them.
+ */
+class TesseractLabOcrEngine private constructor(
+    private val dataParentDir: File,
+    private val language: String,
+) : LabOcrEngine {
+
+    private var api: TessBaseAPI? = null
+
+    override fun isAvailable(): Boolean = language.isNotEmpty()
+
+    override suspend fun recognise(bitmap: Bitmap, page: Int): List<OcrLine> =
+        withContext(Dispatchers.Default) {
+            if (!isAvailable()) return@withContext emptyList()
+            val engine = obtainApi() ?: return@withContext emptyList()
+            val text = try {
+                engine.setImage(bitmap)
+                engine.getUTF8Text().orEmpty()
+            } catch (e: Exception) {
+                Log.w(TAG, "Tesseract recognise failed on page $page", e)
+                ""
+            } finally {
+                engine.clear()
+            }
+            // Line-level split keeps reading order without depending on the
+            // result-iterator bbox API; `top` is just the running line index.
+            text.split('\n')
+                .mapIndexedNotNull { index, line ->
+                    line.trim().ifBlank { null }?.let { OcrLine(it, page, index) }
+                }
+        }
+
+    private fun obtainApi(): TessBaseAPI? {
+        api?.let { return it }
+        return try {
+            TessBaseAPI().also {
+                // init wants the directory that *contains* the `tessdata/` folder.
+                if (!it.init(dataParentDir.absolutePath, language)) {
+                    Log.w(TAG, "TessBaseAPI.init failed for '$language'")
+                    it.end()
+                    return null
+                }
+                api = it
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "TessBaseAPI init threw", e)
+            null
+        }
+    }
+
+    override fun close() {
+        try {
+            api?.end()
+        } catch (_: Exception) {
+            // already ended / never inited
+        }
+        api = null
+    }
+
+    companion object {
+        private const val TAG = "TesseractLabOcr"
+
+        /** Languages we ship aliases for; provisioned if their data is present. */
+        private val SUPPORTED = listOf("cat", "spa", "eng")
+
+        /**
+         * Build an engine for [context], copying any bundled trained data out
+         * of assets into private storage and selecting the `+`-joined language
+         * string from whatever resolved. Returns an engine whose [isAvailable]
+         * is false when no trained data could be provisioned.
+         */
+        fun create(context: Context): TesseractLabOcrEngine {
+            val parent = File(context.filesDir, OCR_DIR)
+            val installed = provisionFromAssets(context, File(parent, "tessdata"))
+            // tess-two language string, e.g. "cat+spa+eng".
+            val language = SUPPORTED.filter { it in installed }.joinToString("+")
+            return TesseractLabOcrEngine(parent, language)
+        }
+
+        /** filesDir subdirectory holding the `tessdata/` Tesseract expects. */
+        const val OCR_DIR = "labocr"
+
+        /**
+         * Copy `tessdata/<lang>.traineddata` from assets into [tessdataDir],
+         * returning the set of language codes now available there. Idempotent —
+         * skips files already copied. Absent assets simply yield an empty set.
+         */
+        private fun provisionFromAssets(context: Context, tessdataDir: File): Set<String> {
+            tessdataDir.mkdirs()
+            return listTessdataAssets(context)
+                .filter { it.endsWith(".traineddata") }
+                .filter { ensureCopied(context, tessdataDir, it) }
+                .map { it.removeSuffix(".traineddata") }
+                .toSet()
+        }
+
+        private fun listTessdataAssets(context: Context): List<String> = try {
+            context.assets.list("tessdata").orEmpty().toList()
+        } catch (e: IOException) {
+            Log.w(TAG, "Could not list tessdata assets", e)
+            emptyList()
+        }
+
+        /** Copy one asset into [tessdataDir] if absent; true when it's present afterwards. */
+        private fun ensureCopied(context: Context, tessdataDir: File, name: String): Boolean {
+            val dest = File(tessdataDir, name)
+            if (dest.exists() && dest.length() > 0L) return true
+            return try {
+                context.assets.open("tessdata/$name").use { input ->
+                    dest.outputStream().use { input.copyTo(it) }
+                }
+                true
+            } catch (e: IOException) {
+                Log.w(TAG, "Failed to provision $name", e)
+                false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
+++ b/android/app/src/main/java/com/bios/app/platform/DataDestroyer.kt
@@ -33,6 +33,9 @@ object DataDestroyer {
 
     private const val TAG = "BiosDataDestroyer"
 
+    /** cacheDir subfolder holding lab-report camera captures (see labocr/). */
+    private const val LAB_SCAN_CACHE_DIR = "labocr"
+
     /**
      * Destroy only reproductive health data.
      * Called by LETHE duress PIN as the fastest path to protecting the most dangerous data.
@@ -75,6 +78,12 @@ object DataDestroyer {
 
         // 4. Delete export files from cache
         destroyExportFiles(context)
+
+        // 4.5. Delete cached lab-report scan sources (camera captures the
+        // owner photographed for OCR ingestion — see labocr/LabScanner). The
+        // readings they produced die with the DB key above; this clears the
+        // raw images too.
+        destroyLabScanSources(context)
 
         // 5. Cancel all background work
         cancelAllWork(context)
@@ -145,6 +154,15 @@ object DataDestroyer {
             Log.d(TAG, "Export files deleted")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to delete export files", e)
+        }
+    }
+
+    private fun destroyLabScanSources(context: Context) {
+        try {
+            File(context.cacheDir, LAB_SCAN_CACHE_DIR).deleteRecursively()
+            Log.d(TAG, "Lab-scan source images deleted")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to delete lab-scan sources", e)
         }
     }
 

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModel.kt
@@ -474,5 +474,9 @@ class AppViewModel(
     fun addManualBiomarker(metricType: MetricType, value: Double, timestamp: Long, context: BiomarkerContext = BiomarkerContext()) =
         biomarkers.addManual(metricType, value, timestamp, context)
 
+    // MARK: - Lab-report OCR ingestion (Phase 10)
+
+    val labScan = AppViewModelLabScan(biomarkers, viewModelScope, _error)
+
     val manualReadingRepo: ManualReadingRepo = ManualReadingRepo(db)
 }

--- a/android/app/src/main/java/com/bios/app/ui/AppViewModelLabScan.kt
+++ b/android/app/src/main/java/com/bios/app/ui/AppViewModelLabScan.kt
@@ -1,0 +1,80 @@
+package com.bios.app.ui
+
+import android.content.Context
+import android.net.Uri
+import com.bios.app.labocr.ExtractedReading
+import com.bios.app.labocr.LabScanSummary
+import com.bios.app.labocr.LabScanner
+import com.bios.app.labocr.PanelMetadata
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Lab-report OCR slice of [AppViewModel] (Phase 10). Holds the pending scan
+ * the review screen renders, runs the scan off the main thread, and writes the
+ * rows the owner confirms through the same manual-entry path as everything
+ * else ([AppViewModelBiomarkers.addManual]). Kept separate so the main
+ * view-model stays under the 500-line cap.
+ *
+ * Nothing is persisted by scanning — only [confirm] writes, and only the rows
+ * handed to it. See docs/LAB_OCR_INGESTION.md §§3,6,7.
+ */
+class AppViewModelLabScan(
+    private val biomarkers: AppViewModelBiomarkers,
+    private val scope: CoroutineScope,
+    private val errorSink: MutableStateFlow<String?>,
+) {
+    private val _scanning = MutableStateFlow(false)
+    val scanning: StateFlow<Boolean> = _scanning.asStateFlow()
+
+    private val _pending = MutableStateFlow<LabScanSummary?>(null)
+    /** The most recent scan awaiting owner review, or null. */
+    val pending: StateFlow<LabScanSummary?> = _pending.asStateFlow()
+
+    /** Scan [uri] (PDF or image) and stash the summary for the review screen. */
+    fun scan(context: Context, uri: Uri, isPdf: Boolean) {
+        if (_scanning.value) return
+        _scanning.value = true
+        scope.launch {
+            try {
+                val summary = withContext(Dispatchers.IO) {
+                    LabScanner.default(context.applicationContext).scan(context.applicationContext, uri, isPdf)
+                }
+                _pending.value = summary
+            } catch (e: Exception) {
+                errorSink.value = "Lab scan failed: ${e.message ?: "unknown error"}"
+            } finally {
+                _scanning.value = false
+            }
+        }
+    }
+
+    /**
+     * Write the owner-confirmed [rows] (edited values included) against the
+     * confirmed [panel]. Each row lands through the SELF_REPORTED manual-entry
+     * path; the panel's collection date and provenance ride on every row.
+     * Clears the pending scan when done.
+     */
+    fun confirm(rows: List<ExtractedReading>, panel: PanelMetadata) {
+        val timestamp = panel.collectionDate
+        if (timestamp == null) {
+            errorSink.value = "Set the collection date before saving the scan."
+            return
+        }
+        val context = panel.toContext()
+        for (row in rows) {
+            biomarkers.addManual(row.metricType, row.value, timestamp, context)
+        }
+        _pending.value = null
+    }
+
+    /** Discard the pending scan without writing anything. */
+    fun discard() {
+        _pending.value = null
+    }
+}

--- a/android/app/src/main/java/com/bios/app/ui/EntryNavRoutes.kt
+++ b/android/app/src/main/java/com/bios/app/ui/EntryNavRoutes.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.bios.app.ui.biomarkers.BiomarkerEntryScreen
+import com.bios.app.ui.biomarkers.LabScanReviewScreen
 import com.bios.app.ui.clinical.ClinicalReadingEntryScreen
 import com.bios.app.ui.clinical.MeasurementPreset
 import com.bios.app.ui.vessel.VesselWatchScreen
@@ -19,7 +20,21 @@ fun NavGraphBuilder.entryAndReadoutRoutes(
     viewModel: AppViewModel,
 ) {
     composable("biomarker_entry") {
-        BiomarkerEntryScreen(viewModel = viewModel, onBack = { navController.popBackStack() })
+        BiomarkerEntryScreen(
+            viewModel = viewModel,
+            onBack = { navController.popBackStack() },
+            onOpenScanReview = { navController.navigate("lab_scan_review") },
+        )
+    }
+    composable("lab_scan_review") {
+        LabScanReviewScreen(
+            viewModel = viewModel,
+            onBack = { navController.popBackStack() },
+            onAddManually = {
+                navController.popBackStack()
+                navController.navigate("biomarker_entry")
+            },
+        )
     }
     composable("clinical_entry") {
         ClinicalReadingEntryScreen(viewModel = viewModel, onBack = { navController.popBackStack() })

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/BiomarkerEntryScreen.kt
@@ -64,7 +64,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun BiomarkerEntryScreen(
     viewModel: AppViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onOpenScanReview: () -> Unit = {},
 ) {
     val biomarkers = remember {
         MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER }
@@ -372,6 +373,8 @@ fun BiomarkerEntryScreen(
                     }
                 }
             }
+
+            LabScanEntryCard(viewModel = viewModel, onOpenScanReview = onOpenScanReview)
 
             Text("Recent entries", style = MaterialTheme.typography.titleSmall)
             if (recent.isEmpty()) {

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/LabScanEntryCard.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/LabScanEntryCard.kt
@@ -1,0 +1,134 @@
+package com.bios.app.ui.biomarkers
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import com.bios.app.ui.AppViewModel
+import java.io.File
+
+/**
+ * "Scan lab report" entry card — the on-device OCR ingestion surface (Phase
+ * 10), split out of [BiomarkerEntryScreen] to keep that file under the
+ * 500-line cap. Self-contained: owns its capture state and the pick / camera /
+ * permission launchers. When a scan finishes it routes to the review screen
+ * via [onOpenScanReview]; nothing is written until the owner confirms there.
+ */
+@Composable
+fun LabScanEntryCard(
+    viewModel: AppViewModel,
+    onOpenScanReview: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scanning by viewModel.labScan.scanning.collectAsState()
+    val pendingScan by viewModel.labScan.pending.collectAsState()
+    var captureUri by remember { mutableStateOf<Uri?>(null) }
+
+    val pickLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument()
+    ) { picked ->
+        if (picked != null) {
+            val isPdf = context.contentResolver.getType(picked) == "application/pdf"
+            viewModel.labScan.scan(context, picked, isPdf)
+        }
+    }
+    val cameraLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { ok ->
+        if (ok) captureUri?.let { viewModel.labScan.scan(context, it, isPdf = false) }
+    }
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) launchLabCapture(context, cameraLauncher) { captureUri = it }
+    }
+
+    // When a scan finishes, hand the owner straight to review-and-confirm.
+    // Nothing has been written yet — the review screen is the gate.
+    LaunchedEffect(pendingScan) {
+        if (pendingScan != null) onOpenScanReview()
+    }
+
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Scan lab report", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            Text(
+                "Photograph or pick a PDF/photo of a lab report. It's read on-device — " +
+                    "no data leaves your phone — and you confirm every value before it's saved.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(
+                    onClick = { pickLauncher.launch(LAB_REPORT_MIME_TYPES) },
+                    enabled = !scanning,
+                    modifier = Modifier.weight(1f)
+                ) { Text("Pick PDF / photo") }
+                OutlinedButton(
+                    onClick = {
+                        if (hasCameraPermission(context)) {
+                            launchLabCapture(context, cameraLauncher) { captureUri = it }
+                        } else {
+                            cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+                        }
+                    },
+                    enabled = !scanning,
+                    modifier = Modifier.weight(1f)
+                ) { Text("Take photo") }
+            }
+            if (scanning) {
+                Text(
+                    "Reading the report…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+private fun hasCameraPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, android.Manifest.permission.CAMERA) ==
+        PackageManager.PERMISSION_GRANTED
+
+/**
+ * Create a fresh app-private capture file under `cacheDir/labocr`, hand its
+ * FileProvider URI to [onUri] (so the result callback can find it), and launch
+ * the camera. The capture is wiped by `DataDestroyer` along with all health data.
+ */
+private fun launchLabCapture(
+    context: Context,
+    launcher: ManagedActivityResultLauncher<Uri, Boolean>,
+    onUri: (Uri) -> Unit,
+) {
+    val dir = File(context.cacheDir, "labocr").apply { mkdirs() }
+    val file = File(dir, "scan_${System.currentTimeMillis()}.jpg")
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+    onUri(uri)
+    launcher.launch(uri)
+}

--- a/android/app/src/main/java/com/bios/app/ui/biomarkers/LabScanReviewScreen.kt
+++ b/android/app/src/main/java/com/bios/app/ui/biomarkers/LabScanReviewScreen.kt
@@ -1,0 +1,297 @@
+package com.bios.app.ui.biomarkers
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.bios.app.labocr.Confidence
+import com.bios.app.labocr.ExtractedReading
+import com.bios.app.labocr.PanelMetadata
+import com.bios.app.model.Specimen
+import com.bios.app.ui.AppViewModel
+
+/** A single review row's editable state (value text + whether it'll be saved). */
+private class ScanRowState(val reading: ExtractedReading) {
+    var valueText by mutableStateOf(trimZeros(reading.value))
+    var checked by mutableStateOf(reading.confidence == Confidence.HIGH)
+    val parsed: Double? get() = valueText.toDoubleOrNull()
+}
+
+/**
+ * Pre-filled, editable batch review of an OCR'd lab report — the gate where
+ * the owner confirms before anything is written (docs LAB_OCR_INGESTION.md
+ * §6). Reuses the manual-entry field idioms so there's one editing UX. OCR
+ * proposes; nothing persists until the owner taps Save.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LabScanReviewScreen(
+    viewModel: AppViewModel,
+    onBack: () -> Unit,
+    onAddManually: () -> Unit,
+) {
+    val summary by viewModel.labScan.pending.collectAsState()
+    val current = summary
+
+    // Editable state, hoisted above the Scaffold so the date dialog shares its
+    // scope. Keyed on `current` so a fresh scan re-seeds the form. remember()
+    // is called unconditionally (current may be null) to respect hook rules.
+    val rows = remember(current) {
+        current?.readings.orEmpty().map { ScanRowState(it) }.toMutableStateList()
+    }
+    var date by remember(current) { mutableStateOf(current?.panel?.collectionDate) }
+    var labName by remember(current) { mutableStateOf(current?.panel?.labName.orEmpty()) }
+    var specimen by remember(current) { mutableStateOf(current?.panel?.specimen) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    var specimenExpanded by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Review scanned report") },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        viewModel.labScan.discard()
+                        onBack()
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (current == null || current.isFileError) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(padding).padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text(current?.fileError ?: "Nothing to review.", style = MaterialTheme.typography.bodyMedium)
+                OutlinedButton(onClick = {
+                    viewModel.labScan.discard()
+                    onBack()
+                }) { Text("Back") }
+            }
+            return@Scaffold
+        }
+
+        val canSave = date != null &&
+            rows.any { it.checked && (it.parsed?.let { v -> v > 0.0 } == true) }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth().padding(padding).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                PanelHeaderCard(
+                    date = date,
+                    labName = labName,
+                    specimen = specimen,
+                    onPickDate = { showDatePicker = true },
+                    onLabNameChange = { labName = it },
+                    specimenExpanded = specimenExpanded,
+                    onSpecimenExpandedChange = { specimenExpanded = it },
+                    onSpecimenChange = { specimen = it },
+                )
+            }
+            item {
+                Text(
+                    "Found ${rows.size} value${if (rows.size == 1) "" else "s"}. " +
+                        "Checked rows will be saved. Amber rows were read with low confidence — verify them.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            items(rows) { row -> ScanReadingRow(row) }
+
+            if (current.skipped.isNotEmpty()) {
+                item {
+                    Text(
+                        "Couldn't read (${current.skipped.size})",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                items(current.skipped) { s ->
+                    Text(
+                        "• ${s.reason}\n  ${s.rawLine}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                item { TextButton(onClick = onAddManually) { Text("+ Add a value manually") } }
+            }
+
+            item {
+                Button(
+                    onClick = {
+                        val confirmed = rows
+                            .filter { it.checked && (it.parsed?.let { v -> v > 0.0 } == true) }
+                            .map { it.reading.copy(value = it.parsed!!) }
+                        val panel = PanelMetadata(
+                            labName = labName.ifBlank { null },
+                            collectionDate = date,
+                            specimen = specimen,
+                            sourceUri = current.panel.sourceUri,
+                        )
+                        viewModel.labScan.confirm(confirmed, panel)
+                        viewModel.refreshRecentBiomarkers()
+                        onBack()
+                    },
+                    enabled = canSave,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(if (date == null) "Set a date to save" else "Save checked values")
+                }
+            }
+        }
+    }
+
+    if (showDatePicker) {
+        val state = rememberDatePickerState(initialSelectedDateMillis = date)
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    state.selectedDateMillis?.let { date = it }
+                    showDatePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = { showDatePicker = false }) { Text("Cancel") } }
+        ) { DatePicker(state = state) }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PanelHeaderCard(
+    date: Long?,
+    labName: String,
+    specimen: Specimen?,
+    onPickDate: () -> Unit,
+    onLabNameChange: (String) -> Unit,
+    specimenExpanded: Boolean,
+    onSpecimenExpandedChange: (Boolean) -> Unit,
+    onSpecimenChange: (Specimen?) -> Unit,
+) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("Report details", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            OutlinedButton(onClick = onPickDate, modifier = Modifier.fillMaxWidth()) {
+                Text(if (date == null) "Set collection date (required)" else "Drawn on: ${formatBiomarkerDate(date)}")
+            }
+            OutlinedTextField(
+                value = labName,
+                onValueChange = onLabNameChange,
+                label = { Text("Lab / facility") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            ExposedDropdownMenuBox(expanded = specimenExpanded, onExpandedChange = onSpecimenExpandedChange) {
+                OutlinedTextField(
+                    value = specimen?.readable ?: "—",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Specimen") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = specimenExpanded) },
+                    modifier = Modifier.fillMaxWidth().menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                )
+                ExposedDropdownMenu(expanded = specimenExpanded, onDismissRequest = { onSpecimenExpandedChange(false) }) {
+                    DropdownMenuItem(text = { Text("—") }, onClick = {
+                        onSpecimenChange(null); onSpecimenExpandedChange(false)
+                    })
+                    Specimen.entries.forEach { s ->
+                        DropdownMenuItem(text = { Text(s.readable) }, onClick = {
+                            onSpecimenChange(s); onSpecimenExpandedChange(false)
+                        })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanReadingRow(row: ScanRowState) {
+    val low = row.reading.confidence == Confidence.LOW
+    val container = if (low) {
+        MaterialTheme.colorScheme.tertiaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+    Card(colors = CardDefaults.cardColors(containerColor = container)) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = row.checked, onCheckedChange = { row.checked = it })
+                Text(
+                    row.reading.metricType.readableName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedTextField(
+                    value = row.valueText,
+                    onValueChange = { row.valueText = it.filter { c -> c.isDigit() || c == '.' } },
+                    suffix = { Text(row.reading.metricType.unit.symbol.ifEmpty { "—" }) },
+                    singleLine = true,
+                    isError = row.checked && (row.parsed == null || (row.parsed ?: 0.0) <= 0.0),
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Text(
+                row.reading.rawLine,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (low) {
+                Text(
+                    "Low confidence — please verify",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+        }
+    }
+}
+
+/** Drop a trailing ".0" so an OCR'd integer doesn't show as "55.0". */
+private fun trimZeros(v: Double): String =
+    if (v % 1.0 == 0.0) v.toLong().toString() else v.toString()

--- a/android/app/src/test/java/com/bios/app/export/LabUnitConversionTest.kt
+++ b/android/app/src/test/java/com/bios/app/export/LabUnitConversionTest.kt
@@ -1,0 +1,56 @@
+package com.bios.app.export
+
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The shared unit-reconciliation table that FHIR import and lab-report OCR
+ * both depend on — so a value imports identically whichever door it comes
+ * through (issue #354 mg/dL↔mg/L, plus the OCR unit gazetteer).
+ */
+class LabUnitConversionTest {
+
+    @Test
+    fun convertsMgPerDlToMgPerLForCrp() {
+        val result = normalizeToCanonicalUnit(MetricType.CRP, "mg/dL", 0.5)
+        assertTrue(result is CanonicalUnit.Ok)
+        assertEquals(5.0, (result as CanonicalUnit.Ok).value, 1e-9)
+    }
+
+    @Test
+    fun passesThroughMatchingUnit() {
+        val result = normalizeToCanonicalUnit(MetricType.TOTAL_CHOLESTEROL, "mg/dL", 190.0)
+        assertEquals(190.0, (result as CanonicalUnit.Ok).value, 1e-9)
+    }
+
+    @Test
+    fun trustsResolutionWhenUnitAbsent() {
+        val result = normalizeToCanonicalUnit(MetricType.FERRITIN, null, 120.0)
+        assertEquals(120.0, (result as CanonicalUnit.Ok).value, 1e-9)
+    }
+
+    @Test
+    fun failsClosedOnIncompatibleUnit() {
+        val result = normalizeToCanonicalUnit(MetricType.TSH, "mg/dL", 2.0)
+        assertTrue(result is CanonicalUnit.Incompatible)
+    }
+
+    @Test
+    fun canonicalisesRealReportSpellings() {
+        assertEquals("m[IU]/L", canonicaliseUnitToken("mU/L"))
+        assertEquals("mg/dL", canonicaliseUnitToken("mg/dl"))
+        assertEquals("10*9/L", canonicaliseUnitToken("10E9/L"))
+    }
+
+    @Test
+    fun distinguishesUnitsFromResultFlags() {
+        assertTrue(isKnownUnitToken("mg/dL"))
+        assertTrue(isKnownUnitToken("%"))
+        assertTrue(isKnownUnitToken("fL"))
+        assertFalse(isKnownUnitToken("H"))
+        assertFalse(isKnownUnitToken("alto"))
+    }
+}

--- a/android/app/src/test/java/com/bios/app/labocr/LabAnalyteAliasesTest.kt
+++ b/android/app/src/test/java/com/bios/app/labocr/LabAnalyteAliasesTest.kt
@@ -1,0 +1,76 @@
+package com.bios.app.labocr
+
+import com.bios.contracts.MetricDomain
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the anti-drift contract for lab-report OCR: the alias resolver is
+ * derived from [MetricType.entries], so a biomarker key shipped without an
+ * alias must fail CI here rather than silently never resolving off a report.
+ */
+class LabAnalyteAliasesTest {
+
+    private val manualBiomarkers: List<MetricType> =
+        MetricType.entries.filter { it.domain == MetricDomain.BIOMARKER && it.allowsManualEntry }
+
+    @Test
+    fun everyManualBiomarkerHasAtLeastOneAlias() {
+        val missing = manualBiomarkers.filter { LabAnalyteAliases.biomarkerAliases(it).isNullOrEmpty() }
+        assertTrue(
+            "Biomarker MetricTypes with no OCR alias (add one in LabAnalyteAliases): " +
+                missing.joinToString { it.key },
+            missing.isEmpty(),
+        )
+    }
+
+    @Test
+    fun aliasesDoNotCollideAcrossMetrics() {
+        val owners = HashMap<String, MutableList<MetricType>>()
+        for (type in MetricType.entries) {
+            for (alias in LabAnalyteAliases.biomarkerAliases(type).orEmpty()) {
+                owners.getOrPut(LabAnalyteAliases.normalise(alias)) { mutableListOf() }.add(type)
+            }
+        }
+        val collisions = owners.filterValues { it.size > 1 }
+        assertTrue(
+            "Aliases normalise to the same key for multiple metrics: " +
+                collisions.entries.joinToString { "${it.key} -> ${it.value.map { m -> m.key }}" },
+            collisions.isEmpty(),
+        )
+    }
+
+    @Test
+    fun everyManualBiomarkerResolvesFromItsOwnFirstAlias() {
+        for (type in manualBiomarkers) {
+            val firstAlias = LabAnalyteAliases.biomarkerAliases(type)!!.first()
+            val match = LabAnalyteAliases.resolve(firstAlias)
+            assertNotNull("No resolve for ${type.key} via \"$firstAlias\"", match)
+            assertEquals("Wrong metric for \"$firstAlias\"", type, match!!.metric)
+            assertTrue("Own alias should resolve exact for ${type.key}", match.exact)
+        }
+    }
+
+    @Test
+    fun resolvesMultilingualNames() {
+        assertEquals(MetricType.TSH, LabAnalyteAliases.resolve("Tirotropina")?.metric)
+        assertEquals(MetricType.MONOCYTES_PCT, LabAnalyteAliases.resolve("Monòcits %")?.metric)
+        assertEquals(MetricType.ABSOLUTE_MONOCYTE_COUNT, LabAnalyteAliases.resolve("Monòcits absoluts")?.metric)
+        assertEquals(MetricType.TOTAL_CHOLESTEROL, LabAnalyteAliases.resolve("Colesterol total")?.metric)
+        assertEquals(MetricType.HDL_CHOLESTEROL, LabAnalyteAliases.resolve("Colesterol HDL")?.metric)
+    }
+
+    @Test
+    fun normaliseFoldsAccentsAndPercent() {
+        assertEquals("monocits percent", LabAnalyteAliases.normalise("Monòcits %"))
+        assertEquals("tirotropina", LabAnalyteAliases.normalise("  Tirotropina  "))
+    }
+
+    @Test
+    fun unknownNameDoesNotResolve() {
+        assertEquals(null, LabAnalyteAliases.resolve("Nota Real Analyte XYZ"))
+    }
+}

--- a/android/app/src/test/java/com/bios/app/labocr/LabLineExtractorTest.kt
+++ b/android/app/src/test/java/com/bios/app/labocr/LabLineExtractorTest.kt
@@ -1,0 +1,96 @@
+package com.bios.app.labocr
+
+import com.bios.contracts.MetricType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Behavioural tests for the per-line extractor — the parsing heart of
+ * lab-report OCR. Covers analyte resolution past digits-in-names, value
+ * selection, the unit-guard skip, locale decimals, and confidence tiers.
+ */
+class LabLineExtractorTest {
+
+    private fun reading(line: String): ExtractedReading {
+        val outcome = LabLineExtractor.extract(line)
+        assertTrue("Expected a Reading for: $line (got $outcome)", outcome is LabLineExtractor.LineOutcome.Reading)
+        return (outcome as LabLineExtractor.LineOutcome.Reading).reading
+    }
+
+    @Test
+    fun parsesValueUnitAndReferenceRange() {
+        val r = reading("Tirotropina 2.10 mU/L 0.550 - 4.780")
+        assertEquals(MetricType.TSH, r.metricType)
+        assertEquals(2.10, r.value, 1e-9)
+        assertEquals(Confidence.HIGH, r.confidence)
+    }
+
+    @Test
+    fun resolvesLongerNameOverShorter() {
+        val r = reading("Colesterol HDL 55 mg/dL")
+        assertEquals(MetricType.HDL_CHOLESTEROL, r.metricType)
+        assertEquals(55.0, r.value, 1e-9)
+    }
+
+    @Test
+    fun digitsInAnalyteNameAreNotTheValue() {
+        val r = reading("Vitamina B12 350 pg/mL")
+        assertEquals(MetricType.VITAMIN_B12, r.metricType)
+        assertEquals(350.0, r.value, 1e-9)
+    }
+
+    @Test
+    fun honoursLocaleDecimalComma() {
+        val r = reading("Hematocrit 41,5 %")
+        assertEquals(MetricType.HEMATOCRIT, r.metricType)
+        assertEquals(41.5, r.value, 1e-9)
+    }
+
+    @Test
+    fun convertsThroughSharedUnitTable() {
+        // CRP stored in mg/L; a report in mg/dL must convert ×10, same as FHIR.
+        val r = reading("PCR 0.5 mg/dL")
+        assertEquals(MetricType.CRP, r.metricType)
+        assertEquals(5.0, r.value, 1e-9)
+    }
+
+    @Test
+    fun incompatibleUnitSkipsAndReports() {
+        val outcome = LabLineExtractor.extract("TSH 2.1 mg/dL")
+        assertTrue(outcome is LabLineExtractor.LineOutcome.Skipped)
+        val reason = (outcome as LabLineExtractor.LineOutcome.Skipped).skipped.reason
+        assertTrue("Reason should name the unit clash: $reason", reason.contains("not compatible"))
+    }
+
+    @Test
+    fun unitlessLineIsLowConfidence() {
+        val r = reading("Ferritina 120")
+        assertEquals(MetricType.FERRITIN, r.metricType)
+        assertEquals(Confidence.LOW, r.confidence)
+    }
+
+    @Test
+    fun magnitudeOutlierDropsToLowConfidence() {
+        // A value three orders outside the printed range = dropped decimal point.
+        val r = reading("Creatinina 880 mg/dL 0.6 - 1.2")
+        assertEquals(MetricType.CREATININE, r.metricType)
+        assertEquals(Confidence.LOW, r.confidence)
+    }
+
+    @Test
+    fun unmappedAnalyteWithNumberIsSkipped() {
+        val outcome = LabLineExtractor.extract("Glucosa 95 mg/dL")
+        assertTrue(outcome is LabLineExtractor.LineOutcome.Skipped)
+    }
+
+    @Test
+    fun structuralLineIsIgnored() {
+        assertEquals(LabLineExtractor.LineOutcome.Ignored, LabLineExtractor.extract("Hemograma"))
+    }
+
+    @Test
+    fun blankLineIsIgnored() {
+        assertEquals(LabLineExtractor.LineOutcome.Ignored, LabLineExtractor.extract("   "))
+    }
+}

--- a/android/app/src/test/java/com/bios/app/labocr/PanelMetadataExtractorTest.kt
+++ b/android/app/src/test/java/com/bios/app/labocr/PanelMetadataExtractorTest.kt
@@ -1,0 +1,62 @@
+package com.bios.app.labocr
+
+import com.bios.app.model.Specimen
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/** Header-level extraction: collection date, specimen, lab name. */
+class PanelMetadataExtractorTest {
+
+    private fun lines(vararg text: String): List<OcrLine> =
+        text.mapIndexed { i, t -> OcrLine(t, page = 0, top = i) }
+
+    private fun epochUtc(y: Int, m: Int, d: Int): Long =
+        LocalDate.of(y, m, d).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+
+    @Test
+    fun extractsLabelledCollectionDate() {
+        val panel = PanelMetadataExtractor.extract(
+            lines(
+                "Laboratori Sagrat Cor",
+                "Data i hora presa de la mostra: 12/03/2026 08:30",
+                "Tirotropina 2.10 mU/L",
+            )
+        )
+        assertEquals(epochUtc(2026, 3, 12), panel.collectionDate)
+    }
+
+    @Test
+    fun parsesIsoDate() {
+        val panel = PanelMetadataExtractor.extract(lines("Collected 2025-11-02", "Glucose 90 mg/dL"))
+        assertEquals(epochUtc(2025, 11, 2), panel.collectionDate)
+    }
+
+    @Test
+    fun extractsSpecimenAndLabName() {
+        val panel = PanelMetadataExtractor.extract(
+            lines(
+                "Laboratori de Referència de Catalunya",
+                "Mostra: Sèrum",
+                "Fecha de toma: 01/02/2026",
+            )
+        )
+        assertEquals(Specimen.SERUM, panel.specimen)
+        assertEquals(epochUtc(2026, 2, 1), panel.collectionDate)
+        assertEquals("Laboratori de Referència de Catalunya", panel.labName)
+    }
+
+    @Test
+    fun neverDefaultsDateWhenAbsent() {
+        val panel = PanelMetadataExtractor.extract(lines("Some header", "Hemoglobina 14 g/dL"))
+        assertNull(panel.collectionDate)
+    }
+
+    @Test
+    fun rejectsImpossibleDate() {
+        val panel = PanelMetadataExtractor.extract(lines("Fecha de toma: 31/02/2026"))
+        assertNull(panel.collectionDate)
+    }
+}

--- a/docs/LAB_OCR_INGESTION.md
+++ b/docs/LAB_OCR_INGESTION.md
@@ -1,0 +1,345 @@
+# Lab-Report OCR Ingestion
+
+> The owner has a paper or PDF lab report. Their lab portal does not export
+> FHIR (most don't — La Meva Salut, Synlab, Cerba, hospital PDFs). Today the
+> only path into Bios is typing ~25 values by hand on a phone keyboard. This
+> feature lets the owner photograph or pick the report, have it parsed
+> **on-device**, eyeball the pre-filled values, and confirm — turning a
+> 10-minute transcription chore into a 30-second review.
+>
+> It is a thin extraction layer in front of the already-shipped §8.6 lab
+> pipeline. It adds no new persistence, no new metric keys, no network, and
+> no Google Play Services. The owner confirms every value before it is
+> written — OCR proposes, the owner disposes.
+
+Status: **DESIGN** (targets v0.3). Builds on §8.6 (lab inbound surface,
+COMPLETE).
+
+---
+
+## 1. Why not FHIR-only
+
+FHIR import (`export/FhirImporter.kt`) is shipped and is the clean path —
+*for the rare owner whose portal exports a FHIR R4 Bundle*. In practice the
+artifact in the owner's hand is a **PDF or a photo**. So FHIR import serves
+the power-user edge; the median owner needs the report read off the page.
+
+This feature does not replace FHIR import or manual entry. It is a third
+input that **funnels into the same review-and-confirm UI** and the same
+write path:
+
+```
+                                 ┌─ FHIR file ──→ FhirImporter ─────┐
+  user-initiated import ─────────┼─ photo/PDF ──→ LabScanner (NEW) ─┼─→ Review screen ─→ BiomarkerEntryRepo.add()
+                                 └─ manual entry (one row at a time) ┘
+```
+
+All three converge on a **`LabScanSummary`-shaped** accepted/skipped result
+(§5), a review screen the owner confirms (§6), and the existing
+`SELF_REPORTED` write path (§7). The OCR layer is everything left of "Review
+screen" on the middle arrow.
+
+---
+
+## 2. On-device constraint (non-negotiable)
+
+Per principles 2 ("on-device processing… never data monetization") and 6
+("No Play Services. Every feature works on degoogled devices"), the OCR
+stack must be **fully on-device and Play-Services-free**. Two viable engines:
+
+| Engine | Artifact | Play Services? | Quality | Size |
+|--------|----------|----------------|---------|------|
+| **ML Kit text recognition (bundled)** | `com.google.mlkit:text-recognition` | **No** — model embedded in the AAR, runs offline | High | ~? +4 MB |
+| **Tesseract** | `cz.adaptech.tesseract4android:tesseract4android` | No — fully FOSS | Lower on dense tables, needs `.traineddata` per language | +trained data |
+
+`com.google.mlkit:text-recognition` is the **bundled** variant (not the
+`com.google.android.gms:play-services-mlkit-*` variant) — it ships the model
+inside the app and does **not** call out to Play Services at runtime, so it
+runs on a degoogled device. It is still a Google-authored library; the
+purist alternative is Tesseract (`tesseract4android`), which is GPL/Apache
+and Google-free but weaker on dense numeric tables and needs bundled
+`eng`/`spa`/`cat` trained data.
+
+**Recommendation:** ship **ML Kit bundled** behind a `LabOcrEngine`
+interface so Tesseract can be swapped in (or offered as a degoogled-build
+flavor) without touching the extraction logic. Decide at implementation
+time; the interface is the hedge.
+
+**PDF rasterization** uses the framework `android.graphics.pdf.PdfRenderer`
+(API 21+, zero dependency, no Google) — render each page to a `Bitmap`, feed
+the bitmap to the OCR engine.
+
+**CameraX is already a dependency** (`androidx.camera:*` 1.4.1, used for
+fingertip-PPG) — reuse it for the "photograph report" capture path. No new
+camera dependency.
+
+New dependency footprint: **one line** (`com.google.mlkit:text-recognition`)
+or the Tesseract equivalent. Everything else is already in the build.
+
+---
+
+## 3. Pipeline
+
+```
+pick/photo → [PdfRenderer if PDF] → Bitmap(s)
+           → LabOcrEngine.recognize() → List<OcrLine> (text + bbox)
+           → PanelMetadataExtractor    → specimen, collection date, lab name   (§4.1)
+           → LineBiomarkerExtractor     → List<ExtractedReading | SkippedLine>  (§4.2)
+           → LabScanSummary             → review screen                          (§5,§6)
+           → owner confirms             → BiomarkerEntryRepo.add() per row       (§7)
+```
+
+Runs in a coroutine off the main thread (WorkManager not required — it is
+user-initiated and foreground, like the FHIR import). No reading is
+persisted until the owner taps confirm.
+
+---
+
+## 4. Extraction
+
+### 4.1 Panel-level metadata (extract once, apply to all rows)
+
+A lab report has one specimen date, often one specimen type and one lab
+name, printed in a header — not repeated per analyte. Extract them once and
+pre-fill the shared `BiomarkerContext`:
+
+- **Lab name** → `lab_name`. Match the report's "Centre / Centro" /
+  facility line, or the most prominent header text. Editable in review.
+- **Collection date** → `timestamp`. Anchor on labelled date fields
+  ("Data i hora presa de la mostra", "Fecha de toma", "Collected",
+  "Specimen date"). Parse `dd/mm/yy(yy)` and ISO. **Never** silently
+  default to "today" — if no date is found, the review screen forces the
+  owner to pick one before confirm is enabled.
+- **Specimen** → `Specimen`. Map free text: `Sèrum`/`Suero`/`Serum` →
+  `SERUM`; `Sang EDTA`/`Sangre`/`Whole blood`/`EDTA` → `WHOLE_BLOOD`;
+  `Plasma` → `PLASMA`; else `OTHER`.
+- **Source provenance** → `source_uri`. The original image/PDF is copied
+  into app-private storage and its `content://` URI is attached as
+  `source_uri` to **every** row from the scan (one shared provenance, same
+  as the FHIR import attaches the source file). The owner can always open
+  the original to audit a value.
+
+### 4.2 Per-line biomarker extraction
+
+Lab lines have a stable shape across labs and languages:
+
+```
+<analyte name> … <value> <unit> <ref-low> – <ref-high>
+```
+
+e.g. (representative Catalan/Spanish lines; values are fabricated examples):
+
+```
+Tirotropina            2.10  mU/L    0.550 - 4.780
+Colesterol d'HDL          55  mg/dL
+Monòcits %               6.5  %       2.0 - 11.0
+Monòcits                 0.5  10E9/L  0.1 - 1.0
+```
+
+For each OCR line:
+
+1. **Tokenize** into `(leadingText, numbers[], unitToken?, range?)`. Parse
+   decimals with a strict numeric regex that respects locale decimal marks
+   (`.` and `,`) and does **not** strip non-digit separators blindly —
+   gluing `6.5` + `%` + `2.0` into one figure is the classic
+   strip-`\D`-concatenation bug. Each printed number is parsed as its own
+   token.
+2. **Resolve the analyte** by normalizing `leadingText` (lowercase, strip
+   accents/diacritics, collapse whitespace, drop trailing `%`/units) and
+   looking it up in the **alias table** (§4.3). `Tirotropina` → `TSH`,
+   `Monòcits %` → `MONOCYTES_PCT`, `Monòcits` (abs) → `ABSOLUTE_MONOCYTE…`.
+3. **Pick the value.** When a line carries multiple numbers (value + ref
+   range), the value is the token *before* the unit / before the range
+   separator. The range (`low – high`) is captured separately and used only
+   as a **confirmation signal** (§4.4) — never written.
+4. **Unit guard (the disambiguation gate).** The extracted unit must be
+   convertible to `metricType.unit` via the existing
+   `FhirImporter.normaliseUnit` / `conversionFactor` machinery. If the name
+   matches but the unit is incompatible (e.g. an OCR misread, or two
+   analytes share a name across panels), **skip-and-report** — do not guess.
+   This reuse means OCR and FHIR share one unit-conversion source of truth.
+5. **Emit** an `ExtractedReading` (with a confidence tier) or a
+   `SkippedLine` (with a reason). No line is dropped silently.
+
+### 4.3 Alias table — derived from `MetricType`, not parallel to it
+
+`MetricType` today carries no synonyms, and a biomarker's English `key`
+(`tsh`, `total_cholesterol`) will not match a Catalan/Spanish report
+(`Tirotropina`, `Colesterol total`). So aliases are the **one genuinely new
+data artifact** this feature needs.
+
+**Critical design rule:** the alias resolver is built by **scanning
+`MetricType.entries`**, exactly as `FhirImporter.loincToMetricType` is built
+by scanning entries through `loincCode()`. A hand-maintained
+`Map<String, MetricType>` *parallel* to the enum silently drifts the day a
+new biomarker key lands without an alias — the same dual-source drift the
+LOINC map was deliberately designed to avoid. So:
+
+```kotlin
+// One source: aliases keyed BY MetricType. Resolver derived FROM it.
+fun biomarkerAliases(metric: MetricType): List<String>? = when (metric) {
+    MetricType.TSH               -> listOf("tsh", "tirotropina", "tirotropina (tsh)", "thyrotropin")
+    MetricType.TOTAL_CHOLESTEROL -> listOf("colesterol total", "colesterol", "cholesterol total", "colesterol (total)")
+    MetricType.MONOCYTES_PCT     -> listOf("monocits %", "monocitos %", "monocytes %", "monocits", "monocitos")
+    // … one entry per BIOMARKER-domain MetricType
+    else -> null
+}
+
+val aliasToMetricType: Map<String, MetricType> by lazy {
+    buildMap {
+        for (type in MetricType.entries) {
+            for (alias in biomarkerAliases(type).orEmpty()) put(normalize(alias), type)
+        }
+    }
+}
+```
+
+A `MetricTypeTest`-style unit test asserts **every `MetricDomain.BIOMARKER`
+entry with `allowsManualEntry` has at least one alias**, so adding a
+biomarker key without an alias fails CI — the drift guard. Ship aliases for
+ES / CA / EN (the owner's locales) at minimum; the `RegionConfigProvider`
+localization layer is the eventual home for broader language coverage.
+
+### 4.4 Confidence tiers (drive the review UX, not silent acceptance)
+
+| Tier | Condition | Review UI |
+|------|-----------|-----------|
+| **HIGH** | exact alias hit **and** unit compatible **and** value within the printed reference range's order of magnitude (or within physiological bounds) | row pre-checked ✓ |
+| **LOW** | fuzzy/partial alias, or no unit on the line, or value implausible vs range | row shown, **unchecked**, flagged for the owner to verify |
+| **SKIPPED** | no alias match, or unit incompatible with the resolved metric, or no numeric value | listed in a "couldn't read" section with the raw line + reason |
+
+The printed reference range is a free plausibility check the lab gives us:
+a value three orders of magnitude outside the printed range is an OCR
+misread (decimal point lost — the magnitude trap), so it drops to LOW rather
+than being written confidently. The range is **never persisted**; it only
+gates confidence.
+
+---
+
+## 5. Result type — mirror `FhirImportSummary`
+
+The FHIR importer already returns an accepted/skipped/fileError shape and
+the entry screen already renders a summary dialog over it. Mirror it so the
+review screen and the post-write summary reuse the same UI:
+
+```kotlin
+data class ExtractedReading(
+    val metricType: MetricType,
+    val value: Double,            // already unit-normalized to metricType.unit
+    val timestamp: Long,          // panel collection date
+    val context: BiomarkerContext,// labName / specimen / sourceUri shared from §4.1
+    val confidence: Confidence,   // HIGH | LOW
+    val rawLine: String,          // the OCR line, shown for verification
+)
+
+data class SkippedLine(
+    val rawLine: String,
+    val reason: String,           // "no analyte match", "unit mg/dL not compatible with %", …
+)
+
+data class LabScanSummary(
+    val readings: List<ExtractedReading>,
+    val skipped: List<SkippedLine>,
+    val panel: PanelMetadata,     // date / specimen / labName, all editable
+    val fileError: String?,       // unreadable file / no pages / OCR failure
+)
+```
+
+`ExtractedReading` carries `rawLine` (FHIR's `AcceptedReading` doesn't need
+it — OCR does, because the owner is verifying a machine read of fuzzy
+pixels).
+
+---
+
+## 6. Review screen — owner confirms before anything is written
+
+A new Compose screen (route `"lab_scan_review"`), reached from a new
+**"Scan lab report"** card on `BiomarkerEntryScreen` alongside the existing
+"Import from FHIR" card. It is a **pre-filled, editable batch** of the same
+fields the single-entry `BiomarkerEntryScreen` already renders:
+
+- **Panel header** (editable): collection date, specimen, lab name —
+  applied to all rows. Confirm is disabled until a date is set.
+- **One row per `ExtractedReading`:** metric name, parsed value (editable
+  number field with the metric's unit suffix), a checkbox, the `rawLine` in
+  small text beneath, and confidence styling (HIGH pre-checked; LOW
+  unchecked + amber flag). Tapping a row opens the full per-metric editor
+  (the existing entry-field widgets) to fix the metric or value.
+- **"Couldn't read" section:** the `SkippedLine`s with their reasons and a
+  "+ add manually" shortcut into the existing single-entry flow — **no
+  silent truncation**; the owner sees exactly what was dropped and why.
+- **Confirm** writes only the checked rows.
+
+Reusing `BiomarkerEntryScreen`'s field composables keeps one editing UX and
+avoids a second numeric-validation path.
+
+---
+
+## 7. Write path — unchanged
+
+Each confirmed row calls the **existing** §8.6 write path, once per reading:
+
+```kotlin
+viewModel.addManualBiomarker(reading.metricType, reading.value, reading.timestamp, reading.context)
+// → BiomarkerEntryRepo.add(...) → SELF_REPORTED DataSource, ConfidenceTier.HIGH
+```
+
+No new repository, table, metric key, or `DataSource`. Rows land as
+`SELF_REPORTED` and so are excluded from sensor baselines per decision 3 in
+`SELF_REPORTED_DATA_HOME.md`, exactly like manually-entered and
+FHIR-imported labs.
+
+**Confidence note:** `BiomarkerEntryRepo.add` hardcodes
+`ConfidenceTier.HIGH`. An owner-confirmed OCR row *is* a human-verified
+value, so HIGH is correct — the OCR engine's own uncertainty is resolved at
+the review gate, not carried into storage. (If a future change wants to
+record "this came from OCR" provenance, thread a `sourceType`/note rather
+than lowering the tier — the owner verified it.)
+
+---
+
+## 8. Privacy & boundary
+
+- **Fully on-device.** OCR model bundled, PDF rendered by the framework, no
+  byte leaves the device. Consistent with the FHIR import (also local).
+- **Source file** is copied into app-private (SQLCipher-adjacent) storage
+  and referenced by `source_uri`; it is destroyed by the existing
+  `DataDestroyer` wipe path along with the readings.
+- **No new companion, no metric-bus change.** Lab data is canonical
+  multi-system body signal owned by Bios (per §8.6 and
+  `ECOSYSTEM_BOUNDARIES.md`); this is an input method, not a new data class.
+- **Manifesto:** the feature reads numbers, it does not evaluate them. Any
+  judgment ("Borderline") is the *separate*, already-shipped clinical-bands
+  surface; OCR only gets the value onto the time-series.
+
+---
+
+## 9. Acceptance
+
+- Owner can pick a PDF **or** photograph a report; both produce a
+  `LabScanSummary`.
+- A representative ES/CA/EN panel (lipids, CBC + differential, glucose,
+  creatinine, ALT/GGT, TSH) extracts its in-schema analytes at HIGH
+  confidence; unknown/unsupported lines surface in "couldn't read" with a
+  reason — none dropped silently.
+- Multilingual analyte names resolve via the alias table (`Tirotropina` →
+  `TSH`, `Monòcits %` → `MONOCYTES_PCT`).
+- Unit incompatibility skips-and-reports; it never writes a guessed value.
+- Every `BIOMARKER` + `allowsManualEntry` `MetricType` has ≥1 alias
+  (CI-enforced) — no dual-source drift.
+- Nothing is persisted until the owner confirms; only checked rows write.
+- No new dependency beyond the one OCR engine line; no Play Services; runs
+  on a degoogled build.
+
+---
+
+## 10. Phasing
+
+- **v0.3 (MVP):** photo + PDF input, ML Kit bundled engine behind
+  `LabOcrEngine`, ES/CA/EN aliases for the common ~30 panel analytes,
+  review screen, panel-metadata extraction. Single-page and simple
+  multi-page reports.
+- **v0.4:** broader alias/language coverage hoisted into
+  `RegionConfigProvider`; better multi-page / multi-column table handling;
+  optional Tesseract degoogled-purist engine flavor; auto lab-name
+  detection from a known-labs gazetteer.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -473,6 +473,32 @@ Bios owns autonomic state).
 
 ---
 
+## Phase 10: Lab-report OCR ingestion — read the report off the page [DESIGN]
+
+> §8.6 shipped the lab inbound surface (FHIR import + manual entry), but the
+> artifact in the owner's hand is almost always a **PDF or a photo** — their
+> portal (La Meva Salut, Synlab, Cerba, hospital labs) does not export FHIR.
+> Today that means typing ~25 values by hand on a phone keyboard. Phase 10
+> lets the owner photograph or pick the report, parse it **on-device**,
+> eyeball the pre-filled values, and confirm. OCR proposes, the owner
+> disposes — nothing is written until confirmed.
+
+A thin extraction layer in front of the existing §8.6 pipeline: no new
+metric keys, no new persistence, no network, no Play Services. Photo/PDF →
+on-device OCR (ML Kit bundled, or Tesseract for a degoogled-purist flavor,
+behind a `LabOcrEngine` interface) → multilingual analyte resolution via an
+alias table **derived from `MetricType`** (same anti-drift pattern as
+`FhirImporter.loincToMetricType`) → a `LabScanSummary` (mirrors
+`FhirImportSummary`) → a pre-filled review screen the owner confirms → the
+existing `BiomarkerEntryRepo` `SELF_REPORTED` write path. Unit
+incompatibility skips-and-reports rather than guessing; no line is dropped
+silently.
+
+Full design: [LAB_OCR_INGESTION.md](LAB_OCR_INGESTION.md). Targets v0.3
+(MVP) → v0.4 (broader language coverage, multi-page tables).
+
+---
+
 ## Phase 9 (deferred): New companions if earned
 
 Two companions are noted in the audit but explicitly *not* committed:


### PR DESCRIPTION
## Summary
Implements **Phase 10 — on-device lab-report OCR ingestion**: a third input method that funnels into the already-shipped §8.6 lab pipeline. The owner photographs or picks a PDF/photo of a lab report, it's parsed **fully on-device**, and they review the pre-filled values and confirm. **OCR proposes, the owner disposes** — nothing is written until each row is confirmed.

Supersedes #409 (the design doc + ROADMAP entry are folded into this PR).

## Pipeline (`com.bios.app.labocr`)
```
pick/photo → PdfPageRasterizer (PDF) / BitmapFactory (image)
  → LabOcrEngine (Tesseract / tess-two) → OcrLines
  → PanelMetadataExtractor (date / specimen / lab)  +  LabLineExtractor (per analyte)
  → LabScanSummary → LabScanReviewScreen → owner confirms → existing SELF_REPORTED write path
```

- **LabAnalyteAliases** — ES/CA/EN analyte names, resolver **derived by scanning `MetricType.entries`** (same anti-drift pattern as `FhirImporter.loincToMetricType`). A unit test fails CI if a manual `BIOMARKER` ships without an alias.
- **LabLineExtractor** — resolves the analyte *before* digits in its name (`Vitamina B12`, `Omega 3`), locale-aware decimals, and a **unit guard** built on the shared conversion table now extracted from `FhirImporter` (`LabUnitConversion`) so OCR and FHIR reconcile units identically. Incompatible units **skip-and-report**; no line is dropped silently.
- **LabScanReviewScreen** — editable batch: collection date (required), per-row value + checkbox, HIGH pre-checked / LOW flagged amber, a "couldn't read" section. Confirm writes only checked rows via the existing manual-entry path.

## Boundary guarantees
- **Fully on-device**, no network, **no Google Play Services** — runs on a degoogled build. Tesseract via **tess-two** (Apache-2.0).
- **No new** metric keys, repository, table, or `DataSource` — rows land as `SELF_REPORTED` (excluded from baselines).
- Trained-data models are **operator-provisioned**, never committed (`assets/tessdata/.gitignore` + README); the engine degrades gracefully when absent.
- `DataDestroyer` wipes cached lab-scan captures alongside all health data.

## Tests
Alias drift guard + collision check, line extractor (unit guard, digits-in-name, locale decimals, magnitude trap), panel metadata, shared unit normaliser. `FhirImporterTest` still green after the conversion refactor.

## Checks
`./scripts/code-quality-check.sh` → **ALL CHECKS PASSED** (file lengths, secrets, detekt, assembleDebug both flavors, unit tests). The one lint error (`CameraPpgAdapter` opt-in) is pre-existing and flagged non-blocking by the script.

## Not runtime-verified
Pure-Kotlin extraction core is unit-tested; the OCR engine, PDF rasterisation, camera capture, and Compose review screen are written against their APIs but not exercised on a device in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)