### PR TITLE
fix(export): FHIR per-metric cap keeps newest rows, never silent

### DIFF
--- a/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
+++ b/android/app/src/main/java/com/bios/app/export/FhirExporter.kt
@@ -1,6 +1,7 @@
 package com.bios.app.export
 
 import android.content.Context
+import android.util.Log
 import com.bios.app.data.BiomarkerContext
 import com.bios.app.data.BiomarkerEntryRepo
 import com.bios.app.data.BiosDatabase
@@ -54,6 +55,17 @@ class FhirExporter(
     private val fastStrokeDao = db.fastStrokeEventDao()
 
     companion object {
+        private const val TAG = "FhirExporter"
+
+        /**
+         * Per-metric ceiling on observations emitted into a single bundle, to
+         * keep the file a manageable size for clinician tooling. When a metric
+         * exceeds this, the export keeps the MOST RECENT rows (not the oldest)
+         * and records the drop in Bundle.meta.tag — the cap is never silent.
+         * See [buildBundle].
+         */
+        internal const val MAX_READINGS_PER_METRIC = 500
+
         /**
          * The MetricTypes the default FHIR export enumerates: everything except
          * the WOMENS_HEALTH (reproductive) domain.
@@ -97,10 +109,19 @@ class FhirExporter(
         // WOMENS_HEALTH (reproductive) keys are excluded — see
         // [defaultExportMetricTypes] for why the main-DB exporter must never
         // touch the isolated ReproductiveDatabase.
+        // metricKey -> [kept, total] for any metric whose readings exceeded the
+        // per-metric cap; surfaced in Bundle.meta.tag so the omission is visible.
+        val truncated = LinkedHashMap<String, IntArray>()
+
         for (metricType in defaultExportMetricTypes()) {
             val isBiomarker = metricType.domain == MetricDomain.BIOMARKER
             val readings = readingDao.fetch(metricType.key, thirtyDaysAgo, Long.MAX_VALUE)
-            for (reading in readings.take(500)) {
+            // fetch() returns rows ORDER BY timestamp ASC; capMostRecent keeps the
+            // newest rows (what a clinician most wants), not the oldest. Any drop
+            // is recorded (never silent) below.
+            val (capped, total) = capMostRecent(readings, MAX_READINGS_PER_METRIC)
+            if (total > capped.size) truncated[metricType.key] = intArrayOf(capped.size, total)
+            for (reading in capped) {
                 // Biomarker readings carry optional provenance (lab name,
                 // fasting status, specimen type) in the event-payload sidecar.
                 // The owner-recall note in MetricReading.note is intentionally
@@ -131,12 +152,36 @@ class FhirExporter(
             }
         }
 
-        return buildBundleResource(entries)
+        val bundle = buildBundleResource(entries)
+        if (truncated.isNotEmpty()) {
+            val meta = bundle.getJSONObject("meta")
+            val tags = meta.optJSONArray("tag") ?: JSONArray().also { meta.put("tag", it) }
+            truncated.forEach { (key, counts) ->
+                tags.put(JSONObject().apply {
+                    put("system", "https://bios.health/fhir/data-completeness")
+                    put("code", "truncated")
+                    put("display", "$key: exported ${counts[0]} most-recent of ${counts[1]} readings in the 30-day window")
+                })
+            }
+            Log.w(TAG, "FHIR export capped ${truncated.size} metric(s) at $MAX_READINGS_PER_METRIC most-recent rows: " +
+                truncated.entries.joinToString { "${it.key}=${it.value[0]}/${it.value[1]}" })
+        }
+        return bundle
     }
 
     private fun timestamp(): String =
         SimpleDateFormat("yyyy-MM-dd_HHmmss", Locale.US).format(Date())
 }
+
+/**
+ * Caps a per-metric, timestamp-ASC reading list to [cap] rows, keeping the
+ * MOST RECENT (so a clinician sees the latest data, not the oldest). Returns the
+ * kept slice paired with the original count, so the caller can record any drop in
+ * Bundle.meta.tag. Pure (no Context/DB) so the unit test can exercise it directly.
+ */
+internal fun <T> capMostRecent(readings: List<T>, cap: Int): Pair<List<T>, Int> =
+    if (readings.size > cap) readings.takeLast(cap) to readings.size
+    else readings to readings.size
 
 // --- Pure FHIR R4 resource builders ---------------------------------------
 // These are top-level `internal` so tests can exercise them without a Context.

--- a/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
+++ b/android/app/src/test/java/com/bios/app/FhirExporterTest.kt
@@ -1,6 +1,7 @@
 package com.bios.app
 
 import com.bios.app.export.FhirExporter
+import com.bios.app.export.capMostRecent
 import com.bios.app.export.loincCode
 import com.bios.app.export.ucumCode
 import com.bios.contracts.MetricDomain
@@ -15,6 +16,29 @@ import org.junit.Test
  * test calls them directly.
  */
 class FhirExporterTest {
+
+    // --- Per-metric cap (data-completeness, never silent) ---
+
+    @Test
+    fun `capMostRecent keeps all rows when under the cap`() {
+        val rows = (1..10).toList()
+        val (kept, total) = capMostRecent(rows, FhirExporter.MAX_READINGS_PER_METRIC)
+        assertEquals(rows, kept)
+        assertEquals(10, total)
+        assertEquals("no drop when under cap", kept.size, total)
+    }
+
+    @Test
+    fun `capMostRecent keeps the most recent rows and reports the true total`() {
+        // Input is timestamp-ASC, so the newest rows are at the end.
+        val cap = FhirExporter.MAX_READINGS_PER_METRIC
+        val rows = (1..(cap + 50)).toList()
+        val (kept, total) = capMostRecent(rows, cap)
+        assertEquals("kept is capped", cap, kept.size)
+        assertEquals("total is the pre-cap count", cap + 50, total)
+        assertEquals("keeps the newest, not the oldest", cap + 50, kept.last())
+        assertEquals(51, kept.first())
+    }
 
     // --- LOINC code coverage ---
 

--- a/docs/GAP_REGISTER.md
+++ b/docs/GAP_REGISTER.md
@@ -1,0 +1,70 @@
+# Bios — Instrumentation Gap Register
+
+Derived from a real-world audit (2026-06-29): a 5-week FHIR export from a Pixel 9a
+was analysed, the symptoms traced back to code, and each finding classified as a
+**defect**, an **activation/adherence gap**, or **by-design**. The goal of the audit
+was the product, not the owner's health.
+
+Severity: **P0** corrupts data integrity / trust · **P1** loses data or coverage ·
+**P2** friction / transparency · **P3** nice-to-have.
+
+## Register
+
+| # | Sev | Gap | Root cause (located) | Class | Status |
+|---|-----|-----|----------------------|-------|--------|
+| G1 | P0 | FHIR export silently truncated and biased to the **oldest** rows | `FhirExporter.kt` — `.take(500)` over a `timestamp ASC` query + 30-day window, no completeness signal | Defect | **FIXED** 2026-06-29 |
+| G2 | P0 | Implausible phone-sleep values exported as fact | Confidence tier is computed (`PhoneSleepInference.confidenceFor`) but **never gates**; no plausibility bounds in `SleepDerivations.kt`; no cross-metric check in `IngestManager.deriveAll`; raw dump in `DataExporter`; LOW-confidence rows feed `BaselineEngine` | Defect | Open |
+| G3 | P1 | Oura built but never activated | `OuraApiAdapter` (~440 lines) + `OuraTokenStore` + a paste-token row in `DataSourcesScreen` all exist; discovery is 4 taps deep, no onboarding prompt | Activation | Open |
+| G4 | — | ~~Periodic workers die on reboot~~ | **Withdrawn.** WorkManager 2.10.0 ships its own boot receiver and reschedules persisted periodic work natively. No app-level `BootReceiver` needed. | Non-bug | Closed |
+| G4b | P2 | Foreground services do not auto-restart after reboot | `SeizureDetectionService`, `PhoneSleepCollectionService` — no boot-time restart; starting a `health` FGS from `BOOT_COMPLETED` has Android restrictions, so this needs design, not a one-liner | Defect (nuanced) | Open |
+| G5 | P2 | Coverage opacity | 198 schema metrics, **~25 with a wired producer**; a 0-sample metric is indistinguishable from "your device can't measure this" | Mostly by-design | Open |
+| G6 | P2 | Manual / companion streams lapse silently | Substances & mood are manual; typing-cadence + mood-drift arrive via the **W2F companion** over the ContentProvider — no logging nudges, no companion-liveness check | Adherence | Open |
+| G7 | P3 | Only 3 personal baselines | `BaselineEngine` gate: ≥10 SENSOR samples / 14-day window, manual entries excluded | By-design | Open (surface progress only) |
+| G8 | P3 | No owner-authorised one-command read | ContentProvider catch-22: `adb` shell lacks `READ_HEALTH`; the app uid lacks the system `ACCESS_CONTENT_PROVIDERS_EXTERNALLY`. An authorised agent on the owner's own machine must tap through the export UI | Friction | Open |
+
+### Open question
+
+The medication-overuse-headache `DetectedIssue` (ICHD-3 §8.2) was found **in the export**.
+It is unverified whether it ever surfaced to the owner as an in-app alert, or only
+persisted. Confirm alert *delivery* fires, not just storage.
+
+## Detail & fix plans for the open items
+
+### G2 — sleep plausibility (P0, the trust item)
+Phone-on-nightstand is currently indistinguishable from a sleeping owner, and the
+derived metrics have no bounds, so the pipeline emitted e.g. ~8 h latency, 8 %
+efficiency, ~12 h WASO. Fixes, in order:
+1. **Gate by confidence** — drop (or flag) LOW-confidence phone-sleep readings before
+   export and before they reach `BaselineEngine`.
+2. **Plausibility bounds** in `SleepDerivations.kt` — reject/flag latency, efficiency,
+   WASO outside physiologic ranges.
+3. **Cross-metric checks** in `deriveAll` — e.g. `latency + duration ≤ time-in-bed`.
+4. **Data-quality flag** on `MetricReading` surfaced in the export, so a clinician
+   sees "low_phone_accel" rather than a bare impossible number.
+
+### G3 — Oura activation (P1, best coverage ROI)
+Connecting Oura yields HRV, resting HR, skin-temperature deviation and a recovery
+score independent of Health Connect — exactly the markers currently empty. The code
+is complete; only discovery is missing. Touch points:
+- `DataSourcesScreen.kt` — add a prominent "Connect Oura" quick-action / empty-state.
+- Onboarding flow — after the Health Connect permission grant, a one-time
+  "Do you have an Oura Ring?" prompt linking to the paste-token dialog.
+- Gate the prompt behind a `ouraOnboardingShown` flag so it never nags.
+> Requires an in-app build + verify pass; not shippable blind.
+
+### G4b — foreground-service boot restart (P2)
+Decide policy first: silent auto-restart of a health FGS on boot is restricted on
+modern Android and is also a UX/consent question. Likely answer is a notification
+("Bios monitoring paused — tap to resume") rather than a silent relaunch.
+
+### G5 — coverage transparency (P2)
+Add a coverage view grouping metrics into *measured · supported-but-no-data ·
+not-supported-by-your-device*, using a runtime capability check rather than the
+"0 samples" heuristic. Folds in G7 (show per-metric baseline progress).
+
+## Notes on what is **not** broken
+
+- **Health Connect is fully wired** — every declared read permission has ingestion.
+  Missing HRV/SpO₂/RHR is a device-capability gap, not dead code.
+- **~173 metrics with no producer** is intentional: they are manual / lab / derived.
+- **Sparse baselines** are the strict-by-design gate, not a failure.

--- a/scripts/fhir_trends.py
+++ b/scripts/fhir_trends.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""fhir_trends.py — one-command evolution report from a Bios FHIR export.
+
+The Bios DB is SQLCipher-encrypted with a hardware-Keystore-wrapped key, so it
+cannot be read off-device. The supported host-side path is the in-app FHIR
+export (Settings -> Data & sources -> Export -> FHIR bundle), which the app
+writes to /sdcard/Download as a password-protected (WinZip-AES) .zip.
+
+Usage:
+  # Pull the newest bios_fhir*.zip off the connected device, decrypt, report:
+  python3 fhir_trends.py --password 'PASS'
+
+  # Or analyze a local file:
+  python3 fhir_trends.py --zip path/to/bios_fhir.json.zip --password 'PASS'
+  python3 fhir_trends.py --json path/to/bios_fhir.json        # already decrypted
+
+Requires pyzipper for AES zips:  pip install pyzipper  (use a venv on PEP-668 systems)
+"""
+import argparse, glob, json, os, statistics as st, subprocess, sys, tempfile
+from collections import defaultdict
+
+DEVICE_DIR = "/sdcard/Download"
+
+
+def pull_newest_zip(dest_dir):
+    out = subprocess.run(["adb", "shell", "ls", "-t", DEVICE_DIR],
+                         capture_output=True, text=True).stdout.split()
+    name = next((n for n in out if n.startswith("bios_fhir") and n.endswith(".zip")), None)
+    if not name:
+        sys.exit(f"No bios_fhir*.zip in {DEVICE_DIR} on device. Export from the app first.")
+    local = os.path.join(dest_dir, name)
+    subprocess.run(["adb", "pull", f"{DEVICE_DIR}/{name}", local], check=True)
+    return local
+
+
+def load_bundle(args, workdir):
+    if args.json:
+        return json.load(open(args.json))
+    zip_path = args.zip or pull_newest_zip(workdir)
+    if not args.password:
+        sys.exit("--password is required to decrypt the export zip.")
+    try:
+        import pyzipper
+    except ImportError:
+        sys.exit("pyzipper not installed:  pip install pyzipper  (venv on PEP-668 systems)")
+    with pyzipper.AESZipFile(zip_path) as z:
+        z.setpassword(args.password.encode())
+        z.extractall(workdir)
+    return json.load(open(glob.glob(f"{workdir}/*.json")[0]))
+
+
+def code_of(o):
+    c = o.get("code", {})
+    return c.get("text") or (c.get("coding", [{}]) or [{}])[0].get("display") or "??"
+
+
+def dt_of(o):
+    return (o.get("effectiveDateTime") or o.get("effectivePeriod", {}).get("start") or "")
+
+
+def val_of(o):
+    if "valueQuantity" in o:
+        return o["valueQuantity"].get("value"), o["valueQuantity"].get("unit", "")
+    for k in ("valueInteger", "valueString", "valueBoolean"):
+        if k in o:
+            return o[k], ""
+    if "valueCodeableConcept" in o:
+        cc = o["valueCodeableConcept"]
+        return cc.get("text") or (cc.get("coding", [{}])[0].get("display")), ""
+    return None, ""
+
+
+def report(bundle):
+    obs = [x["resource"] for x in bundle.get("entry", [])
+           if x["resource"].get("resourceType") == "Observation"]
+    series = defaultdict(list)
+    for o in obs:
+        d = dt_of(o)
+        if d:
+            v, u = val_of(o)
+            series[code_of(o)].append((d[:10], v, u))
+    for k in series:
+        series[k].sort()
+
+    alld = sorted(d for s in series.values() for d, _, _ in s)
+    print(f"\n{'='*64}\nBIOS FHIR EVOLUTION REPORT")
+    if alld:
+        print(f"span: {alld[0]} -> {alld[-1]}   ({len(obs)} observations, {len(series)} metrics)")
+    print("=" * 64)
+
+    def is_num(x):
+        return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+    print(f"\n{'metric':30s} {'n':>4}  {'1st-half':>9} {'2nd-half':>9} {'delta':>9}   range")
+    for k in sorted(series, key=lambda k: -len(series[k])):
+        vals = [v for _, v, _ in series[k] if is_num(v)]
+        unit = next((u for _, _, u in series[k] if u), "")
+        if len(vals) >= 4:
+            h = len(vals) // 2
+            a, z = st.mean(vals[:h]), st.mean(vals[h:])
+            print(f"{k:30.30s} {len(vals):>4}  {a:9.2f} {z:9.2f} {z-a:+9.2f}   "
+                  f"[{min(vals):g}-{max(vals):g}] {unit}")
+        else:
+            print(f"{k:30.30s} {len(series[k]):>4}  {'(sparse)':>9}")
+
+    issues = [x["resource"] for x in bundle.get("entry", [])
+              if x["resource"].get("resourceType") == "DetectedIssue"]
+    if issues:
+        print(f"\n{'-'*64}\nDETECTED ISSUES ({len(issues)}):")
+        for r in issues:
+            detail = r.get("detail") or r.get("code", {}).get("text") or ""
+            print(f"  [{r.get('severity','?')}] {detail}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Bios FHIR evolution report")
+    ap.add_argument("--password", help="export zip password")
+    ap.add_argument("--zip", help="local bios_fhir*.zip (skip adb pull)")
+    ap.add_argument("--json", help="already-decrypted FHIR json")
+    args = ap.parse_args()
+    with tempfile.TemporaryDirectory() as wd:
+        report(load_bundle(args, wd))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The FHIR exporter capped each metric at 500 readings via `.take(500)` over a `timestamp ASC` query — silently dropping the **newest** rows and keeping the oldest, biasing every export toward stale data with no signal anything was withheld (contra the manifesto's *"we never withhold information"*).

This was caught during a real audit: a 5-week export showed Heart Rate and Steps each at *exactly* 500 rows clustered at the window start, which initially read as "logging stopped" — it was the cap hiding recent data.

## Changes

- **`capMostRecent()`** — pure helper that keeps the **newest** rows and reports the true pre-cap count. Unit-tested (no Context/DB needed).
- **`Bundle.meta.tag`** — every drop is recorded as a `data-completeness` tag and logged, so a truncated export is never silent.
- **`docs/GAP_REGISTER.md`** — instrumentation-gap audit from the same export. G1 (this) fixed; **G2** (phone-sleep confidence never gates → implausible values) and **G3** (Oura fully coded but never activated) remain open. The "workers die on reboot" theory was **withdrawn** — WorkManager self-reschedules on boot.
- **`scripts/fhir_trends.py`** — one-command evolution report from a FHIR export (pull → decrypt AES zip → per-metric trends).

## Verification

- `:app:testStandaloneDebugUnitTest` green (51 tests, incl. 2 new cap tests).
- Argus secret/PII scan clean.
- Pre-existing lint errors (issue #385) are unrelated and non-blocking.

## Not in scope

G2 and G3 are tracked in `docs/GAP_REGISTER.md` with fix plans; both need an in-app build+verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)